### PR TITLE
Spawn reads env from prototype

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -215,8 +215,7 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
 
   var envPairs = [];
   var keys = Object.keys(env);
-  for (var index = 0, keysLength = keys.length; index < keysLength; index++) {
-    var key = keys[index];
+  for (var key in env) {
     envPairs.push(key + '=' + env[key]);
   }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -214,7 +214,6 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
   }
 
   var envPairs = [];
-  var keys = Object.keys(env);
   for (var key in env) {
     envPairs.push(key + '=' + env[key]);
   }

--- a/test/simple/test-child-process-env.js
+++ b/test/simple/test-child-process-env.js
@@ -2,7 +2,15 @@ var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;
-var child = spawn('/usr/bin/env', [], {env: {'HELLO': 'WORLD'}});
+
+var env = {
+  'HELLO': 'WORLD'
+};
+env.__proto__ = {
+  'FOO': 'BAR'
+}
+
+var child = spawn('/usr/bin/env', [], {env: env});
 
 var response = '';
 
@@ -15,4 +23,5 @@ child.stdout.addListener('data', function(chunk) {
 
 process.addListener('exit', function() {
   assert.ok(response.indexOf('HELLO=WORLD') >= 0);
+  assert.ok(response.indexOf('FOO=BAR') >= 0);
 });


### PR DESCRIPTION
When using a custom `env` object with `ChildProcess#spawn()`, this patch allows for additional env properties up the prototype of the env object to be included in the child process' environment as well.

See here: http://groups.google.com/group/nodejs-dev/browse_thread/thread/b3272eda3f08d38d
