### PR TITLE
Crypto documentation fixes

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -93,7 +93,7 @@ Returns the enciphered contents, and can be called many times with new data as i
 
 ### cipher.final(output_encoding='binary')
 
-Returns any remaining enciphered contents, with `output_encoding` being one of: `'binary'`, `'ascii'` or `'utf8'`.
+Returns any remaining enciphered contents, with `output_encoding` being one of: `'binary'`, `'base64'` or `'hex'`.
 
 ### crypto.createDecipher(algorithm, key)
 
@@ -142,7 +142,7 @@ This can be called many times with new data as it is streamed.
 ### verifier.verify(cert, signature, signature_format='binary')
 
 Verifies the signed data by using the `cert` which is a string containing
-the PEM encoded certificate, and `signature`, which is the previously calculates
+the PEM encoded certificate, and `signature`, which is the previously calculated
 signature for the data, in the `signature_format` which can be `'binary'`, `'hex'` or `'base64'`.
 
 Returns true or false depending on the validity of the signature for the data and public key.


### PR DESCRIPTION
cipher.final description has the wrong encodings listed and a minor spelling error in the verifier.verify description.
