### PR TITLE
Always use `this` in EventEmitter.once()

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -141,9 +141,8 @@ EventEmitter.prototype.once = function(type, listener) {
     throw new Error('.once only takes instances of Function');
   }
 
-  var self = this;
-  self.on(type, function g() {
-    self.removeListener(type, g);
+  this.on(type, function g() {
+    this.removeListener(type, g);
     listener.apply(this, arguments);
   });
 


### PR DESCRIPTION
I ran into a funny edge-case when trying to move some `data` listeners from one socket to another. Since the closure generated by `once` references `self` instead of just using `this`, it can't unbind itself from the new socket.

The existing implementation uses both `self` and `this` anyway, so this patch just always uses `this`. 

Here's an example of my use-case:

```
// ... STARTTLS ...
socket.listeners('data').splice(0).forEach(function(listener) {
  cleartext.on('data', listener);
});
```
