### PR TITLE
Fix mismatch between net.createConnection() and net.Socket.connect()

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -26,14 +26,16 @@ the socket is established the `'connect'` event will be emitted.
 
 The arguments for this method change the type of connection:
 
-* `net.createConnection(port, [host])`
+* `net.createConnection(port, [host], [callback])`
 
-  Creates a TCP connection to `port` on `host`. If `host` is omitted, `localhost`
-  will be assumed.
+  Creates a TCP connection to `port` on `host`. If `host` is omitted,
+  `localhost` will be assumed.
 
-* `net.createConnection(path)`
+* `net.createConnection(path, [callback])`
 
   Creates unix socket connection to `path`
+
+The `callback` parameter will be added as an listener for the 'connect` event.
 
 ---
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -260,9 +260,9 @@ Socket.prototype.open = function(fd, type) {
 };
 
 
-exports.createConnection = function(port, host) {
+exports.createConnection = function(port, host, callback) {
   var s = new Socket();
-  s.connect(port, host);
+  s.connect(port, host, callback);
   return s;
 };
 

--- a/test/simple/test-net-create-connection.js
+++ b/test/simple/test-net-create-connection.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var tcpPort = common.PORT;
+var connectHappened = false;
+
+var server = net.createServer(function(socket) {
+  server.close();
+  socket.end();
+});
+server.listen(tcpPort, function() {
+    var client = net.createConnection(tcpPort, 'localhost', function() {
+      connectHappened = true;
+    });
+});
+
+process.on('exit', function () {
+  assert.ok(connectHappened);
+});
+


### PR DESCRIPTION
`net.createConnection()` is wrapper for `net.Socket.connect()`,
but there is mismatch between them.

```
net.createConnection(port, [host])
net.Socket.connect(port, [host], [callback])
```

When I don't specify the `host` to `net.createConnection()`,
I can pass a callback function and it was called.

```
net.createConnection(3000, function(socket) {
  // called
});
```

But it is never called with `host`.

```
net.createConnection(3000, 'localhost', function(socket) {
  // not called
});
```
