### PR TITLE
Directory load ordering

### DIFF
--- a/test/simple/test-module-loading.js
+++ b/test/simple/test-module-loading.js
@@ -112,13 +112,6 @@ try {
   assert.equal(err.message, 'Cannot find module \'../fixtures/empty\'');
 }
 
-// Should not attempt to load a file
-try {
-  require('../fixtures/a/');
-} catch (err) {
-  assert.equal(err.message, 'Cannot find module \'../fixtures/a/\'');
-}
-
 // Check load order is as expected
 common.debug('load order');
 

--- a/test/simple/test-module-loading.js
+++ b/test/simple/test-module-loading.js
@@ -112,6 +112,13 @@ try {
   assert.equal(err.message, 'Cannot find module \'../fixtures/empty\'');
 }
 
+// Should not attempt to load a file
+try {
+  require('../fixtures/a/');
+} catch (err) {
+  assert.equal(err.message, 'Cannot find module \'../fixtures/a/\'');
+}
+
 // Check load order is as expected
 common.debug('load order');
 
@@ -123,6 +130,7 @@ require.extensions['.reg2'] = require.extensions['.js'];
 
 assert.equal(require(loadOrder + 'file1').file1, 'file1', msg);
 assert.equal(require(loadOrder + 'file2').file2, 'file2.js', msg);
+assert.equal(require(loadOrder + 'file2/').file2, 'file2/index.js', msg);
 try {
   require(loadOrder + 'file3');
 } catch (e) {


### PR DESCRIPTION
Currently if there is a foo.js and foo/index.js and you require('foo/') then the foo.js file is loaded. It should be that the foo/index.js is loaded. I've added a failing test. Not sure how to fix this yet, very new to node. Starting the pull request now in case it's a 5 second fix for you.
