### PR TITLE
Bug Fix for https://github.com/joyent/node/issues/562

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -54,9 +54,7 @@ var protocolPattern = /^([a-z0-9]+:)/i,
     // protocols that never have a hostname.
     hostlessProtocol = {
       'javascript': true,
-      'javascript:': true,
-      'file': true,
-      'file:': true
+      'javascript:': true
     },
     // protocols that always have a path component.
     pathedProtocol = {

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -169,11 +169,11 @@ var parseTests = {
     'pathname': '/etc/passwd',
     'hostname': ''
   },
-  'file://localhost/etc/node/' : {
-    'href': 'file://localhost/etc/node/',
+  'file:///etc/node/' : {
+    'href': 'file:///etc/node/',
     'protocol': 'file:',
     'pathname': '/etc/node/',
-    'hostname': 'localhost'
+    'hostname': ''
   },
   'http:/baz/../foo/bar' : {
     'href': 'http:/baz/../foo/bar',

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -169,11 +169,11 @@ var parseTests = {
     'pathname': '/etc/passwd',
     'hostname': ''
   },
-  'file:///etc/node/' : {
-    'href': 'file:///etc/node/',
+  'file://localhost/etc/node/' : {
+    'href': 'file://localhost/etc/node/',
     'protocol': 'file:',
     'pathname': '/etc/node/',
-    'hostname': ''
+    'hostname': 'localhost'
   },
   'http:/baz/../foo/bar' : {
     'href': 'http:/baz/../foo/bar',

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -166,12 +166,14 @@ var parseTests = {
   'file:///etc/passwd' : {
     'href': 'file:///etc/passwd',
     'protocol': 'file:',
-    'pathname': '///etc/passwd'
+    'pathname': '/etc/passwd',
+    'hostname': ''
   },
   'file:///etc/node/' : {
     'href': 'file:///etc/node/',
     'protocol': 'file:',
-    'pathname': '///etc/node/'
+    'pathname': '/etc/node/',
+    'hostname': ''
   },
   'http:/baz/../foo/bar' : {
     'href': 'http:/baz/../foo/bar',

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -169,11 +169,35 @@ var parseTests = {
     'pathname': '/etc/passwd',
     'hostname': ''
   },
+  'file://localhost/etc/passwd' : {
+    'href': 'file://localhost/etc/passwd',
+    'protocol': 'file:',
+    'pathname': '/etc/passwd',
+    'hostname': 'localhost'
+  },
+  'file://foo/etc/passwd' : {
+    'href': 'file://foo/etc/passwd',
+    'protocol': 'file:',
+    'pathname': '/etc/passwd',
+    'hostname': 'foo'
+  },
   'file:///etc/node/' : {
     'href': 'file:///etc/node/',
     'protocol': 'file:',
     'pathname': '/etc/node/',
     'hostname': ''
+  },
+  'file://localhost/etc/node/' : {
+    'href': 'file://localhost/etc/node/',
+    'protocol': 'file:',
+    'pathname': '/etc/node/',
+    'hostname': 'localhost'
+  },
+  'file://foo/etc/node/' : {
+    'href': 'file://foo/etc/node/',
+    'protocol': 'file:',
+    'pathname': '/etc/node/',
+    'hostname': 'foo'
   },
   'http:/baz/../foo/bar' : {
     'href': 'http:/baz/../foo/bar',


### PR DESCRIPTION
Fixing a bug in url.parse: https://github.com/joyent/node/issues/562

The file:// protocol _always_ has a hostname; it's frequently abbreviated as
an empty string, which represents 'localhost' implicitly.

According to RFC 1738 (http://tools.ietf.org/html/rfc1738):

A file URL takes the form:

```
file://<host>/<path>
```

where <host> is the fully qualified domain name of the system on
which the <path> is accessible...

As a special case, <host> can be the string "localhost" or the empty
string; this is interpreted as `the machine from which the URL is
being interpreted'.
