### PR TITLE
<DOC> Crypto module documentation typo

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -124,7 +124,7 @@ This can be called many times with new data as it is streamed.
 ### verifier.verify(cert, signature, signature_format='binary')
 
 Verifies the signed data by using the `cert` which is a string containing
-the PEM encoded public key, and `signature`, which is the previously calculates
+the PEM encoded certificate, and `signature`, which is the previously calculates
 signature for the data, in the `signature_format` which can be `'binary'`, `'hex'` or `'base64'`.
 
 Returns true or false depending on the validity of the signature for the data and public key.


### PR DESCRIPTION
`crypto.verifier` requires certificate as param passed to `verify` method, but there is typo in doc (fixed in my fork). Also, for saving time of developers would be great to add some example of openssl private key and certificate/public key generation. Like that:

```
# generate private key
openssl genrsa -out private.pem 2048
# fetch cert
openssl req -new -x509 -key private.pem -out cacert.pem -days 1095 -batch
# fetch public key
openssl rsa -in private.pem -out public.pem
```

Thanks,
Anatoliy.
