### PR TITLE
Fixes the vm.createSandbox circural refference problem addressed in an issue #822

### DIFF
--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -224,6 +224,7 @@ Handle<Value> WrappedScript::CreateContext(const Arguments& args) {
     for (uint32_t i = 0; i < keys->Length(); i++) {
       Handle<String> key = keys->Get(Integer::New(i))->ToString();
       Handle<Value> value = sandbox->Get(key);
+      if(value == sandbox) { value = context; }
       context->Set(key, value);
     }
   }

--- a/test/simple/test-vm-create-context-circular-reference.js
+++ b/test/simple/test-vm-create-context-circular-reference.js
@@ -1,0 +1,12 @@
+var common = require('../common');
+var assert = require('assert');
+var vm = require('vm');
+
+var sbx = {};
+sbx.window = sbx;
+
+sbx = vm.createContext(sbx);
+
+sbx.test = 123;
+
+assert.equal(sbx.window.window.window.window.window.test, 123);


### PR DESCRIPTION
Now the refference works as it should.
