### PR TITLE
Remove .once events using removeListener

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -138,10 +138,13 @@ EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 EventEmitter.prototype.once = function(type, listener) {
   var self = this;
-  self.on(type, function g() {
+  function g() {
     self.removeListener(type, g);
     listener.apply(this, arguments);
-  });
+  };
+
+  g.listener = listener;
+  self.on(type, g);
 
   return this;
 };
@@ -157,12 +160,23 @@ EventEmitter.prototype.removeListener = function(type, listener) {
   var list = this._events[type];
 
   if (isArray(list)) {
-    var i = list.indexOf(listener);
-    if (i < 0) return this;
-    list.splice(i, 1);
+    var position = -1;
+    for (var i = 0, length = list.length; i < length; i++) {
+      if (list[i] === listener ||
+          (list[i].listener && list[i].listener === listener))
+      {
+        position = i;
+        break;
+      }
+    }
+
+    if (position < 0) return this;
+    list.splice(position, 1);
     if (list.length == 0)
       delete this._events[type];
-  } else if (this._events[type] === listener) {
+  } else if (list === listener ||
+             (list.listener && list.listener === listener))
+  {
     delete this._events[type];
   }
 

--- a/test/simple/test-event-emitter-once.js
+++ b/test/simple/test-event-emitter-once.js
@@ -35,6 +35,14 @@ e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
 
+var remove = function() {
+  assert.fail(1,0, 'once->foo should not be emitted', '!');
+};
+
+e.once('foo', remove);
+e.removeListener('foo', remove);
+e.emit('foo');
+
 process.addListener('exit', function() {
   assert.equal(1, times_hello_emited);
 });


### PR DESCRIPTION
Howdy,

When you add a new `once` listener on a EventEmitter, it gets wrapped in a closure and pushed in the events hash. When this is done, you will lose the reference to the original listener and lose the abilities to remove the same listener again as the removeListener checks if the supplied functions are matching..

This patch will allow us to remove the attached `once` listeners again, because closure function will now have a reference attached to him where we can check on.
