### PR TITLE
Fix error handling bug in stream.pipe()

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -95,7 +95,7 @@ Stream.prototype.pipe = function(dest, options) {
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (this.listeners('error').length === 1) {
+    if (this.listeners('error').length === 0) {
       throw er; // Unhandled stream error in pipe.
     }
   }

--- a/test/simple/test-stream-pipe-error-handling.js
+++ b/test/simple/test-stream-pipe-error-handling.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var Stream = require('stream').Stream;
+
+(function testErrorListenerCatches() {
+  var source = new Stream();
+  var dest = new Stream();
+
+  source.pipe(dest);
+
+  var gotErr = null;
+  source.on('error', function(err) {
+    gotErr = err;
+  });
+
+  var err = new Error('This stream turned into bacon.');
+  source.emit('error', err);
+  assert.strictEqual(gotErr, err);
+})();
+
+(function testErrorWithoutListenerThrows() {
+  var source = new Stream();
+  var dest = new Stream();
+
+  source.pipe(dest);
+
+  var err = new Error('This stream turned into bacon.');
+
+  var gotErr = null;
+  try {
+    source.emit('error', err);
+  } catch (e) {
+    gotErr = e;
+  }
+
+  assert.strictEqual(gotErr, err);
+})();


### PR DESCRIPTION
Problem: Since stream.pipe() is registering it's own error handlers on
the source and destination stream, it needs to replicate the
EventEmitter 'error' emitting semantics of throwing an error if there
are no other listeners. However, there was a off-by-one error because
the check for remaining listeners was done after cleanup() which means
the pipe's own listener was no longer included.

This would cause 'error' events on either the dest or the source to
throw if there was one other error listener, and while swallowing
the 'error' event if there was no other listener.

Solution: I added a test demonstrating the two issues and fixed the
problem by correcting the off-by-one error.
