### PR TITLE
V8: Backported fix for segfaults with large, long-lived arrays that have been .splice()d

### DIFF
--- a/deps/v8/src/builtins.cc
+++ b/deps/v8/src/builtins.cc
@@ -818,8 +818,8 @@ BUILTIN(ArraySplice) {
       const int delta = actual_delete_count - item_count;
 
       if (actual_start > 0) {
-        Object** start = elms->data_start();
-        memmove(start + delta, start, actual_start * kPointerSize);
+        AssertNoAllocation no_gc;
+        MoveElements(&no_gc, elms, delta, elms, 0, actual_start);
       }
 
       elms = LeftTrimFixedArray(elms, delta);


### PR DESCRIPTION
This V8 bug caused segmentation faults for me when building large web applications with https://github.com/One-com/assetgraph. I reported it last week and it has been promptly fixed.

V. Egorov says that 3.1.19 will include the fix and that this backport is correct.

Here's the fix on the bleeding edge branch: http://code.google.com/p/v8/source/detail?r=7706
