### PR TITLE
Allow to remove all EventEmitter listeners at once

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -56,9 +56,9 @@ Remove a listener from the listener array for the specified event.
     server.removeListener('connection', callback);
 
 
-#### emitter.removeAllListeners(event)
+#### emitter.removeAllListeners([event])
 
-Removes all listeners from the listener array for the specified event.
+Removes all listeners, or those of the specified event.
 
 
 #### emitter.setMaxListeners(n)

--- a/lib/events.js
+++ b/lib/events.js
@@ -184,6 +184,11 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 };
 
 EventEmitter.prototype.removeAllListeners = function(type) {
+  if (arguments.length === 0) {
+    this._events = {};
+    return this;
+  }
+
   // does not use listeners(), so no side effect of creating _events[type]
   if (type && this._events && this._events[type]) this._events[type] = null;
   return this;

--- a/test/simple/test-event-emitter-remove-all-listeners.js
+++ b/test/simple/test-event-emitter-remove-all-listeners.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+
+function listener() {}
+
+var e1 = new events.EventEmitter();
+e1.addListener('foo', listener);
+e1.addListener('bar', listener);
+e1.removeAllListeners('foo');
+assert.deepEqual([], e1.listeners('foo'));
+assert.deepEqual([listener], e1.listeners('bar'));
+
+
+var e2 = new events.EventEmitter();
+e2.addListener('foo', listener);
+e2.addListener('bar', listener);
+e2.removeAllListeners();
+console.error(e2);
+assert.deepEqual([], e2.listeners('foo'));
+assert.deepEqual([], e2.listeners('bar'));


### PR DESCRIPTION
This patch adds support for calling EventEmitter#removeAllListeners
with no parameters in order to remove all listeners as once.

See discussion: https://groups.google.com/forum/#!topic/nodejs-dev/Mcyal1ThTHY

This does not break the existing API signature, so I think it would be reasonable to consider this patch for 0.4.x.
