### PR TITLE
Add quotes around ARCH and PLATFORM

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1993,10 +1993,10 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
 
   // process.arch
-  process->Set(String::NewSymbol("arch"), String::New(ARCH));
+  process->Set(String::NewSymbol("arch"), String::New("ARCH"));
 
   // process.platform
-  process->Set(String::NewSymbol("platform"), String::New(PLATFORM));
+  process->Set(String::NewSymbol("platform"), String::New("PLATFORM"));
 
   // process.argv
   Local<Array> arguments = Array::New(argc - option_end_index + 1);


### PR DESCRIPTION
Just a simple patch for node.cc to make it compile on x86_64 linux.
