### PR TITLE
Partial fix to crash due to missing req object on error event

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1192,8 +1192,10 @@ Agent.prototype._establishNewConnection = function() {
       assert(0);
     }
 
-    req.emit('error', err);
-    req._hadError = true; // hacky
+    if (req) {
+      req.emit('error', err);
+      req._hadError = true; // hacky
+    }
 
     // clean up so that agent can handle new requests
     parser.finish();


### PR DESCRIPTION
Node consistently crash on some connections when making an HTTP client request. Shortly after a request is completed, an error event comes in but no req is found, causing an exception in line 1195 (req.emit()). This doesn't fix the cause but prevents the crash.
