### PR TITLE
Zero-copy buffers for binding external libraries

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -168,7 +168,6 @@ Handle<Value> Buffer::New(const Arguments &args) {
 
 
 Buffer::Buffer(size_t length) : ObjectWrap() {
-  off_ = 0;
   length_ = length;
   data_ = new char[length_];
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -107,35 +107,15 @@ Buffer* Buffer::New(char* data, size_t len) {
 
 
 char* Buffer::Data(Handle<Object> obj) {
-  if (obj->HasIndexedPropertiesInPixelData()) {
-    return (char*)obj->GetIndexedPropertiesPixelData();
-  }
-
-  HandleScope scope;
-
-  // Return true for "SlowBuffer"
-  if (constructor_template->HasInstance(obj)) {
-    return ObjectWrap::Unwrap<Buffer>(obj)->data_;
-  }
-
-  // Not a buffer.
+  if (Buffer::HasInstance(obj))
+    return (char*)obj->GetIndexedPropertiesExternalArrayData();
   return NULL;
 }
 
 
 size_t Buffer::Length(Handle<Object> obj) {
-  if (obj->HasIndexedPropertiesInPixelData()) {
-    return (size_t)obj->GetIndexedPropertiesPixelDataLength();
-  }
-
-  HandleScope scope;
-
-  // Return true for "SlowBuffer"
-  if (constructor_template->HasInstance(obj)) {
-    return ObjectWrap::Unwrap<Buffer>(obj)->length_;
-  }
-
-  // Not a buffer.
+  if (Buffer::HasInstance(obj))
+    return (size_t)obj->GetIndexedPropertiesExternalArrayDataLength();
   return 0;
 }
 
@@ -584,8 +564,9 @@ Handle<Value> Buffer::MakeFastBuffer(const Arguments &args) {
   uint32_t offset = args[2]->Uint32Value();
   uint32_t length = args[3]->Uint32Value();
 
-  fast_buffer->SetIndexedPropertiesToPixelData((uint8_t*)buffer->data_ + offset,
-                                               length);
+  fast_buffer->SetIndexedPropertiesToExternalArrayData(buffer->data_ + offset,
+                                                       kExternalUnsignedByteArray,
+                                                       length);
 
   return Undefined();
 }
@@ -594,13 +575,7 @@ Handle<Value> Buffer::MakeFastBuffer(const Arguments &args) {
 bool Buffer::HasInstance(v8::Handle<v8::Value> val) {
   if (!val->IsObject()) return false;
   v8::Local<v8::Object> obj = val->ToObject();
-
-  if (obj->HasIndexedPropertiesInPixelData()) return true;
-
-  // Return true for "SlowBuffer"
-  if (constructor_template->HasInstance(obj)) return true;
-
-  return false;
+  return obj->GetIndexedPropertiesExternalArrayDataType() == kExternalUnsignedByteArray;
 }
 
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -304,7 +304,9 @@ Handle<Value> Buffer::Copy(const Arguments &args) {
             "First arg should be a Buffer")));
   }
 
-  Buffer *target = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+  Local<Object> target = args[0]->ToObject();
+  char *target_data = Buffer::Data(target);
+  ssize_t target_length = Buffer::Length(target);
 
   ssize_t target_start = args[1]->Int32Value();
   ssize_t source_start = args[2]->Int32Value();
@@ -321,7 +323,7 @@ Handle<Value> Buffer::Copy(const Arguments &args) {
     return scope.Close(Integer::New(0));
   }
 
-  if (target_start < 0 || target_start >= target->length_) {
+  if (target_start < 0 || target_start >= target_length) {
     return ThrowException(Exception::Error(String::New(
             "targetStart out of bounds")));
   }
@@ -337,12 +339,12 @@ Handle<Value> Buffer::Copy(const Arguments &args) {
   }
 
   ssize_t to_copy = MIN(MIN(source_end - source_start,
-                            target->length_ - target_start), 
+                            target_length - target_start),
                             source->length_ - source_start);
   
 
   // need to use slightly slower memmove is the ranges might overlap
-  memmove((void*)(target->data_ + target_start),
+  memmove((void *)(target_data + target_start),
           (const void*)(source->data_ + source_start),
           to_copy);
 

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -13,21 +13,10 @@ namespace node {
  * individual bytes with [] and slice it into substrings or sub-buffers
  * without copying memory.
  *
- * // return an ascii encoded string - no memory iscopied
- * buffer.asciiSlide(0, 3)
- *
- * // returns another buffer - no memory is copied
- * buffer.slice(0, 3)
- *
- * Interally, each javascript buffer object is backed by a "struct buffer"
- * object.  These "struct buffer" objects are either a root buffer (in the
- * case that buffer->root == NULL) or slice objects (in which case
- * buffer->root != NULL).  A root buffer is only GCed once all its slices
- * are GCed.
+ * // return an ascii encoded string - no memory is copied
+ * buffer.asciiSlice(0, 3)
  */
 
-
-struct Blob_;
 
 class Buffer : public ObjectWrap {
  public:
@@ -46,20 +35,15 @@ class Buffer : public ObjectWrap {
     return NULL;
   }
 
-
   size_t length() const {
     assert(0 && "v0.3 API change: Use node::Buffer::Length().");
     return 0;
   }
 
-  int AsciiWrite(char *string, int offset, int length);
-  int Utf8Write(char *string, int offset, int length);
-
  private:
   static v8::Persistent<v8::FunctionTemplate> constructor_template;
 
   static v8::Handle<v8::Value> New(const v8::Arguments &args);
-  static v8::Handle<v8::Value> Slice(const v8::Arguments &args);
   static v8::Handle<v8::Value> BinarySlice(const v8::Arguments &args);
   static v8::Handle<v8::Value> AsciiSlice(const v8::Arguments &args);
   static v8::Handle<v8::Value> Base64Slice(const v8::Arguments &args);
@@ -70,13 +54,10 @@ class Buffer : public ObjectWrap {
   static v8::Handle<v8::Value> Utf8Write(const v8::Arguments &args);
   static v8::Handle<v8::Value> ByteLength(const v8::Arguments &args);
   static v8::Handle<v8::Value> MakeFastBuffer(const v8::Arguments &args);
-  static v8::Handle<v8::Value> Unpack(const v8::Arguments &args);
   static v8::Handle<v8::Value> Copy(const v8::Arguments &args);
 
   Buffer(size_t length);
-  Buffer(Buffer *parent, size_t start, size_t end);
 
-  size_t off_;
   size_t length_;
   char* data_;
 };

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -22,9 +22,13 @@ class Buffer : public ObjectWrap {
  public:
   ~Buffer();
 
+  typedef void (*free_callback)(char *data, void *hint);
+
   static void Initialize(v8::Handle<v8::Object> target);
   static Buffer* New(size_t length); // public constructor
   static Buffer* New(char *data, size_t len); // public constructor
+  static Buffer* New(char *data, size_t length,
+                     free_callback callback, void *hint); // public constructor
   static bool HasInstance(v8::Handle<v8::Value> val);
 
   static char* Data(v8::Handle<v8::Object>);
@@ -56,10 +60,13 @@ class Buffer : public ObjectWrap {
   static v8::Handle<v8::Value> MakeFastBuffer(const v8::Arguments &args);
   static v8::Handle<v8::Value> Copy(const v8::Arguments &args);
 
-  Buffer(size_t length);
+  Buffer(v8::Handle<v8::Object> wrapper, size_t length);
+  void Replace(char *data, size_t length, free_callback callback, void *hint);
 
   size_t length_;
   char* data_;
+  free_callback callback_;
+  void* callback_hint_;
 };
 
 


### PR DESCRIPTION
[Resubmitting #304, because I reorganized my repo clone. Sorry for the noise.]

The gist of these changes is to add a zero-copy interface to Buffer, for binding external libraries that do their own allocation. An example of such a library is ØMQ.

The addition is an alternate public constructor `Buffer::New`, that takes a data pointer and callback to call once the buffer is done with said data. The optional `hint` parameter is simply passed verbatim to the callback, for its own use.

Besides that, I've also gathered a small number of other Buffer-related changes here:
- Replace `*PixelData` calls with `*ArrayData` calls, to be consistent everywhere.
- Generalized `Copy` method, which can now target any ArrayData-like object.
- Cleaned up some old cruft that was left around after fast-buffers was merged.

Tests pass with flying colors.
