### PR TITLE
Add protected EventEmitter::HaveListener() function.

### DIFF
--- a/src/node_events.cc
+++ b/src/node_events.cc
@@ -89,4 +89,15 @@ bool EventEmitter::Emit(Handle<String> event, int argc, Handle<Value> argv[]) {
   return true;
 }
 
+bool EventEmitter::HaveListeners(Handle<String> event) {
+  HandleScope scope;
+  // HandleScope not needed here because only called from one of the two
+  // functions below
+  Local<Value> events_v = handle_->Get(events_symbol);
+  if (!events_v->IsObject()) return false;
+  Local<Object> events = events_v->ToObject();
+  Local<Value> listeners_v = events->Get(event);
+  return (listeners_v->IsFunction() || listeners_v->IsArray());
+}
+
 }  // namespace node

--- a/src/node_events.h
+++ b/src/node_events.h
@@ -37,6 +37,7 @@ class EventEmitter : public ObjectWrap {
             v8::Handle<v8::Value> argv[]);
 
  protected:
+  bool HaveListeners(v8::Handle<v8::String> event);
   EventEmitter() : ObjectWrap () { }
 };
 


### PR DESCRIPTION
if EventEmitter exposed a protected HaveListeners method then objects that emit events with payloads which are particularly costly to construct could optimize by using it.  This is a naive implementation that affords a 15% performance improvement in one sample use case (yajl node bindings).  This patch might be more interesting if the HaveListeners check itself could be made less expensive.
