### PR TITLE
[tls] fix '[object] has no end method'

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -396,6 +396,8 @@ CleartextStream.prototype._pusher = function(pool, offset, length) {
   return this.pair._ssl.clearOut(pool, offset, length);
 };
 
+CleartextStream.prototype.end = function() {};
+
 
 function EncryptedStream(pair) {
   CryptoStream.call(this, pair);
@@ -423,6 +425,8 @@ EncryptedStream.prototype._pusher = function(pool, offset, length) {
   if (!this.pair._ssl) return -1;
   return this.pair._ssl.encOut(pool, offset, length);
 };
+
+EncryptedStream.prototype.end = function() {};
 
 
 /**


### PR DESCRIPTION
Sometimes tls module is throwing this error, b/c of stream pipe's onend function.
