### PR TITLE
lib/net.js used fs assuming it was required

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1094,7 +1094,7 @@ Server.prototype.listen = function () {
         if (!r.isSocket()) {
           throw new Error("Non-socket exists at  " + path);
         } else {
-          fs.unlink(path, function (err) {
+          require('fs').unlink(path, function (err) {
             if (err) throw err;
             self._doListen(path);
           });


### PR DESCRIPTION
lib/net.js calls fs.unlink() in Server.prototype.listen() (L:1097) I've patched it to require('fs') prior to the call to be consistent with style prior in the method.
