### PR TITLE
Calling EventEmitter.setMaxListeners() prior to an addListener() call results in an error

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -9,6 +9,7 @@ var isArray = Array.isArray;
 // that to be increased. Set to zero for unlimited.
 var defaultMaxListeners = 10;
 EventEmitter.prototype.setMaxListeners = function(n) {
+  if (!this._events) this._events = {};
   this._events.maxListeners = n;
 };
 


### PR DESCRIPTION
this._events is initialized by addListener(), so calls to setMaxListeners() are bound to fail if it is called prior to addListener().

This patch corrects that by checking if _events is set in setMaxListeners(), and -- if not -- initializes it.
