### PR TITLE
Create new Buffer(length) zeroed

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -192,10 +192,7 @@ void Buffer::Replace(char *data, size_t length,
       memcpy(data_, data, length_);
     }
     else {
-      size_t n = length_;
-      while (n--) {
-        data_[n]= 0;
-      }
+      memset( (void*)(data_), 0, length_);
     }
     V8::AdjustAmountOfExternalAllocatedMemory(sizeof(Buffer) + length_);
   } else {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -188,8 +188,15 @@ void Buffer::Replace(char *data, size_t length,
     data_ = data;
   } else if (length_) {
     data_ = new char[length_];
-    if (data)
+    if (data) {
       memcpy(data_, data, length_);
+    }
+    else {
+      size_t n = length_;
+      while (n--) {
+        data_[n]= 0;
+      }
+    }
     V8::AdjustAmountOfExternalAllocatedMemory(sizeof(Buffer) + length_);
   } else {
     data_ = NULL;


### PR DESCRIPTION
Currently a new Buffer() contains garbage:

new Buffer(5) -> Buffer 0f 82 1e 03 00, with this patch : new Buffer(5) -> Buffer 00 00 00 00 00
