### PR TITLE
Added binding of HTTP and general TCP client sockets to local interfaces

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -960,9 +960,10 @@ exports._connectionListener = connectionListener;
 
 
 
-function Agent(host, port) {
+function Agent(host, port, local) {
   this.host = host;
   this.port = port;
+  this.local = local;
 
   this.queue = [];
   this.sockets = [];
@@ -1006,7 +1007,7 @@ Agent.prototype._establishNewConnection = function() {
 
   // Grab a new "socket". Depending on the implementation of _getConnection
   // this could either be a raw TCP socket or a TLS stream.
-  var socket = this._getConnection(this.host, this.port, function() {
+  var socket = this._getConnection(this.host, this.port, this.local, function() {
     socket._httpConnecting = false;
     self.emit('connect'); // mostly for the shim.
     debug('Agent _getConnection callback');
@@ -1161,9 +1162,9 @@ Agent.prototype._establishNewConnection = function() {
 
 // Sub-classes can overwrite this method with e.g. something that supplies
 // TLS streams.
-Agent.prototype._getConnection = function(host, port, cb) {
+Agent.prototype._getConnection = function(host, port, local, cb) {
   debug('Agent connected!');
-  var c = net.createConnection(port, host);
+  var c = net.createConnection(port, host, local);
   c.on('connect', cb);
   return c;
 };
@@ -1223,12 +1224,12 @@ Agent.prototype._cycle = function() {
 var agents = {};
 
 
-function getAgent(host, port) {
-  var id = host + ':' + port;
+function getAgent(host, port, local) {
+  var id = host + ':' + port + '@' + local;
   var agent = agents[id];
 
   if (!agent) {
-    agent = agents[id] = new Agent(host, port);
+    agent = agents[id] = new Agent(host, port, local);
   }
 
   return agent;
@@ -1246,9 +1247,9 @@ exports._requestFromAgent = function(options, cb) {
 
 exports.request = function(options, cb) {
   if (options.agent === undefined) {
-    options.agent = getAgent(options.host, options.port);
+    options.agent = getAgent(options.host, options.port, options.local);
   } else if (options.agent === false) {
-    options.agent = new Agent(options.host, options.port);
+    options.agent = new Agent(options.host, options.port, options.local);
   }
   return exports._requestFromAgent(options, cb);
 };
@@ -1358,10 +1359,11 @@ util.inherits(Client, net.Stream);
 exports.Client = Client;
 
 
-exports.createClient = function(port, host) {
+exports.createClient = function(port, host, local) {
   var c = new Client();
   c.port = port;
   c.host = host;
+  c.local = local;
   return c;
 };
 
@@ -1445,7 +1447,7 @@ Client.prototype._cycle = function() {
 Client.prototype._ensureConnection = function() {
   if (this._state == 'disconnected') {
     debug('CLIENT reconnecting state = ' + this._state);
-    this.connect(this.port, this.host);
+    this.connect(this.port, this.host, this.local);
     this._state = 'connecting';
   }
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -239,9 +239,9 @@ Socket.prototype.open = function(fd, type) {
 };
 
 
-exports.createConnection = function(port, host) {
+exports.createConnection = function(port, host, local) {
   var s = new Socket();
-  s.connect(port, host);
+  s.connect(port, host, local);
   return s;
 };
 
@@ -656,7 +656,9 @@ Socket.prototype._onReadable = function() {
 // var socket = new Socket();
 // socket.connect(80)               - TCP connect to port 80 on the localhost
 // socket.connect(80, 'nodejs.org') - TCP connect to port 80 on nodejs.org
+// socket.connect(80, 'nodejs.org', '198.51.100.23') - TCP connect to port 80 on nodejs.org using local interface 198.51.100.23
 // socket.connect('/tmp/socket')    - UNIX connect to socket specified by path
+
 Socket.prototype.connect = function() {
   var self = this;
   initSocket(self);
@@ -673,7 +675,9 @@ Socket.prototype.connect = function() {
     self.addListener('connect', lastArg);
   }
 
-  var port = toPort(arguments[0]);
+  var port = toPort(arguments[0]),
+	  local = arguments[2];
+
   if (port === false) {
     // UNIX
     self.fd = socket('unix');
@@ -683,13 +687,16 @@ Socket.prototype.connect = function() {
     doConnect(self, arguments[0]);
   } else {
     // TCP
-    require('dns').lookup(arguments[1], function(err, ip, addressType) {
+    dns = require('dns').lookup(arguments[1], function(err, ip, addressType) {
       if (err) {
         self.emit('error', err);
       } else {
         timers.active(self);
         self.type = addressType == 4 ? 'tcp4' : 'tcp6';
         self.fd = socket(self.type);
+	    if ( local ) {
+		    bind(self.fd, 0, local);
+	    }
         doConnect(self, port, ip);
       }
     });


### PR DESCRIPTION
Added an option to bind an HTTP / TCP client to a specified local interface. Also see the "Patch for http.Client" multi interface" thread on the node Mailinglist.
