### PR TITLE
Add a trace when a empty response is send

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -591,6 +591,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
   }
 
   if (!this._hasBody) {
+    console.trace();
     console.error('This type of response MUST NOT have a body. ' +
                   'Ignoring write() calls.');
     return true;


### PR DESCRIPTION
Add a trace so we can track down where the empty response occurred in our applications.

As seeing this

```
26 Apr 21:38:06 - Client 9508768464438617 connected
26 Apr 21:43:24 - Initializing client with transport "websocket"
26 Apr 21:43:24 - Client 8368203134741634 connected
This type of response MUST NOT have a body. Ignoring write() calls.
This type of response MUST NOT have a body. Ignoring write() calls.
26 Apr 21:45:08 - Initializing client with transport "websocket"
```

in your log doesn't really help. Having a trace back to our application or even where the error occurs does help allot when debugging such issues. 
