### PR TITLE
Removed mention of 2mb thread stack allocations

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -124,10 +124,6 @@ server.listen(8124, "127.0.0.1");
         <a href="http://www.kegel.com/c10k.html">this</a> and 
         <a href="http://bulk.fefe.de/scalable-networking.pdf">this.</a>
 
-        Node will show much better memory efficiency under high-loads
-        <!-- TODO benchmark -->
-        than systems which allocate 2mb thread stacks for each connection.
-
         Furthermore, users of Node are free from worries of dead-locking
         the process&mdash;there are no locks.  Almost no function in Node
         directly performs I/O, so the process never blocks. Because


### PR DESCRIPTION
index.html should not state that servers that allocate 2mb of stack space per thread are more memory inefficient than node. How much stack space that is allocated is irrelevant because of virtual memory. Actual memory usage will vary between servers and applications, and context switching can lead to unnecessary stack saves, but that has nothing to do with how much virtual memory is allocated.
