### PR TITLE
make including expected and actual values in assert fail messages easier

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -53,6 +53,9 @@ util.inherits(assert.AssertionError, Error);
 
 assert.AssertionError.prototype.toString = function() {
   if (this.message) {
+    this.message = this.message
+	  .replace(':expected:', JSON.stringify(this.expected))
+	  .replace(':actual:', JSON.stringify(this.actual));
     return [this.name + ':', this.message].join(' ');
   } else {
     return [this.name + ':',


### PR DESCRIPTION
More of an RFC than a feature - it makes writing tests slightly less repetitive if replacing expected and actual values in the error message (where specified) is built in

thus errors can be shown like so:

```
 assert.equal(retrived, expect, "The number returned (:actual:) does
```

not equal the number expected (:expected:)");
