### PR TITLE
detect secure stream

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -351,18 +351,19 @@ function setImplmentationMethods (self) {
     };
 
     var oldRead = self._readImpl;
-    self._readImpl = function (buf, off, len, calledByIOWatcher) {
+    self._readImpl = function (buf, off, len, calledByIOWatcher, readFunc) {
       assert(self.secure);
 
       var bytesRead = 0;
       var secureBytesRead = null;
+      readFunc = readFunc || oldRead;
 
       if (!securePool) {
         allocNewSecurePool();
       }
 
       if (calledByIOWatcher) {
-        secureBytesRead = oldRead(securePool, 0, securePool.length);
+        secureBytesRead = readFunc(securePool, 0, securePool.length);
         self.secureStream.encIn(securePool, 0, secureBytesRead);
       }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -435,6 +435,21 @@ function setImplmentationMethods (self) {
 
       oldShutdown();
     };
+  } else if (self.secureDetect) {
+    var oldRead = self._readImpl;
+    self._readImpl = function (buf, off, len, calledByIOWatcher) {
+      var bytesRead = oldRead.apply(self, arguments);
+      if (self.secureDetect(buf, off, len)) {
+        self.setSecure(self.credentials);
+        return self._readImpl(buf, off, len, calledByIOWatcher, function (sbuf, soff, slen) {
+          buf.copy(sbuf, soff, off, off+len);
+          return bytesRead;
+        });
+      } else {
+        self._readImpl = oldRead;
+        return bytesRead;
+      }
+    };
   }
 };
 
@@ -568,6 +583,25 @@ Stream.prototype.setSecure = function (credentials) {
     // If client, trigger handshake
     this._checkForSecureHandshake();
   }
+}
+
+
+Stream.prototype.setSecureDetect = function (credentials, secureDetect) {
+  this.credentials = credentials;
+  this.secureDetect = secureDetect || function (buf, off, len) {
+    /*
+     * Autodetect if SSL/TLS is used by having a look at the first incoming bytes
+     * This technique is from http://webview.jabberd.org/cgi-bin/viewvc.cgi/trunk/jadc2s/clients.cc?view=markup
+     *
+     * used heuristic:
+     * - an incoming connection using SSLv3/TLSv1 records should start with 0x16
+     * - an incoming connection using SSLv2 records should start with the record size
+     *   and as the first record should not be very big we can expect 0x80 or 0x00 (the MSB is a flag)
+     * - everything else is considered to be unencrypted
+     */
+    return buf[off] == 0x16 || buf[off] == 0x80 || buf[off] == 0x00;
+  };
+  setImplmentationMethods(this);
 }
 
 


### PR DESCRIPTION
Hi,

this patch adds a setSecureDetect(credentials, [callback]) function to net.Stream which allows
detecting a secure stream by looking at the first received bytes.

It adds a _readImpl which calls the callback function with a buffer containing the first bytes, if the callback returns true it calls setSecure, otherwise sets _readImpl back to the original read function.
## 

tg
