### PR TITLE
Fix build on OSX

### DIFF
--- a/src/platform_darwin.cc
+++ b/src/platform_darwin.cc
@@ -38,6 +38,7 @@
 namespace node {
 
 using namespace v8;
+using v8::Handle; // Handle is also defined in MacTypes.h
 
 static char *process_title;
 double Platform::prog_start_time = Platform::GetUptime();


### PR DESCRIPTION
Currently node fails to build in OSX with this error:

[73/75] cxx: src/platform_darwin.cc -> build/default/src/platform_darwin_4.o
/usr/bin/g++ -pthread -arch x86_64 -g -O3 -DHAVE_OPENSSL=1 -DHAVE_MONOTONIC_CLOCK=0 -DEV_FORK_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_MULTIPLICITY=0 -DX_STACKSIZE=65536 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DEV_MULTIPLICITY=0 -DHAVE_FDATASYNC=0 -DPLATFORM="darwin" -D__POSIX__=1 -Wno-unused-parameter -D_FORTIFY_SOURCE=2 -DNDEBUG -Idefault/src -I../src -Idefault/deps/libeio -I../deps/libeio -Idefault/deps/http_parser -I../deps/http_parser -Idefault/deps/v8/include -I../deps/v8/include -Idefault/deps/libev -I../deps/libev -Idefault/deps/c-ares -I../deps/c-ares -Idefault/deps/c-ares/darwin-x64 -I../deps/c-ares/darwin-x64 -Ideps/v8/include ../src/platform_darwin.cc -c -o default/src/platform_darwin_4.o
../src/platform_darwin.cc:213: error: expected constructor, destructor, or type conversion before ‘<’ token

The issue is here:

Handle<Value> Platform::GetInterfaceAddresses() {
...

The compiler picks Handle as defined from MacTypes.h. I added an using v8::Handle directive
to fix this. 
