### PR TITLE
node -e '' (passing an empty program to node(1)) invokes REPL, which behavior seems wrong

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -75,7 +75,7 @@
       // Main entry point into most programs:
       process.nextTick(Module.runMain);
 
-    } else if (process._eval) {
+    } else if (process._eval != null) {
       // User passed '-e' or '--eval' arguments to Node.
       var Module = NativeModule.require('module');
       var rv = new Module()._compile('return eval(process._eval)', 'eval');

--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -47,3 +47,10 @@ child.exec(nodejs + ' --eval "require(\'./test/simple/test-cli-eval.js\')"',
     function(status, stdout, stderr) {
       assert.equal(status.code, 42);
     });
+
+// empty program should do nothing
+child.exec(nodejs + ' -e ""',
+    function(status, stdout, stderr) {
+      assert.equal(stdout, 'undefined\n');
+      assert.equal(stderr, '');
+    });


### PR DESCRIPTION
Hi,

Unlike other interpreters (e.g. perl and ruby), `node -e ''` doesn't mean "do nothing". Instead, it invokes REPL unexpectedly.
I think it is a bug, so have written a patch and a test. Can you please review my patch?

Regards,
gfx
