### PR TITLE
Updated 302 status code description

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -131,7 +131,7 @@ var STATUS_CODES = exports.STATUS_CODES = {
   207 : 'Multi-Status',               // RFC 4918
   300 : 'Multiple Choices',
   301 : 'Moved Permanently',
-  302 : 'Moved Temporarily',
+  302 : 'Found',
   303 : 'See Other',
   304 : 'Not Modified',
   305 : 'Use Proxy',


### PR DESCRIPTION
HTTP/1.1 RFC says that 302 description should be "Found". It is currently "Moved Temporarily", which was the proper description under HTTP/1.0.
