### PR TITLE
Openssl NPN Support

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -429,7 +429,8 @@ EncryptedStream.prototype._pusher = function(pool, offset, length) {
  * Provides a pair of streams to do encrypted communication.
  */
 
-function SecurePair(credentials, isServer, requestCert, rejectUnauthorized) {
+function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
+                    NPNProtocols) {
   if (!(this instanceof SecurePair)) {
     return new SecurePair(credentials,
                           isServer,
@@ -470,6 +471,9 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized) {
                              this._requestCert,
                              this._rejectUnauthorized);
 
+  if (this._ssl.setNPNProtocols && NPNProtocols) {
+    this._ssl.setNPNProtocols(NPNProtocols);
+  }
 
   /* Acts as a r/w stream to the cleartext side of the stream. */
   this.cleartext = new CleartextStream(this);
@@ -730,7 +734,8 @@ function Server(/* [options], listener */) {
     var pair = new SecurePair(creds,
                               true,
                               self.requestCert,
-                              self.rejectUnauthorized);
+                              self.rejectUnauthorized,
+                              self.NPNProtocols);
 
     var cleartext = pipe(pair, socket);
     cleartext._controlReleased = false;
@@ -793,6 +798,8 @@ Server.prototype.setOptions = function(options) {
   if (options.cert) this.cert = options.cert;
   if (options.ca) this.ca = options.ca;
   if (options.crl) this.crl = options.crl;
+
+  if (options.NPNProtocols) this.NPNProtocols = options.NPNProtocols;
 };
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -474,6 +474,7 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
 
   if (Connection.hasNPN && NPNProtocols) {
     this._ssl.setNPNProtocols(NPNProtocols);
+    this.npnProtocol = null;
   }
 
   /* Acts as a r/w stream to the cleartext side of the stream. */
@@ -581,6 +582,7 @@ SecurePair.prototype._cycle = function(depth) {
 
 SecurePair.prototype._maybeInitFinished = function() {
   if (this._ssl && !this._secureEstablished && this._ssl.isInitFinished()) {
+    this.npnProtocol = this._ssl.getNegotiatedProtocol();
     this._secureEstablished = true;
     debug('secure established');
     this.emit('secure');
@@ -743,6 +745,7 @@ function Server(/* [options], listener */) {
 
     pair.on('secure', function() {
       pair.cleartext.authorized = false;
+      pair.cleartext.npnProtocol = pair.npnProtocol;
       if (!self.requestCert) {
         cleartext._controlReleased = true;
         self.emit('secureConnection', pair.cleartext, pair.encrypted);

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -387,7 +387,14 @@ CleartextStream.prototype._pendingBytes = function() {
 
 CleartextStream.prototype._puller = function(b) {
   debug('clearIn ' + b.length + ' bytes');
-  return this.pair._ssl.clearIn(b, 0, b.length);
+  var result = 0;
+
+  for (var offset = 0, len = b.length; offset < len; offset += 1400) {
+    var chunk = b.slice(offset, Math.min(len, offset + 1400));
+    result += this.pair._ssl.clearIn(chunk, 0, chunk.length);
+  }
+
+  return result;
 };
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -387,11 +387,17 @@ CleartextStream.prototype._pendingBytes = function() {
 
 CleartextStream.prototype._puller = function(b) {
   debug('clearIn ' + b.length + ' bytes');
-  var result = 0;
+  var result = 0,
+      blen = b.length,
+      delta = Math.max(1400, Math.round(blen / 64));
 
-  for (var offset = 0, len = b.length; offset < len; offset += 1400) {
-    var chunk = b.slice(offset, Math.min(len, offset + 1400));
-    result += this.pair._ssl.clearIn(chunk, 0, chunk.length);
+  for (var offset = 0; offset < blen; offset += delta) {
+    var chunk = b.slice(offset, Math.min(blen, offset + delta)),
+        local_result = this.pair._ssl.clearIn(chunk, 0, chunk.length);
+
+    if (local_result < 0) return local_result;
+
+    result += local_result;
   }
 
   return result;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -38,6 +38,7 @@ if (process.env.NODE_DEBUG && /tls/.test(process.env.NODE_DEBUG)) {
 var Connection = null;
 try {
   Connection = process.binding('crypto').Connection;
+  exports.hasNPN = Connection.hasNPN;
 } catch (e) {
   throw new Error('node.js not compiled with openssl crypto support.');
 }
@@ -471,7 +472,7 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
                              this._requestCert,
                              this._rejectUnauthorized);
 
-  if (this._ssl.setNPNProtocols && NPNProtocols) {
+  if (Connection.hasNPN && NPNProtocols) {
     this._ssl.setNPNProtocols(NPNProtocols);
   }
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -810,7 +810,31 @@ Server.prototype.setOptions = function(options) {
   if (options.ca) this.ca = options.ca;
   if (options.crl) this.crl = options.crl;
 
-  if (options.NPNProtocols) this.NPNProtocols = options.NPNProtocols;
+  if (options.NPNProtocols) {
+    var NPNProtocols = options.NPNProtocols;
+
+    // If NPNProtocols is Array - translate it into buffer
+    if (Array.isArray(NPNProtocols)) {
+      var buff = new Buffer(NPNProtocols.reduce(function(p, c) {
+        return p + 1 + Buffer.byteLength(c);
+      }, 0));
+
+      NPNProtocols.reduce(function(offset, c) {
+        var clen = Buffer.byteLength(c);
+        buff[offset] = clen;
+        buff.write(c, offset + 1);
+
+        return offset + 1 + clen;
+      }, 0);
+
+      NPNProtocols = buff;
+    }
+
+    // If it's already a Buffer - store it
+    if (Buffer.isBuffer(NPNProtocols)) {
+      this.NPNProtocols = NPNProtocols;
+    }
+  }
 };
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -550,8 +550,11 @@ void Connection::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "close", Connection::Close);
 
 #ifdef OPENSSL_NPN_NEGOTIATED
+  t->Set(String::NewSymbol("hasNPN"), True());
   NODE_SET_PROTOTYPE_METHOD(t, "getNegotiatedProtocol", Connection::GetNegotiatedProto);
   NODE_SET_PROTOTYPE_METHOD(t, "setNPNProtocols", Connection::SetNPNProtocols);
+#else
+  t->Set(String::NewSymbol("hasNPN"), False());
 #endif
 
   target->Set(String::NewSymbol("Connection"), t->GetFunction());

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -23,6 +23,11 @@
 #define SRC_NODE_CRYPTO_H_
 
 #include <node.h>
+
+#ifdef OPENSSL_NPN_NEGOTIATED
+#include <node_buffer.h>
+#endif
+
 #include <node_object_wrap.h>
 #include <v8.h>
 
@@ -93,6 +98,10 @@ class Connection : ObjectWrap {
  public:
   static void Initialize(v8::Handle<v8::Object> target);
 
+#ifdef OPENSSL_NPN_NEGOTIATED
+  v8::Persistent<v8::Object> npnProtos_;
+#endif
+
  protected:
   static v8::Handle<v8::Value> New(const v8::Arguments& args);
   static v8::Handle<v8::Value> EncIn(const v8::Arguments& args);
@@ -109,6 +118,16 @@ class Connection : ObjectWrap {
   static v8::Handle<v8::Value> ReceivedShutdown(const v8::Arguments& args);
   static v8::Handle<v8::Value> Start(const v8::Arguments& args);
   static v8::Handle<v8::Value> Close(const v8::Arguments& args);
+
+#ifdef OPENSSL_NPN_NEGOTIATED
+  // NPN
+  static v8::Handle<v8::Value> GetNegotiatedProto(const v8::Arguments& args);
+  static v8::Handle<v8::Value> SetNPNProtocols(const v8::Arguments& args);
+  static int AdvertiseNextProtoCallback_(SSL *s,
+                                         const unsigned char **data,
+                                         unsigned int *len,
+                                         void *arg);
+#endif
 
   int HandleBIOError(BIO *bio, const char* func, int rv);
   int HandleSSLError(const char* func, int rv);
@@ -138,6 +157,7 @@ class Connection : ObjectWrap {
   BIO *bio_read_;
   BIO *bio_write_;
   SSL *ssl_;
+  
   bool is_server_; /* coverity[member_decl] */
 };
 


### PR DESCRIPTION
With this patch we'll be able to control NPN advertise and receive current protocol:

```
require('tls').createServer({
    ... ,
    NPNProtocols: ['spdy/2'],
    ...
}, function(c){
    console.log(c.npnProtocol);
});
```

And I'm doing some microoptimizations for server writes in TLS module according to: http://www.belshe.com/2010/12/17/performance-and-the-tls-record-size/
