### PR TITLE
Remove 'connect' event from server side sockets

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -948,15 +948,6 @@ function Server(/* [ options, ] listener */) {
 
       DTRACE_NET_SERVER_CONNECTION(s);
       self.emit('connection', s);
-
-      // The 'connect' event  probably should be removed for server-side
-      // sockets. It's redundant.
-      try {
-        s.emit('connect');
-      } catch (e) {
-        s.destroy(e);
-        return;
-      }
     }
   };
 }

--- a/test/simple/test-net-reconnect.js
+++ b/test/simple/test-net-reconnect.js
@@ -30,9 +30,7 @@ var client_recv_count = 0;
 var disconnect_count = 0;
 
 var server = net.createServer(function(socket) {
-  socket.addListener('connect', function() {
-    socket.write('hello\r\n');
-  });
+  socket.write('hello\r\n');
 
   socket.addListener('end', function() {
     socket.end();


### PR DESCRIPTION
Sockets emitted by the 'connection' event are always connected, having
them emit the 'connect' event makes no sense. It only confused people,
as it's not clear if you have to listen to 'connect' or not.

That try..catch block was also very scary. It would silently swallow
exceptions in 'connect' listeners and destroy the socket. Makes no
sense.
