### PR TITLE
Buffer::Length(Buffer*) should not invoke itself recursively.

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -63,7 +63,7 @@ class Buffer : public ObjectWrap {
   }
 
   static inline size_t Length(Buffer *b) {
-    return Buffer::Length(b);
+    return Buffer::Length(b->handle_);
   }
 
 


### PR DESCRIPTION
Only it does. Go fix, Ryan!
