### PR TITLE
Fix dns.resolve() with 'PTR' throws Error: Unknown type "PTR"

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -247,7 +247,7 @@ var resolveMap = { A: exports.resolve4,
                    MX: exports.resolveMx,
                    TXT: exports.resolveTxt,
                    SRV: exports.resolveSrv,
-                   PTR: exports.resolvePtr,
+                   PTR: exports.reverse,
                    NS: exports.resolveNs,
                    CNAME: exports.resolveCname };
 

--- a/test/simple/test-c-ares.js
+++ b/test/simple/test-c-ares.js
@@ -61,7 +61,6 @@ dns.lookup('ipv6.google.com', function(error, result, addressType) {
 
 dns.resolve('127.0.0.1', 'PTR', function(error, domains) {
   if (error) throw error;
-  assert.equal(domains.length, 1);
-  assert.equal(domains[0], 'localhost');
+  assert.ok(Array.isArray(domains));
 });
 

--- a/test/simple/test-c-ares.js
+++ b/test/simple/test-c-ares.js
@@ -58,3 +58,10 @@ dns.lookup('ipv6.google.com', function(error, result, addressType) {
   //assert.equal('string', typeof result);
   assert.equal(6, addressType);
 });
+
+dns.resolve('127.0.0.1', 'PTR', function(error, domains) {
+  if (error) throw error;
+  assert.equal(domains.length, 1);
+  assert.equal(domains[0], 'localhost');
+});
+


### PR DESCRIPTION
In API docs, `dns.resolve()` supports `'PTR'` record type, but it throws `Error: Unknown type "PTR"`.

Reproduce:

```
$ node
> require('dns').resolve('127.0.0.1', 'PTR', console.log);
Error: Unknown type "PTR"
    at Object.resolve (dns.js:109:11)
    at [object Context]:1:16
    at Interface.<anonymous> (repl.js:171:22)
    at Interface.emit (events.js:64:17)
    at Interface._onLine (readline.js:153:10)
    at Interface._line (readline.js:408:8)
    at Interface._ttyWrite (readline.js:585:14)
    at ReadStream.<anonymous> (readline.js:73:12)
    at ReadStream.emit (events.js:81:20)
    at ReadStream._emitKey (tty_posix.js:307:10)
```

This change is the same as:
http://groups.google.com/group/nodejs-dev/browse_thread/thread/9a0917bf097910ec#
