### PR TITLE
Fixes "comma at end of enumerator list" build issue with some packages

### DIFF
--- a/deps/libeio/eio.h
+++ b/deps/libeio/eio.h
@@ -176,7 +176,7 @@ enum
 enum
 {
   EIO_MCL_CURRENT = 1,
-  EIO_MCL_FUTURE  = 2,
+  EIO_MCL_FUTURE  = 2
 };
 
 /* request priorities */
@@ -184,7 +184,7 @@ enum
 enum {
   EIO_PRI_MIN     = -4,
   EIO_PRI_MAX     =  4,
-  EIO_PRI_DEFAULT =  0,
+  EIO_PRI_DEFAULT =  0
 };
 
 /* eio request structure */


### PR DESCRIPTION
I've had two different packages fail to compile with this error (node-stringprep and something else). I just removed the extra commas at the end of the enums in libeio.h
