### PR TITLE
Expect/continue - minor fix

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -653,7 +653,7 @@ ServerResponse.prototype.writeHead = function (statusCode) {
   // don't keep alive connections where the client expects 100 Continue
   // but we sent a final status; they may put extra bytes on the wire.
   if (this._expect_continue && ! this._sent100) {
-      this._shouldKeepAlive = false;
+      this.shouldKeepAlive = false;
   }
 
   this._storeHeader(statusLine, headers);


### PR DESCRIPTION
As pointed out by @ignacio, a bug about E/C and keep-alive was introduced, thanks to a typo.
