### PR TITLE
Implement `process.arch` to get a String of the current processor architecture

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -271,6 +271,13 @@ The PID of the process.
 Getter/setter to set what is displayed in 'ps'.
 
 
+### process.arch
+
+What processor architecture you're running on. `'arm'`, `'ia32'`, etc.
+
+    console.log('This processor architecture is ' + process.arch);
+
+
 ### process.platform
 
 What platform you're running on. `'linux2'`, `'darwin'`, etc.

--- a/src/node.cc
+++ b/src/node.cc
@@ -1992,6 +1992,9 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
 
 
+  // process.arch
+  process->Set(String::NewSymbol("arch"), String::New(ARCH));
+
   // process.platform
   process->Set(String::NewSymbol("platform"), String::New(PLATFORM));
 

--- a/wscript
+++ b/wscript
@@ -501,6 +501,9 @@ def configure(conf):
   else:
     conf.env.append_value('CPPFLAGS', '-DHAVE_FDATASYNC=0')
 
+  # arch
+  conf.env.append_value('CPPFLAGS', '-DARCH="' + conf.env['DEST_CPU'] + '"')
+
   # platform
   conf.env.append_value('CPPFLAGS', '-DPLATFORM="' + conf.env['DEST_OS'] + '"')
 


### PR DESCRIPTION
Implement `process.arch` to get a String of the current processor architecture, with docs.

Do this one instead of #980.
