### PR TITLE
Add "all" event type for listen all handlers.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -50,11 +50,13 @@ EventEmitter.prototype.emit = function(type) {
     }
   }
 
-  if (!this._events) return false;
+  var returnVal = true;
+  
+  if (!this._events) returnVal = false;
   var handler = this._events[type];
-  if (!handler) return false;
-
-  if (typeof handler == 'function') {
+  if (!handler) {
+    returnVal = false;
+  } else if (typeof handler == 'function') {
     switch (arguments.length) {
       // fast cases
       case 1:
@@ -71,7 +73,6 @@ EventEmitter.prototype.emit = function(type) {
         var args = Array.prototype.slice.call(arguments, 1);
         handler.apply(this, args);
     }
-    return true;
 
   } else if (isArray(handler)) {
     var args = Array.prototype.slice.call(arguments, 1);
@@ -80,11 +81,16 @@ EventEmitter.prototype.emit = function(type) {
     for (var i = 0, l = listeners.length; i < l; i++) {
       listeners[i].apply(this, args);
     }
-    return true;
 
   } else {
-    return false;
+    returnVal = false;
   }
+  
+  if (type !== "all") {
+    var args = Array.prototype.slice.call(arguments, 0);
+    this.emit.apply(this, ["all"].concat(args));
+  }
+  return returnVal;
 };
 
 // EventEmitter is defined in src/node_events.cc


### PR DESCRIPTION
The "all" emit event is a aspect to listen every events. This aspect helps us avoid depth level callback.

For an emitter instances, I can add a "task" method to implement call methods like assign task, but depth level callback.

```
EventEmitter.prototype.task = function (first, second, callback) {
    var that = this;
    var args = Array.prototype.slice.call(arguments, 0);
    var callback = args.pop();
    if (typeof callback !== "function") {
        return false;
    }

    var length = args.length;
    var i= 0, _deps = {};
    for (i = 0; i < length; i++) {
        (function (key) {
            that.on(key, function (data) {
                _deps[key] = _deps[key] || {};
                var flag = _deps[key];
                flag.ready = true;
                flag.data = data;
            });
        } (args[i]));
    }

    that.on("all", function () {
        var fire = true, data = [];
        var i = 0;
        for (i = 0; i < length; i++) {
            if (_deps[args[i]] && _deps[args[i]].ready) {
                data.push(_deps[args[i]].data);
            } else {
                fire = false;
                break;
            }
        }
        if (fire) {
            callback.apply(that, data);
        }
    });
};
```

usage: 
emitter.task("readfile", "getDatafromDB", function (file, data) {
      // TODO
});
