### PR TITLE
Move process.memoryUsage() to os.memoryUsage() (fix #988)

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -24,6 +24,7 @@ var binding = process.binding('os');
 exports.hostname = binding.getHostname;
 exports.loadavg = binding.getLoadAvg;
 exports.uptime = binding.getUptime;
+exports.memoryUsage = binding.getMemoryUsage;
 exports.freemem = binding.getFreeMem;
 exports.totalmem = binding.getTotalMem;
 exports.cpus = binding.getCPUs;

--- a/src/platform.h
+++ b/src/platform.h
@@ -33,6 +33,7 @@ class Platform {
   static const char* GetProcessTitle(int *len);
 
   static int GetMemory(size_t *rss, size_t *vsize);
+  static int GetProcessMemory(size_t *rss, size_t *vsize, int pid);
   static int GetExecutablePath(char* buffer, size_t* size);
   static int GetCPUInfo(v8::Local<v8::Array> *cpus);
   static double GetFreeMemory();

--- a/src/platform_cygwin.cc
+++ b/src/platform_cygwin.cc
@@ -184,6 +184,11 @@ const char* Platform::GetProcessTitle(int *len) {
 }
 
 
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 int Platform::GetMemory(size_t *rss, size_t *vsize) {
   FILE *f = fopen("/proc/self/stat", "r");
   if (!f) return -1;

--- a/src/platform_darwin.cc
+++ b/src/platform_darwin.cc
@@ -70,6 +70,12 @@ const char* Platform::GetProcessTitle(int *len) {
   return NULL;
 }
 
+
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 // Researched by Tim Becker and Michael Knight
 // http://blog.kuriositaet.de/?p=257
 int Platform::GetMemory(size_t *rss, size_t *vsize) {

--- a/src/platform_freebsd.cc
+++ b/src/platform_freebsd.cc
@@ -66,6 +66,12 @@ const char* Platform::GetProcessTitle(int *len) {
   return NULL;
 }
 
+
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 int Platform::GetMemory(size_t *rss, size_t *vsize) {
   kvm_t *kd = NULL;
   struct kinfo_proc *kinfo = NULL;

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -79,9 +79,21 @@ const char* Platform::GetProcessTitle(int *len) {
   return NULL;
 }
 
-
 int Platform::GetMemory(size_t *rss, size_t *vsize) {
-  FILE *f = fopen("/proc/self/stat", "r");
+  return Platform::GetProcessMemory(rss, vsize, NULL);
+}
+
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  FILE *f;
+  /* If pid == NULL, look at the current process */
+  if (pid == NULL) {
+    f = fopen("/proc/self/stat", "r");
+  } else {
+    char path[256];
+    snprintf(path, sizeof(path), "/proc/%u/stat", pid);
+    f = fopen(path, "r");
+  }
+  
   if (!f) return -1;
 
   int itmp;

--- a/src/platform_none.cc
+++ b/src/platform_none.cc
@@ -42,6 +42,11 @@ const char* OS::GetProcessTitle(int *len) {
 }
 
 
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 int OS::GetMemory(size_t *rss, size_t *vsize) {
   // Not implemented
   *rss = 0;

--- a/src/platform_openbsd.cc
+++ b/src/platform_openbsd.cc
@@ -66,6 +66,12 @@ const char* Platform::GetProcessTitle(int *len) {
   return NULL;
 }
 
+
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 int Platform::GetMemory(size_t *rss, size_t *vsize) {
   kvm_t *kd = NULL;
   struct kinfo_proc2 *kinfo = NULL;

--- a/src/platform_sunos.cc
+++ b/src/platform_sunos.cc
@@ -76,6 +76,11 @@ const char* Platform::GetProcessTitle(int *len) {
 }
 
 
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 int Platform::GetMemory(size_t *rss, size_t *vsize) {
   pid_t pid = getpid();
 

--- a/src/platform_win32.cc
+++ b/src/platform_win32.cc
@@ -215,6 +215,11 @@ const char* Platform::GetProcessTitle(int *len) {
 }
 
 
+int Platform::GetProcessMemory(size_t *rss, size_t *vsize, int pid) {
+  assert(0 && "implement me");
+}
+
+
 int Platform::GetMemory(size_t *rss, size_t *vsize) {
   *rss = 0;
   *vsize = 0;

--- a/test/simple/test-memory-usage.js
+++ b/test/simple/test-memory-usage.js
@@ -21,8 +21,20 @@
 
 var common = require('../common');
 var assert = require('assert');
+var os = require('os');
 
-var r = process.memoryUsage();
+var k = process.memoryUsage();
+console.log(common.inspect(k));
+assert.equal(true, k['rss'] > 0);
+assert.equal(true, k['vsize'] > 0);
+
+var r = os.memoryUsage();
 console.log(common.inspect(r));
 assert.equal(true, r['rss'] > 0);
 assert.equal(true, r['vsize'] > 0);
+
+var d = os.memoryUsage(1);
+console.log(common.inspect(r));
+assert.equal(true, d['rss'] > 0);
+assert.equal(true, d['vsize'] > 0);
+


### PR DESCRIPTION
I messed up with git, so that's why I opened this new pull request (closing the old one now). Tried fixing the things that ry commented on:

"Please do process.memoryUsage() (leave it in the test) and please stub out the other platform's GetProcessMemory() functions and put assert(0 && "implement me") int them."

If I misunderstood anything, please say so.
