### PR TITLE
Response object socket & connection properties fix

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1078,9 +1078,13 @@ function connectionListener(socket) {
     if (socket._httpMessage) {
       // There are already pending outgoing res, append.
       outgoing.push(res);
+
+      res.socket = socket;
+      res.connection = socket;
+    } else {
+      res.assignSocket(socket);
     }
 
-	res.assignSocket(socket);
 
 
     // When we're finished writing the response, check if this is the last

--- a/lib/http.js
+++ b/lib/http.js
@@ -1071,9 +1071,10 @@ function connectionListener(socket) {
     if (socket._httpMessage) {
       // There are already pending outgoing res, append.
       outgoing.push(res);
-    } else {
-      res.assignSocket(socket);
     }
+
+	res.assignSocket(socket);
+
 
     // When we're finished writing the response, check if this is the last
     // respose, if so destroy the socket.

--- a/lib/http.js
+++ b/lib/http.js
@@ -386,7 +386,7 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
       this.connection.write(c, e);
     }
 
-    
+    // buffer data if socket is not yet writable
     if ( !this.connection.writable ) {
       this._buffer(data, encoding);
       return false;

--- a/lib/http.js
+++ b/lib/http.js
@@ -375,25 +375,24 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
   if (this.connection &&
       this.connection._httpMessage === this &&
       this.connection.writable) {
+
     // There might be pending data in the this.output buffer.
     while (this.output.length) {
+
+      var c = this.output.shift();
+      var e = this.outputEncodings.shift();
+      this.connection.write(c, e);
+
       if (!this.connection.writable) {
         this._buffer(data, encoding);
         return false;
       }
-      var c = this.output.shift();
-      var e = this.outputEncodings.shift();
-      this.connection.write(c, e);
+
     }
 
-    // buffer data if socket is not yet writable
-    if ( !this.connection.writable ) {
-      this._buffer(data, encoding);
-      return false;
-    } else {
-      // Directly write to socket.
-      return this.connection.write(data, encoding);
-    }
+    // Directly write to socket.
+    return this.connection.write(data, encoding);
+
 
   } else {
     this._buffer(data, encoding);

--- a/lib/http.js
+++ b/lib/http.js
@@ -386,8 +386,15 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
       this.connection.write(c, e);
     }
 
-    // Directly write to socket.
-    return this.connection.write(data, encoding);
+    
+    if ( !this.connection.writable ) {
+      this._buffer(data, encoding);
+      return false;
+    } else {
+      // Directly write to socket.
+      return this.connection.write(data, encoding);
+    }
+
   } else {
     this._buffer(data, encoding);
     return false;

--- a/test/simple/test-gets-auto-fd.js
+++ b/test/simple/test-gets-auto-fd.js
@@ -7,6 +7,7 @@ var server = net.createServer();
 //test unix sockets
 var fds = process.binding('net').socketpair();
 var unixsocket = new net.Socket(fds[0]);
+
 assert.ok(unixsocket.type == 'unix', 'Should be UNIX');
 
 //test that stdin is default file

--- a/test/simple/test-http-socket-property-on-second-piped-response-object.js
+++ b/test/simple/test-http-socket-property-on-second-piped-response-object.js
@@ -1,0 +1,52 @@
+var net = require('net'), http = require('http'), assert = require('assert');
+var gotError = false;
+var count = 0;
+
+var server = http.createServer(function(req, res) {
+  var id = ++count;
+  assert.equal(typeof res.socket, 'object');
+  assert.equal(typeof res.connection, 'object');
+  setTimeout(function() {
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('id: ' + id);
+  }, (1 - count) * 1000);
+});
+
+server.on('clientError', function(e) {
+  gotError = true;
+});
+
+server.listen(8080, '127.0.0.1', function() {
+  var socket = net.createConnection(8080, '127.0.0.1');
+  socket.setEncoding('utf8');
+  socket.on('connect', function() {
+    socket.write('GET / HTTP/1.1\r\n');
+    socket.write('Host: localhost\r\n\r\n');
+    socket.flush();
+    socket.write('GET / HTTP/1.1\r\n');
+    socket.write('Host: localhost\r\n\r\n');
+    socket.flush();
+
+    var buf = '';
+    socket.on('data', function(data) {      
+      buf += data;
+    });
+    socket.on('end', function() {
+      server.close();
+      var lines = buf.split('\r\n').filter(function(s) {
+        return s.indexOf('id: ') === 0;
+      });
+      assert.equal(lines.length, 2);
+      assert.equal(lines[0], 'id: 1');
+      assert.equal(lines[1], 'id: 2');
+    });
+
+    setTimeout(function() {
+      socket.end();
+    }, 1000);
+  });
+});
+
+process.on('exit', function() {
+  assert.ok(!gotError);
+});


### PR DESCRIPTION
Hi guys, 

I found that if browsers makes several http request on a single TCP connection, response object passed into the HTTP server's requestListener callback on a _second request_ missed socket and connection properties.

Alex.
