### PR TITLE
Concatenate WWW-Authenticate HTTP headers.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -345,6 +345,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
     case 'cookie':
     case 'pragma':
     case 'link':
+    case 'www-authenticate':
       if (field in dest) {
         dest[field] += ', ' + value;
       } else {

--- a/test/simple/test-http-server-multiheaders.js
+++ b/test/simple/test-http-server-multiheaders.js
@@ -30,6 +30,7 @@ var http = require('http');
 var srv = http.createServer(function(req, res) {
   assert.equal(req.headers.accept, 'abc, def, ghijklmnopqrst');
   assert.equal(req.headers.host, 'foo');
+  assert.equal(req.headers['www-authenticate'], 'foo, bar, baz');
   assert.equal(req.headers['x-foo'], 'bingo');
   assert.equal(req.headers['x-bar'], 'banjo, bango');
 
@@ -51,6 +52,9 @@ srv.listen(common.PORT, function() {
       ['host', 'foo'],
       ['Host', 'bar'],
       ['hOst', 'baz'],
+      ['www-authenticate', 'foo'],
+      ['WWW-Authenticate', 'bar'],
+      ['WWW-AUTHENTICATE', 'baz'],
       ['x-foo', 'bingo'],
       ['x-bar', 'banjo'],
       ['x-bar', 'bango']


### PR DESCRIPTION
IIS sends two WWW-Authenticate headers if NTLM or Kerberos auth is enabled.

```
WWW-Authenticate: NTLM <challenge>
WWW-Authenticate: Negotiate
```

I only see the second one, right now - the one I don't care about.
