### PR TITLE
make it possible to do repl.start("", stream)

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -80,7 +80,7 @@ function REPLServer(prompt, stream) {
     process.stdin.resume();
   }
 
-  self.prompt = prompt || '> ';
+  self.prompt = (prompt != undefined ? prompt : '> ');
 
   function complete(text) {
     return self.complete(text);


### PR DESCRIPTION
If you do repl.start("", stream), you get the default prompt of "> " instead of a blank prompt as expected from reading the docs. It doesn't seem like there should be any reason not to support a blank prompt string (and it can be useful)
