### PR TITLE
Allow passing optional arguments to process.nextTick. 

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -296,11 +296,11 @@ This will generate:
 `heapTotal` and `heapUsed` refer to V8's memory usage.
 
 
-### process.nextTick(callback)
+### process.nextTick(callback, [args], [...])
 
-On the next loop around the event loop call this callback.
-This is *not* a simple alias to `setTimeout(fn, 0)`, it's much more
-efficient.
+On the next loop around the event loop call this callback. Optionally, you
+can also pass arguments to the callback. This is *not* a simple alias to 
+`setTimeout(fn, 0)`, it's much more efficient.
 
     process.nextTick(function () {
       console.log('nextTick callback');

--- a/src/node.js
+++ b/src/node.js
@@ -119,8 +119,17 @@
       nextTickQueue.splice(0, l);
     };
 
+    var pSlice = Array.prototype.slice;
+
     process.nextTick = function(callback) {
-      nextTickQueue.push(callback);
+      if (arguments.length == 1) {
+        nextTickQueue.push(callback);
+      } else {
+        var args = pSlice.call(arguments, 1);
+        nextTickQueue.push(function() {
+          callback.apply(null, args);
+        });
+      }
       process._needTickCallback();
     };
   };

--- a/test/simple/test-next-tick-extra-args.js
+++ b/test/simple/test-next-tick-extra-args.js
@@ -1,0 +1,18 @@
+var common = require('../common');
+var assert = require('assert');
+
+var argumentsLength, firstArg, secondArg;
+
+function callback() {
+  argumentsLength = arguments.length;
+  firstArg = arguments[0];
+  secondArg = arguments[1];
+}
+
+process.nextTick(callback, 123, 456);
+
+process.addListener('exit', function() {
+  assert.equal(2, argumentsLength);
+  assert.equal(123, firstArg);
+  assert.equal(456, secondArg);
+});


### PR DESCRIPTION
This patch allows for extra, optional arguments to  `process.nextTick` to be simply passed to the callback when it is invoked. This is modeled after setTimeout's API:

```
// Allows turning:

process.nextTick(function() {
  callback(null, someValue);
});

// into:

process.nextTick(callback, null, someValue);
```

Comes with tests and doc.
