### PR TITLE
Attempt to connect to debug process more than once

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1043,19 +1043,16 @@ Interface.prototype.trySpawn = function(cb) {
 
   this.pause();
 
-  setTimeout(function() {
-    process.stdout.write('connecting...');
-    var client = self.client = new Client();
-    client.connect(exports.port);
+  var client = self.client = new Client();
+  var connectionAttempts = 0;
 
-    client.once('ready', function() {
-      process.stdout.write('ok\r\n');
+  client.once('ready', function() {
+    process.stdout.write(' ok\r\n');
 
-      // since we did debug-brk, we're hitting a break point immediately
-      // continue before anything else.
-      client.reqContinue(function() {
-        if (cb) cb();
-      });
+    // since we did debug-brk, we're hitting a break point immediately
+    // continue before anything else.
+    client.reqContinue(function() {
+      if (cb) cb();
     });
 
     client.on('close', function() {
@@ -1064,17 +1061,37 @@ Interface.prototype.trySpawn = function(cb) {
       self.killChild();
       if (!self.quitting) self.term.prompt();
     });
+  });
 
-    client.on('unhandledResponse', function(res) {
-      console.log('\r\nunhandled res:');
-      console.log(res);
-      self.term.prompt();
-    });
+  client.on('unhandledResponse', function(res) {
+    console.log('\r\nunhandled res:');
+    console.log(res);
+    self.term.prompt();
+  });
 
-    client.on('break', function(res) {
-      self.handleBreak(res.body);
-    });
-  }, 100);
+  client.on('break', function(res) {
+    self.handleBreak(res.body);
+  });
+
+  client.on('error', connectError);
+  function connectError() {
+    // If it's failed to connect 4 times then don't catch the next error
+    if (connectionAttempts >= 4) {
+      client.removeListener('error', connectError);
+    }
+    setTimeout(attemptConnect, 50);
+  }
+
+  function attemptConnect() {
+    ++connectionAttempts;
+    process.stdout.write('.');
+    client.connect(exports.port);
+  }
+
+  setTimeout(function() {
+    process.stdout.write('connecting..');
+    attemptConnect();
+  }, 50);
 };
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2251,7 +2251,7 @@ static void EnableDebug(bool wait_connect) {
   assert(r);
 
   // Print out some information.
-  fprintf(stderr, "debugger listening on port %d\r\n", debug_port);
+  fprintf(stderr, "debugger listening on port %d", debug_port);
 }
 
 


### PR DESCRIPTION
The debugger would give up after only 100ms but on my system this
timeout isn't enough. The startup process is now modified to try 6
times every 50ms instead.
