### PR TITLE
Prevents a flood of connections keeping you out of the event loop

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -75,6 +75,9 @@ var EMFILE = constants.EMFILE;
 
 var END_OF_FILE = 42;
 
+var MIN_ACCEPT = 5;
+var MAX_ACCEPT = 640; // needs to be MIN_ACCEPT * (2 ^ N)
+
 
 var ioWatchers = new FreeList('iowatcher', 100, function() {
   return new IOWatcher();
@@ -904,6 +907,9 @@ function Server(/* [ options, ] listener */) {
 
   self.watcher = new IOWatcher();
   self.watcher.host = self;
+  
+  var max_accept = MIN_ACCEPT;
+  
   self.watcher.callback = function() {
     // Just in case we don't have a dummy fd.
     getDummyFD();
@@ -913,10 +919,19 @@ function Server(/* [ options, ] listener */) {
       // the timer finishes.
       self.watcher.stop();
     }
+    
+    var accept_count = 0;
 
     while (typeof self.fd === 'number') {
       try {
         var peerInfo = accept(self.fd);
+        accept_count++;
+        if (accept_count > max_accept) {
+          if (max_accept < MAX_ACCEPT) max_accept *= 2;
+        }
+        else {
+          if (max_accept > MIN_ACCEPT) max_accept /= 2;
+        }
       } catch (e) {
         if (e.errno != EMFILE) throw e;
 


### PR DESCRIPTION
May need to check that more than max_accept connections coming in will re-fire the IOWatcher if we don't immediately accept it. Otherwise we need to do this another way.
