### PR TITLE
Cleaner readfilesync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -88,43 +88,45 @@ fs.readFile = function(path, encoding_) {
 };
 
 fs.readFileSync = function(path, encoding) {
-  var fd = fs.openSync(path, constants.O_RDONLY, 0666);
-  var buffer = new Buffer(4048);
-  var buffers = [];
-  var nread = 0;
-  var lastRead = 0;
+  var fd = fs.openSync(path, constants.O_RDONLY, 0666),
+      buffers = [],
+      nread = 0,
+      buffer = new Buffer(4048),
+      lastRead = fs.readSync(fd, buffer, 0, buffer.length, null);
 
-  do {
-    if (lastRead) {
-      buffer._bytesRead = lastRead;
-      nread += lastRead;
-      buffers.push(buffer);
-    }
-    var buffer = new Buffer(4048);
+  // we read in chunks of 4048 until we get to the end
+  while (lastRead > 0) {
+    buffer._bytesRead = lastRead;
+    nread += lastRead;
+    buffers.push(buffer);
+    buffer = new Buffer(4048);
     lastRead = fs.readSync(fd, buffer, 0, buffer.length, null);
-  } while (lastRead > 0);
+  }
 
   fs.closeSync(fd);
 
+  // then we copy all those bits into on big buffer
+  var newBuffer;
   if (buffers.length > 1) {
     var offset = 0;
-    var i;
-    buffer = new Buffer(nread);
+    newBuffer = new Buffer(nread);
     buffers.forEach(function(i) {
-      if (!i._bytesRead) return;
-      i.copy(buffer, offset, 0, i._bytesRead);
+      i.copy(newBuffer, offset, 0, i._bytesRead);
       offset += i._bytesRead;
     });
   } else if (buffers.length) {
     // buffers has exactly 1 (possibly zero length) buffer, so this should
     // be a shortcut
-    buffer = buffers[0].slice(0, buffers[0]._bytesRead);
+    newBuffer = buffers[0].slice(0, buffers[0]._bytesRead);
   } else {
-    buffer = new Buffer(0);
+    newBuffer = new Buffer(0);
   }
 
-  if (encoding) buffer = buffer.toString(encoding);
-  return buffer;
+  if (encoding) {
+    newBuffer = newBuffer.toString(encoding);
+  }
+
+  return newBuffer;
 };
 
 


### PR DESCRIPTION
I hate that there's not a good way to do a "pull for review", so here's a pull request for some very minor changes to fs.readFileSync. Like previous pull requests the goal is not change any of the behavior of readFileSync, and to only make this function easier to read and edit later.

The primary source of confusion in this function was the "do while" block and nested conditional. By pulling the last read variable initialization out of the do while, we can make it the slightly less confusing while block, and remove a conditional.
