### PR TITLE
bug in Agent code in http.js when a request error occurs, e.g. DNS failure

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1042,6 +1042,13 @@ Agent.prototype._establishNewConnection = function() {
 
     req.emit('error', err);
     req._hadError = true; // hacky
+
+    // clean up so that agent can handle new requests
+    parser.finish();
+    socket.destroy();
+    self._removeSocket(socket);
+    parsers.free(parser);
+    self._cycle();
   });
 
   socket.ondata = function(d, start, end) {

--- a/test/simple/test-http-dns-fail.js
+++ b/test/simple/test-http-dns-fail.js
@@ -1,0 +1,43 @@
+/* 
+ * Repeated requests for a domain that fails to resolve
+ * should trigger the error event after each attempt.
+ */
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+
+var res_despite_error = false
+var had_error = 0
+
+function httpreq(count) {
+  if( 1 < count ) {
+    return
+  }
+
+  var req = http.request({
+    host:'not-a-real-domain-name-at-all-at-all.nobody-would-register-this-as-a-tld-would-they-now',
+    port:80,
+    path:'/',
+    method:'GET'
+  }, function(res){
+    res_despite_error = true
+  })
+
+  req.on('error', function(e){
+    console.log(e.message);
+    had_error++
+    httpreq(count+1)
+  })
+
+  req.end()
+}
+
+httpreq(0)
+
+
+process.on('exit', function() {
+  assert.equal(false, res_despite_error);
+  assert.equal(2, had_error);
+});


### PR DESCRIPTION
This issue occurs when you try to make a http.request for a domain name that fails to resolve. An Agent with that domain name and port is created and cached, but gets stuck in a bad state and can no longer make requests.

The pull request includes a separate test case and suggested fix.
