### PR TITLE
Allow for a 'stream' property to be set on the `console.{log,info,warn,error}` functions

### DIFF
--- a/doc/api/stdio.markdown
+++ b/doc/api/stdio.markdown
@@ -1,11 +1,18 @@
 ## console
 
-Browser-like object for printing to stdout and stderr.
+Browser-like object for printing to stdout and stderr. For all logging functions
+below, you may override the default stream with _any_ desired stream, by setting
+the `stream` property of the logging function to a different Stream object.
+
+For instance, to redirect `console.log()` to stderr instead of stdout, try this:
+
+    console.log.stream = process.stderr;
+
 
 ### console.log()
 
-Prints to stdout with newline. This function can take multiple arguments in a
-`printf()`-like way. Example:
+Prints to stdout (by default) with newline. This function can take multiple
+arguments in a `printf()`-like way. Example:
 
     console.log('count: %d', count);
 
@@ -19,11 +26,11 @@ Same as `console.log`.
 ### console.warn()
 ### console.error()
 
-Same as `console.log` but prints to stderr.
+Same as `console.log` but prints to stderr (by default).
 
 ### console.dir(obj)
 
-Uses `util.inspect` on `obj` and prints resulting string to stderr.
+Uses `util.inspect` on `obj` and prints resulting string to stderr (by default).
 
 ### console.time(label)
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -19,8 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var writeError = process.binding('stdio').writeError;
-
 // console object
 var formatRegExp = /%[sdj]/g;
 function format(f) {
@@ -57,26 +55,27 @@ function format(f) {
 }
 
 
-exports.log = function() {
-  process.stdout.write(format.apply(this, arguments) + '\n');
-};
+function writeFormattedToStream(stream) {
+  function log() {
+    log.stream.write(format.apply(this, arguments) + '\n');
+  }
+  log.stream = stream;
+  return log;
+}
 
+exports.log = writeFormattedToStream(process.stdout);
 
-exports.info = exports.log;
+exports.info = writeFormattedToStream(process.stdout);
 
+exports.warn = writeFormattedToStream(process.stderr);
 
-exports.warn = function() {
-  writeError(format.apply(this, arguments) + '\n');
-};
-
-
-exports.error = exports.warn;
-
+exports.error = writeFormattedToStream(process.stderr);
 
 exports.dir = function(object) {
   var util = require('util');
-  process.stdout.write(util.inspect(object) + '\n');
+  exports.dir.stream.write(util.inspect(object) + '\n');
 };
+exports.dir.stream = process.stdout;
 
 
 var times = {};
@@ -98,7 +97,7 @@ exports.trace = function(label) {
   err.name = 'Trace';
   err.message = label || '';
   Error.captureStackTrace(err, arguments.callee);
-  console.error(err.stack);
+  exports.error(err.stack);
 };
 
 

--- a/src/node.js
+++ b/src/node.js
@@ -30,13 +30,15 @@
   function startup() {
     startup.globalVariables();
     startup.globalTimeouts();
-    startup.globalConsole();
 
     startup.processAssert();
     startup.processNextTick();
     startup.processStdio();
     startup.processKillAndExit();
     startup.processSignalHandlers();
+
+    // Needs to be after 'startup.processStdio()'
+    startup.globalConsole();
 
     startup.removedMethods();
 

--- a/test/simple/test-console.js
+++ b/test/simple/test-console.js
@@ -40,3 +40,15 @@ assert.equal('foo bar hop\n', strings.shift());
 assert.equal("{ slashes: '\\\\\\\\' }\n", strings.shift());
 
 assert.equal(true, process.stderr.write("hello world"));
+
+
+// Test that setting the 'stream' property on these functions
+// will write to the desired Stream object.
+var s;
+console.log.stream = {
+  write: function(str) {
+    s = str;
+  }
+}
+console.log('Test!');
+assert.equal(s, 'Test!\n');


### PR DESCRIPTION
This was motivated from: http://groups.google.com/group/nodejs/browse_thread/thread/6dd8f27076cacb51

Allow for a 'stream' property to be set on the `console.{log,info,warn,error,dir}` functions, so that the end-user has control over where these functions get written to.
