### PR TITLE
V0.4

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -297,6 +297,7 @@ Handle<Value> SecureContext::AddCACert(const Arguments& args) {
   if (!x509) return False();
 
   X509_STORE_add_cert(sc->ca_store_, x509);
+  SSL_CTX_add_client_CA(sc->ctx_, x509);
 
   X509_free(x509);
 


### PR DESCRIPTION
The client certificate validation stuff works, but most clients will refuse to send a cert unless they have one that is signed by one of the server advertised client CAs.  So, while the server would validate if the client force-sended it, this is needed to get most clients to actually send the client cert up.  It has no affect on client ssl contexts, so it doesn't need to be conditionally called only in server mode.
