### PR TITLE
Event propagation

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1,5 +1,10 @@
 var EventEmitter = exports.EventEmitter = process.EventEmitter;
 
+// Some constants
+var NO_EFFECT = exports.NO_EFFECT = 0,
+    EVENT_EMITED = exports.EVENT_EMITED = 1,
+    STOPPED_PROPAGATION = exports.STOPPED_PROPAGATION = 2;
+
 var isArray = Array.isArray;
 
 EventEmitter.prototype.emit = function (type) {
@@ -13,24 +18,25 @@ EventEmitter.prototype.emit = function (type) {
       } else {
         throw new Error("Uncaught, unspecified 'error' event.");
       }
-      return false;
+      return NO_EFFECT;
     }
   }
 
   if (!this._events) return false;
   var handler = this._events[type];
   if (!handler) return false;
-
+  
+  var result;
+  
   if (typeof handler == 'function') {
     if (arguments.length <= 3) {
       // fast case
-      handler.call(this, arguments[1], arguments[2]);
+      result = handler.call(this, arguments[1], arguments[2]) === false;
     } else {
       // slower
       var args = Array.prototype.slice.call(arguments, 1);
-      handler.apply(this, args);
+      result = handler.apply(this, args) === false;
     }
-    return true;
 
   } else if (isArray(handler)) {
     var args = Array.prototype.slice.call(arguments, 1);
@@ -38,13 +44,19 @@ EventEmitter.prototype.emit = function (type) {
 
     var listeners = handler.slice();
     for (var i = 0, l = listeners.length; i < l; i++) {
-      listeners[i].apply(this, args);
+      result = listeners[i].apply(this, args) === false;
+      
+      // If some of event listeners stopped propagation
+      // (returned false)
+      // We should not call other event listeners
+      if (result) break;
     }
-    return true;
 
   } else {
-    return false;
+    return NO_EFFECT;
   }
+  
+  return result ? STOPPED_PROPAGATION : EVENT_EMITED;
 };
 
 // EventEmitter is defined in src/node_events.cc

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,4 +1,5 @@
-var util = require('util');
+var util = require('util'),
+    events = require('events');
 
 var debug;
 var debugLevel = parseInt(process.env.NODE_DEBUG, 16);
@@ -794,9 +795,11 @@ function connectionListener (socket) {
       // in the upgradeHead from the closing lines of the headers
       var upgradeHead = d.slice(start + bytesParsed + 1, end);
 
-      if (self.listeners("upgrade").length) {
-        self.emit('upgrade', req, req.socket, upgradeHead);
-      } else {
+      var result = self.emit('upgrade', req, req.socket, upgradeHead);
+      
+      // Event listener should stop propagation (return false)
+      // To get us notified that upgrade connection was used
+      if (result !== events.STOPPED_PROPAGATION) {
         // Got upgrade header, but have no handler.
         socket.destroy();
       }
@@ -889,9 +892,12 @@ function Client ( ) {
 
       var upgradeHead = d.slice(start + bytesParsed + 1, end);
 
-      if (self.listeners('upgrade').length) {
-        self.emit('upgrade', req, self, upgradeHead);
-      } else {
+      var result = self.emit('upgrade', req, self, upgradeHead);
+      
+      // Event listener should stop propagation (return false)
+      // To get us notified that upgrade connection was used
+      if (result !== events.STOPPED_PROPAGATION) {
+        // Got upgrade header, but have no handler.
         self.destroy();
       }
     }

--- a/test/fixtures/cycles/folder/cycles
+++ b/test/fixtures/cycles/folder/cycles
@@ -1,0 +1,1 @@
+/home/donnerjack/github/my/node/test/fixtures/cycles

--- a/test/simple/test-event-emitter-add-listeners.js
+++ b/test/simple/test-event-emitter-add-listeners.js
@@ -21,11 +21,28 @@ e.on("hello", function (a, b) {
 
 console.log("start");
 
-e.emit("hello", "a", "b");
+var times_prop_emited = 0;
+
+function onprop() {
+  times_prop_emited++;
+  return false;
+}
+e.on("prop", onprop);
+e.on("prop", onprop);
+
+var result_of_not_stopped = e.emit("hello", "a", "b");
+
+var result_of_not_called = e.emit("does-not-exist");
+
+var result_of_stopped = e.emit("prop");
 
 process.addListener("exit", function () {
-  assert.deepEqual(["hello"], events_new_listener_emited);
+  assert.deepEqual(["hello", "prop", "prop"], events_new_listener_emited);
   assert.equal(1, times_hello_emited);
+  assert.equal(1, times_prop_emited);
+  assert.equal(result_of_not_stopped, events.EVENT_EMITED);
+  assert.equal(result_of_not_called, events.NO_EFFECT);
+  assert.equal(result_of_stopped, events.STOPPED_PROPAGATION);
 });
 
 

--- a/test/simple/test-http-upgrade-client.js
+++ b/test/simple/test-http-upgrade-client.js
@@ -48,6 +48,10 @@ srv.listen(common.PORT, '127.0.0.1', function () {
       srv.close();
 
       gotUpgrade = true;
+      
+      // Stop propagation
+      // So 'http' module will know, that it should not destroy socket
+      return false;
   });
   hc.request('GET', '/').end();
 });

--- a/test/simple/test-http-upgrade-client2.js
+++ b/test/simple/test-http-upgrade-client2.js
@@ -11,6 +11,9 @@ server.on('upgrade', function(req, socket, head) {
   socket.on('end', function () {
     socket.end();               
   });
+  // Stop propagation
+  // So 'http' module will know, that it should not destroy socket
+  return false;
 });
 
 
@@ -30,7 +33,11 @@ server.listen(common.PORT, function () {
       wasUpgrade = true;
       
       client.removeListener('upgrade', onUpgrade);
-      socket.end();    
+      socket.end(); 
+      
+      // Stop propagation
+      // So 'http' module will know, that it should not destroy socket
+      return false;   
     }
     client.on('upgrade', onUpgrade);
     

--- a/test/simple/test-http-upgrade-server.js
+++ b/test/simple/test-http-upgrade-server.js
@@ -45,6 +45,10 @@ function testServer(){
         socket.write(data, "utf8");
       }
     };
+    
+    // Stop propagation
+    // So 'http' module will know, that it should not destroy socket
+    return false;
   });
 };
 

--- a/test/simple/test-http-upgrade-server2.js
+++ b/test/simple/test-http-upgrade-server2.js
@@ -14,6 +14,12 @@ server.addListener('upgrade', function (req, socket, upgradeHead) {
   // test that throwing an error from upgrade gets
   // is uncaught
   throw new Error('upgrade error');
+  
+  // Stop propagation
+  // So 'http' module will know, that it should not destroy socket
+  // Actually, this line wouldn't be called
+  // But anyway return false
+  return false;
 });
 
 gotError = false;

--- a/test/simple/test-http-upgrade-server3.js
+++ b/test/simple/test-http-upgrade-server3.js
@@ -1,0 +1,45 @@
+common = require("../common");
+assert = common.assert
+
+http = require('http');
+net = require('net');
+
+server = http.createServer();
+
+server.addListener('upgrade', function (req, socket, upgradeHead) {
+  common.error('server got upgrade event');
+  // We won't step propagation
+  // (not return false)
+  // And see - what will happen
+  
+  process.nextTick(function() {
+    // Socket should be destroyed here
+    // Because upgrade event wasn't catched
+    // (Propagation was not stopped)
+    
+    assert.ok(socket.fd === null);
+    server.close();
+  });
+});
+
+server.listen(common.PORT, function () {
+  var c = net.createConnection(common.PORT);
+
+  c.addListener('connect', function () {
+    common.error('client wrote message');
+    c.write( "GET /blah HTTP/1.1\r\n"
+           + "Upgrade: WebSocket\r\n"
+           + "Connection: Upgrade\r\n"
+           + "\r\n\r\nhello world"
+           );
+  });
+
+  c.addListener('end', function () {
+    c.end();
+  });
+
+  c.addListener('close', function () {
+    common.error('client close');    
+  });
+});
+


### PR DESCRIPTION
Event propagation patch, as was discussed on IRC.
## Proposal (events.js)

With this patch:
emit() will return one of this values:
- events.NO_EFFECT
- events.EVENT_EMITED
- events.PROPAGATION_STOPPED
### events.NO_EFFECT

Returned if no event listeners was called
### events.EVENT_EMITED

Returned if all event listeners was called, and propagation wasn't stopped (see below).
### events.PROPAGATION_STOPPED

Returned if one of event listeners returns <code>false</code> value.
_Note: that in this case next event listeners won't be called._
## Proposal (http.js)

Using this _event-propagation_ system
We can have more control on 'upgrade' events.
### Details

You know, that if you have no event listeners for 'upgrade' event - socket will be destroyed?
My proposal is to destroy socket if propagation was not stopped (some of event listeners returned <code>false</code> value).
