### PR TITLE
[TEST + PATCH] bug in http request's end method

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -565,6 +565,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
             typeof(data) === 'string' &&
             data.length > 0 &&
             this.output.length === 0 &&
+            this.connection &&
             this.connection.writable &&
             this.connection._httpMessage === this;
 

--- a/test/simple/test-http-request-end.js
+++ b/test/simple/test-http-request-end.js
@@ -1,0 +1,34 @@
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var expected = 'Post Body For Test';
+var result = '';
+
+var server = http.Server(function(req, res) {
+  req.on('data', function(chunk) {
+    result += chunk;
+  });
+  req.on('end', function() {
+    server.close();
+  });
+  res.writeHead(200);
+  res.end("hello world\n");
+});
+
+server.listen(common.PORT, function() {
+  http.request({
+    port: common.PORT,
+    path: '/',
+    method: 'POST'
+  }, function(res) {
+    console.log(res.statusCode);
+  }).on('error', function(e) {
+    console.log(e.message);
+    process.exit(1);
+  }).end(expected);
+});
+
+process.on('exit', function() {
+  assert.equal(expected, result);
+});


### PR DESCRIPTION
Hi,
I found a bug in http request's end method.
This bug will occur when you call request.end and pass data to it without calling request.write.
