### PR TITLE
Support CNAME lookups in DNS module.

### DIFF
--- a/deps/c-ares/ares_parse_a_reply.c
+++ b/deps/c-ares/ares_parse_a_reply.c
@@ -201,7 +201,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
         }
     }
 
-  if (status == ARES_SUCCESS && naddrs == 0)
+  if (status == ARES_SUCCESS && naddrs == 0 && naliases == 0)
     status = ARES_ENODATA;
   if (status == ARES_SUCCESS)
     {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -199,15 +199,19 @@ exports.reverse     = function(domain, callback) {
 exports.resolveNs   = function(domain, callback) {
   channel.query(domain, dns.NS, callback);
 };
+exports.resolveCname = function(domain, callback) {
+  channel.query(domain, dns.CNAME, callback);
+};
 
 var resolveMap = {
-  'A'   : exports.resolve4,
-  'AAAA': exports.resolve6,
-  'MX'  : exports.resolveMx,
-  'TXT' : exports.resolveTxt,
-  'SRV' : exports.resolveSrv,
-  'PTR' : exports.resolvePtr,
-  'NS'  : exports.resolveNs
+  'A'     : exports.resolve4,
+  'AAAA'  : exports.resolve6,
+  'MX'    : exports.resolveMx,
+  'TXT'   : exports.resolveTxt,
+  'SRV'   : exports.resolveSrv,
+  'PTR'   : exports.resolvePtr,
+  'NS'    : exports.resolveNs,
+  'CNAME' : exports.resolveCname
 };
 
 // ERROR CODES

--- a/test/disabled/test-dns.js
+++ b/test/disabled/test-dns.js
@@ -38,6 +38,16 @@ while (i--) {
   }
 }
 
+// CNAME should resolve
+dns.resolve('labs.nrcmedia.nl', 'CNAME', function(err, result) {
+  assert.deepEqual(result, ['nrcmedia.nl']);
+});
+
+// CNAME should not resolve
+dns.resolve('nrcmedia.nl', 'CNAME', function(err, result) {
+  assert.ok(err.errno, dns.NODATA);
+});
+
 function checkDnsRecord(host, record) {
   var myHost = host,
       myRecord = record;


### PR DESCRIPTION
Add support for CNAME lookups, includes test cases.

This also contains a one-liner patch to c-ares. I'll report it upstream if the issue hasn't been fixed there yet.
