### PR TITLE
Debugger sometimes executes callbacks with wrong sequence number

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -171,8 +171,10 @@ Client.prototype._removeScript = function(desc) {
 
 Client.prototype._onResponse = function(res) {
   for (var i = 0; i < this._reqCallbacks.length; i++) {
-    var cb = this._reqCallbacks[i];
-    if (this._reqCallbacks[i].request_seq == res.body.request_seq) break;
+    if (this._reqCallbacks[i].request_seq == res.body.request_seq) {
+      var cb = this._reqCallbacks[i];
+      break;
+    }
   }
 
   var self = this;


### PR DESCRIPTION
When the V8 debugger client's `_onResponse` function does not find a request callback with a matching sequence number, it just uses the last registered request callback.
