### PR TITLE
Fix number of args emitted by EventEmitter during "fast case" (<= 3 args) (v0.2 patch)

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -22,19 +22,26 @@ EventEmitter.prototype.emit = function (type) {
   if (!handler) return false;
 
   if (typeof handler == 'function') {
-    if (arguments.length <= 3) {
-      // fast case
-      handler.call(this, arguments[1], arguments[2]);
-    } else {
+    switch (arguments.length) {
+      // fast cases
+      case 1:
+        handler.call(this);
+        break;
+      case 2:
+        handler.call(this, arguments[1]);
+        break;
+      case 3:
+        handler.call(this, arguments[1], arguments[2]);
+        break;
       // slower
-      var args = Array.prototype.slice.call(arguments, 1);
-      handler.apply(this, args);
+      default:
+        var args = Array.prototype.slice.call(arguments, 1);
+        handler.apply(this, args);
     }
     return true;
 
   } else if (isArray(handler)) {
     var args = Array.prototype.slice.call(arguments, 1);
-
 
     var listeners = handler.slice();
     for (var i = 0, l = listeners.length; i < l; i++) {

--- a/test/simple/test-event-emitter-num-args.js
+++ b/test/simple/test-event-emitter-num-args.js
@@ -1,0 +1,27 @@
+common = require("../common");
+assert = common.assert
+var events = require('events');
+
+var e = new events.EventEmitter(),
+  num_args_emited = [];
+
+e.on("numArgs", function() {
+  var numArgs = arguments.length;
+  console.log("numArgs: " + numArgs);
+  num_args_emited.push(numArgs);
+});
+
+console.log("start");
+
+e.emit("numArgs");
+e.emit("numArgs", null);
+e.emit("numArgs", null, null);
+e.emit("numArgs", null, null, null);
+e.emit("numArgs", null, null, null, null);
+e.emit("numArgs", null, null, null, null, null);
+
+process.addListener("exit", function () {
+  assert.deepEqual([0, 1, 2, 3, 4, 5], num_args_emited);
+});
+
+


### PR DESCRIPTION
Patch for v0.2 branch (see http://groups.google.com/group/nodejs-dev/browse_thread/thread/c9ee9eef3af87f66)
