### PR TITLE
Fix GH-160: http server response should get "end" if client closes the connection prematurely

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -316,6 +316,11 @@ OutgoingMessage.prototype.assignSocket = function(socket) {
   this.socket = socket;
   this.connection = socket;
   this._flush();
+
+  var self = this;
+  socket.on('end', function() {
+    self.emit('end');
+  });
 };
 
 

--- a/test/simple/test-http-response-end.js
+++ b/test/simple/test-http-response-end.js
@@ -1,0 +1,30 @@
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var gotEnd = false;
+
+var server = http.createServer(function(req, res) {
+  res.writeHead(200);
+  res.write('a');
+
+  res.on('end', function() {
+    gotEnd = true;
+  });
+});
+server.listen(common.PORT);
+
+server.addListener('listening', function() {
+  http.get({
+    port: common.PORT
+  }, function(res) {
+    res.on('data', function(data) {
+      res.destroy();
+      server.close();
+    });
+  });
+});
+
+process.on('exit', function() {
+  assert.ok(gotEnd);
+});


### PR DESCRIPTION
Hi Ryan,

this patch adds a test and fix for #160. The solution is rather simple, but I'm not sure if the semantics are right (should the response `'end'` event be identical to that of the socket?).

So if you want a different solution, please let me know. The patch should be good so.

--fg
