### PR TITLE
Mentioning key and cert in HTTPS request documentation.

### DIFF
--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -36,7 +36,9 @@ Example:
       host: 'encrypted.google.com',
       port: 443,
       path: '/',
-      method: 'GET'
+      method: 'GET',
+      key: fs.readFileSync('path/to/client.key'),
+      cert: fs.readFileSync('path/to/client.crt')
     };
 
     var req = https.request(options, function(res) {


### PR DESCRIPTION
It's not obvious that HTTPS request use the same options for cert and key as https servers. This patch adds a faux key and cert option to the `https.request` documentation.
