### PR TITLE
Fix missing namespace in NODE_PSYMBOL macro

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -19,7 +19,7 @@ namespace node {
 
 int Start (int argc, char *argv[]);
 
-#define NODE_PSYMBOL(s) Persistent<String>::New(String::NewSymbol(s))
+#define NODE_PSYMBOL(s) v8::Persistent<v8::String>::New(v8::String::NewSymbol(s))
 
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(1000*static_cast<double>(t))


### PR DESCRIPTION
Usage of NODE_PSYMBOL macro in a v8 namespace agnostic file will produce a compiler error. The commit included in this pull request adds the missing namespace to the macro.
