### PR TITLE
`os.arch()` function, to determine the processor architecture type that node is currently running on

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -21,6 +21,7 @@
 
 var binding = process.binding('os');
 
+exports.arch = binding.getArch;
 exports.hostname = binding.getHostname;
 exports.loadavg = binding.getLoadAvg;
 exports.uptime = binding.getUptime;

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -45,6 +45,18 @@ namespace node {
 
 using namespace v8;
 
+static Handle<Value> GetArch(const Arguments& args) {
+  HandleScope scope;
+  char type[256];
+  struct utsname info;
+
+  uname(&info);
+  strncpy(type, info.machine, strlen(info.machine));
+  type[strlen(info.machine)] = 0;
+
+  return scope.Close(String::New(type));
+}
+
 static Handle<Value> GetHostname(const Arguments& args) {
   HandleScope scope;
   char s[255];
@@ -184,6 +196,7 @@ static Handle<Value> OpenOSHandle(const Arguments& args) {
 void OS::Initialize(v8::Handle<v8::Object> target) {
   HandleScope scope;
 
+  NODE_SET_METHOD(target, "getArch", GetArch);
   NODE_SET_METHOD(target, "getHostname", GetHostname);
   NODE_SET_METHOD(target, "getLoadAvg", GetLoadAvg);
   NODE_SET_METHOD(target, "getUptime", GetUptime);


### PR DESCRIPTION
I want to get this `os.arch()` function into core. I foresee it being necessary when somebody wants to publish a module with pre-compiled binaries for the module, for different platforms. They could use this function along with `process.platform` to get something like `linux-i386` and load the required pre-compiiled module from there.

This inital implementation is the equivalent of calling `uname -m` from the command line. However, I don't think it's quite complete. For instance, on my iPhone, this function returns `iPhone3,1`, though really I think it should return `arm`.

So on that note, I'm opening this pull request (prematurely) in hopes that somebody else will have some "cross-platform" improvements that could be made. Thanks!
