### PR TITLE
Fix module tests

### DIFF
--- a/test/simple/test-module-loading.js
+++ b/test/simple/test-module-loading.js
@@ -5,6 +5,12 @@ var path = require('path'),
 
 common.debug("load test-module-loading.js");
 
+// require a file with a request that includes the extension
+var a_js = require("../fixtures/a.js");
+
+// require a file without any extensions
+var foo_no_ext = require("../fixtures/foo");
+
 var a = require("../fixtures/a");
 var c = require("../fixtures/b/c");
 var d = require("../fixtures/b/d");


### PR DESCRIPTION
This patch adds two new tests to the module test suite, that checks that the module implementation can load files with not extension on that, and request to load a file including the extension.

See commit log for more details
