### PR TITLE
onerror throws exceptions even when it shouldn't

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -95,7 +95,7 @@ Stream.prototype.pipe = function(dest, options) {
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (this.listeners('error').length === 1) {
+    if (this.listeners('error').length === 0) {
       throw er; // Unhandled stream error in pipe.
     }
   }


### PR DESCRIPTION
In stream.js, function onerror() calls cleanup() and then checks if there is exactly 1 error handler attached, if so, it throws an exception.  However, cleanup() already detached its error handler. Which means an exception is thrown even when a legitimate error handler is attached.
