### PR TITLE
Use an alias of stream.Stream.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -9,8 +9,8 @@ if (debugLevel & 0x4) {
 }
 
 var net = require('net');
-var stream = require('stream');
 
+var Stream = require('stream').Stream;
 var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;
 
@@ -185,7 +185,7 @@ var continueExpression = /100-continue/i;
 
 /* Abstract base class for ServerRequest and ClientResponse. */
 function IncomingMessage (socket) {
-  stream.Stream.call(this);
+  Stream.call(this);
 
   // TODO Remove one of these eventually.
   this.socket = socket;
@@ -207,7 +207,7 @@ function IncomingMessage (socket) {
   this.statusCode = null;
   this.client = this.socket;
 }
-util.inherits(IncomingMessage, stream.Stream);
+util.inherits(IncomingMessage, Stream);
 exports.IncomingMessage = IncomingMessage;
 
 
@@ -285,7 +285,7 @@ IncomingMessage.prototype._addHeaderLine = function (field, value) {
 };
 
 function OutgoingMessage (socket) {
-  stream.Stream.call(this);
+  Stream.call(this);
 
   // TODO Remove one of these eventually.
   this.socket = socket;
@@ -306,7 +306,7 @@ function OutgoingMessage (socket) {
 
   this.finished = false;
 }
-util.inherits(OutgoingMessage, stream.Stream);
+util.inherits(OutgoingMessage, Stream);
 exports.OutgoingMessage = OutgoingMessage;
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1,7 +1,7 @@
 var util = require("util");
 var fs = require("fs");
 var events = require("events");
-var stream = require("stream");
+var stream = require("stream").Stream;
 var dns = require('dns');
 
 var kMinPoolSpace = 128;
@@ -520,7 +520,7 @@ function initStream (self) {
 
 function Stream (fd, type) {
   if (!(this instanceof Stream)) return new Stream(fd, type);
-  stream.Stream.call(this);
+  stream.call(this);
 
   this.fd = null;
   this.type = null;
@@ -532,7 +532,7 @@ function Stream (fd, type) {
     setImplmentationMethods(this);
   }
 };
-util.inherits(Stream, stream.Stream);
+util.inherits(Stream, stream);
 exports.Stream = Stream;
 
 


### PR DESCRIPTION
This is for two reasons: 
1) inline with other code style.
2) less property lookups.
