### PR TITLE
Fix several tests that fail due to improper path escaping

### DIFF
--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -1,7 +1,7 @@
 assert = require('assert');
 child = require('child_process');
 
-nodejs = process.execPath;
+nodejs = '"' + process.execPath + '"';
 
 if (module.parent) {
   // signal we've been loaded as a module

--- a/test/simple/test-error-reporting.js
+++ b/test/simple/test-error-reporting.js
@@ -6,7 +6,7 @@ var path = require('path');
 var exits = 0;
 
 function errExec(script, callback) {
-  var cmd = process.argv[0] + ' ' + path.join(common.fixturesDir, script);
+  var cmd = '"' + process.argv[0] + '" "' + path.join(common.fixturesDir, script) + '"';
   return exec(cmd, function(err, stdout, stderr) {
     // There was some error
     assert.ok(err);

--- a/test/simple/test-http-curl-chunk-problem.js
+++ b/test/simple/test-http-curl-chunk-problem.js
@@ -22,7 +22,7 @@ function maybeMakeRequest() {
 }
 
 
-cp.exec('dd if=/dev/zero of=' + filename + ' bs=1024 count=10240',
+cp.exec('dd if=/dev/zero of="' + filename + '" bs=1024 count=10240',
         function(err, stdout, stderr) {
           if (err) throw err;
           maybeMakeRequest();

--- a/test/simple/test-pipe-head.js
+++ b/test/simple/test-pipe-head.js
@@ -7,7 +7,7 @@ var join = require('path').join;
 var nodePath = process.argv[0];
 var script = join(common.fixturesDir, 'print-10-lines.js');
 
-var cmd = nodePath + ' ' + script + ' | head -2';
+var cmd = '"' + nodePath + '" "' + script + '" | head -2';
 
 var finished = false;
 

--- a/test/simple/test-stdin-from-file.js
+++ b/test/simple/test-stdin-from-file.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var stdoutScript = join(common.fixturesDir, 'echo.js');
 var tmpFile = join(common.fixturesDir, 'stdin.txt');
 
-var cmd = process.argv[0] + ' ' + stdoutScript + ' < ' + tmpFile;
+var cmd = '"' + process.argv[0] + '" "' + stdoutScript + '" < "' + tmpFile + '"';
 
 var string = 'abc\nümlaut.\nsomething else\n' +
              '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，' +

--- a/test/simple/test-stdout-to-file.js
+++ b/test/simple/test-stdout-to-file.js
@@ -9,13 +9,13 @@ var scriptBuffer = path.join(common.fixturesDir, 'print-chars-from-buffer.js');
 var tmpFile = path.join(common.fixturesDir, 'stdout.txt');
 
 function test(size, useBuffer, cb) {
-  var cmd = process.argv[0] +
+  var cmd = '"' + process.argv[0] + '"' +
             ' ' +
-            (useBuffer ? scriptBuffer : scriptString) +
+            '"' + (useBuffer ? scriptBuffer : scriptString) + '"' +
             ' ' +
             size +
             ' > ' +
-            tmpFile;
+            '"' + tmpFile + '"';
 
   try {
     fs.unlinkSync(tmpFile);


### PR DESCRIPTION
There are quite a few tests that fail when the Node source folder is located at a path that contains spaces. This fixes the errors by modifying the tests to use quoted forms of all necessary paths. This is a bit of a hack, and I will be looking into a better way to incorporate this into the actual node source code. Perhaps a Path.escape() function?
