### PR TITLE
CRC32 support for crypto.createHash 

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -26,7 +26,7 @@ Creates and returns a hash object, a cryptographic hash with the given algorithm
 which can be used to generate hash digests.
 
 `algorithm` is dependent on the available algorithms supported by the version
-of OpenSSL on the platform. Examples are `'sha1'`, `'md5'`, `'sha256'`, `'sha512'`, etc.
+of OpenSSL on the platform. Examples are `'sha1'`, `'md5'`, `'sha256'`, `'sha512'`, `'crc32'` etc.
 On recent releases, `openssl list-message-digest-algorithms` will display the available digest algorithms.
 
 Example: this program that takes the sha1 sum of a file
@@ -55,8 +55,9 @@ This can be called many times with new data as it is streamed.
 ### hash.digest(encoding='binary')
 
 Calculates the digest of all of the passed data to be hashed.
-The `encoding` can be `'hex'`, `'binary'` or `'base64'`.
+The `encoding` can be `'hex'`, `'binary'` or `'base64'` or `'decimal'`.
 
+Only `'crc32'` digests currently can be expressed in `'decimal'`.
 
 ### crypto.createHmac(algorithm, key)
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2362,7 +2362,7 @@ class Hash : public ObjectWrap {
 
   bool HashInit (const char* hashType) {
 
-    if(strcasecmp(hashType, "crc32") == 0) {
+    if(strcmp(hashType, "crc32") == 0) {
       crc32_ = 0;
       initialised_ = true;
       is_crc32_ = true;
@@ -2468,12 +2468,13 @@ class Hash : public ObjectWrap {
     if(!hash->is_crc32_) {
       EVP_DigestFinal_ex(&hash->mdctx, md_value, &md_len);
       EVP_MD_CTX_cleanup(&hash->mdctx);
+
+      if (md_len == 0) {
+	return scope.Close(String::New(""));
+      }
     } 
     hash->initialised_ = false;
 
-    if (md_len == 0) {
-      return scope.Close(String::New(""));
-    }
 
 
     if (args.Length() == 0 || !args[0]->IsString()) {
@@ -2502,7 +2503,7 @@ class Hash : public ObjectWrap {
 
       } else if (strcasecmp(*encoding, "decimal") == 0) {
 	if(hash->is_crc32_) {
-	  return scope.Close(Integer::New(hash->crc32_));
+	  return scope.Close(Integer::NewFromUnsigned(hash->crc32_));
 	} else {
 	  return ThrowException(Exception::Error(String::New("Cannot express as an integer")));
 	}

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -28,7 +28,8 @@
 
 #include <string.h>
 #include <stdlib.h>
-
+#include <zlib.h>
+#include <arpa/inet.h>
 #include <errno.h>
 
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
@@ -2338,6 +2339,8 @@ class Hmac : public ObjectWrap {
 
   HMAC_CTX ctx; /* coverity[member_decl] */
   const EVP_MD *md; /* coverity[member_decl] */
+
+  uLong crc32;
   bool initialised_;
 };
 
@@ -2358,6 +2361,15 @@ class Hash : public ObjectWrap {
   }
 
   bool HashInit (const char* hashType) {
+
+    if(strcasecmp(hashType, "crc32") == 0) {
+      crc32_ = 0;
+      initialised_ = true;
+      is_crc32_ = true;
+      return true;
+    }
+    is_crc32_ = false;
+
     md = EVP_get_digestbyname(hashType);
     if(!md) {
       fprintf(stderr, "node-crypto : Unknown message digest %s\n", hashType);
@@ -2371,6 +2383,11 @@ class Hash : public ObjectWrap {
 
   int HashUpdate(char* data, int len) {
     if (!initialised_) return 0;
+
+    if(is_crc32_) {
+      crc32_ = crc32(crc32_, (const Bytef*)data, len);
+      return 1;
+    } 
     EVP_DigestUpdate(&mdctx, data, len);
     return 1;
   }
@@ -2445,42 +2462,74 @@ class Hash : public ObjectWrap {
     unsigned char md_value[EVP_MAX_MD_SIZE];
     unsigned int md_len;
 
-    EVP_DigestFinal_ex(&hash->mdctx, md_value, &md_len);
-    EVP_MD_CTX_cleanup(&hash->mdctx);
+    Local<Value> outString;
+
+
+    if(!hash->is_crc32_) {
+      EVP_DigestFinal_ex(&hash->mdctx, md_value, &md_len);
+      EVP_MD_CTX_cleanup(&hash->mdctx);
+    } 
     hash->initialised_ = false;
 
     if (md_len == 0) {
       return scope.Close(String::New(""));
     }
 
-    Local<Value> outString;
 
     if (args.Length() == 0 || !args[0]->IsString()) {
       // Binary
-      outString = Encode(md_value, md_len, BINARY);
+
+      if(hash->is_crc32_) {
+	outString = Encode(&hash->crc32_, 4, BINARY);
+      } else {
+	outString = Encode(md_value, md_len, BINARY);
+      }
     } else {
       String::Utf8Value encoding(args[0]->ToString());
       if (strcasecmp(*encoding, "hex") == 0) {
         // Hex encoding
         char* md_hexdigest;
         int md_hex_len;
-        HexEncode(md_value, md_len, &md_hexdigest, &md_hex_len);
+
+	if(hash->is_crc32_) {
+	  hash->crc32_ = htonl(hash->crc32_);
+	  HexEncode((unsigned char *)&hash->crc32_, 4, &md_hexdigest, &md_hex_len);
+	} else {
+	  HexEncode(md_value, md_len, &md_hexdigest, &md_hex_len);
+	}
         outString = Encode(md_hexdigest, md_hex_len, BINARY);
         delete [] md_hexdigest;
+
+      } else if (strcasecmp(*encoding, "decimal") == 0) {
+	if(hash->is_crc32_) {
+	  return scope.Close(Integer::New(hash->crc32_));
+	} else {
+	  return ThrowException(Exception::Error(String::New("Cannot express as an integer")));
+	}
       } else if (strcasecmp(*encoding, "base64") == 0) {
         char* md_hexdigest;
         int md_hex_len;
-        base64(md_value, md_len, &md_hexdigest, &md_hex_len);
+	if(hash->is_crc32_) {
+	  base64((unsigned char *)&hash->crc32_, 4, &md_hexdigest, &md_hex_len);
+	} else {
+	  base64(md_value, md_len, &md_hexdigest, &md_hex_len);
+	}
         outString = Encode(md_hexdigest, md_hex_len, BINARY);
         delete [] md_hexdigest;
       } else if (strcasecmp(*encoding, "binary") == 0) {
-        outString = Encode(md_value, md_len, BINARY);
+
+	if(hash->is_crc32_) {
+	  outString = Encode(&hash->crc32_, 4, BINARY);
+	} else {
+	  outString = Encode(md_value, md_len, BINARY);
+	}
+
       } else {
         fprintf(stderr, "node-crypto : Hash .digest encoding "
                         "can be binary, hex or base64\n");
       }
     }
-
+    
     return scope.Close(outString);
   }
 
@@ -2495,6 +2544,8 @@ class Hash : public ObjectWrap {
   EVP_MD_CTX mdctx; /* coverity[member_decl] */
   const EVP_MD *md; /* coverity[member_decl] */
   bool initialised_;
+  bool is_crc32_;
+  uint32_t crc32_;
 };
 
 class Sign : public ObjectWrap {


### PR DESCRIPTION
Add support to use zlib's CRC32 implementation for crypto.createHash, add the ability to return the hash as an integer with the 'decimal' encoding.  Amend docs as needed.
