### PR TITLE
HTTPParser gets confused if a socket error occurs in an Agent (http.request)

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1153,9 +1153,11 @@ Agent.prototype._establishNewConnection = function() {
 
   // Add a parser to the socket.
   var parser = parsers.alloc();
-  parser.reinitialize('response');
   parser.socket = socket;
-  parser.incoming = null;
+  socket.on('connect', function() {
+    parser.reinitialize('response');
+    parser.incoming = null;
+  });
 
   socket.on('error', function(err) {
     debug('AGENT SOCKET ERROR: ' + err.message);

--- a/test/simple/test-http-client-socket-error.js
+++ b/test/simple/test-http-client-socket-error.js
@@ -1,0 +1,35 @@
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var net = require("net");
+
+var server = http.createServer(function(req, resp) {
+  // TODO is there a better way to force a socket error?
+  var options = {
+    host: "localhost",
+    port: -1,
+    url: req.url,
+    headers: req.headers,
+    method: req.method
+  };
+  var req2 = http.request(options, function(backendResp) {});
+
+  // capture the error to prevent a hard crash
+  req2.on("error", function(exc) {});
+});
+server.listen(common.PORT, function() {
+    var n = 0;
+    var nmax = 2;
+
+    for (var i = 0; i < nmax; i++) {
+      setTimeout(function() {
+        var sck = net.createConnection(common.PORT);
+        sck.write("GET / HTTP/1.0\r\n\r\n");
+        sck.end();
+        sck.on("close", function() {
+          if (++n == nmax) server.close();
+        });
+      }, 250 * i); // important! necessary to reuse pooled HTTPParser.
+    };
+});
+


### PR DESCRIPTION
I believe that socket errors are causing HTTPParsers assigned to an Agent to get into a confused state. In particular, the HTTPParser associated with an Agent is not reinitialized if we are able to reuse a socket: see the getAgent() code path of http.request(). This path is executed when we send a request to the same host twice.

By moving the reinitialization of the parser into the 'connect' event of the socket, we ensure the parser is reinitialized for every new outbound connection.

I can't seem to reproduce this without creating a server -- there may be something more insidious happening here. The test case in this patch demonstrates the issue. Output of running the test without the fix applied:

```
$ node test/simple/test-http-client-socket-error.js 

node.js:116
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: Cannot set property 'complete' of null
    at HTTPParser.onMessageComplete (http.js:105:28)
    at Socket.<anonymous> (http.js:1180:12)
    at Socket.emit (events.js:42:17)
    at Array.<anonymous> (net.js:799:27)
    at EventEmitter._tickCallback (node.js:108:26)
```

I think there are similar issues in the http lib that I stumbled across while trying to reproduce this particular issue. I'll investigate further and at the very least provide tests demonstrating the remaining problems, but this fix addresses my immediate issue.
