### PR TITLE
Add  equals rules for RegExp and Function objects in assert.deepEqual

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -146,6 +146,16 @@ function _deepEqual(actual, expected) {
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 
+  // 7.2.1 If the expected value is a RegExp  object, the actual value is
+  // equivalent if it is also a RegExp object that refers to the same time.
+  } else if (actual instanceof RegExp && expected instanceof RegExp) {
+    return actual.toString() === expected.toString();
+
+  // 7.2.2 If the expected value is a Function  object, the actual value is
+  // equivalent if it is also a Function object that refers to the same time.
+  } else if (actual instanceof Function && expected instanceof Function) {
+    return actual.toString() === expected.toString();
+
   // 7.3. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {


### PR DESCRIPTION
I think assert.deepEqual must support all standard objects. 
