### PR TITLE
In WriteStream, avoid emitting 'drain' events before ws.write() has been called.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -840,7 +840,10 @@ WriteStream.prototype.flush = function () {
   var self = this;
 
   var args = this._queue.shift();
-  if (!args) return self.emit('drain');
+  if (!args) {
+    if (this.drainable) { self.emit('drain'); }
+    return;
+  }
 
   this.busy = true;
 
@@ -895,6 +898,8 @@ WriteStream.prototype.write = function (data) {
   if (!this.writeable) {
     throw new Error('stream not writeable');
   }
+
+  this.drainable = true;
 
   var cb;
   if (typeof(arguments[arguments.length-1]) == 'function') {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -946,7 +946,9 @@ WriteStream.prototype.forceClose = function (cb) {
 
 
 WriteStream.prototype.destroy = function (cb) {
+  var self = this;
   this.writeable = false;
+
   fs.close(self.fd, function(err) {
     if (err) {
       if (cb) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -949,20 +949,23 @@ WriteStream.prototype.destroy = function (cb) {
   var self = this;
   this.writeable = false;
 
-  fs.close(self.fd, function(err) {
-    if (err) {
-      if (cb) {
-        cb(err);
+  function close() {
+    fs.close(self.fd, function(err) {
+      if (err) {
+        if (cb) { cb(err); }
+        self.emit('error', err);
+        return;
       }
 
-      self.emit('error', err);
-      return;
-    }
+      if (cb) { cb(null); }
+      self.emit('close');
+    });
+  }
 
-    if (cb) {
-      cb(null);
-    }
-    self.emit('close');
-  });
+  if (this.fd) {
+    close();
+  } else {
+    this.addListener('open', close);
+  }
 };
 

--- a/test/simple/test-fs-write-stream.js
+++ b/test/simple/test-fs-write-stream.js
@@ -17,3 +17,12 @@ var file = path.join(common.fixturesDir, "write.txt");
   stream.destroy();
 })();
 
+(function() {
+  var stream = fs.createWriteStream(file);
+  
+  stream.addListener('drain', function () {
+    assert.fail('"drain" event must not be emitted before stream.write() has been called at least once.')
+  });
+  stream.destroy();
+})();
+

--- a/test/simple/test-fs-write-stream.js
+++ b/test/simple/test-fs-write-stream.js
@@ -1,0 +1,19 @@
+common = require("../common");
+assert = common.assert
+
+var path = require('path'),
+    fs = require('fs');
+    
+var file = path.join(common.fixturesDir, "write.txt");
+
+(function() {
+  var stream = fs.createWriteStream(file),
+      _fs_close = fs.close;
+      
+  fs.close = function(fd) {
+    assert.ok(fd, "fs.close must not be called without an undefined fd.")
+    fs.close = _fs_close;
+  }
+  stream.destroy();
+})();
+


### PR DESCRIPTION
Following the [mailing list thread](http://groups.google.com/group/nodejs/browse_thread/thread/dea595040c31a0d5), here's a fix to avoid 'drain' being called for empty files.

Couple of related bug fixes included in separate commits.
