### PR TITLE
Fix darwin build errors

### DIFF
--- a/src/platform_darwin.cc
+++ b/src/platform_darwin.cc
@@ -210,7 +210,7 @@ int Platform::GetLoadAvg(Local<Array> *loads) {
 }
 
 
-Handle<Value> Platform::GetInterfaceAddresses() {
+v8::Handle<v8::Value> Platform::GetInterfaceAddresses() {
   HandleScope scope;
   return scope.Close(Object::New());
 }


### PR DESCRIPTION
Added v8 namespace to fix build errors on darwin. Pretty tiny change.
