### PR TITLE
Fix incorrect documentation for assert.fail()

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -5,7 +5,7 @@ access it with `require('assert')`.
 
 ### assert.fail(actual, expected, message, operator)
 
-Tests if `actual` is equal to `expected` using the operator provided.
+Throws an exception that displays the values for `actual` and `expected` separated by the provided operator.
 
 ### assert.ok(value, [message])
 


### PR DESCRIPTION
assert.fail() doesn't actually test values.
