### PR TITLE
segfaults with crypto and openssl 1.0.0a

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1617,8 +1617,12 @@ class Hmac : public ObjectWrap {
       fprintf(stderr, "node-crypto : Unknown message digest %s\n", hashType);
       return false;
     }
+
+    ENGINE_load_builtin_engines();
+    ENGINE_register_all_complete();
+
     HMAC_CTX_init(&ctx);
-    HMAC_Init(&ctx, key, key_len, md);
+    HMAC_Init_ex(&ctx, key, key_len, md, NULL);
     initialised_ = true;
     return true;
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -11,6 +11,7 @@
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/hmac.h>
+#include <openssl/engine.h>
 
 #define EVP_F_EVP_DECRYPTFINAL 101
 


### PR DESCRIPTION
Hey,

I'm using OpenSSL 1.0.0a on my Mac (10.6.4) and 

```
var crypto = require('crypto');
crypto.createHmac('sha1', 'x').update('x').digest('hex');
```

segfaults. I'm by no means an expert in neither C++ nor OpenSSL, but due to the remote debugging capabilities of #node.js member wink_, I was able to put together a patch that fixes it on my machine.

Other tests in test-crypto still fail on my machine, but I'll open separate issues for them.
