### PR TITLE
Documentation: Fixed description of http.ServerRequest´s data event

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -141,7 +141,7 @@ Emitted when a piece of the message body is received.
 Example: A chunk of the body is given as the single
 argument. The transfer-encoding has been decoded.  The
 body chunk is a string.  The body encoding is set with
-`request.setBodyEncoding()`.
+`request.setEncoding()`.
 
 ### Event: 'end'
 


### PR DESCRIPTION
The doc states:
    The body encoding is set with request.setBodyEncoding().

but it must be:
    The body encoding is set with request.setEncoding().
