### PR TITLE
Add support for UPnP-defined HTTP request methods.

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -56,6 +56,8 @@ static Persistent<String> report_sym;
 static Persistent<String> mkactivity_sym;
 static Persistent<String> checkout_sym;
 static Persistent<String> merge_sym;
+static Persistent<String> msearch_sym;
+static Persistent<String> notify_sym;
 static Persistent<String> unknown_method_sym;
 
 static Persistent<String> method_sym;
@@ -138,6 +140,8 @@ method_to_str(unsigned short m) {
     case HTTP_MKACTIVITY: return mkactivity_sym;
     case HTTP_CHECKOUT:   return checkout_sym;
     case HTTP_MERGE:      return merge_sym;
+    case HTTP_MSEARCH:    return msearch_sym;
+    case HTTP_NOTIFY:     return notify_sym;
     default:              return unknown_method_sym;
   }
 }
@@ -462,6 +466,8 @@ void InitHttpParser(Handle<Object> target) {
   mkactivity_sym = NODE_PSYMBOL("MKACTIVITY");
   checkout_sym = NODE_PSYMBOL("CHECKOUT");
   merge_sym = NODE_PSYMBOL("MERGE");
+  msearch_sym = NODE_PSYMBOL("M-SEARCH");
+  notify_sym = NODE_PSYMBOL("NOTIFY");
   unknown_method_sym = NODE_PSYMBOL("UNKNOWN_METHOD");
 
   method_sym = NODE_PSYMBOL("method");

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -58,6 +58,8 @@ static Persistent<String> checkout_sym;
 static Persistent<String> merge_sym;
 static Persistent<String> msearch_sym;
 static Persistent<String> notify_sym;
+static Persistent<String> subscribe_sym;
+static Persistent<String> unsubscribe_sym;
 static Persistent<String> unknown_method_sym;
 
 static Persistent<String> method_sym;
@@ -142,6 +144,8 @@ method_to_str(unsigned short m) {
     case HTTP_MERGE:      return merge_sym;
     case HTTP_MSEARCH:    return msearch_sym;
     case HTTP_NOTIFY:     return notify_sym;
+    case HTTP_SUBSCRIBE:  return subscribe_sym;
+    case HTTP_UNSUBSCRIBE:return unsubscribe_sym;
     default:              return unknown_method_sym;
   }
 }
@@ -468,6 +472,8 @@ void InitHttpParser(Handle<Object> target) {
   merge_sym = NODE_PSYMBOL("MERGE");
   msearch_sym = NODE_PSYMBOL("M-SEARCH");
   notify_sym = NODE_PSYMBOL("NOTIFY");
+  subscribe_sym = NODE_PSYMBOL("SUBSCRIBE");
+  unsubscribe_sym = NODE_PSYMBOL("UNSUBSCRIBE");
   unknown_method_sym = NODE_PSYMBOL("UNKNOWN_METHOD");
 
   method_sym = NODE_PSYMBOL("method");

--- a/test/simple/test-http-msearch.js
+++ b/test/simple/test-http-msearch.js
@@ -1,0 +1,30 @@
+common = require("../common");
+assert = common.assert;
+net  = require('net');
+http = require('http');
+
+server = http.createServer(function (req, res) {
+  assert.equal(req.method, "M-SEARCH");
+  assert.equal(req.url, "*");
+
+  res.writeHead(200, { Connection : 'close' });
+  res.end();
+});
+server.listen(common.PORT, function () {
+
+  stream = net.createConnection(common.PORT);
+  body = "";
+  stream.setEncoding("ascii");
+  stream.on("data", function (chunk) { body += chunk; });
+  stream.on("end", function () {
+    server.close();
+  });
+  stream.write(
+    'M-SEARCH * HTTP/1.1\r\n'+
+    'HOST: 239.255.255.250:1900\r\n'+
+    'MAN: "ssdp:discover"\r\n'+
+    'MX: 3\r\n'+
+    'ST: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n'+
+    '\r\n'
+  );
+});


### PR DESCRIPTION
This patch depends on the [patch I've made for `http-parser`](http://github.com/ry/http-parser/pull/17).

It adds support for 4 new HTTP request methods to be parsable and handleable with an `http.Server`. The new methods are `M-SEARCH`, `NOTIFY`, `SUBSCRIBE`, and `UNSUBSCRIBE`.

Also included is a test script testing for the `M-SEARCH` request method, and the `*` url.
