### PR TITLE
Fix -e/--eval can't load module from node_modules

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -353,8 +353,13 @@
     }
 
     var Module = NativeModule.require('module');
+    var path = NativeModule.require('path');
+    var cwd = process.cwd();
 
-    var rv = new Module()._compile('return eval(process._eval)', 'eval');
+    var module = new Module('eval');
+    module.filename = path.join(cwd, 'eval');
+    module.paths = Module._nodeModulePaths(cwd);
+    var rv = module._compile('return eval(process._eval)', 'eval');
     console.log(rv);
     return true;
   };

--- a/test/simple/test-eval-require.js
+++ b/test/simple/test-eval-require.js
@@ -1,0 +1,35 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var path = require('path');
+var fs = require('fs');
+
+var options = {
+  cwd: common.fixturesDir
+};
+var child = spawn(process.execPath, ['-e', 'require("foo")'], options);
+child.on('exit', function(code) {
+  assert.equal(code, 0);
+});
+


### PR DESCRIPTION
With `-e` or `--eval`, `require()` can load module using relative path.

```
node -e 'require("./foo")'
```

But it can't load module from `node_modules` directory.
Reproduce:

```
$ node -e 'require("foo")'

module.js:322
    throw new Error("Cannot find module '" + request + "'");
          ^
Error: Cannot find module 'foo'
    at Function._resolveFilename (module.js:322:11)
    at Function._load (module.js:267:25)
    at require (module.js:351:19)
    at Object.<anonymous> (eval at <anonymous> (eval:1:82))
    at Object.<anonymous> (eval:1:70)
    at Module._compile (module.js:407:26)
    at Function.runEval (node.js:357:27)
    at startup (node.js:57:17)
    at node.js:443:3
```
