### PR TITLE
Much faster socket write()s

### DIFF
--- a/benchmark/socket.write_1.js
+++ b/benchmark/socket.write_1.js
@@ -1,0 +1,13 @@
+var a= 'a';
+var kMaxLength= Math.pow(2,27);
+
+do {
+  
+  a= [a,a].join('');
+  console.log("*** BEGIN -> " + a.length);
+  console.log(a);
+  console.log("*** END -> " + a.length);
+
+} while (a.length < kMaxLength);
+
+a= null;

--- a/benchmark/socket.write_2.js
+++ b/benchmark/socket.write_2.js
@@ -1,0 +1,8 @@
+var a= 'a';
+var kMaxLength= 8192;
+do a= [a,a].join(''); while (a.length < kMaxLength);
+
+var i= 1e4;
+while (i--) console.log(a);
+
+a= null;

--- a/lib/http.js
+++ b/lib/http.js
@@ -653,7 +653,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   var ret;
 
   var hot = this._headerSent === false &&
-            typeof(data) === 'string' &&
+            typeof data === 'string' &&
             data.length > 0 &&
             this.output.length === 0 &&
             this.connection &&
@@ -671,7 +671,8 @@ OutgoingMessage.prototype.end = function(data, encoding) {
                                   data + '\r\n0\r\n' +
                                   this._trailer + '\r\n', encoding);
     } else {
-      ret = this.connection.write(this._header + data, encoding);
+      this.connection.write(this._header, 'ascii');
+      ret =  this.connection.write(new Buffer(data, encoding));
     }
     this._headerSent = true;
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -344,7 +344,13 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
         typeof this._writeQueue[last] === 'string' &&
         this._writeQueueEncoding[last] === encoding) {
       // optimization - concat onto last
-      this._writeQueue[last] += data;
+      data= (this._writeQueue[last]+= data);
+      
+      if (data.length > 64 * 1024 * 1024) {
+        this._writeQueue[last]= new Buffer(data, encoding);
+        this._writeQueueEncoding[last]= undefined;
+      }
+      
 
       if (cb) {
         if (!this._writeQueueCallbacks[last]) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -344,11 +344,11 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
         typeof this._writeQueue[last] === 'string' &&
         this._writeQueueEncoding[last] === encoding) {
       // optimization - concat onto last
-      data= (this._writeQueue[last]+= data);
+      data = (this._writeQueue[last] += data);
       
       if (data.length > 8 * 1024 * 1024) {
-        this._writeQueue[last]= new Buffer(data, encoding);
-        this._writeQueueEncoding[last]= undefined;
+        this._writeQueue[last] = new Buffer(data, encoding);
+        this._writeQueueEncoding[last] = undefined;
       }
       
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -346,7 +346,7 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
       // optimization - concat onto last
       data= (this._writeQueue[last]+= data);
       
-      if (data.length > 64 * 1024 * 1024) {
+      if (data.length > 8 * 1024 * 1024) {
         this._writeQueue[last]= new Buffer(data, encoding);
         this._writeQueueEncoding[last]= undefined;
       }

--- a/lib/net.js
+++ b/lib/net.js
@@ -196,10 +196,10 @@ function initSocket(self) {
   self.readable = self.destroyed = false;
 
   // Queue of buffers and string that need to be written to socket.
-  self._writeQueue = new Queue;
-  self._writeQueueEncoding = new Queue;
-  self._writeQueueFD = new Queue;
-  self._writeQueueCallbacks = new Queue;
+  self._writeQueue = [];
+  self._writeQueueEncoding = [];
+  self._writeQueueFD = [];
+  self._writeQueueCallbacks = [];
   // Number of charactes (which approx. equals number of bytes)
   self.bufferSize = 0;
 
@@ -289,79 +289,6 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 });
 
 
-function queuePeek () {
-  // return but don't pop() the last element
-  
-  if (this.length > 0) {
-    return this[this.firstIndex+ this.length- 1];
-  }
-  else {
-    return undefined;
-  }
-}
-
-function queuePoke (e) {
-  // overwrite the last element: it must exist, no checks are done !
-  
-  this[this.firstIndex+ this.length- 1]= e;
-}
-
-function queuePop () {
-  //rmv and return the last element
-  var e;
-  if (this.length) {
-    var i= this.firstIndex+ this.length- 1;
-    e= this[i];
-    delete this[i];
-    if (--this.length <= 0) {
-      this.firstIndex= this.length= 0;
-    }
-  }
-  return e;
-}
-
-function queuePush (e) {
-  //insert e after the last element and return length
-  
-  this[this.firstIndex+ this.length]= e;
-  return ++this.length;
-}
-
-function queueShift () {
-  //rmv and return the first element
-  var e;
-  if (this.length) {
-    e= this[this.firstIndex];
-    delete this[this.firstIndex++];
-    if (--this.length <= 0) {
-      this.firstIndex= this.length= 0;
-    }
-  }
-  return e;
-}
-
-function queueUnShift (e) {
-  //insert e before the first element and return length
-  
-  this[--this.firstIndex]= e;
-  return ++this.length;
-}
-
-
-
-function Queue () {
-  return {
-    firstIndex: 0,
-    length: 0,
-    shift: queueShift,
-    unshift: queueUnShift,
-    pop: queuePop,
-    push: queuePush,
-    peek: queuePeek,
-    poke: queuePoke
-  };
-}
-
 // Returns true if all the data was flushed to socket. Returns false if
 // something was queued. If data was queued, then the 'drain' event will
 // signal when it has been finally flushed to socket.
@@ -397,38 +324,34 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
   if (this._connecting || (this._writeQueue && this._writeQueue.length)) {
     if (!this._writeQueue) {
       this.bufferSize = 0;
-      this._writeQueue = new Queue;
-      this._writeQueueEncoding = new Queue;
-      this._writeQueueFD = new Queue;
-      this._writeQueueCallbacks = new Queue;
+      this._writeQueue = [];
+      this._writeQueueEncoding = [];
+      this._writeQueueFD = [];
+      this._writeQueueCallbacks = [];
     }
 
     // Slow. There is already a write queue, so let's append to it.
-    if (this._writeQueue.peek() === END_OF_FILE) {
+    if (this._writeQueueLast() === END_OF_FILE) {
       throw new Error('Socket.end() called already; cannot write.');
     }
 
+    var last = this._writeQueue.length - 1;
 
     this.bufferSize += data.length;
-    var lastData= this._writeQueue.peek();
-    
+
     if (typeof data == 'string' &&
-        typeof lastData === 'string' &&
-        this._writeQueueEncoding.peek() === encoding) {
+        this._writeQueue.length &&
+        typeof this._writeQueue[last] === 'string' &&
+        this._writeQueueEncoding[last] === encoding) {
       // optimization - concat onto last
+      data= (this._writeQueue[last]+= data);
       
-      lastData+= data;
-      data= null;
-      
-      if (lastData.length > 8 * 1024 * 1024) {
-        this._writeQueue.poke(new Buffer(lastData, encoding));
-        this._writeQueueEncoding.poke(undefined);
+      if (data.length > 8 * 1024 * 1024) {
+        this._writeQueue[last]= new Buffer(data, encoding);
+        this._writeQueueEncoding[last]= undefined;
       }
-      else {
-        this._writeQueue.poke(lastData);
-      }
-      lastData= null;
       
+
       if (cb) {
         if (!this._writeQueueCallbacks[last]) {
           this._writeQueueCallbacks[last] = cb;
@@ -615,6 +538,12 @@ Socket.prototype.flush = function() {
   }
   if (this._writeWatcher) this._writeWatcher.stop();
   return true;
+};
+
+
+Socket.prototype._writeQueueLast = function() {
+  return this._writeQueue.length > 0 ?
+      this._writeQueue[this._writeQueue.length - 1] : null;
 };
 
 
@@ -867,10 +796,10 @@ Socket.prototype.destroy = function(exception) {
   // TODO would like to set _writeQueue to null to avoid extra object alloc,
   // but lots of code assumes this._writeQueue is always an array.
   assert(this.bufferSize >= 0);
-  this._writeQueue = new Queue;
-  this._writeQueueEncoding = new Queue;
-  this._writeQueueCallbacks = new Queue;
-  this._writeQueueFD = new Queue;
+  this._writeQueue = [];
+  this._writeQueueEncoding = [];
+  this._writeQueueCallbacks = [];
+  this._writeQueueFD = [];
   this.bufferSize = 0;
 
   this.readable = this.writable = false;
@@ -934,7 +863,7 @@ Socket.prototype._shutdown = function() {
 
 Socket.prototype.end = function(data, encoding) {
   if (this.writable) {
-    if (this._writeQueue.peek() !== END_OF_FILE) {
+    if (this._writeQueueLast() !== END_OF_FILE) {
       DTRACE_NET_STREAM_END(this);
       if (data) this.write(data, encoding);
       this._writeQueue.push(END_OF_FILE);

--- a/lib/net.js
+++ b/lib/net.js
@@ -196,10 +196,10 @@ function initSocket(self) {
   self.readable = self.destroyed = false;
 
   // Queue of buffers and string that need to be written to socket.
-  self._writeQueue = [];
-  self._writeQueueEncoding = [];
-  self._writeQueueFD = [];
-  self._writeQueueCallbacks = [];
+  self._writeQueue = new Queue;
+  self._writeQueueEncoding = new Queue;
+  self._writeQueueFD = new Queue;
+  self._writeQueueCallbacks = new Queue;
   // Number of charactes (which approx. equals number of bytes)
   self.bufferSize = 0;
 
@@ -289,6 +289,79 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 });
 
 
+function queuePeek () {
+  // return but don't pop() the last element
+  
+  if (this.length > 0) {
+    return this[this.firstIndex+ this.length- 1];
+  }
+  else {
+    return undefined;
+  }
+}
+
+function queuePoke (e) {
+  // overwrite the last element: it must exist, no checks are done !
+  
+  this[this.firstIndex+ this.length- 1]= e;
+}
+
+function queuePop () {
+  //rmv and return the last element
+  var e;
+  if (this.length) {
+    var i= this.firstIndex+ this.length- 1;
+    e= this[i];
+    delete this[i];
+    if (--this.length <= 0) {
+      this.firstIndex= this.length= 0;
+    }
+  }
+  return e;
+}
+
+function queuePush (e) {
+  //insert e after the last element and return length
+  
+  this[this.firstIndex+ this.length]= e;
+  return ++this.length;
+}
+
+function queueShift () {
+  //rmv and return the first element
+  var e;
+  if (this.length) {
+    e= this[this.firstIndex];
+    delete this[this.firstIndex++];
+    if (--this.length <= 0) {
+      this.firstIndex= this.length= 0;
+    }
+  }
+  return e;
+}
+
+function queueUnShift (e) {
+  //insert e before the first element and return length
+  
+  this[--this.firstIndex]= e;
+  return ++this.length;
+}
+
+
+
+function Queue () {
+  return {
+    firstIndex: 0,
+    length: 0,
+    shift: queueShift,
+    unshift: queueUnShift,
+    pop: queuePop,
+    push: queuePush,
+    peek: queuePeek,
+    poke: queuePoke
+  };
+}
+
 // Returns true if all the data was flushed to socket. Returns false if
 // something was queued. If data was queued, then the 'drain' event will
 // signal when it has been finally flushed to socket.
@@ -324,34 +397,38 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
   if (this._connecting || (this._writeQueue && this._writeQueue.length)) {
     if (!this._writeQueue) {
       this.bufferSize = 0;
-      this._writeQueue = [];
-      this._writeQueueEncoding = [];
-      this._writeQueueFD = [];
-      this._writeQueueCallbacks = [];
+      this._writeQueue = new Queue;
+      this._writeQueueEncoding = new Queue;
+      this._writeQueueFD = new Queue;
+      this._writeQueueCallbacks = new Queue;
     }
 
     // Slow. There is already a write queue, so let's append to it.
-    if (this._writeQueueLast() === END_OF_FILE) {
+    if (this._writeQueue.peek() === END_OF_FILE) {
       throw new Error('Socket.end() called already; cannot write.');
     }
 
-    var last = this._writeQueue.length - 1;
 
     this.bufferSize += data.length;
-
+    var lastData= this._writeQueue.peek();
+    
     if (typeof data == 'string' &&
-        this._writeQueue.length &&
-        typeof this._writeQueue[last] === 'string' &&
-        this._writeQueueEncoding[last] === encoding) {
+        typeof lastData === 'string' &&
+        this._writeQueueEncoding.peek() === encoding) {
       // optimization - concat onto last
-      data= (this._writeQueue[last]+= data);
       
-      if (data.length > 8 * 1024 * 1024) {
-        this._writeQueue[last]= new Buffer(data, encoding);
-        this._writeQueueEncoding[last]= undefined;
+      lastData+= data;
+      data= null;
+      
+      if (lastData.length > 8 * 1024 * 1024) {
+        this._writeQueue.poke(new Buffer(lastData, encoding));
+        this._writeQueueEncoding.poke(undefined);
       }
+      else {
+        this._writeQueue.poke(lastData);
+      }
+      lastData= null;
       
-
       if (cb) {
         if (!this._writeQueueCallbacks[last]) {
           this._writeQueueCallbacks[last] = cb;
@@ -538,12 +615,6 @@ Socket.prototype.flush = function() {
   }
   if (this._writeWatcher) this._writeWatcher.stop();
   return true;
-};
-
-
-Socket.prototype._writeQueueLast = function() {
-  return this._writeQueue.length > 0 ?
-      this._writeQueue[this._writeQueue.length - 1] : null;
 };
 
 
@@ -796,10 +867,10 @@ Socket.prototype.destroy = function(exception) {
   // TODO would like to set _writeQueue to null to avoid extra object alloc,
   // but lots of code assumes this._writeQueue is always an array.
   assert(this.bufferSize >= 0);
-  this._writeQueue = [];
-  this._writeQueueEncoding = [];
-  this._writeQueueCallbacks = [];
-  this._writeQueueFD = [];
+  this._writeQueue = new Queue;
+  this._writeQueueEncoding = new Queue;
+  this._writeQueueCallbacks = new Queue;
+  this._writeQueueFD = new Queue;
   this.bufferSize = 0;
 
   this.readable = this.writable = false;
@@ -863,7 +934,7 @@ Socket.prototype._shutdown = function() {
 
 Socket.prototype.end = function(data, encoding) {
   if (this.writable) {
-    if (this._writeQueueLast() !== END_OF_FILE) {
+    if (this._writeQueue.peek() !== END_OF_FILE) {
       DTRACE_NET_STREAM_END(this);
       if (data) this.write(data, encoding);
       this._writeQueue.push(END_OF_FILE);

--- a/lib/net.js
+++ b/lib/net.js
@@ -103,12 +103,6 @@ function allocNewPool() {
   pool.used = 0;
 }
 
-var emptyBuffer = null;
-function allocEmptyBuffer() {
-  emptyBuffer = new Buffer(1);
-  emptyBuffer.sent = 0;
-  emptyBuffer.length = 0;
-}
 
 function setImplmentationMethods(self) {
   function noData(buf, off, len) {
@@ -196,10 +190,10 @@ function initSocket(self) {
   self.readable = self.destroyed = false;
 
   // Queue of buffers and string that need to be written to socket.
-  self._writeQueue = [];
-  self._writeQueueEncoding = [];
-  self._writeQueueFD = [];
-  self._writeQueueCallbacks = [];
+  self._writeQueue.length = 0;
+  self._writeQueueEncoding.length = 0;
+  self._writeQueueFD.length = 0;
+  self._writeQueueCallbacks.length = 0;
   // Number of charactes (which approx. equals number of bytes)
   self.bufferSize = 0;
 
@@ -216,6 +210,10 @@ function Socket(options) {
   stream.Stream.call(this);
 
   this.bufferSize = 0;
+  this._writeQueue = [];
+  this._writeQueueEncoding = [];
+  this._writeQueueFD = [];
+  this._writeQueueCallbacks = [];
   this.fd = null;
   this.type = null;
   this.allowHalfOpen = false;
@@ -235,7 +233,6 @@ function Socket(options) {
     setImplmentationMethods(this);
   }
 }
-
 util.inherits(Socket, stream.Stream);
 exports.Socket = Socket;
 
@@ -251,7 +248,7 @@ Socket.prototype.open = function(fd, type) {
   initSocket(this);
 
   this.fd = fd;
-  this.type = type || getFdType(fd)
+  this.type = type || getFdType(fd);
   this.readable = true;
 
   setImplmentationMethods(this);
@@ -289,6 +286,11 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 });
 
 
+function peek (array) {
+  var len = array.length;
+  return len ? array[len - 1] : undefined;
+}
+
 // Returns true if all the data was flushed to socket. Returns false if
 // something was queued. If data was queued, then the 'drain' event will
 // signal when it has been finally flushed to socket.
@@ -319,59 +321,45 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
     cb = arguments[1];
   }
 
-  // TODO - actually use cb
+  if (!data.length) return this.flush();
 
-  if (this._connecting || (this._writeQueue && this._writeQueue.length)) {
-    if (!this._writeQueue) {
-      this.bufferSize = 0;
-      this._writeQueue = [];
-      this._writeQueueEncoding = [];
-      this._writeQueueFD = [];
-      this._writeQueueCallbacks = [];
-    }
-
-    // Slow. There is already a write queue, so let's append to it.
-    if (this._writeQueueLast() === END_OF_FILE) {
+  if (this._connecting || this._writeQueue.length) {
+    // Slow. Put it into the write queue.
+    
+    var lastData = peek(this._writeQueue);
+    if (lastData === END_OF_FILE) {
       throw new Error('Socket.end() called already; cannot write.');
     }
-
-    var last = this._writeQueue.length - 1;
-
-    this.bufferSize += data.length;
-
-    if (typeof data == 'string' &&
-        this._writeQueue.length &&
-        typeof this._writeQueue[last] === 'string' &&
-        this._writeQueueEncoding[last] === encoding) {
+    
+    var index = this._writeQueue.length;
+    if (index &&
+        typeof data === 'string' &&
+        typeof lastData === 'string' &&
+        this._writeQueueEncoding[index - 1] === encoding) {
+      
       // optimization - concat onto last
-      data = (this._writeQueue[last] += data);
-      
-      if (data.length > 8 * 1024 * 1024) {
-        this._writeQueue[last] = new Buffer(data, encoding);
-        this._writeQueueEncoding[last] = undefined;
-      }
-      
+      index--;
+      this.bufferSize -= lastData.length;
+      data = lastData + data;
 
-      if (cb) {
-        if (!this._writeQueueCallbacks[last]) {
-          this._writeQueueCallbacks[last] = cb;
-        } else {
-          // awful
-          this._writeQueueCallbacks[last] = function() {
-            this._writeQueueCallbacks[last]();
-            cb();
-          };
-        }
+      if (data.length > 2 * 1024 * 1024) {
+        data = new Buffer(data, encoding);
+        encoding = undefined;
       }
-    } else {
-      this._writeQueue.push(data);
-      this._writeQueueEncoding.push(encoding);
-      this._writeQueueCallbacks.push(cb);
     }
-
-    if (fd != undefined) {
-      this._writeQueueFD.push(fd);
+    
+    this.bufferSize += data.length;
+    this._writeQueue[index] = data;
+    this._writeQueueEncoding[index] = encoding;
+    if (cb) {
+      var prev = this._writeQueueCallbacks[index];
+      if (prev) {
+        prev.push(cb);
+      } else {
+        this._writeQueueCallbacks[index] = [cb];
+      }
     }
+    if (fd != undefined) this._writeQueueFD.push(fd);
 
     this._onBufferChange();
     DTRACE_NET_SOCKET_WRITE(this, 0);
@@ -381,9 +369,11 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
     // Fast.
     // The most common case. There is no write queue. Just push the data
     // directly to the socket.
-    return this._writeOut(data, encoding, fd, cb);
+    this.bufferSize += data.length;
+    return this._writeOut(data, encoding, fd, cb ? [cb] : cb);
   }
 };
+
 
 // Directly writes the data to socket.
 //
@@ -393,68 +383,18 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
 //   2. Write data to socket. Return true if flushed.
 //   3. Slice out remaining
 //   4. Unshift remaining onto _writeQueue. Return false.
-Socket.prototype._writeOut = function(data, encoding, fd, cb) {
+Socket.prototype._writeOut = function(buffer, encoding, fd, cb) {
   if (!this.writable) {
     throw new Error('Socket is not writable');
   }
 
-  var buffer, off, len;
-  var bytesWritten, charsWritten;
-  var queuedData = false;
-
-  if (typeof data != 'string') {
-    // 'data' is a buffer, ignore 'encoding'
-    buffer = data;
-    off = 0;
-    len = data.length;
-
-  } else {
-    assert(typeof data == 'string');
-
-    if (!pool || pool.length - pool.used < kMinPoolSpace) {
-      pool = null;
-      allocNewPool();
-    }
-
-    if (!encoding || encoding == 'utf8' || encoding == 'utf-8') {
-      // default to utf8
-      bytesWritten = pool.write(data, 'utf8', pool.used);
-      charsWritten = Buffer._charsWritten;
-    } else {
-      bytesWritten = pool.write(data, encoding, pool.used);
-      charsWritten = bytesWritten;
-    }
-
-    if (encoding && data.length > 0) {
-      assert(bytesWritten > 0);
-    }
-
-    buffer = pool;
-    len = bytesWritten;
-    off = pool.used;
-
-    pool.used += bytesWritten;
-
-    debug('wrote ' + bytesWritten + ' bytes to pool');
-
-    if (charsWritten != data.length) {
-      // debug('couldn't fit ' +
-      //      (data.length - charsWritten) +
-      //      ' bytes into the pool\n');
-      // Unshift whatever didn't fit onto the buffer
-      assert(data.length > charsWritten);
-      this.bufferSize += data.length - charsWritten;
-      this._writeQueue.unshift(data.slice(charsWritten));
-      this._writeQueueEncoding.unshift(encoding);
-      this._writeQueueCallbacks.unshift(cb);
-      this._writeWatcher.start();
-      this._onBufferChange();
-      queuedData = true;
-    }
-  }
-
+  this.bufferSize -= buffer.length;
+  
+  if (typeof buffer === 'string') buffer= new Buffer(buffer, encoding);
+  
+  var len = buffer.length;
   try {
-    bytesWritten = this._writeImpl(buffer, off, len, fd, 0);
+    var bytesWritten = this._writeImpl(buffer, 0, len, fd, 0);
     DTRACE_NET_SOCKET_WRITE(this, bytesWritten);
   } catch (e) {
     this.destroy(e);
@@ -462,24 +402,14 @@ Socket.prototype._writeOut = function(data, encoding, fd, cb) {
   }
 
   debug('wrote ' + bytesWritten + ' bytes to socket.')
-  debug('[fd, off, len] = ' + JSON.stringify([this.fd, off, len]));
+  debug('[fd, off, len] = ' + JSON.stringify([this.fd, len]));
 
   timers.active(this);
 
-  if (bytesWritten == len) {
+  if (bytesWritten === len) {
     // awesome. sent to buffer.
-    if (buffer === pool) {
-      // If we're just writing from the pool then we can make a little
-      // optimization and save the space.
-      buffer.used -= len;
-    }
-
-    if (queuedData) {
-      return false;
-    } else {
-      if (cb) cb();
-      return true;
-    }
+    cb && cb.forEach(function (f) { f() });
+    return true;
   }
 
   // Didn't write the entire thing to buffer.
@@ -487,16 +417,12 @@ Socket.prototype._writeOut = function(data, encoding, fd, cb) {
   this._writeWatcher.start();
 
   // Slice out the data left.
-  var leftOver = buffer.slice(off + bytesWritten, off + len);
-  leftOver.used = leftOver.length; // used the whole thing...
-
-  //  util.error('data.used = ' + data.used);
-  //if (!this._writeQueue) initWriteSocket(this);
+  buffer = buffer.slice(bytesWritten);
 
   // data should be the next thing to write.
-  this.bufferSize += leftOver.length;
-  this._writeQueue.unshift(leftOver);
-  this._writeQueueEncoding.unshift(null);
+  this.bufferSize += buffer.length;
+  this._writeQueue.unshift(buffer);
+  this._writeQueueEncoding.unshift(undefined);
   this._writeQueueCallbacks.unshift(cb);
   this._onBufferChange();
 
@@ -518,7 +444,7 @@ Socket.prototype._onBufferChange = function() {
 // Flushes the write buffer out.
 // Returns true if the entire buffer was flushed.
 Socket.prototype.flush = function() {
-  while (this._writeQueue && this._writeQueue.length) {
+  while (this._writeQueue.length) {
     var data = this._writeQueue.shift();
     var encoding = this._writeQueueEncoding.shift();
     var cb = this._writeQueueCallbacks.shift();
@@ -529,21 +455,11 @@ Socket.prototype.flush = function() {
       return true;
     }
 
-    // Only decrement if it's not the END_OF_FILE object...
-    this.bufferSize -= data.length;
-    this._onBufferChange();
-
-    var flushed = this._writeOut(data, encoding, fd, cb);
-    if (!flushed) return false;
+    if (!this._writeOut(data, encoding, fd, cb)) return false;
   }
+  
   if (this._writeWatcher) this._writeWatcher.stop();
   return true;
-};
-
-
-Socket.prototype._writeQueueLast = function() {
-  return this._writeQueue.length > 0 ?
-      this._writeQueue[this._writeQueue.length - 1] : null;
 };
 
 
@@ -599,7 +515,7 @@ Socket.prototype._onConnect = function() {
     }
 
 
-    if (this._writeQueue && this._writeQueue.length) {
+    if (this._writeQueue.length) {
       // Flush this in case any writes are queued up while connecting.
       this._onWritable();
     }
@@ -796,10 +712,10 @@ Socket.prototype.destroy = function(exception) {
   // TODO would like to set _writeQueue to null to avoid extra object alloc,
   // but lots of code assumes this._writeQueue is always an array.
   assert(this.bufferSize >= 0);
-  this._writeQueue = [];
-  this._writeQueueEncoding = [];
-  this._writeQueueCallbacks = [];
-  this._writeQueueFD = [];
+  this._writeQueue.length = 0;
+  this._writeQueueEncoding.length = 0;
+  this._writeQueueCallbacks.length = 0;
+  this._writeQueueFD.length = 0;
   this.bufferSize = 0;
 
   this.readable = this.writable = false;
@@ -863,7 +779,7 @@ Socket.prototype._shutdown = function() {
 
 Socket.prototype.end = function(data, encoding) {
   if (this.writable) {
-    if (this._writeQueueLast() !== END_OF_FILE) {
+    if (peek(this._writeQueue) !== END_OF_FILE) {
       DTRACE_NET_STREAM_END(this);
       if (data) this.write(data, encoding);
       this._writeQueue.push(END_OF_FILE);
@@ -1151,6 +1067,7 @@ Server.prototype.close = function() {
   }
 };
 
+
 function getFdType(fd) {
   var type = 'file';
   var family;
@@ -1178,6 +1095,7 @@ function getFdType(fd) {
   return type;
 }
 exports.getFdType = getFdType;
+
 
 var dummyFD = null;
 var lastEMFILEWarning = 0;


### PR DESCRIPTION
Rewrites as buffers queued strings longer than 64k.
Also a benefit because buffers unlike strings are allocated
outside of v8's heap.
