### PR TITLE
Fix for failures in test/simple

### DIFF
--- a/test/internet/testcfg.py
+++ b/test/internet/testcfg.py
@@ -35,10 +35,10 @@ FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
 FILES_PATTERN = re.compile(r"//\s+Files:(.*)")
 
 
-class SimpleTestCase(test.TestCase):
+class IntenetTestCase(test.TestCase):
 
   def __init__(self, path, file, mode, context, config):
-    super(SimpleTestCase, self).__init__(context, path)
+    super(IntenetTestCase, self).__init__(context, path)
     self.file = file
     self.config = config
     self.mode = mode
@@ -91,7 +91,7 @@ class SimpleTestConfiguration(test.TestConfiguration):
     for test in all_tests:
       if self.Contains(path, test):
         file_path = join(self.root, reduce(join, test[1:], "") + ".js")
-        result.append(SimpleTestCase(test, file_path, mode, self.context, self))
+        result.append(IntenetTestCase(test, file_path, mode, self.context, self))
     return result
 
   def GetBuildRequirements(self):

--- a/test/pummel/testcfg.py
+++ b/test/pummel/testcfg.py
@@ -35,10 +35,10 @@ FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
 FILES_PATTERN = re.compile(r"//\s+Files:(.*)")
 
 
-class SimpleTestCase(test.TestCase):
+class PummelTestCase(test.TestCase):
 
   def __init__(self, path, file, mode, context, config):
-    super(SimpleTestCase, self).__init__(context, path)
+    super(PummelTestCase, self).__init__(context, path)
     self.file = file
     self.config = config
     self.mode = mode
@@ -91,7 +91,7 @@ class SimpleTestConfiguration(test.TestConfiguration):
     for test in all_tests:
       if self.Contains(path, test):
         file_path = join(self.root, reduce(join, test[1:], "") + ".js")
-        result.append(SimpleTestCase(test, file_path, mode, self.context, self))
+        result.append(PummelTestCase(test, file_path, mode, self.context, self))
     return result
 
   def GetBuildRequirements(self):

--- a/test/simple/testcfg.py
+++ b/test/simple/testcfg.py
@@ -27,7 +27,6 @@
 
 import test
 import os
-import shutil
 from shutil import rmtree
 from os import mkdir
 from os.path import join, dirname, exists
@@ -47,12 +46,14 @@ class SimpleTestCase(test.TestCase):
     self.mode = mode
   
   def tearDown(self):
+    super(SimpleTestCase, self).tearDown()
     try:
       rmtree(join(dirname(self.config.root), 'tmp'))
     except:
       pass
 
   def setUp(self):
+    super(SimpleTestCase, self).setUp()
     try:
       mkdir(join(dirname(self.config.root), 'tmp'))
     except:


### PR DESCRIPTION
Hello there!

I pinged you on irc today. I built node.js on Ubuntu 10.10 and two tests failed: test/simple/test-mkdir-rmdir.js and test/simple/test-fs-symlink.js

I dug into the problem (3 test config classes with an identical name ('SimpleTestCase')) and fixed it.

Please have a look at the patch and apply it if you like it.

Best regards -- Muharem
