### PR TITLE
Remove env cruft

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -12,11 +12,9 @@ var spawn = exports.spawn = function (path, args /*, options OR env, customFds *
 };
 
 exports.exec = function (command /*, options, callback */) {
-  if (arguments.length < 3) {
-    return exports.execFile("/bin/sh", ["-c", command], arguments[1]);
-  } else {
-    return exports.execFile("/bin/sh", ["-c", command], arguments[1], arguments[2]);
-  }
+  var _slice = Array.prototype.slice;
+  var args = ["/bin/sh", ["-c", command]].concat(_slice.call(arguments, 1));
+  return exports.execFile.apply(this, args)
 };
 
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -14,10 +14,8 @@ var spawn = exports.spawn = function (path, args /*, options OR env, customFds *
 exports.exec = function (command /*, options, callback */) {
   if (arguments.length < 3) {
     return exports.execFile("/bin/sh", ["-c", command], arguments[1]);
-  } else if (arguments.length < 4) {
-    return exports.execFile("/bin/sh", ["-c", command], arguments[1], arguments[2]);
   } else {
-    return exports.execFile("/bin/sh", ["-c", command], arguments[1], arguments[2], arguments[3]);
+    return exports.execFile("/bin/sh", ["-c", command], arguments[1], arguments[2]);
   }
 };
 


### PR DESCRIPTION
This simplifies the code inside `child_process.exec`.  Did it in two steps to show the removal of the `env` code as a separate change.
