### PR TITLE
GH 892 fix

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -92,8 +92,6 @@ CryptoStream.prototype.write = function(data /* , encoding, cb */) {
 
   this.pair._writeCalled = true;
   this.pair._cycle();
-
-  return this._writeState;
 };
 
 


### PR DESCRIPTION
_writeState should not affect CryptoStream.write behaviour, b/c it's purposed to stop emitting 'data' events and reading from SSL stream.
