### PR TITLE
Docs: place table of contents in right-margin pane

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -168,7 +168,8 @@ code.pre {
 
 #container {
   position: relative;
-  padding: 6em;
+  margin-left: 4em;
+  width: 65%;
   max-width: 50em;
   text-align: left;
 }
@@ -194,7 +195,8 @@ hr {
   position:fixed;
   top: 0;
   right: 0;
-  width: 20em;
+  width: 25%;
+  max-width: 24em;
   height: 95%;
   margin: 1em;
   border: 1px solid #d8d8d8;

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -191,7 +191,17 @@ hr {
 }
 
 #toc {
-  
+  position:fixed;
+  top: 0;
+  right: 0;
+  width: 20em;
+  height: 95%;
+  margin: 1em;
+  border: 1px solid #d8d8d8;
+  padding-left: 0.5em;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  white-space: nowrap;
 }
 
   #toc h2 {

--- a/tools/doctool/doctool.js
+++ b/tools/doctool/doctool.js
@@ -51,7 +51,7 @@ function generateToc(data) {
     }
 
     toc.push("<li>");
-    toc.push('<a href="#'+formatIdString(text)+'">'+text+'</a>');
+    toc.push('<a href="#'+formatIdString(text)+'" title="'+text.replace(/"/g, "''")+'">'+text+'</a>');
 
     last_level = level;
   });
@@ -61,7 +61,6 @@ function generateToc(data) {
     toc.push("</ul>");
   }
 
-  toc.push("<hr />")
   toc.push("</div>");
 
   return toc.join("");

--- a/tools/doctool/doctool.js
+++ b/tools/doctool/doctool.js
@@ -51,7 +51,7 @@ function generateToc(data) {
     }
 
     toc.push("<li>");
-    toc.push('<a href="#'+formatIdString(text)+'" title="'+text.replace(/"/g, "''")+'">'+text+'</a>');
+    toc.push('<a href="#'+formatIdString(text)+'" title="'+text.replace(/"/g, '&quot;')+'">'+text+'</a>');
 
     last_level = level;
   });


### PR DESCRIPTION
For folks who prefer the all.html doc page, lack of an accessible TOC & API-reference is a real pain.

I submitted this to Micheil's docs fork, but he rejected it: "For now, design is the lowest priority... As long as the documentation is readable, then we've passed the design goal there for now. If it's a bit of a hassle to scroll to the top of the page to find another method, so be it..."

Design has a huge and measurable impact on usability, and therefore the quality of the docs. so I hope you'll take this. Preview at http://networkimprov.github.com/node-doc-api/all.html
