### PR TITLE
Feature: WriteStream#bytesWritten property

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -396,6 +396,11 @@ An example to read the last 10 bytes of a file which is 100 bytes long:
 
  `fd` is the file descriptor used by the WriteStream.
 
+### file.bytesWritten
+
+The number of bytes written so far. Does not include data that is still queued
+for writing.
+
 ### fs.createWriteStream(path, [options])
 
 Returns a new WriteStream object (See `Writable Stream`).

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1019,6 +1019,7 @@ var WriteStream = fs.WriteStream = function(path, options) {
   this.flags = 'w';
   this.encoding = 'binary';
   this.mode = parseInt('0666', 8);
+  this.bytesWritten = 0;
 
   options = options || {};
 
@@ -1068,6 +1069,10 @@ WriteStream.prototype.flush = function() {
       }
       self.emit('error', err);
       return;
+    }
+
+    if (method == fs.write) {
+      self.bytesWritten += arguments[1];
     }
 
     // stop flushing after close

--- a/test/simple/test-file-write-stream.js
+++ b/test/simple/test-file-write-stream.js
@@ -58,6 +58,8 @@ file
       }
     })
   .addListener('close', function() {
+      assert.strictEqual(file.bytesWritten, EXPECTED.length * 2);
+
       callbacks.close++;
       assert.throws(function() {
         file.write('should not work anymore');


### PR DESCRIPTION
Implemented a new property for writable file streams that keeps track
of the bytes written (not queued). This helps when you are piping
another stream to a file, and would like to know how big the file is
without having to issue another stat call.
