### PR TITLE
Patch for GH-814

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -239,8 +239,14 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
       (cb)(err, str, bytesRead);
     };
   }
-
-  binding.read(fd, buffer, offset, length, position, callback || noop);
+  
+  function wrapper (err, bytesRead) {
+    //retain a reference to buffer so that it can't be GC'ed too soon.
+    callback && callback(err, bytesRead);
+    buffer= null;
+  }
+  
+  binding.read(fd, buffer, offset, length, position, wrapper);
 };
 
 fs.readSync = function(fd, buffer, offset, length, position) {
@@ -285,7 +291,13 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     return;
   }
 
-  binding.write(fd, buffer, offset, length, position, callback || noop);
+  function wrapper (err, written) {
+    //retain a reference to buffer so that it can't be GC'ed too soon.
+    callback && callback(err, written);
+    buffer= null;
+  }
+
+  binding.write(fd, buffer, offset, length, position, wrapper);
 };
 
 fs.writeSync = function(fd, buffer, offset, length, position) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -242,8 +242,7 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
   
   function wrapper (err, bytesRead) {
     //retain a reference to buffer so that it can't be GC'ed too soon.
-    callback && callback(err, bytesRead);
-    buffer= null;
+    callback && callback(err, bytesRead || 0, buffer);
   }
   
   binding.read(fd, buffer, offset, length, position, wrapper);
@@ -293,8 +292,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
 
   function wrapper (err, written) {
     //retain a reference to buffer so that it can't be GC'ed too soon.
-    callback && callback(err, written);
-    buffer= null;
+    callback && callback(err, written || 0, buffer);
   }
 
   binding.write(fd, buffer, offset, length, position, wrapper);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -713,9 +713,6 @@ static Handle<Value> Write(const Arguments& args) {
   Local<Value> cb = args[5];
 
   if (cb->IsFunction()) {
-    // Grab a reference to buffer so it isn't GCed
-    Local<Object> cb_obj = cb->ToObject();
-    cb_obj->Set(buf_symbol, buffer_obj);
 
     ASYNC_CALL(write, cb, fd, buf, len, pos)
   } else {
@@ -781,10 +778,6 @@ static Handle<Value> Read(const Arguments& args) {
   cb = args[5];
 
   if (cb->IsFunction()) {
-    // Grab a reference to buffer so it isn't GCed
-    // TODO: need test coverage
-    Local<Object> cb_obj = cb->ToObject();
-    cb_obj->Set(buf_symbol, buffer_obj);
 
     ASYNC_CALL(read, cb, fd, buf, len, pos);
   } else {

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -1,0 +1,71 @@
+// Flags: --expose_gc
+
+function newBuffer (size, value) {
+  var buffer= new Buffer(size);
+  while (size--) {
+    buffer[size]= value;
+  }
+  //buffer[buffer.length-2]= 0x0d;
+  buffer[buffer.length-1]= 0x0a;
+  return  buffer;
+}
+
+
+
+var fs= require('fs');
+var testFileName= process.env.TMPDIR+ "GH-814_testFile.txt";
+var testFileFD= fs.openSync(testFileName, "w");
+console.log(testFileName);
+
+
+
+var kBufSize= 128*1024;
+var PASS= true;
+var neverWrittenBuffer= newBuffer(kBufSize, 0x2e); //0x2e === '.'
+var bufPool= [];
+
+
+
+var tail= require('child_process').spawn('tail', ['-f', testFileName]);
+tail.stdout.on('data', tailCB);
+
+function tailCB (data) {
+  PASS= data.toString().indexOf('.') < 0;
+}
+
+
+
+var timeToQuit= Date.now()+ 8e3; //Test during no more than this seconds.
+(function main () {
+  
+  if (PASS) {
+    fs.write(testFileFD, newBuffer(kBufSize, 0x61), 0, kBufSize, -1, cb);
+    gc();
+    var nuBuf= new Buffer(kBufSize);
+    neverWrittenBuffer.copy(nuBuf);
+    if (bufPool.push(nuBuf) > 100) {
+      bufPool.length= 0;
+    }
+  }
+  else {
+    throw Error("Buffer GC'ed test -> FAIL");
+  }
+  
+  if (Date.now() < timeToQuit) {
+    process.nextTick(main);
+  }
+  else {
+    tail.kill();
+    console.log("Buffer GC'ed test -> PASS (OK)");
+  }
+  
+})();
+
+
+function cb (err, written) {
+  if (err) {
+    throw err;
+  }
+}
+
+

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -1,0 +1,102 @@
+// Flags: --expose_gc
+
+
+console.flush= consoleFlush;
+
+var fs= require('fs');
+var testFileName= process.env.TMPDIR+ "GH-814_test.txt";
+var testFD= fs.openSync(testFileName, 'w');
+console.flush(testFileName+ "\n");
+
+
+var tailProc= require('child_process').spawn('tail', [ '-f', testFileName ]);
+tailProc.stdout.on('data', tailCB);
+
+function tailCB (data) {
+  PASS= data.toString().indexOf('.') < 0;
+  
+  if (PASS) {
+    console.flush('i');
+  }
+  else {
+    console.flush('[FAIL]\n DATA -> ');
+    console.flush(data);
+    console.flush("\n");
+    throw Error("Buffers GC test -> FAIL");
+  }
+}
+
+
+var PASS= true;
+var bufPool= [];
+var kBufSize= 16*1024;
+var neverWrittenBuffer= newBuffer(kBufSize, 0x2e); //0x2e === '.'
+
+var timeToQuit= Date.now()+ 5e3; //Test should last no more than this.
+writer();
+
+function writer () {
+  
+  if (PASS) {
+    if (Date.now() > timeToQuit) {
+      setTimeout(function () {
+        process.kill(tailProc.pid);
+        console.flush("\nBuffers GC test -> PASS (OK)\n");
+      }, 555);
+    }
+    else {
+      fs.write(testFD, newBuffer(kBufSize, 0x61), 0, kBufSize, -1, writerCB);
+      gc();
+      var nuBuf= new Buffer(kBufSize);
+      neverWrittenBuffer.copy(nuBuf);
+      if (bufPool.push(nuBuf) > 100) {
+        bufPool.length= 0;
+      }
+      process.nextTick(writer);
+      console.flush('o');
+    }
+  }
+  
+}
+
+function writerCB (err, written) {
+  //console.flush('cb.');
+  if (err) {
+    throw err;
+  }
+}
+
+
+
+
+// ******************* UTILITIES
+
+function consoleFlush (data) {
+  if (!Buffer.isBuffer(data)) {
+    data= new Buffer(''+ data);
+  }
+  
+  if (data.length) {
+    var written= 0;
+    do {
+      try {
+        var len= data.length- written;
+        written+= fs.writeSync(process.stdout.fd, data, written, len, -1);
+      }
+      catch (e) {
+        
+      }
+    } while(written < data.length);
+  }
+}
+
+
+function newBuffer (size, value) {
+  var buffer= new Buffer(size);
+  while (size--) {
+    buffer[size]= value;
+  }
+  buffer[buffer.length-1]= 0x0d;
+  buffer[buffer.length-1]= 0x0a;
+  return  buffer;
+}


### PR DESCRIPTION
Retain buffers at least until after callback() in fs.read()s and fs.write()s.

Jorge.
