### PR TITLE
Module caching

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -178,7 +178,7 @@ var module = (function () {
     var location, stats;
     while (location = nextLoc()) {
       try { stats = fs.statSync(location); } catch(e) { continue; }
-      if (stats && !stats.isDirectory()) return location;
+      if (stats && !stats.isDirectory()) return fs.realpathSync(location);
     }
     return false;
   }

--- a/test/simple/test-require-cache.js
+++ b/test/simple/test-require-cache.js
@@ -1,0 +1,16 @@
+common = require("../common");
+var fixturesDir = common.fixturesDir;
+var assert = common.assert;
+
+// relative path causes caching problems (absolute works fine)
+require.paths.unshift( '../fixtures' );
+
+var Foo1 = require('../fixtures/a').A,
+    Foo2 = require('a').A,
+    obj = new Foo1();
+
+assert.ok( obj instanceof Foo1 ); // always true
+assert.ok( obj instanceof Foo2 ); // regression test
+
+console.log('ok')
+


### PR DESCRIPTION
When adding a relative path to require.paths, the module will be reloaded under certain circumstances. This causes problems with the `instanceof` operator.

http://mikegerwitz.com/2010/11/09/node-js-modules-and-instanceof-operator/

This seemed like the easiest way to solve this issue, but I'm unsure if it's the most efficient, since it only applies to a small number of scenarios.
