### PR TITLE
Make SlowBuffer pass Buffer.isBuffer test.

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -166,7 +166,7 @@ function allocPool () {
 
 // Static methods
 Buffer.isBuffer = function isBuffer(b) {
-  return b instanceof Buffer;
+  return b instanceof Buffer || b instanceof SlowBuffer;
 };
 
 


### PR DESCRIPTION
Buffers created directly from C++ cannot be written out using, for example, `fs.writeFile`. This small change fixes that. All tests pass.
