### PR TITLE
assert.deepEqual support for RegExp objects

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -146,12 +146,17 @@ function _deepEqual(actual, expected) {
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 
-  // 7.3. Other pairs that do not both pass typeof value == 'object',
+  // 7.3 If the expected value is a RegExp object, the actual value is
+  // equivalent if it is also a RegExp object with the same source.
+  } else if (actual instanceof RegExp && expected instanceof RegExp) {
+    return actual.source === expected.source;
+  
+  // 7.4. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {
     return actual == expected;
 
-  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // 7.5 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified
   // with Object.prototype.hasOwnProperty.call), the same set of keys
   // (although not necessarily the same order), equivalent values for every

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -55,13 +55,18 @@ assert.throws(makeBlock(a.deepEqual, new Date(), new Date(2000, 3, 14)),
               'deepEqual date');
 
 // 7.3
+assert.doesNotThrow(makeBlock(a.deepEqual, /a/, /a/));
+assert.throws(makeBlock(a.deepEqual, /ab/, /a/));
+
+
+// 7.4
 assert.doesNotThrow(makeBlock(a.deepEqual, 4, '4'), 'deepEqual == check');
 assert.doesNotThrow(makeBlock(a.deepEqual, true, 1), 'deepEqual == check');
 assert.throws(makeBlock(a.deepEqual, 4, '5'),
               a.AssertionError,
               'deepEqual == check');
 
-// 7.4
+// 7.5
 // having the same number of owned properties && the same set of keys
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4}, {a: 4}));
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '2'}, {a: 4, b: '2'}));


### PR DESCRIPTION
assert.deepEqual(/a/, /a/) or deep-comparing an object containing a RegExp object was failing.
Added support for it on lib/assert.js and a 2 tests on test/simple/test-assert.js.
Also I had to shift the 7.x numberings on the comments to accomodate this new case.
