### PR TITLE
fixes ReadStream range option problem of restart at start of file after first _read 

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -727,7 +727,7 @@ ReadStream.prototype._read = function () {
 
   // pass null for position after we've seeked to the start of a range read
   // always pass null on a non-range read
-  fs.read(self.fd, pool, pool.used, toRead, (self.firstRead ? self.pos : null), afterRead);
+  fs.read(self.fd, pool, pool.used, toRead, (self.start === undefined ? null : self.pos), afterRead);
   self.firstRead = false;
 
   if (self.pos !== undefined) {

--- a/test/simple/test-fs-read-stream.js
+++ b/test/simple/test-fs-read-stream.js
@@ -96,6 +96,16 @@ file4.addListener('end', function(data) {
 	assert.equal(contentRead, 'yz');
 });
 
+// starts at an offset position and reads until a specific position short of the
+// end of the file, has a small buffer size to ensure multiple reads occure
+var a = '';
+fs.createReadStream('../fixtures/x.txt', {bufferSize: 1, start: 1, end: 2})
+.on('data', function(data) {
+  a += data;
+}).on('end', function() {
+  common.assert.equal("yz", a);
+});
+
 try {
   fs.createReadStream(rangeFile, {start: 10, end: 2});
   assert.fail('Creating a ReadStream with incorrect range limits must throw.');

--- a/test/simple/test-fs-read-stream.js
+++ b/test/simple/test-fs-read-stream.js
@@ -99,7 +99,7 @@ file4.addListener('end', function(data) {
 // starts at an offset position and reads until a specific position short of the
 // end of the file, has a small buffer size to ensure multiple reads occure
 var a = '';
-fs.createReadStream('../fixtures/x.txt', {bufferSize: 1, start: 1, end: 2})
+fs.createReadStream(rangeFile, {bufferSize: 1, start: 1, end: 2})
 .on('data', function(data) {
   a += data;
 }).on('end', function() {


### PR DESCRIPTION
When reading a file with ReadStream if range options, start and end, are specified and the content being read is longer than bufferSize then the second _read would pull from the start of the file as opposed to the start + bufferSize.

<pre>
-  fs.read(self.fd, pool, pool.used, toRead, (self.firstRead ? self.pos : null), afterRead);
+  fs.read(self.fd, pool, pool.used, toRead, (self.start === undefined ? null : self.pos), afterRead);
</pre>
