### PR TITLE
missing header file dependencies need to be installed

### DIFF
--- a/wscript
+++ b/wscript
@@ -901,6 +901,12 @@ def build(bld):
     src/node_events.h
     src/node_version.h
   """)
+  bld.install_files('${PREFIX}/include/node/c-ares', """
+    deps/uv/c-ares/ares.h
+    deps/uv/c-ares/ares_version.h
+    deps/uv/c-ares/ares_build.h
+    deps/uv/c-ares/ares_rules.h
+  """)
 
   # Only install the man page if it exists.
   # Do 'make doc install' to build and install it.


### PR DESCRIPTION
node.h includes 'c-ares/ares.h' and subsequent includes from 'c-ares/ares.h' that should be installed by the build.
