### PR TITLE
Add support for --console-to-stderr switch

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -56,11 +56,15 @@ function format(f) {
   return str;
 }
 
-
-exports.log = function() {
-  process.stdout.write(format.apply(this, arguments) + '\n');
+if (!process._console_selector) {
+  exports.log = function() {
+    process.stdout.write(format.apply(this, arguments) + '\n');
+  };
+} else { 
+  exports.log = function() {
+    process[process._console_selector].write(format.apply(this, arguments) + '\n');
+  };
 };
-
 
 exports.info = exports.log;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -104,6 +104,7 @@ static Persistent<String> emit_symbol;
 
 
 static char *eval_string = NULL;
+static char *console_selector = NULL;
 static int option_end_index = 0;
 static bool use_debug_agent = false;
 static bool debug_wait_connect = false;
@@ -2037,6 +2038,11 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
     process->Set(String::NewSymbol("_eval"), String::New(eval_string));
   }
 
+  // --console-to-stderr
+  if (console_selector) {
+    process->Set(String::NewSymbol("_console_selector"), String::New(console_selector));
+  }
+
   size_t size = 2*PATH_MAX;
   char execPath[size];
   if (Platform::GetExecutablePath(execPath, &size) != 0) {
@@ -2221,6 +2227,9 @@ static void ParseArgs(int argc, char **argv) {
       }
       argv[i] = const_cast<char*>("");
       eval_string = argv[++i];
+    } else if (strcmp(arg, "--console-to-stderr") == 0) {
+      console_selector="stderr";
+      argv[i] = const_cast<char*>("");
     } else if (strcmp(arg, "--v8-options") == 0) {
       argv[i] = const_cast<char*>("--help");
     } else if (argv[i][0] != '-') {


### PR DESCRIPTION
This series adds support for --console-to-stderr switch.

If the switch is not specified, existing behaviour is unchanged.

If this switch is specified, process._console_selector is set to 'stderr', and console.log() writes to process[process._console_selector].
