### PR TITLE
write diagnostic output with console.err to avoid polluting stdout with s

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -126,8 +126,7 @@ Socket.prototype.bind = function() {
           self._startWatcher();
           self.emit('listening');
         } catch (err) {
-          console.log('Error in unix_dgram bind of ' + self.path);
-          console.log(err.stack);
+          console.error('Error in unix_dgram bind of ' + self.path);
           throw err;
         }
       }


### PR DESCRIPTION
write diagnostic output with console.err to avoid polluting stdout with same

Signed-off-by: Jon Seymour jon.seymour@gmail.com
