### PR TITLE
Bugs/null signal

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -194,13 +194,17 @@
     };
 
     process.kill = function(pid, sig) {
-      sig = sig || 'SIGTERM';
-
-      if (!startup.lazyConstants()[sig]) {
-        throw new Error('Unknown signal: ' + sig);
+      // preserve null signal
+      if (0 === sig) {
+        process._kill(pid, 0);
+      } else {
+        sig = sig || 'SIGTERM';
+        if (startup.lazyConstants()[sig]) {
+          process._kill(pid, startup.lazyConstants()[sig]);
+        } else {
+          throw new Error('Unknown signal: ' + sig);
+        }
       }
-
-      process._kill(pid, startup.lazyConstants()[sig]);
     };
   };
 

--- a/test/simple/test-process-kill-null.js
+++ b/test/simple/test-process-kill-null.js
@@ -1,21 +1,20 @@
 
-var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
 var cat = spawn('cat');
+var called;
 
-try {
-  process.kill(cat.pid, 0);
-} catch (err) {
-  assert.fail('null signal failed');
-}
+process.kill(cat.pid, 0);
 
-process.kill(cat.pid, 'SIGTERM');
+cat.stdout.on('data', function(){
+  called = true;
+  process.kill(cat.pid, 'SIGKILL');
+});
 
-try {
-  process.kill(cat.pid, 0);
-  assert.fail('null signal failed');
-} catch (err) {
-  assert.ok(err);
-}
+// EPIPE when null sig fails
+cat.stdin.write('test');
+
+process.on('exit', function(){
+  assert.ok(called);
+});

--- a/test/simple/test-process-kill-null.js
+++ b/test/simple/test-process-kill-null.js
@@ -1,0 +1,21 @@
+
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+var cat = spawn('cat');
+
+try {
+  process.kill(cat.pid, 0);
+} catch (err) {
+  assert.fail('null signal failed');
+}
+
+process.kill(cat.pid, 'SIGTERM');
+
+try {
+  process.kill(cat.pid, 0);
+  assert.fail('null signal failed');
+} catch (err) {
+  assert.ok(err);
+}


### PR DESCRIPTION
as far as I know the null signal does not have a constant, but the `sig || 'SIGTERM'` was clobbering it. This is untested since we have the strnlen() issue right now for OSX breaking the build, but I can add some tests if needed
