### PR TITLE
Fix fs can't handle large file on 64bit platform

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -81,6 +81,12 @@ static inline bool SetCloseOnExec(int fd) {
 #endif
 }
 
+#ifdef _LARGEFILE_SOURCE
+static inline int IsInt64(double x) {
+  return x == static_cast<double>(static_cast<int64_t>(x));
+}
+#endif
+
 
 static int After(eio_req *req) {
   HandleScope scope;
@@ -451,9 +457,17 @@ static Handle<Value> Rename(const Arguments& args) {
 }
 
 #ifndef _LARGEFILE_SOURCE
-#define GET_TRUNCATE_LEN(a) (a)->UInt32Value();
+#define ASSERT_TRUNCATE_LENGTH(a) \
+  if (!(a)->IsUndefined() && !(a)->IsNull() && !(a)->IsUInt32()) { \
+    return ThrowException(Exception::TypeError(String::New("Not an integer"))); \
+  }
+#define GET_TRUNCATE_LENGTH(a) ((a)->UInt32Value())
 #else
-#define GET_TRUNCATE_LEN(a) (a)->IntegerValue();
+#define ASSERT_TRUNCATE_LENGTH(a) \
+  if (!(a)->IsUndefined() && !(a)->IsNull() && !IsInt64((a)->NumberValue())) { \
+    return ThrowException(Exception::TypeError(String::New("Not an integer"))); \
+  }
+#define GET_TRUNCATE_LENGTH(a) ((a)->IntegerValue())
 #endif
 
 static Handle<Value> Truncate(const Arguments& args) {
@@ -464,7 +478,9 @@ static Handle<Value> Truncate(const Arguments& args) {
   }
 
   int fd = args[0]->Int32Value();
-  off_t len = GET_TRUNCATE_LEN(args[1]);
+
+  ASSERT_TRUNCATE_LENGTH(args[1]);
+  off_t len = GET_TRUNCATE_LENGTH(args[1]);
 
   if (args[2]->IsFunction()) {
     ASYNC_CALL(ftruncate, args[2], fd, len)
@@ -667,13 +683,17 @@ static Handle<Value> Open(const Arguments& args) {
 }
 
 #ifndef _LARGEFILE_SOURCE
-#define GET_OFFSET(a) (a)->IsInt32() ? (a)->IntegerValue() : -1;
+#define ASSERT_OFFSET(a) \
+  if (!(a)->IsUndefined() && !(a)->IsNull() && !(a)->IsInt32()) { \
+    return ThrowException(Exception::TypeError(String::New("Not an integer"))); \
+  }
+#define GET_OFFSET(a) ((a)->IsNumber() ? (a)->Int32Value() : -1)
 #else
-static inline int IsInt64(double x) {
-  return x == static_cast<double>(static_cast<int64_t>(x));
-}
-#define GET_OFFSET(a) \
-  (a)->IsNumber() && IsInt64((a)->NumberValue()) ? (a)->IntegerValue() : -1;
+#define ASSERT_OFFSET(a) \
+  if (!(a)->IsUndefined() && !(a)->IsNull() && !IsInt64((a)->NumberValue())) { \
+    return ThrowException(Exception::TypeError(String::New("Not an integer"))); \
+  }
+#define GET_OFFSET(a) ((a)->IsNumber() ? (a)->IntegerValue() : -1)
 #endif
 
 // bytesWritten = write(fd, data, position, enc, callback)
@@ -715,6 +735,7 @@ static Handle<Value> Write(const Arguments& args) {
           String::New("Length is extends beyond buffer")));
   }
 
+  ASSERT_OFFSET(args[4]);
   off_t pos = GET_OFFSET(args[4]);
 
   char * buf = (char*)buffer_data + off;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -450,7 +450,7 @@ static Handle<Value> Rename(const Arguments& args) {
   }
 }
 
-#ifndef __USE_FILE_OFFSET64
+#ifndef _LARGEFILE_SOURCE
 #define GET_TRUNCATE_LEN(a) (a)->UInt32Value();
 #else
 #define GET_TRUNCATE_LEN(a) (a)->IntegerValue();
@@ -666,7 +666,7 @@ static Handle<Value> Open(const Arguments& args) {
   }
 }
 
-#ifndef __USE_FILE_OFFSET64
+#ifndef _LARGEFILE_SOURCE
 #define GET_OFFSET(a) (a)->IsInt32() ? (a)->IntegerValue() : -1;
 #else
 static inline int IsInt64(double x) {

--- a/test/disabled/test-fs-largefile.js
+++ b/test/disabled/test-fs-largefile.js
@@ -1,0 +1,40 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var path = require('path'),
+    fs = require('fs'),
+    filepath = path.join(common.tmpDir, 'large.txt'),
+    fd = fs.openSync(filepath, 'w+'),
+    offset = 5 * 1024 * 1024 * 1024, // 5GB
+    message = 'Large File';
+
+fs.truncateSync(fd, offset);
+assert.equal(fs.statSync(filepath).size, offset);
+var writeBuf = new Buffer(message);
+fs.writeSync(fd, writeBuf, 0, writeBuf.length, offset);
+var readBuf = new Buffer(writeBuf.length);
+fs.readSync(fd, readBuf, 0, readBuf.length, offset);
+assert.equal(readBuf.toString(), message);
+fs.readSync(fd, readBuf, 0, 1, 0);
+assert.equal(readBuf[0], 0);
+

--- a/test/disabled/test-fs-largefile.js
+++ b/test/disabled/test-fs-largefile.js
@@ -38,3 +38,16 @@ assert.equal(readBuf.toString(), message);
 fs.readSync(fd, readBuf, 0, 1, 0);
 assert.equal(readBuf[0], 0);
 
+var exceptionRaised = false;
+try {
+  fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
+} catch (err) {
+  console.log(err);
+  exceptionRaised = true;
+  assert.equal(err.message, 'Not an integer');
+}
+
+process.on('exit', function() {
+  assert.ok(exceptionRaised);
+});
+


### PR DESCRIPTION
`fs.read()` and `fs.write()` can't handle more than 2GB files on 64bit platform.
Also `fs.truncate()` can't handle more than 4GB files.

Node already has the capability to handle large files.
This patch changes only a parameter check (read/write) and
type conversion from JS's number to C types (truncate).

The testcase only works on 64bit platform, then I put it into test/disabled.
