### PR TITLE
Date header generation

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -173,6 +173,7 @@ var transferEncodingExpression = /Transfer-Encoding/i;
 var closeExpression = /close/i;
 var chunkExpression = /chunk/i;
 var contentLengthExpression = /Content-Length/i;
+var dateExpression = /Date/i;
 
 
 /* Abstract base class for ServerRequest and ClientResponse. */
@@ -279,6 +280,7 @@ function OutgoingMessage (socket) {
   this.chunkedEncoding = false;
   this.shouldKeepAlive = true;
   this.useChunkedEncodingByDefault = true;
+  this.shouldSendDate = false;
 
   this._hasBody = true;
   this._trailer = '';
@@ -358,6 +360,7 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
   var sentConnectionHeader = false;
   var sentContentLengthHeader = false;
   var sentTransferEncodingHeader = false;
+  var sentDateHeader = false;
 
   // firstLine in the case of request is: "GET /index.html HTTP/1.1\r\n"
   // in the case of response it is: "HTTP/1.1 200 OK\r\n"
@@ -383,6 +386,8 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
     } else if (contentLengthExpression.test(field)) {
       sentContentLengthHeader = true;
 
+    } else if (dateExpression.test(field)) {
+      sentDateHeader = true;
     }
   }
 
@@ -409,6 +414,11 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
         store(field, value);
       }
     }
+  }
+
+  // Date header
+  if (this.shouldSendDate == true && sentDateHeader == false) {
+      messageHeader += "Date: " + sys.utcDate() + CRLF;
   }
 
   // keep-alive logic
@@ -570,6 +580,8 @@ function ServerResponse (req) {
   OutgoingMessage.call(this, req.socket);
 
   if (req.method === 'HEAD') this._hasBody = false;
+
+  this.shouldSendDate = true;
 
   if (req.httpVersionMajor < 1 || req.httpVersionMinor < 1) {
     this.useChunkedEncodingByDefault = false;

--- a/lib/http.js
+++ b/lib/http.js
@@ -418,7 +418,7 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
 
   // Date header
   if (this.shouldSendDate == true && sentDateHeader == false) {
-    messageHeader += "Date: " + sys.utcDate() + CRLF;
+    messageHeader += "Date: " + utcDate() + CRLF;
   }
 
   // keep-alive logic
@@ -1135,3 +1135,15 @@ exports.cat = function (url, encoding_, headers_) {
   });
   req.end();
 };
+
+var date_cache;
+utcDate = function () {
+  if (! date_cache) {
+    var d = new Date();
+    date_cache = d.toUTCString();
+    setTimeout(function () {
+      date_cache = undefined;
+    }, 1000 - d.getMilliseconds());
+  }
+  return date_cache;
+}

--- a/lib/http.js
+++ b/lib/http.js
@@ -418,7 +418,7 @@ OutgoingMessage.prototype._storeHeader = function (firstLine, headers) {
 
   // Date header
   if (this.shouldSendDate == true && sentDateHeader == false) {
-      messageHeader += "Date: " + sys.utcDate() + CRLF;
+    messageHeader += "Date: " + sys.utcDate() + CRLF;
   }
 
   // keep-alive logic

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -276,6 +276,17 @@ function isDate (d) {
   return JSON.stringify(proto) === JSON.stringify(properties);
 }
 
+var date_cache;
+exports.utcDate = function () {
+    if (! date_cache) {
+        update_date();
+    }
+    return date_cache;
+}
+    function update_date() {
+        date_cache = new Date().toUTCString();
+        setTimeout(update_date, 1000);
+    }
 
 var pWarning;
 

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -276,18 +276,6 @@ function isDate (d) {
   return JSON.stringify(proto) === JSON.stringify(properties);
 }
 
-var date_cache;
-exports.utcDate = function () {
-  if (! date_cache) {
-    var d = new Date();
-    date_cache = d.toUTCString();
-    setTimeout(function () {
-      date_cache = undefined;
-    }, 1000 - d.getMilliseconds());
-  }
-  return date_cache;
-}
-
 var pWarning;
 
 exports.p = function () {

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -279,14 +279,14 @@ function isDate (d) {
 var date_cache;
 exports.utcDate = function () {
     if (! date_cache) {
-        update_date();
+        var d = new Date();
+        date_cache = d.toUTCString();
+        setTimeout(function () {
+            date_cache = undefined;
+        }, 1000 - d.getMilliseconds());
     }
     return date_cache;
 }
-    function update_date() {
-        date_cache = new Date().toUTCString();
-        setTimeout(update_date, 1000);
-    }
 
 var pWarning;
 

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -278,14 +278,14 @@ function isDate (d) {
 
 var date_cache;
 exports.utcDate = function () {
-    if (! date_cache) {
-        var d = new Date();
-        date_cache = d.toUTCString();
-        setTimeout(function () {
-            date_cache = undefined;
-        }, 1000 - d.getMilliseconds());
-    }
-    return date_cache;
+  if (! date_cache) {
+    var d = new Date();
+    date_cache = d.toUTCString();
+    setTimeout(function () {
+      date_cache = undefined;
+    }, 1000 - d.getMilliseconds());
+  }
+  return date_cache;
 }
 
 var pWarning;

--- a/test/simple/test-http-date-header.js
+++ b/test/simple/test-http-date-header.js
@@ -1,0 +1,32 @@
+var common = require("../common");
+var assert = common.assert;
+var http = require("http");
+
+var test_res_body = "other stuff!\n";
+
+var server = http.createServer(function(req, res) {
+  assert.ok(! ("date" in req.headers), 
+    "Request headers contained a Date."
+  );
+  res.writeHead(200, {
+    'Content-Type' : 'text/plain',
+  });
+  res.end(test_res_body);
+});
+server.listen(common.PORT);
+
+
+server.addListener("listening", function() {
+  var client = http.createClient(common.PORT);
+  req = client.request("GET", "/", {});
+  req.end();
+  req.addListener('response', function (res) {
+    assert.ok("date" in res.headers, 
+      "Response headers didn't contain a Date."
+    );
+    res.addListener('end', function () {
+      server.close();
+      process.exit();
+    });
+  });
+});


### PR DESCRIPTION
As per RFC2616 section 14.18, Date headers are required in responses.

This patch adds them (except when already set), and caches the date string once per second to avoid the perf it of system calls and conversion to a string. 

In my testing, the performance impact is negligible (i.e., lost in the noise; runs with and without it get around 14,000 req/sec for hello world, whereas generating the date each time results in an ~11% perf drop).

I haven't documented sys.utcDate (the date cache), as it's not clear it's useful elsewhere. Am happy to do so, or move it into http.js, if you think that's better. 
