### PR TITLE
Fix SSL secureProtocol and add secureOptions and ciphers

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -36,7 +36,7 @@ try {
 }
 
 
-function Credentials(secureProtocol) {
+function Credentials(secureProtocol, flags) {
   if (!(this instanceof Credentials)) {
     return new Credentials(secureProtocol);
   }
@@ -53,6 +53,8 @@ function Credentials(secureProtocol) {
     this.context.init();
   }
 
+  if(flags) this.context.setOptions(flags);
+
 }
 
 exports.Credentials = Credentials;
@@ -60,7 +62,7 @@ exports.Credentials = Credentials;
 
 exports.createCredentials = function(options) {
   if (!options) options = {};
-  var c = new Credentials(options.secureProtocol);
+  var c = new Credentials(options.secureProtocol, options.secureOptions);
 
   if (options.key) c.context.setKey(options.key);
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -68,6 +68,8 @@ exports.createCredentials = function(options) {
 
   if (options.cert) c.context.setCert(options.cert);
 
+  if (options.ciphers) c.context.setCiphers(options.ciphers);
+
   if (options.ca) {
     if (Array.isArray(options.ca)) {
       for (var i = 0, len = options.ca.length; i < len; i++) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -723,7 +723,9 @@ function Server(/* [options], listener */) {
       key: self.key,
       cert: self.cert,
       ca: self.ca,
-      crl: self.crl
+      crl: self.crl,
+      secureProtocol: self.secureProtocol,
+      secureOptions: self.secureOptions
     });
     //creds.context.setCiphers('RC4-SHA:AES128-SHA:AES256-SHA');
 
@@ -793,6 +795,8 @@ Server.prototype.setOptions = function(options) {
   if (options.cert) this.cert = options.cert;
   if (options.ca) this.ca = options.ca;
   if (options.crl) this.crl = options.crl;
+  if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
+  if (options.secureOptions) this.secureOptions = options.secureOptions;
 };
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -724,6 +724,7 @@ function Server(/* [options], listener */) {
       cert: self.cert,
       ca: self.ca,
       crl: self.crl,
+      ciphers: self.ciphers,
       secureProtocol: self.secureProtocol,
       secureOptions: self.secureOptions
     });
@@ -795,6 +796,7 @@ Server.prototype.setOptions = function(options) {
   if (options.cert) this.cert = options.cert;
   if (options.ca) this.ca = options.ca;
   if (options.crl) this.crl = options.crl;
+  if (options.ciphers) this.ciphers = options.ciphers;
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
   if (options.secureOptions) this.secureOptions = options.secureOptions;
 };

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -908,6 +908,10 @@ void DefineConstants(Handle<Object> target) {
 #ifdef SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG
   NODE_DEFINE_CONSTANT(target, SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG);
 #endif
+
+#ifdef SSL_OP_CRYPTOPRO_TLSEXT_BUG
+  NODE_DEFINE_CONSTANT(target, SSL_OP_CRYPTOPRO_TLSEXT_BUG);
+#endif
 }
 
 }  // namespace node

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -35,6 +35,10 @@
 # include <platform_win32_winsock.h>
 #endif
 
+#ifdef HAVE_OPENSSL
+# include <openssl/ssl.h>
+#endif
+
 namespace node {
 
 using namespace v8;
@@ -837,6 +841,72 @@ void DefineConstants(Handle<Object> target) {
 
 #ifdef SIGUNUSED
   NODE_DEFINE_CONSTANT(target, SIGUNUSED);
+#endif
+
+// OpenSSL SSL context options
+
+#ifdef SSL_OP_NO_QUERY_MTU
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NO_QUERY_MTU);
+#endif
+
+#ifdef SSL_OP_COOKIE_EXCHANGE
+  NODE_DEFINE_CONSTANT(target, SSL_OP_COOKIE_EXCHANGE);
+#endif
+
+#ifdef SSL_OP_NO_TICKET
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NO_TICKET);
+#endif
+
+#ifdef SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+#endif
+
+#ifdef SSL_OP_SINGLE_ECDH_USE
+  NODE_DEFINE_CONSTANT(target, SSL_OP_SINGLE_ECDH_USE);
+#endif
+
+#ifdef SSL_OP_SINGLE_DH_USE
+  NODE_DEFINE_CONSTANT(target, SSL_OP_SINGLE_DH_USE);
+#endif
+
+#ifdef SSL_OP_EPHEMERAL_RSA
+  NODE_DEFINE_CONSTANT(target, SSL_OP_EPHEMERAL_RSA);
+#endif
+
+#ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
+  NODE_DEFINE_CONSTANT(target, SSL_OP_CIPHER_SERVER_PREFERENCE);
+#endif
+
+#ifdef SSL_OP_TLS_ROLLBACK_BUG
+  NODE_DEFINE_CONSTANT(target, SSL_OP_TLS_ROLLBACK_BUG);
+#endif
+
+#ifdef SSL_OP_NO_SSLv2
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NO_SSLv2);
+#endif
+
+#ifdef SSL_OP_NO_SSLv3
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NO_SSLv3);
+#endif
+
+#ifdef SSL_OP_NO_TLSv1
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NO_TLSv1);
+#endif
+
+#ifdef SSL_OP_PKCS1_CHECK_1
+  NODE_DEFINE_CONSTANT(target, SSL_OP_PKCS1_CHECK_1);
+#endif
+
+#ifdef SSL_OP_PKCS1_CHECK_2
+  NODE_DEFINE_CONSTANT(target, SSL_OP_PKCS1_CHECK_2);
+#endif
+
+#ifdef SSL_OP_NETSCAPE_CA_DN_BUG
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NETSCAPE_CA_DN_BUG);
+#endif
+
+#ifdef SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG
+  NODE_DEFINE_CONSTANT(target, SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG);
 #endif
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -73,6 +73,7 @@ void SecureContext::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "addCRL", SecureContext::AddCRL);
   NODE_SET_PROTOTYPE_METHOD(t, "addRootCerts", SecureContext::AddRootCerts);
   NODE_SET_PROTOTYPE_METHOD(t, "setCiphers", SecureContext::SetCiphers);
+  NODE_SET_PROTOTYPE_METHOD(t, "setOptions", SecureContext::SetOptions);
   NODE_SET_PROTOTYPE_METHOD(t, "close", SecureContext::Close);
 
   target->Set(String::NewSymbol("SecureContext"), t->GetFunction());
@@ -426,6 +427,21 @@ Handle<Value> SecureContext::SetCiphers(const Arguments& args) {
   return True();
 }
 
+Handle<Value> SecureContext::SetOptions(const Arguments& args) {
+  HandleScope scope;
+
+  SecureContext *sc = ObjectWrap::Unwrap<SecureContext>(args.Holder());
+
+  if (args.Length() != 1 || !args[0]->IsUint32()) {
+    return ThrowException(Exception::TypeError(String::New("Bad parameter")));
+  }
+
+  unsigned int opts = args[0]->Uint32Value();
+
+  SSL_CTX_set_options(sc->ctx_, opts);
+
+  return True();
+}
 
 Handle<Value> SecureContext::Close(const Arguments& args) {
   HandleScope scope;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -58,6 +58,7 @@ class SecureContext : ObjectWrap {
   static v8::Handle<v8::Value> AddCRL(const v8::Arguments& args);
   static v8::Handle<v8::Value> AddRootCerts(const v8::Arguments& args);
   static v8::Handle<v8::Value> SetCiphers(const v8::Arguments& args);
+  static v8::Handle<v8::Value> SetOptions(const v8::Arguments& args);
   static v8::Handle<v8::Value> Close(const v8::Arguments& args);
 
   SecureContext() : ObjectWrap() {


### PR DESCRIPTION
The secureProtocol option to building the SSL context was not being
properly passed through in the credentials in the tls code.  This is
fixed.

Also, secureOptions flag was added (and passed through) and allows
the context to have all supported SSL_OP_\* set via createCredentials.
All SSL_OP_ flags (outside of ALL) have been added to constants.

Add a ciphers key to credentials and set those into SecureContext.
