### PR TITLE
Fixed pointless assert.fail extension

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -97,7 +97,7 @@ assert.fail = fail;
 // assert.strictEqual(true, guard, message_opt);.
 
 assert.ok = function ok(value, message) {
-  if (!!!value) fail(value, true, message, "==", assert.ok);
+  if (!!!value) assert.fail(value, true, message, "==", assert.ok);
 };
 
 // 5. The equality assertion tests shallow, coercive equality with
@@ -105,7 +105,7 @@ assert.ok = function ok(value, message) {
 // assert.equal(actual, expected, message_opt);
 
 assert.equal = function equal(actual, expected, message) {
-  if (actual != expected) fail(actual, expected, message, "==", assert.equal);
+  if (actual != expected) assert.fail(actual, expected, message, "==", assert.equal);
 };
 
 // 6. The non-equality assertion tests for whether two objects are not equal
@@ -113,7 +113,7 @@ assert.equal = function equal(actual, expected, message) {
 
 assert.notEqual = function notEqual(actual, expected, message) {
   if (actual == expected) {
-    fail(actual, expected, message, "!=", assert.notEqual);
+    assert.fail(actual, expected, message, "!=", assert.notEqual);
   }
 };
 
@@ -122,7 +122,7 @@ assert.notEqual = function notEqual(actual, expected, message) {
 
 assert.deepEqual = function deepEqual(actual, expected, message) {
   if (!_deepEqual(actual, expected)) {
-    fail(actual, expected, message, "deepEqual", assert.deepEqual);
+    assert.fail(actual, expected, message, "deepEqual", assert.deepEqual);
   }
 };
 
@@ -217,7 +217,7 @@ function objEquiv (a, b) {
 
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
   if (_deepEqual(actual, expected)) {
-    fail(actual, expected, message, "notDeepEqual", assert.notDeepEqual);
+    assert.fail(actual, expected, message, "notDeepEqual", assert.notDeepEqual);
   }
 };
 
@@ -226,7 +226,7 @@ assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
 
 assert.strictEqual = function strictEqual(actual, expected, message) {
   if (actual !== expected) {
-    fail(actual, expected, message, "===", assert.strictEqual);
+    assert.fail(actual, expected, message, "===", assert.strictEqual);
   }
 };
 
@@ -235,7 +235,7 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
 
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   if (actual === expected) {
-    fail(actual, expected, message, "!==", assert.notStrictEqual);
+    assert.fail(actual, expected, message, "!==", assert.notStrictEqual);
   }
 };
 
@@ -264,13 +264,13 @@ function _throws (shouldThrow, block, err, message) {
   }
 
   if (shouldThrow && !threw) {
-    fail( "Missing expected exception"
+    assert.fail( "Missing expected exception"
         + (err && err.name ? " ("+err.name+")." : '.')
         + (message ? " " + message : "")
         );
   }
   if (!shouldThrow && threw && typematters && exception instanceof err) {
-    fail( "Got unwanted exception"
+    assert.fail( "Got unwanted exception"
         + (err && err.name ? " ("+err.name+")." : '.')
         + (message ? " " + message : "")
         );


### PR DESCRIPTION
Hi,

Before this patch overriding assert.fail method which is the extension point of assert module was pointless.

Please check the gist below.

http://gist.github.com/604556#file_test_assert.js

Thank you!
