### PR TITLE
assert.throws is currently broken

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -65,8 +65,8 @@ Custom error validation:
         throw new Error("Wrong value");
       },
       function(err) {
-        if ( !(err instanceof Error) || !/value/.test(err) ) {
-          return false;
+        if ( (err instanceof Error) && /value/.test(err) ) {
+          return true;
         }
       },
       "unexpected error"

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -246,13 +246,14 @@ function expectedException(actual, expected) {
   }
 
   if (expected instanceof RegExp) {
-    if (expected.test(actual)) {
-      return true;
-    }
-  } else if (actual instanceof expected ||
-             expected.call({}, actual) !== false) {
+    return expected.test(actual);
+  } else if (actual instanceof expected) {
+    return true;
+  } else if ( expected.call({}, actual) === true ) {
     return true;
   }
+  
+  return false;
 }
 
 function _throws(shouldThrow, block, expected, message) {

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -165,12 +165,26 @@ assert.throws(function() {assert.ifError(new Error('test error'))});
 assert.doesNotThrow(function() {assert.ifError(null)});
 assert.doesNotThrow(function() {assert.ifError()});
 
+// make sure that validating using constructor really works
+threw = false;
+try {
+  assert.throws(
+    function() {
+      throw {};
+    },
+    Array
+  );
+} catch(e) {
+  threw = true;
+}
+assert.ok(threw, "wrong constructor validation");
+
 // use a RegExp to validate error message
 a.throws(makeBlock(thrower, TypeError), /test/);
 
 // use a fn to validate error object
 a.throws(makeBlock(thrower, TypeError), function(err) {
-  if (!(err instanceof TypeError) || !/test/.test(err)) {
-    return false;
+  if ( (err instanceof TypeError) && /test/.test(err)) {
+    return true;
   }
 });


### PR DESCRIPTION
This is a test which shows how to reproduce it:

```
var a = require("assert");

a.throws(
    function() {
        throw {};
    },
    Array
);

console.log( {} instanceof Array );
```
1. I have to change a bit the api. Custom validation function have to return true if it passes, because if it returns false if it not passes we can't differentiate between a constructor which never returns a value and a validation function which returns a value only if it passes.
2. I have added a test, which makes sure this will not happen again
3. I actually think the main reason why this happened is because the logic of _throws function too complicated, it handles both assert.throws and assert.doesNotThrow - at this point I think a bit copy/paste would make it much more simple.
