### PR TITLE
Fixing bug in build

### DIFF
--- a/wscript
+++ b/wscript
@@ -339,7 +339,7 @@ def v8_cmd(bld, variant):
   else:
     snapshot = ""
 
-  cmd_R = 'python "%s" -j %d -C "%s" -Y "%s" visibility=default mode=%s %s library=static %s'
+  cmd_R = 'PYTHONPATH=; python "%s" -j %d -C "%s" -Y "%s" visibility=default mode=%s %s library=static %s'
 
   cmd = cmd_R % ( scons
                 , Options.options.jobs


### PR DESCRIPTION
utils.py is imported by SConstruct, but if you have a utils.py in your PYTHONPATH it will choose your utils and the build breaks.

This unsets the PYTHONPATH before running python to help remove any external dependencies.
