### PR TITLE
FD Type detection for Net Sockets and Mapped Pair Custom FDs for Child Processes

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -62,12 +62,32 @@ The third argument is used to specify additional options, which defaults to:
       customFds: [-1, -1, -1],
       setsid: false
     }
+#### options
+  - `cwd`: allows you to specify the working directory from which the process is spawned.
+  - `env`: Specify environment variables that will be visible to the new process.
+  - `setsid`: if set true, will cause the subprocess to be run in a new session.
+  - `customFds`: Format: `[stdin, stout, stderr]`. Where each
+  of stdin/stdout/stderr is either an `array`, the string `unix`, `-1`, or
+  a single integer file descriptor.
+  #### values for each of stdin, stdout, and stderr:
+    - If the value is an array like `[4,5]` for stdin,
+  The child process will read from the `5` FD and the `4` fd will be used for
+  child.stdin.
+    - If the value is `-1`, a standard pipe pair will be automatically
+  assigned.
+    - If value is `unix`, a unix domain socket is used as the pair
+  (useful for sending file descriptors to child processes).
+    - If you pass a single integer file descriptor, that FD will be used
+    on the child process, however, the matching end of
+    child.stdin/stdout/stderr will be set to null and must be
+    manually created (for example `child.stdin = new net.Stream(fd)`)
 
-`cwd` allows you to specify the working directory from which the process is spawned.
-Use `env` to specify environment variables that will be visible to the new process.
-With `customFds` it is possible to hook up the new process' [stdin, stout, stderr] to
-existing streams; `-1` means that a new stream should be created. `setsid`,
-if set true, will cause the subprocess to be run in a new session.
+  - Example customFds setup: `['unix', [3, 4], -1]`
+  This would assign a unix domain socket to process.stdin
+  and the childs stdin, then would assign FD 3 to parents child.stdout and
+  the childs stdout would write to FD 4, then finally stderr would get a
+  standard read/write pipe (not capable of sending file descriptors).
+
 
 Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit code:
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -358,3 +358,6 @@ Returns true if input is a version 4 IP address, otherwise returns false.
 
 Returns true if input is a version 6 IP address, otherwise returns false.
 
+### net.socketpair()
+Returns an array of 2 File Descriptors to matching Unix Domain Sockets.
+(***Only available on linux***)

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var Stream = require('net').Stream;
+var netBinding = process.binding('net');
 var InternalChildProcess = process.binding('child_process').ChildProcess;
 var constants;
 
@@ -219,6 +220,22 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
     envPairs.push(key + '=' + env[key]);
   }
 
+  // check for matched pairs.
+  var otherEndFds = [];
+  customFds.forEach(function(value, key) {
+    // if value is 'unix' create a socketpair and map them together.
+    if (value == 'unix') {
+      var fds = netBinding.socketpair();
+      customFds[key] = fds[1];
+      otherEndFds[key] = fds[0];
+    } else {
+      // if value is an array of 2 FDs, map them together.
+      if (Array.isArray(value)) {
+        otherEndFds[key] = customFds[key][0];
+        customFds[key] = customFds[key][1];
+      }
+    }
+  })
   var fds = this._internal.spawn(path,
                                  args,
                                  cwd,
@@ -228,8 +245,11 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
                                  uid,
                                  gid);
   this.fds = fds;
-
-  if (customFds[0] === -1 || customFds[0] === undefined) {
+  if (otherEndFds[0] !== undefined) {
+    this.stdin.open(otherEndFds[0]);
+    this.stdin.writable = true;
+    this.stdin.readable = false;
+  } else if (customFds[0] === -1 || customFds[0] === undefined) {
     this.stdin.open(fds[0]);
     this.stdin.writable = true;
     this.stdin.readable = false;
@@ -237,7 +257,12 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
     this.stdin = null;
   }
 
-  if (customFds[1] === -1 || customFds[1] === undefined) {
+  if (otherEndFds[1] !== undefined) {
+    this.stdout.open(otherEndFds[1]);
+    this.stdout.writable = false;
+    this.stdout.readable = true;
+    this.stdout.resume();
+  } else if (customFds[1] === -1 || customFds[1] === undefined) {
     this.stdout.open(fds[1]);
     this.stdout.writable = false;
     this.stdout.readable = true;
@@ -246,7 +271,12 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
     this.stdout = null;
   }
 
-  if (customFds[2] === -1 || customFds[2] === undefined) {
+  if (otherEndFds[2] !== undefined) {
+    this.stderr.open(otherEndFds[2]);
+    this.stderr.writable = false;
+    this.stderr.readable = true;
+    this.stderr.resume();
+  } else if (customFds[2] === -1 || customFds[2] === undefined) {
     this.stderr.open(fds[2]);
     this.stderr.writable = false;
     this.stderr.readable = true;

--- a/lib/net.js
+++ b/lib/net.js
@@ -205,7 +205,7 @@ function Socket(options) {
     this.allowHalfOpen = options.allowHalfOpen || false;
   } else if (typeof options == 'number') {
     this.fd = arguments[0];
-    this.type = arguments[1];
+    this.type = arguments[1] || null;
   }
 
   if (parseInt(this.fd, 10) >= 0) {
@@ -214,11 +214,14 @@ function Socket(options) {
     setImplmentationMethods(this);
   }
 }
+
 util.inherits(Socket, stream.Stream);
 exports.Socket = Socket;
 
 // Legacy naming.
 exports.Stream = Socket;
+
+exports.socketpair = binding.socketpair;
 
 Socket.prototype._onTimeout = function() {
   this.emit('timeout');
@@ -229,7 +232,7 @@ Socket.prototype.open = function(fd, type) {
   initSocket(this);
 
   this.fd = fd;
-  this.type = type || null;
+  this.type = type || getFdType(fd)
   this.readable = true;
 
   setImplmentationMethods(this);
@@ -1116,17 +1119,43 @@ Server.prototype.close = function() {
     self.emit('close');
   }
 };
-
+function getFdType(fd) {
+  var type = 'file';
+  var family;
+  try {
+    type = binding.getsocktype(fd);
+    family = binding.getsockfamily(fd);
+    if (family == "AF_UNIX") {
+      type = "unix";
+    } else if (type == "SOCK_STREAM" && family == "AF_INET") {
+      type = "tcp";
+    } else if (type == "SOCK_STREAM" && family == "AF_INET6") {
+      type = "tcp6";
+    } else if (type == "SOCK_DGRAM" && family == "AF_INET") {
+      type = "udp";
+    } else if (type == "SOCK_DGRAM" && family == "AF_INET6") {
+      type = "udp6";
+    }
+  } catch (e) {
+    if (e.code == 'ENOTSOCK') {
+      type = 'file';
+    } else {
+      throw e;
+    }
+  }
+  return type;
+}
+exports.getFdType = getFdType;
 
 var dummyFD = null;
 var lastEMFILEWarning = 0;
-// Ensures to have at least on free file-descriptor free.
+// Ensures to have at least one free file-descriptor free.
 // callback should only use 1 file descriptor and close it before end of call
 function rescueEMFILE(callback) {
   // Output a warning, but only at most every 5 seconds.
   var now = new Date();
   if (now - lastEMFILEWarning > 5000) {
-    console.error('(node) Hit max file limit. Increase "ulimit - n"');
+    console.error('(node) Hit max file limit. Increase "ulimit -n"');
     lastEMFILEWarning = now;
   }
 

--- a/src/node_net.cc
+++ b/src/node_net.cc
@@ -570,6 +570,42 @@ static Handle<Value> GetSockName(const Arguments& args) {
   return scope.Close(info);
 }
 
+static Handle<Value> GetSockFamily(const Arguments& args) {
+  HandleScope scope;
+
+  FD_ARG(args[0])
+
+  Local<Value> result;
+
+  struct sockaddr_storage address_storage;
+  socklen_t len = sizeof(struct sockaddr_storage);
+
+#ifdef __POSIX__
+  if (0 > getsockname(fd, (struct sockaddr *) &address_storage, &len)) {
+    return ThrowException(ErrnoException(errno, "getsockname"));
+  }
+
+#else // __MINGW32__
+  if (SOCKET_ERROR == getsockname(_get_osfhandle(fd),
+      (struct sockaddr *) &address_storage, &len)) {
+    return ThrowException(ErrnoException(WSAGetLastError(), "getsockname"));
+  }
+#endif // __MINGW32__
+  switch ((address_storage).ss_family) {
+    case AF_INET6:
+      result = String::New("AF_INET6");
+      break;
+    case AF_INET:
+      result = String::New("AF_INET");
+      break;
+    case AF_UNIX:
+      result = String::New("AF_UNIX");
+      break;
+    default:
+      result = Integer::New((address_storage).ss_family);
+  }
+  scope.Close(result);
+}
 
 static Handle<Value> GetPeerName(const Arguments& args) {
   HandleScope scope;
@@ -699,6 +735,40 @@ static Handle<Value> SocketError(const Arguments& args) {
   return scope.Close(Integer::New(error));
 }
 
+static Handle<Value> GetSockType(const Arguments& args) {
+  HandleScope scope;
+
+  FD_ARG(args[0])
+
+  int type;
+  socklen_t len = sizeof(int);
+
+#ifdef __POSIX__
+  int r = getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &len);
+
+  if (r < 0) {
+    return ThrowException(ErrnoException(errno, "getsockopt"));
+  }
+#else // __MINGW32__
+  int r = getsockopt(_get_osfhandle(fd), SOL_SOCKET, SO_TYPE, (char*)&type, &len);
+
+  if (r < 0) {
+    return ThrowException(ErrnoException(WSAGetLastError(), "getsockopt"));
+  }
+#endif
+  Local<Value> result;
+  switch (type) {
+    case SOCK_STREAM:
+      result = String::New("SOCK_STREAM");
+      break;
+    case SOCK_DGRAM:
+      result = String::New("SOCK_DGRAM");
+      break;
+    default:
+      result = Integer::New(type);
+  }
+  return scope.Close(result);
+}
 
 //  var bytesRead = t.read(fd, buffer, offset, length);
 //  returns null on EAGAIN or EINTR, raises an exception on all other errors
@@ -1739,6 +1809,8 @@ void InitNet(Handle<Object> target) {
   NODE_SET_METHOD(target, "getaddrinfo", GetAddrInfo);
   NODE_SET_METHOD(target, "isIP", IsIP);
   NODE_SET_METHOD(target, "errnoException", CreateErrnoException);
+  NODE_SET_METHOD(target, "getsocktype", GetSockType);
+  NODE_SET_METHOD(target, "getsockfamily", GetSockFamily);
 
   errno_symbol          = NODE_PSYMBOL("errno");
   syscall_symbol        = NODE_PSYMBOL("syscall");

--- a/test/fixtures/get-stdin-type.js
+++ b/test/fixtures/get-stdin-type.js
@@ -1,0 +1,1 @@
+require('util').print(process.stdin.type);

--- a/test/simple/test-child-process-mapped-pairs.js
+++ b/test/simple/test-child-process-mapped-pairs.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var common = require('../common');
+var net = require('net');
+
+var args = [common.fixturesDir + '/get-stdin-type'];
+
+//test auto socketpair
+var opts = {
+  customFds: ['unix']
+};
+spawn(process.execPath, args, opts).stdout.on('data', function (data) {
+  assert.ok(data.toString() == 'unix');
+});
+//test manual socketpair
+var fds = net.socketpair();
+var opts = {
+  customFds: [fds, -1, -1]
+};
+
+var child = spawn(process.execPath, args, opts);
+child.stdout.on('data', function (data) {
+  assert.ok(data.toString() == 'unix');
+});
+
+assert.ok(child.stdin.type == 'unix', 'Should be unix');

--- a/test/simple/test-gets-auto-fd.js
+++ b/test/simple/test-gets-auto-fd.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var net = require('net');
+var common = require('../common');
+
+var server = net.createServer();
+
+//test unix sockets
+var fds = net.socketpair();
+var unixsocket = new net.Socket(fds[0]);
+assert.ok(unixsocket.type == 'unix', 'Should be UNIX');
+
+//test that stdin is default file
+assert.ok(process.stdin.type == 'file', 'Should be File');
+
+//test tcp sockets.
+server.listen(function() {
+  var client = net.createConnection(this.address().port);
+  client.on('connect', function() {
+    var newStream = new net.Socket(client.fd);
+    assert.ok(newStream.type == 'tcp', 'Should be TCP');
+    client.destroy();
+    server.close();
+  });
+});


### PR DESCRIPTION
Added support for node to read the type and family of a file descriptor to detect its type when it specified (ie: var stdin = new net.Stream(0) will auto set type to unix if its a unix domain socket and have the ability to send FDs)

Also added support for passing mapped pairs of file descriptors for CustomFds setting so child_process can properly configure the matching end for like child.stdin instead of setting it to null. Updated docs to recommend using pairs instead of single FDs.

Also added a shortcut to binding to unix domain socket with ['unix', -1, -1]

Finally, exposed socketpair to net so people wont have to include the bindings just to get it, and added docs.
