### PR TITLE
selective addition to require.paths for $HOME/.node_(libraries|modules)

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -328,8 +328,17 @@ Module._initPaths = function() {
   var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];
 
   if (process.env['HOME']) {
-    paths.unshift(path.resolve(process.env['HOME'], '.node_libraries'));
-    paths.unshift(path.resolve(process.env['HOME'], '.node_modules'));
+    var dirpath;
+    try {
+        dirpath = path.resolve(process.env['HOME'], '.node_libraries');
+        fs.statSync(dirpath);
+        paths.unshift(dirpath);
+    } catch (e) {}
+    try {
+        dirpath = path.resolve(process.env['HOME'], '.node_modules');
+        fs.statSync(dirpath);
+        paths.unshift(dirpath);
+    } catch (e) {}
   }
 
   if (process.env['NODE_PATH']) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -329,6 +329,7 @@ Module._initPaths = function() {
 
   if (process.env['HOME']) {
     var dirpath;
+    var fs = NativeModule.require('fs');
     try {
         dirpath = path.resolve(process.env['HOME'], '.node_libraries');
         fs.statSync(dirpath);


### PR DESCRIPTION
This change makes it so node will not add the $HOME directory module folders to require.paths if they do not exists.

Should help improve startup time as require will not be stating 2 'known to be dead' paths to require a module.
