### PR TITLE
Add UCS-2 encoding support (aka the UTF-16 subset supported by JavaScript)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -41,6 +41,10 @@ SlowBuffer.prototype.toString = function(encoding, start, end) {
     case 'base64':
       return this.base64Slice(start, end);
 
+    case 'ucs2':
+    case 'ucs-2':
+      return this.ucs2Slice(start, end);
+
     default:
       throw new Error('Unknown encoding');
   }
@@ -72,6 +76,10 @@ SlowBuffer.prototype.write = function(string, offset, encoding) {
 
     case 'base64':
       return this.base64Write(string, offset);
+
+    case 'ucs2':
+    case 'ucs-2':
+      return this.ucs2Write(start, end);
 
     default:
       throw new Error('Unknown encoding');
@@ -228,6 +236,11 @@ Buffer.prototype.write = function(string, offset, encoding) {
       ret = this.parent.base64Write(string, this.offset + offset, maxLength);
       break;
 
+    case 'ucs2':
+    case 'ucs-2':
+      ret = this.parent.ucs2Write(string, this.offset + offset, maxLength);
+      break;
+
     default:
       throw new Error('Unknown encoding');
   }
@@ -270,6 +283,10 @@ Buffer.prototype.toString = function(encoding, start, end) {
 
     case 'base64':
       return this.parent.base64Slice(start, end);
+
+    case 'ucs2':
+    case 'ucs-2':
+      return this.parent.ucs2Slice(start, end);
 
     default:
       throw new Error('Unknown encoding');

--- a/src/node.cc
+++ b/src/node.cc
@@ -1078,6 +1078,10 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
     return ASCII;
   } else if (strcasecmp(*encoding, "base64") == 0) {
     return BASE64;
+  } else if (strcasecmp(*encoding, "ucs2") == 0) {
+    return UCS2;
+  } else if (strcasecmp(*encoding, "ucs-2") == 0) {
+    return UCS2;
   } else if (strcasecmp(*encoding, "binary") == 0) {
     return BINARY;
   } else if (strcasecmp(*encoding, "raw") == 0) {
@@ -1129,6 +1133,7 @@ ssize_t DecodeBytes(v8::Handle<v8::Value> val, enum encoding encoding) {
   Local<String> str = val->ToString();
 
   if (encoding == UTF8) return str->Utf8Length();
+  else if (encoding == UCS2) return str->Length() * 2;
 
   return str->Length();
 }

--- a/src/node.h
+++ b/src/node.h
@@ -44,7 +44,7 @@ do {                                                                      \
                                   __callback##_TEM);                      \
 } while (0)
 
-enum encoding {ASCII, UTF8, BASE64, BINARY};
+enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY};
 enum encoding ParseEncoding(v8::Handle<v8::Value> encoding_v,
                             enum encoding _default = BINARY);
 void FatalException(v8::TryCatch &try_catch);

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -88,10 +88,12 @@ class Buffer : public ObjectWrap {
   static v8::Handle<v8::Value> AsciiSlice(const v8::Arguments &args);
   static v8::Handle<v8::Value> Base64Slice(const v8::Arguments &args);
   static v8::Handle<v8::Value> Utf8Slice(const v8::Arguments &args);
+  static v8::Handle<v8::Value> Ucs2Slice(const v8::Arguments &args);
   static v8::Handle<v8::Value> BinaryWrite(const v8::Arguments &args);
   static v8::Handle<v8::Value> Base64Write(const v8::Arguments &args);
   static v8::Handle<v8::Value> AsciiWrite(const v8::Arguments &args);
   static v8::Handle<v8::Value> Utf8Write(const v8::Arguments &args);
+  static v8::Handle<v8::Value> Ucs2Write(const v8::Arguments &args);
   static v8::Handle<v8::Value> ByteLength(const v8::Arguments &args);
   static v8::Handle<v8::Value> MakeFastBuffer(const v8::Arguments &args);
   static v8::Handle<v8::Value> Copy(const v8::Arguments &args);

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -225,6 +225,14 @@ var f = new Buffer('über', 'ascii');
 console.error('f.length: %d     (should be 4)', f.length);
 assert.deepEqual(f, new Buffer([252, 98, 101, 114]));
 
+var f = new Buffer('über', 'ucs2');
+console.error('f.length: %d     (should be 8)', f.length);
+assert.deepEqual(f, new Buffer([252, 0, 98, 0, 101, 0, 114, 0]));
+
+var f = new Buffer('привет', 'ucs2');
+console.error('f.length: %d     (should be 12)', f.length);
+assert.deepEqual(f, new Buffer([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
+assert.equal(f.toString('ucs2'), 'привет');
 
 //
 // Test toString('base64')
@@ -386,9 +394,9 @@ assert.equal('bcde', b.slice(1).toString());
 // byte length
 assert.equal(14, Buffer.byteLength('Il était tué'));
 assert.equal(14, Buffer.byteLength('Il était tué', 'utf8'));
+assert.equal(24, Buffer.byteLength('Il était tué', 'ucs2'));
 assert.equal(12, Buffer.byteLength('Il était tué', 'ascii'));
 assert.equal(12, Buffer.byteLength('Il était tué', 'binary'));
-
 
 // slice(0,0).length === 0
 assert.equal(0, Buffer('hello').slice(0, 0).length);


### PR DESCRIPTION
It looks like v8 only supports little endian encoding (ä will be encoded as fc 00, not as 00 fc).
