### PR TITLE
Fix warning: control reaches end of non-void function.

### DIFF
--- a/src/node_net.cc
+++ b/src/node_net.cc
@@ -625,7 +625,7 @@ static Handle<Value> GetSockFamily(const Arguments& args) {
     default:
       result = Integer::New((address_storage).ss_family);
   }
-  scope.Close(result);
+  return scope.Close(result);
 }
 
 static Handle<Value> GetPeerName(const Arguments& args) {

--- a/test/simple/test-net-getsockfamily.js
+++ b/test/simple/test-net-getsockfamily.js
@@ -1,0 +1,27 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var socket = process.binding('net').socket;
+var getsockfamily = process.binding('net').getsockfamily;
+
+assert.equal(getsockfamily(socket('unix')), 'AF_UNIX');
+assert.equal(getsockfamily(socket('tcp4')), 'AF_INET');


### PR DESCRIPTION
Add a test case - the missing return breaks net.getsockfamily() but only in debug builds.

Fun one to track down. This bug subtly breaks UNIX sockets in debug mode because they get the generic read and write implementations, not the custom ones.
