### PR TITLE
Fix for Cygwin build after V8 3.0.0 update.

### DIFF
--- a/deps/v8/src/utils.h
+++ b/deps/v8/src/utils.h
@@ -28,6 +28,7 @@
 #ifndef V8_UTILS_H_
 #define V8_UTILS_H_
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Commit c30f113 ("Upgrade V8 to 3.0.0") has broken the Cygwin build of Node.js 0.3.2-pre; this pull request fixes it. The only regression is that V8 profiling is no longer possible on Cygwin, as all profiling code has been wiped out from platform-cygwin.cc. Please see the discussion in nodejs-dev mailing list:

http://groups.google.com/group/nodejs-dev/browse_thread/thread/9f9147b80da1f539

Update is (largely) by Bert Belder and (in minor part) by Dmitriy Khudorozhkov.
