### PR TITLE
nodejs.org ChangeLog should link to the appropriate branch

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -24,7 +24,7 @@
     <div id="toc">
       <ol>
         <li><a href="#download">Download</a></li>
-        <li><a href="https://github.com/joyent/node/raw/master/ChangeLog">ChangeLog</a></li>
+        <li><a href="https://github.com/joyent/node/raw/v0.4/ChangeLog">ChangeLog</a></li>
         <li><a href="#about">About</a></li>
         <li><a href="http://nodejs.org/docs/v0.4.6/api">v0.4.6 docs</a></li>
         <br/>


### PR DESCRIPTION
I suggest that the link to the ChangeLog be a link to the appropriate branch. The docs link already requires this step. What has been happening is the master branch ChangeLog has not been kept up to date as promptly, and during those times (now and the time mentioned here http://stackoverflow.com/questions/5522877/node-js-wheres-the-changelog-the-describes-v0-4-4-and-0-4-5). Also, a note should be made on whatever new-release-todo-list you have so when 0.5 comes along, this is updated. If this change is rejected, the home page of nodejs.org will likely continue to at times show an out of date ChangeLog. When this happened to me, I never found the new change log after serious looking around because I did not know about the other branches. Eventually the StackOverflow question found somebody who knew.
