### PR TITLE
isBuffer should return true for SlowBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -166,7 +166,7 @@ function allocPool () {
 
 // Static methods
 Buffer.isBuffer = function isBuffer(b) {
-  return b instanceof Buffer;
+  return (b instanceof Buffer) || (b instanceof SlowBuffer);
 };
 
 


### PR DESCRIPTION
`SlowBuffer`s created in native code was not being recognized by as a buffer which results in binary data being mangled by WriteStream as they are written out.

`node-canvas` was using `Buffer::New` in its native PNG stream output code. When these buffers are written out using `WriteStream.write`, `isBuffer` check fails (because it's no longer an `instanceof Buffer` after fast buffer related changes) and content of the buffer is written out as a string, destroying bytes > 127.
