### PR TITLE
Fix http.ServerRequest pause() and resume()

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -96,9 +96,9 @@ var parsers = new FreeList('parsers', 1000, function () {
     var slice = b.slice(start, start+len);
     if (parser.incoming._decoder) {
       var string = parser.incoming._decoder.write(slice);
-      if (string.length) parser.incoming.emit('data', string);
+      if (string.length) parser.incoming._emit('data', string);
     } else {
-      parser.incoming.emit('data', slice);
+      parser.incoming._emit('data', slice);
     }
   };
 
@@ -109,7 +109,7 @@ var parsers = new FreeList('parsers', 1000, function () {
     }
     if (!parser.incoming.upgrade) {
       // For upgraded connections, also emit this after parser.execute
-      parser.incoming.emit("end");
+      parser.incoming._emit("end");
     }
   };
 
@@ -191,6 +191,9 @@ function IncomingMessage (socket) {
   this.socket = socket;
   this.connection = socket;
 
+  this.paused = false;
+  this._eventQueue = [];
+
   this.httpVersion = null;
   this.complete = false;
   this.headers = {};
@@ -218,11 +221,30 @@ IncomingMessage.prototype.setEncoding = function (encoding) {
   this._decoder = new StringDecoder(encoding);
 };
 
+IncomingMessage.prototype._emit = function() {
+  if (this.paused) {
+    this._eventQueue.push(arguments);
+  } else {
+    this.emit.apply(this, arguments);
+  }
+}
+
 IncomingMessage.prototype.pause = function () {
+  this.paused = true;
   this.socket.pause();
 };
 
 IncomingMessage.prototype.resume = function () {
+  this.paused = false;
+
+  var len = this._eventQueue.length;
+  if (len > 0) {
+    for (var i = 0; i < len; i++) {
+      this.emit.apply(this, this._eventQueue[i]);
+    }
+    this._eventQueue = [];
+  }
+
   this.socket.resume();
 };
 

--- a/test/simple/test-http-server-pause.js
+++ b/test/simple/test-http-server-pause.js
@@ -1,0 +1,71 @@
+common = require("../common");
+assert = common.assert;
+net = require("net");
+http = require("http");
+
+var serverResponse = "";
+var clientGotEOF = false;
+
+server = http.createServer(function (req, res) {
+  console.log('server req');
+  assert.equal('/hello', req.url);
+  assert.equal('GET', req.method);
+
+  req.pause();
+
+  var timeoutComplete = false;
+
+  req.addListener('data', function (d) {
+    console.log('server req data');
+    assert.equal(true, timeoutComplete);
+    assert.equal(12, d.length);
+  });
+
+  req.addListener('end', function (d) {
+    console.log('server req end');
+    assert.equal(true, timeoutComplete);
+    res.writeHead(200);
+    res.end("bye\n");
+    server.close();
+  });
+
+  setTimeout(function () {
+    timeoutComplete = true
+    req.resume();
+  }, 500);
+});
+
+
+server.listen(common.PORT, function () {
+  var c = net.createConnection(common.PORT);
+
+  c.setEncoding("utf8");
+
+  c.addListener("connect", function () {
+    c.write( "GET /hello HTTP/1.1\r\n"
+           + "Content-Type: text/plain\r\n"
+           + "Content-Length: 12\r\n"
+           + "\r\n"
+           + "hello world\n"
+           );
+    c.end();
+  });
+
+  c.addListener("data", function (chunk) {
+    serverResponse += chunk;
+  });
+
+  c.addListener("end", function () {
+    clientGotEOF = true;
+  });
+
+  c.addListener("close", function () {
+    assert.equal(c.readyState, "closed");
+  });
+});
+
+
+process.addListener("exit", function () {
+  assert.ok(/bye/.test(serverResponse));
+  assert.ok(clientGotEOF);
+});


### PR DESCRIPTION
`http.ServerRequest` continues to emit `data` and `end` events after `pause()` is called.

This patch queues `data` and `end` events emitted from the HTTP parser in `_eventQueue` while paused. Then flushes this queue when `resume()` is called.

Ideally we would push this buffering down into the HTTP parser itself.

But this does fix the control flow issue.

```
http.createServer(function (req, res) {
  req.pause();

  conn = net.createConnection(1234);

  conn.on('connect', function () {
    req.on('data', function (chunk) {
      conn.write(chunk);
    });

    req.on('end', function () {
      conn.end();
    });

    req.resume();
  });
});
```

Related #220
