### PR TITLE
Doc improvements

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -353,6 +353,12 @@ Objects returned from `fs.stat()` and `fs.lstat()` are of this type.
 
 `ReadStream` is a `Readable Stream`.
 
+### Event: 'open'
+
+`function (fd) { }`
+
+ `fd` is the file descriptor used by the ReadStream.
+
 ### fs.createReadStream(path, [options])
 
 Returns a new ReadStream object (See `Readable Stream`).

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -52,7 +52,7 @@ per connection (in the case of keep-alive connections).
 
 ### Event: 'checkContinue'
 
-`function (request, response) {}`
+`function (request, response) { }`
 
 Emitted each time a request with an http Expect: 100-continue is received.
 If this event isn't listened for, the server will automatically respond
@@ -68,7 +68,7 @@ not be emitted.
 
 ### Event: 'upgrade'
 
-`function (request, socket, head)`
+`function (request, socket, head) { }`
 
 Emitted each time a client requests a http upgrade. If this event isn't
 listened for, then clients requesting an upgrade will have their connections
@@ -84,7 +84,7 @@ sent to the server on that socket.
 
 ### Event: 'clientError'
 
-`function (exception) {}`
+`function (exception) { }`
 
 If a client connection emits an 'error' event - it will forwarded here.
 
@@ -252,6 +252,12 @@ authentication details.
 
 This object is created internally by a HTTP server--not by the user. It is
 passed as the second parameter to the `'request'` event. It is a `Writable Stream`.
+
+### Event: 'finish'
+
+`function () { }`
+
+Emitted when the sending request body was completed.
 
 ### response.writeContinue()
 
@@ -476,7 +482,7 @@ agent. The `http.getAgent()` function allows you to access the agents.
 
 ### Event: 'upgrade'
 
-`function (response, socket, head)`
+`function (response, socket, head) { }`
 
 Emitted each time a server responds to a request with an upgrade. If this
 event isn't being listened for, clients receiving an upgrade header will have
@@ -529,14 +535,6 @@ A client server pair that show you how to listen for the `upgrade` event using `
       });
     });
 
-
-### Event: 'continue'
-
-`function ()`
-
-Emitted when the server sends a '100 Continue' HTTP response, usually because
-the request contained 'Expect: 100-continue'. This is an instruction that
-the client should send the request body.
 
 ### agent.maxSockets
 
@@ -593,6 +591,20 @@ This is a `Writable Stream`.
 
 This is an `EventEmitter` with the following events:
 
+### Event: 'continue'
+
+`function () { }`
+
+Emitted when the server sends a '100 Continue' HTTP response, usually because
+the request contained 'Expect: 100-continue'. This is an instruction that
+the client should send the request body.
+
+### Event: 'finish'
+
+`function () { }`
+
+Emitted when the sending request body was completed.
+
 ### Event 'response'
 
 `function (response) { }`
@@ -639,17 +651,26 @@ The response implements the `Readable Stream` interface.
 
 ### Event: 'data'
 
-`function (chunk) {}`
+`function (chunk) { }`
 
 Emitted when a piece of the message body is received.
 
 
 ### Event: 'end'
 
-`function () {}`
+`function () { }`
 
 Emitted exactly once for each message. No arguments. After
 emitted no other events will be emitted on the response.
+
+### Event: 'close'
+
+`function (err) { }`
+
+Indicates that the underlaying connection was terminated before
+`end` event was emitted.
+See [http.ServerRequest](#http.ServerRequest)'s `'close'` event for more
+information.
 
 ### response.statusCode
 


### PR DESCRIPTION
added 'finish' event to http.ServerResponse.
moved 'continue' event from http.Agent to http.ClientRequest.
added 'finish' event to http.ClientRequest.
added 'close' event to http.ClientResponse.
added 'open' event to fs.ReadStream.
