### PR TITLE
Fix built-in debugger breaks just before a script

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1054,8 +1054,10 @@ Interface.prototype.trySpawn = function(cb) {
 
     // since we did debug-brk, we're hitting a break point immediately
     // continue before anything else.
-    client.reqContinue(function() {
-      if (cb) cb();
+    client.once('break', function() {
+      client.reqContinue(function() {
+        if (cb) cb();
+      });
     });
 
     client.on('close', function() {

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -646,6 +646,7 @@ function Interface() {
     }
   });
 }
+exports.Interface = Interface;
 
 
 Interface.prototype.complete = function(line) {
@@ -1058,6 +1059,10 @@ Interface.prototype.trySpawn = function(cb) {
       client.reqContinue(function() {
         if (cb) cb();
       });
+
+      client.on('break', function(res) {
+        self.handleBreak(res.body);
+      });
     });
 
     client.on('close', function() {
@@ -1072,10 +1077,6 @@ Interface.prototype.trySpawn = function(cb) {
     console.log('\r\nunhandled res:');
     console.log(res);
     self.term.prompt();
-  });
-
-  client.on('break', function(res) {
-    self.handleBreak(res.body);
   });
 
   client.on('error', connectError);

--- a/test/simple/test-debugger-interface.js
+++ b/test/simple/test-debugger-interface.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+process.argv[2] = common.fixturesDir + '/exit.js';
+var debug = require('_debugger');
+var interface = new debug.Interface();
+
+var events = [];
+interface.trySpawn(function() {
+  events.push('continue');
+});
+
+var client = interface.client;
+client.on('break', function() {
+  events.push('break');
+});
+client.on('end', function() {
+  interface.quit();
+});
+setTimeout(function() {
+  interface.quit();
+}, 1000);
+
+process.on('exit', function() {
+  assert.deepEqual(events, ['break', 'continue']);
+});
+


### PR DESCRIPTION
When the built-in debugger is started, it runs script until hits breakpoint. But on a slow (virtual) machine, the debugger breaks just before a script.

Reproduce:

```
$ node debug simple.js 
debug> run
debugger listening on port 5858
connecting...ok
breakpoint #1 in #<Object>.[anonymous](exports=#<Object>, require=function require(path) {
    return Module._load(path, self);
  }, module=#<Module>, __filename=/tmp/simple.js, __dirname=/tmp), /tmp/simple.js:1
(function (exports, require, module, __filename, __dirname) { var s = 'Hello, Debugger!';
                                                              ^
debug> 
```

The debugger (parent) process spawned child process with `--debug-brk` option and sent `'continue'` request to the V8. On the slow machine, the V8 still compiles the scripts, it did not yet break it. So the `'continue'` request was ignored.

The debugger should wait to send `'continue'` until it receives `'break'` event.
