### PR TITLE
Fix: clearTimeout called multiple times breaks new timer system.

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -43,6 +43,7 @@ function shift (list) {
 function remove (item) {
   item._idleNext._idlePrev = item._idlePrev;
   item._idlePrev._idleNext = item._idleNext;
+  delete item._idleNext;
 }
 
 
@@ -111,8 +112,7 @@ function insert (item, msecs) {
 
 var unenroll = exports.unenroll = function (item) {
   if (item._idleNext) {
-    item._idleNext._idlePrev = item._idlePrev;
-    item._idlePrev._idleNext = item._idleNext;
+    remove(item);
 
     var list = lists[item._idleTimeout];
     // if empty then stop the watcher

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -84,8 +84,19 @@ interval4 = setInterval(function () {
   if (++count4 > 10) clearInterval(interval4);
 }, 0);
 
+// we should be able to clearTimeout multiple times without breakage.
+var expectedTimeouts = 3,
+    t = function() { expectedTimeouts--; },
+    w = setTimeout(t, 200),
+    x = setTimeout(t, 200),
+    y = setTimeout(t, 200),
+    yy = clearTimeout(y),
+    z = setTimeout(t, 200),
+    yyy = clearTimeout(y);
+
 process.addListener("exit", function () {
   assert.equal(true, setTimeout_called);
   assert.equal(3, interval_count);
   assert.equal(11, count4);
+  assert.equal(0, expectedTimeouts, "clearTimeout cleared too many timeouts");
 });


### PR DESCRIPTION
Hallo!
https://gist.github.com/d8a808260260c9371fae <-- this breaks on node master but works on 0.3.0.
Here's a rather small fix for one bug I found. Patch + test case inside!
