### PR TITLE
moduleCache

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -80,6 +80,8 @@ var module = (function () {
     this.loaded = false;
     this.exited = false;
     this.children = [];
+    
+    this.moduleCache = moduleCache;
   };
 
   function createInternalModule (id, constructor) {


### PR DESCRIPTION
Hey, 
[This commit](http://github.com/ry/node/commit/1a2c1c8a96b4e05d496d05d99f7cf1f7c2fb1829) made moduleCache private. The commit I made (one-line) just re-exposes it to the sandbox so it can be accessed with module.moduleCache. I was using moduleCache to create a hot-reloading plugin but node v0.2.3 broke it.

Thanks!
