### PR TITLE
Disallow repeated event handlers

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -103,10 +103,14 @@ EventEmitter.prototype.addListener = function(type, listener) {
     }
 
     // If we've already got an array, just append.
-    this._events[type].push(listener);
+    if (this._events[type].indexOf(listener) < 0) {
+      this._events[type].push(listener);
+    }
   } else {
     // Adding the second element, need to change to array.
-    this._events[type] = [this._events[type], listener];
+    if (this._events[type] !== listener) {
+      this._events[type] = [this._events[type], listener];
+    }
   }
 
   return this;


### PR DESCRIPTION
As in the DOM, the same handler function should not be allowed to be installed more than once for the same event in the same eventemitter.
