### PR TITLE
AssertionError#toString no longer fails ugly when expected or actual object has a cycle

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -51,14 +51,22 @@ assert.AssertionError = function AssertionError(options) {
 };
 util.inherits(assert.AssertionError, Error);
 
+function attemptToJSONStringify(label, objectToStringify) {
+  try {
+    return JSON.stringify(objectToStringify);
+  } catch (jsonError) {
+    return '<Error when attempting JSON.stringify of ' + label + ': "' + jsonError.toString() + '">';
+  }
+}
+
 assert.AssertionError.prototype.toString = function() {
   if (this.message) {
     return [this.name + ':', this.message].join(' ');
   } else {
     return [this.name + ':',
-            JSON.stringify(this.expected),
+            attemptToJSONStringify('expected', this.expected),
             this.operator,
-            JSON.stringify(this.actual)].join(' ');
+            attemptToJSONStringify('actual', this.actual)].join(' ');
   }
 };
 

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -48,19 +48,27 @@ assert.doesNotThrow(makeBlock(a.notStrictEqual, 2, '2'), 'notStrictEqual');
 
 //failure message (AssertionError#toString)
 function failAndReturnToString(actual, expected) {
-  var explode = false
+  var explode = false;
   try{
-    assert.equal(actual, expected)
-    explode = true
+    assert.equal(actual, expected);
+    explode = true;
   } catch(assertionError) {
-    return assertionError.toString()
+    return assertionError.toString();
   }  
-  if (explode) assert.fail("shouldn't have passed, something's wrong")
+  if (explode) assert.fail("shouldn't have passed, something's wrong");
 }
 
-assert.equal('AssertionError: 999 == 1', failAndReturnToString(1, 999))
-assert.equal('AssertionError: 999 == "\x"', failAndReturnToString('x', 999))
-assert.deepEqual('AssertionError: {\"x\":1} == {\"x\":2}', failAndReturnToString({x:2}, {x:1}))
+assert.equal('AssertionError: 999 == 1', failAndReturnToString(1, 999));
+assert.equal('AssertionError: 999 == "\x"', failAndReturnToString('x', 999));
+assert.deepEqual('AssertionError: {\"x\":1} == {\"x\":2}', failAndReturnToString({x:2}, {x:1}));
+
+//failure message for object with a cycle
+var cycle = {};
+cycle.x = cycle;
+assert.deepEqual('AssertionError: {\"x\":1} == <Error when attempting JSON.stringify of actual: "TypeError: Converting circular structure to JSON">', 
+                 failAndReturnToString(cycle, {x:1}));
+assert.deepEqual('AssertionError: <Error when attempting JSON.stringify of expected: "TypeError: Converting circular structure to JSON"> == {\"x\":2}', 
+                 failAndReturnToString({x:2}, cycle));
 
 
 // deepEquals joy!

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -45,6 +45,24 @@ assert.throws(makeBlock(a.strictEqual, null, undefined),
 
 assert.doesNotThrow(makeBlock(a.notStrictEqual, 2, '2'), 'notStrictEqual');
 
+
+//failure message (AssertionError#toString)
+function failAndReturnToString(actual, expected) {
+  var explode = false
+  try{
+    assert.equal(actual, expected)
+    explode = true
+  } catch(assertionError) {
+    return assertionError.toString()
+  }  
+  if (explode) assert.fail("shouldn't have passed, something's wrong")
+}
+
+assert.equal('AssertionError: 999 == 1', failAndReturnToString(1, 999))
+assert.equal('AssertionError: 999 == "\x"', failAndReturnToString('x', 999))
+assert.deepEqual('AssertionError: {\"x\":1} == {\"x\":2}', failAndReturnToString({x:2}, {x:1}))
+
+
 // deepEquals joy!
 // 7.2
 assert.doesNotThrow(makeBlock(a.deepEqual, new Date(2000, 3, 14),


### PR DESCRIPTION
The tests should neatly show what the problem was.

I tried to follow the style of the surrounding code as much as possible, I'll of course revise if I've missed anything.

-Steve
