### PR TITLE
Better test for timers ordering (setTimeout()s, really)

### DIFF
--- a/test/simple/test-next-tick-ordering.js
+++ b/test/simple/test-next-tick-ordering.js
@@ -2,7 +2,7 @@ var common = require('../common');
 var assert = require('assert');
 var i;
 
-var N = 30;
+var N = 333;
 var done = [];
 
 function get_printer(timeout) {


### PR DESCRIPTION
test-next-tick-ordering.js needs to loop longer to detect ordering faults. Changed N from 30 to 333. This test fails in Mac OSX.

Thanks,
Jorge.
