### PR TITLE
Note that multiple simultaneous calls to `fs.write` are unsafe

### DIFF
--- a/doc/api/buffers.markdown
+++ b/doc/api/buffers.markdown
@@ -22,7 +22,7 @@ strip the high bit if set.
 * `'base64'` - Base64 string encoding.
 
 * `'binary'` - A way of encoding raw binary data into strings by using only
-the first 8 bits of each character. This encoding method is depreciated and
+the first 8 bits of each character. This encoding method is deprecated and
 should be avoided in favor of `Buffer` objects where possible. This encoding
 will be removed in future versions of Node.
 

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -242,6 +242,10 @@ See pwrite(2).
 The callback will be given two arguments `(err, written)` where `written`
 specifies how many _bytes_ were written.
 
+Note that it is unsafe to use `fs.write` multiple times on the same file
+without waiting for the callback. For this scenario,
+`fs.createWriteStream` is strongly recommended.
+
 ### fs.writeSync(fd, buffer, offset, length, position)
 
 Synchronous version of buffer-based `fs.write()`. Returns the number of bytes

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -302,7 +302,8 @@ returns a buffer.
 
 ### fs.writeFile(filename, data, encoding='utf8', [callback])
 
-Asynchronously writes data to a file. `data` can be a string or a buffer.
+Asynchronously writes data to a file, replacing the file if it already exists.
+`data` can be a string or a buffer.
 
 Example:
 


### PR DESCRIPTION
This patch updates the docs so that no one else has to bang their head against the wall as I did before I raised #808. It advises folks to use `fs.createWriteStream` instead of `fs.write` for repeated writes to the same file.

There are also two other changes to the docs in this patch: a typo fix, and a line in `fs.writeFile` clarifying that the existing file will be overwritten.
