### PR TITLE
Added recursive directory creation to the fs.mkdir() function

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -178,10 +178,11 @@ to the completion callback.
 
 Synchronous rmdir(2).
 
-### fs.mkdir(path, mode, [callback])
+### fs.mkdir(path, mode, [recursive], [callback])
 
-Asynchronous mkdir(2). No arguments other than a possible exception are given
-to the completion callback.
+Asynchronous mkdir(2). The optional recursive boolean parameter turns on
+creation of intermediate directories as the command `mkdir -p` does.
+No arguments other than a possible exception are given to the completion callback.
 
 ### fs.mkdirSync(path, mode)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -355,9 +355,16 @@ function mkdir_p(path, mode, callback, position) {
   })
 }
 
-fs.mkdirSync = function(path, mode) {
-  return binding.mkdir(path, mode);
-};
+fs.mkdirSync = function(path, mode, recursive) {
+  if ('boolean' != typeof(recursive)) {
+    recursive = false;
+  }
+  if (!recursive) {
+    return binding.mkdir(path, mode);
+  } else {
+    return mkdir_p(path, mode);
+  }
+}
 
 fs.sendfile = function(outFd, inFd, inOffset, length, callback) {
   binding.sendfile(outFd, inFd, inOffset, length, callback || noop);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -335,7 +335,7 @@ function mkdir_p(path, mode, callback, position) {
     }
   }
 
-  var directory = parts.slice(0, position + 1).join('/');
+  var directory = parts.slice(0, position + 1).join('/') || '/';
   fs.stat(directory, function(err) {
     if (err === null) {
       mkdir_p(path, mode, callback, position + 1);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -323,7 +323,7 @@ fs.mkdir = function(path, mode, recursive, callback) {
 //Asynchronous operation. No arguments other than a
 //possible exception are given to the completion callback.
 function mkdir_p(path, mode, callback, position) {
-  mode = mode || 0777;
+  mode = mode || process.umask();
   position = position || 0;
   var parts = require('path').normalize(path).split('/');
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -305,9 +305,56 @@ fs.fsyncSync = function(fd) {
   return binding.fsync(fd);
 };
 
-fs.mkdir = function(path, mode, callback) {
-  binding.mkdir(path, mode, callback || noop);
+//Polymorphic approach: If the third parameter is boolean
+//and true assume that caller wants recursive operation.
+fs.mkdir = function(path, mode, recursive, callback) {
+    if (typeof(recursive) != 'boolean') {
+        callback = recursive;
+        recursive = false;
+    }
+    if (!recursive) {
+        binding.mkdir(path, mode, callback || noop);
+    } else {
+        mkdir_p(path, mode, callback || noop);
+    }
 };
+
+//Offers functionality similar to mkdir -p
+//Asynchronous operation. No arguments other than a
+//possible exception are given to the completion callback.
+function mkdir_p (path, mode, callback, position) {
+    mode = mode || 0777;
+    position = position || 0;
+    parts = require('path').normalize(path).split('/');
+
+    if (position >= parts.length) {
+        if (callback) {
+            return callback();
+        } else {
+            return true;
+        }
+    }
+
+    var directory = parts.slice(0, position + 1).join('/');
+    fs.stat(directory, function(err) {
+        if (err === null) {
+            mkdir_p(path, mode, callback, position + 1);
+        } else {
+            fs.mkdir(directory, mode, function (err) {
+                if (err) {
+                    if (callback) {
+                        return callback(err);
+                    } else {
+                        throw err;
+                    }
+                } else {
+                    mkdir_p(path, mode, callback, position + 1);
+                }
+            })
+        }
+    })
+}
+
 
 fs.mkdirSync = function(path, mode) {
   return binding.mkdir(path, mode);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -341,7 +341,7 @@ function mkdir_p(path, mode, callback, position) {
       mkdir_p(path, mode, callback, position + 1);
     } else {
       fs.mkdir(directory, mode, function (err) {
-        if (err) {
+        if (err && err.errno != 17) {
           if (callback) {
             return callback(err);
           } else {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -308,53 +308,52 @@ fs.fsyncSync = function(fd) {
 //Polymorphic approach: If the third parameter is boolean
 //and true assume that caller wants recursive operation.
 fs.mkdir = function(path, mode, recursive, callback) {
-    if (typeof(recursive) != 'boolean') {
-        callback = recursive;
-        recursive = false;
-    }
-    if (!recursive) {
-        binding.mkdir(path, mode, callback || noop);
-    } else {
-        mkdir_p(path, mode, callback || noop);
-    }
+  if (typeof(recursive) != 'boolean') {
+    callback = recursive;
+    recursive = false;
+  }
+  if (!recursive) {
+    binding.mkdir(path, mode, callback || noop);
+  } else {
+    mkdir_p(path, mode, callback || noop);
+  }
 };
 
 //Offers functionality similar to mkdir -p
 //Asynchronous operation. No arguments other than a
 //possible exception are given to the completion callback.
-function mkdir_p (path, mode, callback, position) {
-    mode = mode || 0777;
-    position = position || 0;
-    parts = require('path').normalize(path).split('/');
+function mkdir_p(path, mode, callback, position) {
+  mode = mode || 0777;
+  position = position || 0;
+  var parts = require('path').normalize(path).split('/');
 
-    if (position >= parts.length) {
-        if (callback) {
-            return callback();
-        } else {
-            return true;
-        }
+  if (position >= parts.length) {
+    if (callback) {
+      return callback();
+    } else {
+      return true;
     }
+  }
 
-    var directory = parts.slice(0, position + 1).join('/');
-    fs.stat(directory, function(err) {
-        if (err === null) {
-            mkdir_p(path, mode, callback, position + 1);
+  var directory = parts.slice(0, position + 1).join('/');
+  fs.stat(directory, function(err) {
+    if (err === null) {
+      mkdir_p(path, mode, callback, position + 1);
+    } else {
+      fs.mkdir(directory, mode, function (err) {
+        if (err) {
+          if (callback) {
+            return callback(err);
+          } else {
+            throw err;
+          }
         } else {
-            fs.mkdir(directory, mode, function (err) {
-                if (err) {
-                    if (callback) {
-                        return callback(err);
-                    } else {
-                        throw err;
-                    }
-                } else {
-                    mkdir_p(path, mode, callback, position + 1);
-                }
-            })
+          mkdir_p(path, mode, callback, position + 1);
         }
-    })
+      })
+    }
+  })
 }
-
 
 fs.mkdirSync = function(path, mode) {
   return binding.mkdir(path, mode);

--- a/test/simple/test-mkdir-rmdir.js
+++ b/test/simple/test-mkdir-rmdir.js
@@ -34,10 +34,6 @@ fs.mkdir(recursive_d, 0766, true, function(err) {
     mkdir_recursive_error = true;
   } else {
     console.log('mkdir recursive okay!');
-    var parts = recursive_d.split('/').slice(d.split('/').length);
-    for (var i = parts.length; i >= 0; i--) {
-      fs.rmdirSync(path.join(d, parts.slice(0, i).join('/')));
-    }
   }
 });
 

--- a/test/simple/test-mkdir-rmdir.js
+++ b/test/simple/test-mkdir-rmdir.js
@@ -5,8 +5,10 @@ var fs = require('fs');
 
 var dirname = path.dirname(__filename);
 var d = path.join(common.tmpDir, 'dir');
+var recursive_d = path.join(d, '/first/second/third/fourth/fifth');
 
 var mkdir_error = false;
+var mkdir_recursive_error = false;
 var rmdir_error = false;
 
 fs.mkdir(d, 0666, function(err) {
@@ -26,8 +28,22 @@ fs.mkdir(d, 0666, function(err) {
   }
 });
 
+fs.mkdir(recursive_d, 0766, true, function(err) {
+  if (err) {
+    console.log('mkdir recursive error: ' + err.message);
+    mkdir_recursive_error = true;
+  } else {
+    console.log('mkdir recursive okay!');
+    var parts = recursive_d.split('/').slice(d.split('/').length);
+    for (var i = parts.length; i >= 0; i--) {
+      fs.rmdirSync(path.join(d, parts.slice(0, i).join('/')));
+    }
+  }
+});
+
 process.addListener('exit', function() {
   assert.equal(false, mkdir_error);
+  assert.equal(false, mkdir_recursive_error);
   assert.equal(false, rmdir_error);
   console.log('exit');
 });


### PR DESCRIPTION
Implemented a polymorphic approach to the mkdir function making it also create directories recursively. This is the functionality offered by 'mkdir -p' and is often desirable to have it available from within node.

Here's the new mkdir() function synopsis:
- mkdir(path, mode, [callback]): original implementation;
- mkdir(path, mode, recursive, [callback]): if recursive == true, the directory will be created recursively.

This change doesn't break any existing test.

Example usage:

```
var fs = require('fs');

//
// Example with non-recursion.
//
fs.mkdir('example_dir/first/second/third/fourth/fifth', 0777, function (err) {
    if (err) {
        console.log(err);
    } else {
        console.log('Directory created');
    }
});

//
// Example with recursion -- notice the parameter
// right before the callback function.
//
fs.mkdir('example_dir/first/second/third/fourth/fifth', 0777, true, function (err) {
    if (err) {
        console.log(err);
    } else {
        console.log('Directory created');
    }
});
```
