### PR TITLE
Documentation for `require.main`

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -305,6 +305,21 @@ the same process.  As the application stack grows, we tend to assemble
 functionality, and it is a problem with those parts interact in ways
 that are difficult to predict.
 
+### Accessing the main module
+
+When a file is run directly from Node, `require.main` is set to its
+`module`. That means that you can determine whether a file has been run
+directly by testing
+
+    require.main === module
+
+For a file `foo.js`, this will be `true` if run via `node foo.js`, but
+`false` if run by `require('./foo')`.
+
+Because `module` provides a `filename` property (normally equivalent to
+`__filename`), the entry point of the current application can be obtained
+by checking `require.main.filename`.
+
 ## Addenda: Package Manager Tips
 
 The semantics of Node's `require()` function were designed to be general


### PR DESCRIPTION
See #997. `require.main` isn't currently mentioned anywhere in the docs; this patch adds a short section on it to the [modules](http://nodejs.org/docs/v0.4/api/modules.html) page.
