### PR TITLE
Rename credentials to secure context and allow bypassing certificate verification

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -6,13 +6,14 @@ The crypto module requires OpenSSL to be available on the underlying platform. I
 
 It also offers a set of wrappers for OpenSSL's hash, hmac, cipher, decipher, sign and verify methods.
 
-### crypto.createCredentials(details)
+### crypto.createContext(details)
 
-Creates a credentials object, with the optional details being a dictionary with keys:
+Creates a secure context object, with the optional details being a dictionary with keys:
 
 * `key` : a string holding the PEM encoded private key
 * `cert` : a string holding the PEM encoded certificate
 * `ca` : either a string or list of strings of PEM encoded CA certificates to trust.
+* `verifyRemote` : a boolean indicating whether the remote certificate should be verified. This defaults to true when the secure context is used as a client and to false when it is used from the server side.
 
 If no 'ca' details are given, then node.js will use the default publicly trusted list of CAs as given in 
 http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -122,11 +122,13 @@ This function is asynchronous. The last parameter `callback` will be called
 when the server has been bound.
 
 
-### server.setSecure(credentials)
+### server.setSecure(context)
 
-Enables HTTPS support for the server, with the crypto module credentials specifying the private key and certificate of the server, and optionally the CA certificates for use in client authentication.
+Enables HTTPS support for the server, with the crypto module secure context specifying the private key and certificate of the server, and optionally the CA certificates for use in client authentication.
 
-If the credentials hold one or more CA certificates, then the server will request for the client to submit a client certificate as part of the HTTPS connection handshake. The validity and content of this can be accessed via verifyPeer() and getPeerCertificate() from the server's request.connection.
+If the secure context holds one or more CA certificates, then the server will request for the client to submit a client certificate as part of the HTTPS connection handshake. The validity and content of this can be accessed via verifyPeer() and getPeerCertificate() from the server's request.connection.
+
+Verifying certificates can be circumvented by creating a context that has `verifyRemote` set to `false`.
 
 ### server.close()
 
@@ -380,15 +382,15 @@ the request contained 'Expect: 100-continue'. This is an instruction that
 the client should send the request body.
 
 
-### http.createClient(port, host='localhost', secure=false, [credentials])
+### http.createClient(port, host='localhost', secure=false, [context])
 
 Constructs a new HTTP client. `port` and
 `host` refer to the server to be connected to. A
 stream is not established until a request is issued.
 
-`secure` is an optional boolean flag to enable https support and `credentials` is an optional credentials object from the crypto module, which may hold the client's private key, certificate, and a list of trusted CA certificates.
+`secure` is an optional boolean flag to enable https support and `context` is an optional secure context object from the crypto module, which may hold the client's private key, certificate, and a list of trusted CA certificates.
 
-If the connection is secure, but no explicit CA certificates are passed in the credentials, then node.js will default to the publicly trusted list of CA certificates, as given in http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt
+If the connection is secure, but no explicit CA certificates are passed in the secure context, then node.js will default to the publicly trusted list of CA certificates, as given in http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt. To suppress certificate verification, create a secure context with `verifyRemote` set to `false`.
 
 ### client.request(method='GET', path, [request_headers])
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -221,11 +221,11 @@ Either `'closed'`, `'open'`, `'opening'`, `'readOnly'`, or `'writeOnly'`.
 Sets the encoding (either `'ascii'`, `'utf8'`, or `'base64'`) for data that is
 received.
 
-### stream.setSecure([credentials])
+### stream.setSecure([context])
 
-Enables SSL support for the stream, with the crypto module credentials specifying the private key and certificate of the stream, and optionally the CA certificates for use in peer authentication.
+Enables SSL support for the stream, with the crypto module secure context specifying the private key and certificate of the stream, and optionally the CA certificates for use in peer authentication.
 
-If the credentials hold one ore more CA certificates, then the stream will request for the peer to submit a client certificate as part of the SSL connection handshake. The validity and content of this can be accessed via verifyPeer() and getPeerCertificate().
+If the secure context holds one ore more CA certificates, then the stream will request for the peer to submit a client certificate as part of the SSL connection handshake. The validity and content of this can be accessed via verifyPeer() and getPeerCertificate().
 
 ### stream.verifyPeer()
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -3604,7 +3604,8 @@ exports.createContext = function(context) {
       throw new Error('node.js not compiled with openssl crypto support.');
   }
   
-  var c = new SecureContext(context.method);  
+  var c = new SecureContext();
+  c.init(context.method);  
   if (context.key) c.setKey(context.key);
   if (context.cert) c.setCert(context.cert);
   if (context.ca) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -3598,38 +3598,31 @@ try {
   var crypto = false;
 }
 
-
-function Credentials(method) {
+exports.createContext = function(context) {
+  if (!context) context = {};
   if (!crypto) {
       throw new Error('node.js not compiled with openssl crypto support.');
   }
-  this.context = new SecureContext();
-  if (method) this.context.init(method);
-  else this.context.init();
-  this.shouldVerify = false;
-}
-
-exports.createCredentials = function(cred) {
-  if (!cred) cred={};
-  var c = new Credentials(cred.method);
-  if (cred.key) c.context.setKey(cred.key);
-  if (cred.cert) c.context.setCert(cred.cert);
-  if (cred.ca) {
-    c.shouldVerify = true;
-    if ( (typeof(cred.ca) == 'object') && cred.ca.length ) {
-      for(var i = 0, len = cred.ca.length; i < len; i++)
-        c.context.addCACert(cred.ca[i]);
+  
+  var c = new SecureContext(context.method);  
+  if (context.key) c.setKey(context.key);
+  if (context.cert) c.setCert(context.cert);
+  if (context.ca) {
+    c.verifyRemote = true;
+    if ( (typeof(context.ca) == 'object') && context.ca.length ) {
+      for(var i = 0, len = context.ca.length; i < len; i++)
+        c.addCACert(context.ca[i]);
     } else {
-      c.context.addCACert(cred.ca);
+      c.addCACert(context.ca);
     }
   } else {
     for (var i = 0, len = RootCaCerts.length; i < len; i++) {
-      c.context.addCACert(RootCaCerts[i]);
+      c.addCACert(RootCaCerts[i]);
     }
   }
+  if ('verifyRemote' in context) c.verifyRemote = context.verifyRemote;
   return c;
 };
-exports.Credentials = Credentials;
 
 exports.Hash = Hash;
 exports.createHash = function(hash) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -753,9 +753,9 @@ function Server (requestListener) {
 }
 util.inherits(Server, net.Server);
 
-Server.prototype.setSecure = function (credentials) {
+Server.prototype.setSecure = function (context) {
   this.secure = true;
-  this.credentials = credentials;
+  this.secureContext = context;
 };
 
 exports.Server = Server;
@@ -781,7 +781,7 @@ function connectionListener (socket) {
   parser.socket = socket;
 
   if (self.secure) {
-    socket.setSecure(self.credentials);
+    socket.setSecure(self.secureContext);
   }
 
   socket.addListener('error', function (e) {
@@ -913,7 +913,7 @@ function Client ( ) {
     self.onend = onEnd;
 
     if (this.https) {
-      this.setSecure(this.credentials);
+      this.setSecure(this.secureContext);
     } else {
       self._initParser();
       debug('requests: ' + util.inspect(self._outgoing));
@@ -954,12 +954,12 @@ util.inherits(Client, net.Stream);
 
 exports.Client = Client;
 
-exports.createClient = function (port, host, https, credentials) {
+exports.createClient = function (port, host, https, context) {
   var c = new Client();
   c.port = port;
   c.host = host;
   c.https = https;
-  c.credentials = credentials;
+  c.secureContext = context;
   return c;
 };
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -340,7 +340,7 @@ Stream.prototype._onTimeout = function () {
 };
 
 
-Stream.prototype.setSecure = function (credentials) {
+Stream.prototype.setSecure = function (context) {
   // Do we have openssl crypto?
   try {
     SecureContext = process.binding('crypto').SecureContext;
@@ -352,19 +352,28 @@ Stream.prototype.setSecure = function (credentials) {
   var crypto = require("crypto");
   this.secure = true;
   this.secureEstablished = false;
-  // If no credentials given, create a new one for just this Stream
-  if (!credentials) {
-    this.credentials = crypto.createCredentials();
+
+  // If no secure context given, create a new one for just this Stream
+  if (!context) {
+    this.secureContext = crypto.createContext();
   } else {
-    this.credentials = credentials;
+    this.secureContext = context;
   }
-  if (!this.server) {
-    // For clients, we will always have either a given ca list or the default on
-    this.credentials.shouldVerify = true;
+
+  // Determine default value. Don't overwrite this.secureContext because the
+  // same context might be shared by a client and a server with different
+  // default values.
+  if (typeof this.secureContext.verifyRemote === "undefined") {
+    // For clients, default to verify; For servers, default to off.
+    var verifyRemote = !this._isServer;
   }
-  this.secureStream = new SecureStream(this.credentials.context,
+  else {
+    var verifyRemote = this.secureContext.verifyRemote;
+  }
+
+  this.secureStream = new SecureStream(this.secureContext,
                                        this.server ? true : false,
-                                       this.credentials.shouldVerify);
+                                       verifyRemote);
 
   setImplmentationMethods(this);
 
@@ -379,7 +388,7 @@ Stream.prototype.verifyPeer = function () {
   if (!this.secure) {
     throw new Error('Stream is not a secure stream.');
   }
-  return this.secureStream.verifyPeer(this.credentials.context);
+  return this.secureStream.verifyPeer(this.secureContext);
 };
 
 
@@ -394,7 +403,7 @@ Stream.prototype._checkForSecureHandshake = function () {
 };
 
 
-Stream.prototype.getPeerCertificate = function (credentials) {
+Stream.prototype.getPeerCertificate = function () {
   if (!this.secure) {
     throw new Error('Stream is not a secure stream.');
   }

--- a/lib/securepair.js
+++ b/lib/securepair.js
@@ -18,9 +18,9 @@ var SecureStream = null;
  * Provides a pair of streams to do encrypted communication.
  */
 
-function SecurePair(credentials, isServer) {
+function SecurePair(context, isServer) {
   if (!(this instanceof SecurePair)) {
-    return new SecurePair(credentials, isServer);
+    return new SecurePair(context, isServer);
   }
 
   var self = this;
@@ -42,24 +42,30 @@ function SecurePair(credentials, isServer) {
 
   var crypto = require("crypto");
 
-  if (!credentials) {
-    this.credentials = crypto.createCredentials();
+  if (!context) {
+    this.secureContext = crypto.createContext();
   } else {
-    this.credentials = credentials;
+    this.secureContext = context;
   }
 
-  if (!this._isServer) {
-    /* For clients, we will always have either a given ca list or be using default one */
-    this.credentials.shouldVerify = true;
+  // Determine default value. Don't overwrite this.secureContext because the
+  // same context might be shared by a client and a server with different
+  // default values.
+  if (typeof this.secureContext.verifyRemote === "undefined") {
+    // For clients, default to verify; For servers, default to off.
+    var verifyRemote = !this._isServer;
+  }
+  else {
+    var verifyRemote = this.secureContext.verifyRemote;
   }
 
   this._secureEstablished = false;
   this._encInPending = [];
   this._clearInPending = [];
 
-  this._ssl = new SecureStream(this.credentials.context,
+  this._ssl = new SecureStream(this.secureContext,
                                this._isServer ? true : false,
-                               this.credentials.shouldVerify);
+                               verifyRemote);
 
 
   /* Acts as a r/w stream to the cleartext side of the stream. */
@@ -168,8 +174,8 @@ function SecurePair(credentials, isServer) {
 
 util.inherits(SecurePair, events.EventEmitter);
 
-exports.createSecurePair = function(credentials, isServer) {
-  var pair = new SecurePair(credentials, isServer);
+exports.createSecurePair = function(context, isServer) {
+  var pair = new SecurePair(context, isServer);
   return pair;
 };
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -43,6 +43,7 @@ void SecureContext::Initialize(Handle<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("SecureContext"));
 
+  NODE_SET_PROTOTYPE_METHOD(t, "init", SecureContext::Init);
   NODE_SET_PROTOTYPE_METHOD(t, "setKey", SecureContext::SetKey);
   NODE_SET_PROTOTYPE_METHOD(t, "setCert", SecureContext::SetCert);
   NODE_SET_PROTOTYPE_METHOD(t, "addCACert", SecureContext::AddCACert);
@@ -55,9 +56,17 @@ void SecureContext::Initialize(Handle<Object> target) {
 
 Handle<Value> SecureContext::New(const Arguments& args) {
   HandleScope scope;
-  SecureContext *sc = new SecureContext();
-  sc->Wrap(args.Holder());
-  
+  SecureContext *p = new SecureContext();
+  p->Wrap(args.Holder());
+  return args.This();
+}
+
+
+Handle<Value> SecureContext::Init(const Arguments& args) {
+  HandleScope scope;
+
+  SecureContext *sc = ObjectWrap::Unwrap<SecureContext>(args.Holder());
+
   OPENSSL_CONST SSL_METHOD *method = SSLv23_method();
 
   if (args.Length() >= 1 && !args[0]->IsUndefined()) {
@@ -99,8 +108,7 @@ Handle<Value> SecureContext::New(const Arguments& args) {
 
   sc->ca_store_ = X509_STORE_new();
   SSL_CTX_set_cert_store(sc->ctx_, sc->ca_store_);
-
-  return args.This();
+  return True();
 }
 
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -26,7 +26,6 @@ class SecureContext : ObjectWrap {
 
  protected:
   static v8::Handle<v8::Value> New(const v8::Arguments& args);
-  static v8::Handle<v8::Value> Init(const v8::Arguments& args);
   static v8::Handle<v8::Value> SetKey(const v8::Arguments& args);
   static v8::Handle<v8::Value> SetCert(const v8::Arguments& args);
   static v8::Handle<v8::Value> AddCACert(const v8::Arguments& args);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -26,6 +26,7 @@ class SecureContext : ObjectWrap {
 
  protected:
   static v8::Handle<v8::Value> New(const v8::Arguments& args);
+  static v8::Handle<v8::Value> Init(const v8::Arguments& args);
   static v8::Handle<v8::Value> SetKey(const v8::Arguments& args);
   static v8::Handle<v8::Value> SetCert(const v8::Arguments& args);
   static v8::Handle<v8::Value> AddCACert(const v8::Arguments& args);

--- a/test/disabled/tls_client.js
+++ b/test/disabled/tls_client.js
@@ -13,7 +13,7 @@ var caPem = fs.readFileSync(common.fixturesDir+"/msca.pem");
 //var caPem = fs.readFileSync("ca.pem");
 
 try{
-  var credentials = crypto.createCredentials({ca:caPem});
+  var context = crypto.createContext({ca:caPem});
 } catch (e) {
   console.log("Not compiled with OPENSSL support.");
   process.exit();
@@ -22,7 +22,7 @@ try{
 client.setEncoding("UTF8");
 client.addListener("connect", function () {
   console.log("client connected.");
-  client.setSecure(credentials);
+  client.setSecure(context);
 });
 
 client.addListener("secure", function () {

--- a/test/disabled/tls_server.js
+++ b/test/disabled/tls_server.js
@@ -10,14 +10,14 @@ var keyPem = fs.readFileSync(common.fixturesDir + "/cert.pem");
 var certPem = fs.readFileSync(common.fixturesDir + "/cert.pem");
 
 try{
-  var credentials = crypto.createCredentials({key:keyPem, cert:certPem});
+  var context = crypto.createContext({key:keyPem, cert:certPem});
 } catch (e) {
   console.log("Not compiled with OPENSSL support.");
   process.exit();
 }
 var i = 0;
 var server = net.createServer(function (connection) {
-  connection.setSecure(credentials);
+  connection.setSecure(context);
   connection.setEncoding("binary");
 
   connection.addListener("secure", function () {

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -17,7 +17,7 @@ var certPem = fs.readFileSync(common.fixturesDir+"/test_cert.pem", 'ascii');
 var keyPem = fs.readFileSync(common.fixturesDir+"/test_key.pem", 'ascii');
 
 try{
-  var credentials = crypto.createCredentials({key:keyPem, cert:certPem, ca:caPem});
+  var context = crypto.createContext({key:keyPem, cert:certPem, ca:caPem});
 } catch (e) {
   console.log("Not compiled with OPENSSL support.");
   process.exit();

--- a/test/simple/test-http-tls.js
+++ b/test/simple/test-http-tls.js
@@ -27,7 +27,7 @@ var certPem = fs.readFileSync(common.fixturesDir+"/test_cert.pem", 'ascii');
 var keyPem = fs.readFileSync(common.fixturesDir+"/test_key.pem", 'ascii');
 
 try{
-  var credentials = crypto.createCredentials({key:keyPem, cert:certPem, ca:caPem});
+  var context = crypto.createContext({key:keyPem, cert:certPem, ca:caPem});
 } catch (e) {
   console.log("Not compiled with OPENSSL support.");
   process.exit();
@@ -77,7 +77,7 @@ var https_server = http.createServer(function (req, res) {
   }, 1);
 
 });
-https_server.setSecure(credentials);
+https_server.setSecure(context);
 https_server.listen(common.PORT);
 
 https_server.addListener("listening", function() {
@@ -86,7 +86,7 @@ https_server.addListener("listening", function() {
   c.setEncoding("utf8");
 
   c.addListener("connect", function () {
-    c.setSecure(credentials);
+    c.setSecure(context);
   });
 
   c.addListener("secure", function () {

--- a/test/simple/test-net-tls.js
+++ b/test/simple/test-net-tls.js
@@ -18,7 +18,7 @@ var certPem = fs.readFileSync(common.fixturesDir+"/test_cert.pem", 'ascii');
 var keyPem = fs.readFileSync(common.fixturesDir+"/test_key.pem", 'ascii');
 
 try{
-  var credentials = crypto.createCredentials({key:keyPem, cert:certPem, ca:caPem});
+  var context = crypto.createContext({key:keyPem, cert:certPem, ca:caPem});
 } catch (e) {
   console.log("Not compiled with OPENSSL support.");
   process.exit();
@@ -32,7 +32,7 @@ var gotSecureClient = false;
 
 var secureServer = net.createServer(function (connection) {
   var self = this;
-  connection.setSecure(credentials);
+  connection.setSecure(context);
   connection.setEncoding("UTF8");
 
   connection.addListener("secure", function () {
@@ -68,7 +68,7 @@ secureServer.addListener("listening", function() {
 
   secureClient.setEncoding("UTF8");
   secureClient.addListener("connect", function () {
-    secureClient.setSecure(credentials);
+    secureClient.setSecure(context);
   });
 
   secureClient.addListener("secure", function () {


### PR DESCRIPTION
This patch renames .createCredentials to .createContext and renames .credentials to .secureContext to better signify its meaning as per pquerna. It also changes the shouldVerify property to verifyRemote and exposes it publicly. This allows circumventing certificate validation for clients, which was previously impossible.
