### PR TITLE
Test net stream destroy RE: issue #431

### DIFF
--- a/test/simple/test-net-stream.js
+++ b/test/simple/test-net-stream.js
@@ -1,0 +1,16 @@
+var common = require('../common');
+var assert = require('assert');
+
+var Stream = require('net').Stream;
+
+var s = new Stream();
+
+// test that destroy called on a stream with a server only ever decrements the
+// server connection count once
+
+s.server = { connections: 10 }
+assert.equal(10, s.server.connections);
+s.destroy()
+assert.equal(9, s.server.connections);
+s.destroy()
+assert.equal(9, s.server.connections);


### PR DESCRIPTION
https://github.com/ry/node/pull/431

you requested a test case for net.Stream destroy decrementing server connections for every call to destroy. So I whipped one up.
