### PR TITLE
Fixme wrt. socket cascade in node_net.cc

### DIFF
--- a/src/node_net.cc
+++ b/src/node_net.cc
@@ -190,7 +190,7 @@ static Handle<Value> Socket(const Arguments& args) {
 
   if (args[0]->IsString()) {
     String::Utf8Value t(args[0]->ToString());
-    // FIXME optimize this cascade.
+    // TCP?
     if (0 == strncasecmp(*t, "TCP", 3)) {
       if (0 == strcasecmp(*t, "TCP")) {
         domain = PF_INET;
@@ -203,8 +203,9 @@ static Handle<Value> Socket(const Arguments& args) {
         type = SOCK_STREAM;
       } else {
         return ThrowException(Exception::Error(
-                  String::New("Unknown socket type.")));
+              String::New("Unknown socket type.")));
       }
+    // UNIX socket?
     } else if (0 == strncasecmp(*t, "UNIX", 4)) {
       if (0 == strcasecmp(*t, "UNIX")) {
         domain = PF_UNIX;
@@ -214,8 +215,9 @@ static Handle<Value> Socket(const Arguments& args) {
         type = SOCK_DGRAM;
       } else {
         return ThrowException(Exception::Error(
-                  String::New("Unknown socket type.")));
+              String::New("Unknown socket type.")));
       }
+    // UDP?
     } else if (0 == strncasecmp(*t, "UDP", 3)) {
       if (0 == strcasecmp(*t, "UDP")) {
         domain = PF_INET;
@@ -228,7 +230,7 @@ static Handle<Value> Socket(const Arguments& args) {
         type = SOCK_DGRAM;
       } else {
         return ThrowException(Exception::Error(
-                  String::New("Unknown socket type.")));
+              String::New("Unknown socket type.")));
       }
 #ifdef SO_REUSEPORT
       set_reuseport = true;

--- a/src/node_net.cc
+++ b/src/node_net.cc
@@ -191,36 +191,45 @@ static Handle<Value> Socket(const Arguments& args) {
   if (args[0]->IsString()) {
     String::Utf8Value t(args[0]->ToString());
     // FIXME optimize this cascade.
-    if (0 == strcasecmp(*t, "TCP")) {
-      domain = PF_INET;
-      type = SOCK_STREAM;
-    } else if (0 == strcasecmp(*t, "TCP4")) {
-      domain = PF_INET;
-      type = SOCK_STREAM;
-    } else if (0 == strcasecmp(*t, "TCP6")) {
-      domain = PF_INET6;
-      type = SOCK_STREAM;
-    } else if (0 == strcasecmp(*t, "UNIX")) {
-      domain = PF_UNIX;
-      type = SOCK_STREAM;
-    } else if (0 == strcasecmp(*t, "UNIX_DGRAM")) {
-      domain = PF_UNIX;
-      type = SOCK_DGRAM;
-    } else if (0 == strcasecmp(*t, "UDP")) {
-      domain = PF_INET;
-      type = SOCK_DGRAM;
-#ifdef SO_REUSEPORT
-      set_reuseport = true;
-#endif
-    } else if (0 == strcasecmp(*t, "UDP4")) {
-      domain = PF_INET;
-      type = SOCK_DGRAM;
-#ifdef SO_REUSEPORT
-      set_reuseport = true;
-#endif
-    } else if (0 == strcasecmp(*t, "UDP6")) {
-      domain = PF_INET6;
-      type = SOCK_DGRAM;
+    if (0 == strncasecmp(*t, "TCP", 3)) {
+      if (0 == strcasecmp(*t, "TCP")) {
+        domain = PF_INET;
+        type = SOCK_STREAM;
+      } else if (0 == strcasecmp(*t, "TCP4")) {
+        domain = PF_INET;
+        type = SOCK_STREAM;
+      } else if (0 == strcasecmp(*t, "TCP6")) {
+        domain = PF_INET6;
+        type = SOCK_STREAM;
+      } else {
+        return ThrowException(Exception::Error(
+                  String::New("Unknown socket type.")));
+      }
+    } else if (0 == strncasecmp(*t, "UNIX", 4)) {
+      if (0 == strcasecmp(*t, "UNIX")) {
+        domain = PF_UNIX;
+        type = SOCK_STREAM;
+      } else if (0 == strcasecmp(*t, "UNIX_DGRAM")) {
+        domain = PF_UNIX;
+        type = SOCK_DGRAM;
+      } else {
+        return ThrowException(Exception::Error(
+                  String::New("Unknown socket type.")));
+      }
+    } else if (0 == strncasecmp(*t, "UDP", 3)) {
+      if (0 == strcasecmp(*t, "UDP")) {
+        domain = PF_INET;
+        type = SOCK_DGRAM;
+      } else if (0 == strcasecmp(*t, "UDP4")) {
+        domain = PF_INET;
+        type = SOCK_DGRAM;
+      } else if (0 == strcasecmp(*t, "UDP6")) {
+        domain = PF_INET6;
+        type = SOCK_DGRAM;
+      } else {
+        return ThrowException(Exception::Error(
+                  String::New("Unknown socket type.")));
+      }
 #ifdef SO_REUSEPORT
       set_reuseport = true;
 #endif


### PR DESCRIPTION
Removed a small fixme in `node_net.cc`, I stumbled across when reading the code.

While I'm not 100% sure if the fixme intends to optimize for the number of string comparisons or the number of assigns. I've chosen to go after the first, as it is a prerequisite for the latter (and it can be done quite trivially now...)
