### PR TITLE
Document existence of `fd` property for ReadStream

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -355,6 +355,7 @@ Returns a new ReadStream object (See `Readable Stream`).
 
     { flags: 'r',
       encoding: null,
+      fd: null,
       mode: 0666,
       bufferSize: 4096 }
 


### PR DESCRIPTION
Fixes #194
