### PR TITLE
Untitled

### DIFF
--- a/lib/tty_posix.js
+++ b/lib/tty_posix.js
@@ -45,7 +45,7 @@ exports.open = function(path, args) {
   child = spawn(path, args, {
     env: env,
     customFds: [masterFD, masterFD, masterFD],
-    setuid: true
+    setsid: true
   });
 
   return [stream, child];


### PR DESCRIPTION
Found a silly typo which made setsid-option not work when passed to tty.open ();

Please pull
