### PR TITLE
Extra comma in an enum declaration

### DIFF
--- a/deps/libeio/eio.h
+++ b/deps/libeio/eio.h
@@ -163,7 +163,7 @@ enum
 enum
 {
   EIO_MCL_CURRENT = 1,
-  EIO_MCL_FUTURE  = 2,
+  EIO_MCL_FUTURE  = 2
 };
 
 /* request priorities */


### PR DESCRIPTION
Hi Ryan!

Seen this on no.de machine:
[1/2] cxx: node-stringprep.cc -> build/default/node-stringprep_1.o
<command line>:2:1: warning: "**STDC**" redefined
In file included from /opt/nodejs/v0.2.2/include/node/node.h:6,
                 from ../node-stringprep.cc:1:
/opt/nodejs/v0.2.2/include/node/eio.h:200: error: comma at end of enumerator list

Went into the eio.h and figured that it has been fixed in the master already. However found another enum comma fix to do...

Best Regards
Standa
