### PR TITLE
allow util.inspect (or other writer) to return null or undefined to signal no write (to bypass superfluous newline)

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1405,13 +1405,18 @@ Agent.prototype._cycle = function() {
 var agents = {};
 
 
-function getAgent(host, port) {
-  port = port || 80;
-  var id = host + ':' + port;
+function getAgent(options, port) {
+  // Handle prior API that isn't in line with https
+  if (typeof options === 'string') {
+    options = {host:options, port:port};
+  }
+  if (!options.port) options.port = 80;
+
+  var id = options.host + ':' + options.port;
   var agent = agents[id];
 
   if (!agent) {
-    agent = agents[id] = new Agent({ host: host, port: port });
+    agent = agents[id] = new Agent(options);
   }
 
   return agent;
@@ -1429,7 +1434,7 @@ exports._requestFromAgent = function(options, cb) {
 
 exports.request = function(options, cb) {
   if (options.agent === undefined) {
-    options.agent = getAgent(options.host, options.port);
+    options.agent = getAgent({host:options.host, port:options.port});
   } else if (options.agent === false) {
     options.agent = new Agent(options);
   }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -170,7 +170,11 @@ function REPLServer(prompt, stream) {
 
           if (ret !== undefined) {
             self.context._ = ret;
-            self.outputStream.write(exports.writer(ret) + '\n');
+            // allow custom writer to return null or undefined as a signal to not write
+            var str = exports.writer(ret);
+            if (str != null) {
+                self.outputStream.write(str + '\n');
+            }
           }
 
           self.bufferedCommand = '';


### PR DESCRIPTION
When using a custom inspect method to control the console representation of a particular object there's currently no way to actually have it return nothing (including no newline). This is a tiny patch that lets the inspect method signal to write nothing by returning null or undefined. This is useful for custom console methods that, for instance, return a promise so that writing can be serialized. As it stands, obj.inspect = function() { return "" } is the best you can do, and that will still dump a newline to the write stream. With this patch you can do obj.inspect = function() {} to have an object disappear on the console, just as if undefined were returned.
