### PR TITLE
Fix dynamic library build

### DIFF
--- a/deps/libeio/wscript
+++ b/deps/libeio/wscript
@@ -125,5 +125,7 @@ def build(bld):
   libeio.install_path = None
   if bld.env["USE_DEBUG"]:
     libeio.clone("debug");
+  if Options.options.product_type != 'program':
+    libeio.ccflags = "-fPIC"
   bld.install_files('${PREFIX}/include/node/', 'eio.h');
 

--- a/wscript
+++ b/wscript
@@ -619,6 +619,8 @@ def build(bld):
   http_parser.install_path = None
   if bld.env["USE_DEBUG"]:
     http_parser.clone("debug")
+  if product_type_is_lib:
+    http_parser.ccflags = '-fPIC'
 
   ### src/native.cc
   def make_macros(loc, content):


### PR DESCRIPTION
libeio and http_parser need to build PIC code to build as a shared library. This fixes that.
