### PR TITLE
fs.writeFile behaviour not consistent with fs.write functions.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -439,7 +439,7 @@ fs.writeFile = function(path, data, encoding_, callback) {
     if (openErr) {
       if (callback) callback(openErr);
     } else {
-      var buffer = Buffer.isBuffer(data) ? data : new Buffer(data, encoding);
+      var buffer = Buffer.isBuffer(data) ? data : new Buffer('' + data, encoding);
       writeAll(fd, buffer, 0, buffer.length, callback);
     }
   });
@@ -448,7 +448,7 @@ fs.writeFile = function(path, data, encoding_, callback) {
 fs.writeFileSync = function(path, data, encoding) {
   var fd = fs.openSync(path, 'w');
   if (!Buffer.isBuffer(data)) {
-    data = new Buffer(data, encoding || 'utf8');
+    data = new Buffer('' + data, encoding || 'utf8');
   }
   var written = 0;
   var length = data.length;

--- a/test/simple/test-fs-write-file.js
+++ b/test/simple/test-fs-write-file.js
@@ -7,6 +7,7 @@ var filename = join(common.fixturesDir, 'test.txt');
 
 common.error('writing to ' + filename);
 
+var n = 220;
 var s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
         '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +
         '南越国是秦朝灭亡后，由南海郡尉赵佗于前203年起兵兼并桂林郡和象郡后建立。' +
@@ -50,11 +51,30 @@ fs.writeFile(filename2, buf, function(e) {
   });
 });
 
+// test that writeFile accepts numbers.
+var filename3 = join(common.fixturesDir, 'test3.txt');
+common.error('writing to ' + filename3);
+
+fs.writeFile(filename3, n, function(e) {
+  if (e) throw e;
+
+  ncallbacks++;
+  common.error('file3 written');
+
+  fs.readFile(filename3, function(e, buffer) {
+    if (e) throw e;
+    common.error('file3 read');
+    ncallbacks++;
+    assert.equal(Buffer.byteLength('' + n), buffer.length);
+  });
+});
+
 
 process.addListener('exit', function() {
   common.error('done');
-  assert.equal(4, ncallbacks);
+  assert.equal(6, ncallbacks);
 
   fs.unlinkSync(filename);
   fs.unlinkSync(filename2);
+  fs.unlinkSync(filename3);
 });


### PR DESCRIPTION
the write and writeSync methods both convert nonbuffer data to be written to a string when called, while writeFile and writeFileSync do not (the data is instead passed directly to the buffer constructor.) It seems inconsistent that

```
fs.write(f, 1234, ...);
```

should produce different results than

```
fs.writeFile("out", 1234, ...);
```

seeing as how the created buffer from inside the function is never accessible to the caller.
