### PR TITLE
ServerResponse#writeHead array header values

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -374,11 +374,35 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
   // in the case of response it is: "HTTP/1.1 200 OK\r\n"
   var messageHeader = firstLine;
   var field, value;
+  var self = this;
+
+  function store(field, value) {
+    messageHeader += field + ": " + value + CRLF;
+
+    if (connectionExpression.test(field)) {
+      sentConnectionHeader = true;
+      if (closeExpression.test(value)) {
+        self._last = true;
+      } else {
+        self.shouldKeepAlive = true;
+      }
+
+    } else if (transferEncodingExpression.test(field)) {
+      sentTransferEncodingHeader = true;
+      if (chunkExpression.test(value)) self.chunkedEncoding = true;
+
+    } else if (contentLengthExpression.test(field)) {
+      sentContentLengthHeader = true;
+
+    }
+  }
 
   if (headers) {
     var keys = Object.keys(headers);
     var isArray = (Array.isArray(headers));
-    for (var i = 0, l = keys.length; i < l; i++) {
+    var i, l;
+
+    for (i = 0, l = keys.length; i < l; i++) {
       var key = keys[i];
       if (isArray) {
         field = headers[key][0];
@@ -388,23 +412,12 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
         value = headers[key];
       }
 
-      messageHeader += field + ": " + value + CRLF;
-
-      if (connectionExpression.test(field)) {
-        sentConnectionHeader = true;
-        if (closeExpression.test(value)) {
-          this._last = true;
-        } else {
-          this.shouldKeepAlive = true;
+      if (Array.isArray(value)) {
+        for (i = 0, l = value.length; i < l; i++) {
+          store(field, value[i]);
         }
-
-      } else if (transferEncodingExpression.test(field)) {
-        sentTransferEncodingHeader = true;
-        if (chunkExpression.test(value)) this.chunkedEncoding = true;
-
-      } else if (contentLengthExpression.test(field)) {
-        sentContentLengthHeader = true;
-
+      } else {
+        store(field, value);
       }
     }
   }

--- a/test/simple/test-http-proxy.js
+++ b/test/simple/test-http-proxy.js
@@ -6,9 +6,14 @@ url = require("url");
 var PROXY_PORT = common.PORT;
 var BACKEND_PORT = common.PORT+1;
 
+var cookies = [
+  "session_token=; path=/; expires=Sun, 15-Sep-2030 13:48:52 GMT",
+  "prefers_open_id=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT"
+];
+
 var backend = http.createServer(function (req, res) {
   common.debug("backend request");
-  res.writeHead(200, {"content-type": "text/plain"});
+  res.writeHead(200, {"content-type": "text/plain", "set-cookie": cookies});
   res.write("hello world\n");
   res.end();
 });
@@ -43,6 +48,7 @@ function startReq () {
   req.addListener('response', function (res) {
     common.debug("got res");
     assert.equal(200, res.statusCode);
+    assert.deepEqual(cookies, res.headers["set-cookie"]);
     res.setEncoding("utf8");
     res.addListener('data', function (chunk) { body += chunk; });
     res.addListener('end', function () {


### PR DESCRIPTION
This patch allows you to specify multiple header values as an array attached to a single key, in the same format as Set-Cookie headers from a ClientResponse.
