### PR TITLE
lib/url.js : protocol and hostname case insensitivity

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -32,7 +32,7 @@ var protocolPattern = /^([a-z0-9]+:)/,
     unwise = ['{', '}', '|', '\\', '^', '~', '[', ']', '`'].concat(delims),
     nonHostChars = ['/', '?', ';', '#'].concat(unwise),
     hostnameMaxLen = 255,
-    hostnamePartPattern = /^[a-z0-9][a-z0-9A-Z-]{0,62}$/,
+    hostnamePartPattern = /^[a-z0-9][a-z0-9-]{0,62}$/i,
     unsafeProtocol = {
       'javascript': true,
       'javascript:': true

--- a/lib/url.js
+++ b/lib/url.js
@@ -26,7 +26,7 @@ exports.format = urlFormat;
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-var protocolPattern = /^([a-z0-9]+:)/,
+var protocolPattern = /^([a-z0-9]+:)/i,
     portPattern = /:[0-9]+$/,
     delims = ['<', '>', '"', '\'', '`', /\s/],
     unwise = ['{', '}', '|', '\\', '^', '~', '[', ']', '`'].concat(delims),
@@ -76,7 +76,7 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
 
   var proto = protocolPattern.exec(rest);
   if (proto) {
-    proto = proto[0];
+    proto = proto[0].toLowerCase();
     out.protocol = proto;
     rest = rest.substr(proto.length);
   }

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -96,6 +96,14 @@ var parseTests = {
     'query': 'baz=quux',
     'pathname': '/foo/bar'
   },
+  // Mixed case hostnames
+  'http://SuB.doMAIN.cOM/foo/bar': {
+    'href': 'http://SuB.doMAIN.cOM/foo/bar',
+    'protocol': 'http:',
+    'host': 'SuB.doMAIN.cOM',
+    'hostname': 'SuB.doMAIN.cOM',
+    'pathname': '/foo/bar'
+  },
   '//user:pass@example.com:8000/foo/bar?baz=quux#frag' : {
     'href': '//user:pass@example.com:8000/foo/bar?baz=quux#frag',
     'host': 'user:pass@example.com:8000',

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -96,6 +96,14 @@ var parseTests = {
     'query': 'baz=quux',
     'pathname': '/foo/bar'
   },
+  // Case insensitive protocols
+  'HTTP://domain.com/bar': {
+    'href': 'http://domain.com/bar',
+    'protocol': 'http:',
+    'host': 'domain.com',
+    'hostname': 'domain.com',
+    'pathname': '/bar'
+  },
   // Mixed case hostnames
   'http://SuB.doMAIN.cOM/foo/bar': {
     'href': 'http://SuB.doMAIN.cOM/foo/bar',
@@ -162,7 +170,7 @@ for (var u in parseTests) {
                  'parse(' + u + ').' + i + ' == ' + e + '\nactual: ' + a);
   }
 
-  var expected = u,
+  var expected = parseTests[u].href,
       actual = url.format(parseTests[u]);
 
   assert.equal(expected, actual,


### PR DESCRIPTION
- scheme/protocol part of the url is case insensitive, and normalized to lowercase
- first character of an hostname part is also case-insensitive

simple tests provided. Full test suite passed.
