### PR TITLE
Fix a little bug in the REPL module

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -105,7 +105,7 @@ function REPLServer(prompt, stream) {
   this.commands = {};
   defineDefaultCommands(this);
 
-  if (rli.enabled && !disableColors) {
+  if (rli.enabled && !disableColors && exports.writer === util.inspect) {
     // Turn on ANSI coloring.
     exports.writer = function(obj, showHidden, depth) {
       return util.inspect(obj, showHidden, depth, true);


### PR DESCRIPTION
From repl.js:

```
// Can overridden with custom print functions, such as `probe` or `eyes.js`
exports.writer = util.inspect;
```

However, exports.writer is later overwritten if ansi colors are supported by the terminal. I've fixed this by testing if exports.writer is the default util.inspect before overwriting it.
