### PR TITLE
crypto.create*() functions should accept buffers for keys and IVs.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1154,6 +1154,10 @@ ssize_t DecodeBytes(v8::Handle<v8::Value> val, enum encoding encoding) {
     return -1;
   }
 
+  if (Buffer::HasInstance(val)) {
+    return Buffer::Length(val->ToObject());
+  }
+
   Local<String> str = val->ToString();
 
   if (encoding == UTF8) return str->Utf8Length();
@@ -1185,6 +1189,13 @@ ssize_t DecodeWrite(char *buf,
                     "Use 'binary'.\n");
     assert(0);
     return -1;
+  }
+
+  if (Buffer::HasInstance(val)) {
+    Local<Object> obj = val->ToObject();
+    const ssize_t size = Buffer::Length(obj);
+    memcpy(buf, Buffer::Data(obj), size);
+    return size;
   }
 
   Local<String> str = val->ToString();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1602,7 +1602,8 @@ class Cipher : public ObjectWrap {
 
     cipher->incomplete_base64=NULL;
 
-    if (args.Length() <= 1 || !args[0]->IsString() || !args[1]->IsString()) {
+    if (args.Length() <= 1 || !args[0]->IsString()
+    || !(args[1]->IsString() || Buffer::HasInstance(args[1]))) {
       return ThrowException(Exception::Error(String::New(
         "Must give cipher-type, key")));
     }
@@ -1640,7 +1641,9 @@ class Cipher : public ObjectWrap {
 
     cipher->incomplete_base64=NULL;
 
-    if (args.Length() <= 2 || !args[0]->IsString() || !args[1]->IsString() || !args[2]->IsString()) {
+    if (args.Length() <= 2 || !args[0]->IsString()
+    || !(args[1]->IsString() || Buffer::HasInstance(args[1]))
+    || !(args[2]->IsString() || Buffer::HasInstance(args[2]))) {
       return ThrowException(Exception::Error(String::New(
         "Must give cipher-type, key, and iv as argument")));
     }
@@ -1968,7 +1971,8 @@ class Decipher : public ObjectWrap {
     cipher->incomplete_utf8=NULL;
     cipher->incomplete_hex_flag=false;
 
-    if (args.Length() <= 1 || !args[0]->IsString() || !args[1]->IsString()) {
+    if (args.Length() <= 1 || !args[0]->IsString()
+    || !(args[1]->IsString() || Buffer::HasInstance(args[1]))) {
       return ThrowException(Exception::Error(String::New(
         "Must give cipher-type, key as argument")));
     }
@@ -2006,7 +2010,9 @@ class Decipher : public ObjectWrap {
     cipher->incomplete_utf8=NULL;
     cipher->incomplete_hex_flag=false;
 
-    if (args.Length() <= 2 || !args[0]->IsString() || !args[1]->IsString() || !args[2]->IsString()) {
+    if (args.Length() <= 2 || !args[0]->IsString()
+    || !(args[1]->IsString() || Buffer::HasInstance(args[1]))
+    || !(args[2]->IsString() || Buffer::HasInstance(args[2]))) {
       return ThrowException(Exception::Error(String::New(
         "Must give cipher-type, key, and iv as argument")));
     }

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -110,35 +110,46 @@ var verified = crypto.createVerify('RSA-SHA256')
                      .verify(certPem, s2); // binary
 assert.ok(verified, 'sign and verify (binary)');
 
-// Test encryption and decryption
 var plaintext = 'Keep this a secret? No! Tell everyone about node.js!';
-var cipher = crypto.createCipher('aes192', 'MySecretKey123');
 
-// encrypt plaintext which is in utf8 format
-// to a ciphertext which will be in hex
-var ciph = cipher.update(plaintext, 'utf8', 'hex');
-// Only use binary or hex, not base64.
-ciph += cipher.final('hex');
+function testCipher(key) {
+  // Test encryption and decryption
+  var cipher = crypto.createCipher('aes192', key);
 
-var decipher = crypto.createDecipher('aes192', 'MySecretKey123');
-var txt = decipher.update(ciph, 'hex', 'utf8');
-txt += decipher.final('utf8');
+  // encrypt plaintext which is in utf8 format
+  // to a ciphertext which will be in hex
+  var ciph = cipher.update(plaintext, 'utf8', 'hex');
+  // Only use binary or hex, not base64.
+  ciph += cipher.final('hex');
 
-assert.equal(txt, plaintext, 'encryption and decryption');
+  var decipher = crypto.createDecipher('aes192', key);
+  var txt = decipher.update(ciph, 'hex', 'utf8');
+  txt += decipher.final('utf8');
 
-// Test encyrption and decryption with explicit key and iv
-var encryption_key = '0123456789abcd0123456789';
-var iv = '12345678';
+  assert.equal(txt, plaintext, 'encryption and decryption');
+}
 
-var cipher = crypto.createCipheriv('des-ede3-cbc', encryption_key, iv);
-var ciph = cipher.update(plaintext, 'utf8', 'hex');
-ciph += cipher.final('hex');
+function testCipherIv(key, iv) {
+  // Test encyrption and decryption with explicit key and iv
+  var encryption_key = '0123456789abcd0123456789';
+  var iv = '12345678';
 
-var decipher = crypto.createDecipheriv('des-ede3-cbc', encryption_key, iv);
-var txt = decipher.update(ciph, 'hex', 'utf8');
-txt += decipher.final('utf8');
+  var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
+  var ciph = cipher.update(plaintext, 'utf8', 'hex');
+  ciph += cipher.final('hex');
 
-assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+  var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
+  var txt = decipher.update(ciph, 'hex', 'utf8');
+  txt += decipher.final('utf8');
+
+  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+}
+
+testCipher('MySecretKey123');
+testCipher(new Buffer('MySecretKey123'));
+
+testCipherIv('0123456789abcd0123456789', '12345678');
+testCipherIv(new Buffer('0123456789abcd0123456789'), new Buffer('12345678'));
 
 // update() should only take buffers / strings
 assert.throws(function() {


### PR DESCRIPTION
Fix for #1089. Updated test cases.
