### PR TITLE
node::DecodeBytes calls toString with no encoding if we have a Buffer

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1152,7 +1152,21 @@ ssize_t DecodeBytes(v8::Handle<v8::Value> val, enum encoding encoding) {
     return -1;
   }
 
-  Local<String> str = val->ToString();
+  Local<String> str;
+  // Buffers are special because their toString method will call the slice
+  // method that is appropriate for the encoding passed in.  If the encoding is
+  // not specified, then it defaults to UTF-8 which isn't ideal for all
+  // encodings.
+  if (Buffer::HasInstance(val)) {
+    assert(val->IsObject());
+    Local<Object> obj = val->ToObject();
+    Local<Function> toString =
+      obj->Get(String::NewSymbol("toString")).As<Function>();
+    Local<Value> argv[] = { Buffer::EncodingToString(encoding) };
+    str = toString->Call(obj, 1, argv)->ToString();
+  } else {
+    str = val->ToString();
+  }
 
   if (encoding == UTF8) return str->Utf8Length();
   else if (encoding == UCS2) return str->Length() * 2;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -708,6 +708,26 @@ bool Buffer::HasInstance(v8::Handle<v8::Value> val) {
   return false;
 }
 
+Local<String> Buffer::EncodingToString(enum encoding e) {
+  // Note: these should match the expected encodings in libs/buffer.js
+  switch (e) {
+    case ASCII:
+      return String::NewSymbol("ascii");
+    case UTF8:
+      return String::NewSymbol("utf8");
+    case BASE64:
+      return String::NewSymbol("base64");
+    case UCS2:
+      return String::NewSymbol("ucs2");
+    case BINARY:
+      return String::NewSymbol("binary");
+    case HEX:
+      return String::NewSymbol("hex");
+    default:
+      // A new encoding was added that we don't know about, so fail hard.
+      assert(0);
+  };
+}
 
 void Buffer::Initialize(Handle<Object> target) {
   HandleScope scope;

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -87,6 +87,7 @@ class Buffer : public ObjectWrap {
     return Buffer::Length(b->handle_);
   }
 
+  static v8::Local<v8::String> EncodingToString(enum encoding e);
 
   ~Buffer();
 


### PR DESCRIPTION
`node::DecodeBytes` should pass the encoding to `toString` if we have a buffer so we use the correct `slice` method.  There are some more detailed comments on the commit in this pull request that explain the issue in more detail.
