### PR TITLE
_FORTIFY_SOURCE=2 + fix compiler warnings

### DIFF
--- a/src/node_child_process.cc
+++ b/src/node_child_process.cc
@@ -226,9 +226,9 @@ int ChildProcess::Spawn(const char *file,
   int stdin_pipe[2], stdout_pipe[2], stderr_pipe[2];
 
   /* An implementation of popen(), basically */
-  if (custom_fds[0] == -1 && pipe(stdin_pipe) < 0 ||
-      custom_fds[1] == -1 && pipe(stdout_pipe) < 0 ||
-      custom_fds[2] == -1 && pipe(stderr_pipe) < 0) {
+  if ((custom_fds[0] == -1 && pipe(stdin_pipe) < 0) ||
+      (custom_fds[1] == -1 && pipe(stdout_pipe) < 0) ||
+      (custom_fds[2] == -1 && pipe(stderr_pipe) < 0)) {
     perror("pipe()");
     return -1;
   }

--- a/src/node_stdio.cc
+++ b/src/node_stdio.cc
@@ -129,7 +129,7 @@ WriteError (const Arguments& args)
 
   ssize_t r;
   size_t written = 0;
-  while (written < msg.length()) {
+  while (written < (size_t) msg.length()) {
     r = write(STDERR_FILENO, (*msg) + written, msg.length() - written);
     if (r < 0) {
       if (errno == EAGAIN || errno == EIO) {
@@ -217,7 +217,7 @@ void Stdio::Initialize(v8::Handle<v8::Object> target) {
     // XXX selecting on tty fds wont work in windows.
     // Must ALWAYS make a coupling on shitty platforms.
     stdout_flags = fcntl(STDOUT_FILENO, F_GETFL, 0);
-    int r = fcntl(STDOUT_FILENO, F_SETFL, stdout_flags | O_NONBLOCK);
+    fcntl(STDOUT_FILENO, F_SETFL, stdout_flags | O_NONBLOCK);
   }
 
   target->Set(String::NewSymbol("stdoutFD"), Integer::New(STDOUT_FILENO));
@@ -233,8 +233,10 @@ void Stdio::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_METHOD(target, "getRows", GetRows);
   NODE_SET_METHOD(target, "isatty", IsATTY);
 
-  struct sigaction sa = {0};
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
   sa.sa_handler = HandleSIGCONT;
+  sa.sa_restorer = NULL;
   sigaction(SIGCONT, &sa, NULL);
 }
 

--- a/wscript
+++ b/wscript
@@ -365,6 +365,9 @@ def configure(conf):
     conf.env.append_value('CPPFLAGS', '-pg')
     conf.env.append_value('LINKFLAGS', '-pg')
 
+  conf.env.append_value('CPPFLAGS', '-Wno-unused-parameter');
+  conf.env.append_value('CPPFLAGS', '-D_FORTIFY_SOURCE=2');
+
   # Split off debug variant before adding variant specific defines
   debug_env = conf.env.copy()
   conf.set_env_name('debug', debug_env)


### PR DESCRIPTION
For the security conscious + anal retentive among us[1].

Passes tests like the current master does (not fully).

[1] To stop Eclipse from pestering me about it, actually.
