### PR TITLE
Double-free of parser from FreeList in http.js

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1199,7 +1199,6 @@ Agent.prototype._establishNewConnection = function() {
     parser.finish();
     socket.destroy();
     self._removeSocket(socket);
-    parsers.free(parser);
     self._cycle();
   });
 


### PR DESCRIPTION
According to the documentation, a socket `error` event will be followed by a socket `close` event. However, the HTTP Agent frees its parser on both events, causing the same parser reference to be pushed twice to the FreeList. This causes strange behavior down the road on further requests, and even HTTP server requests are affected by it.

This patch fixed for us what's been seen in the following discussion: https://groups.google.com/d/topic/nodejs/kYnfJZeqGZ4/discussion

Possibly related issue: https://github.com/joyent/node/issues/784

The patch on top of v0.4 is at: https://github.com/AngryBytes/node/tree/v0.4-parser-fixes
