### PR TITLE
V0.4 Resolves issue #1206: fs.readdir() memory leak

### DIFF
--- a/deps/libeio/eio.c
+++ b/deps/libeio/eio.c
@@ -1265,6 +1265,10 @@ eio__scandir (eio_req *req, etp_worker *self)
   X_LOCK (wrklock);
   /* the corresponding closedir is in ETP_WORKER_CLEAR */
   self->dirp = dirp = opendir (req->ptr1);
+
+  if (req->flags & EIO_FLAG_PTR1_FREE)
+    free (req->ptr1);
+
   req->flags |= EIO_FLAG_PTR1_FREE | EIO_FLAG_PTR2_FREE;
   req->ptr1 = dents = flags ? malloc (dentalloc * sizeof (eio_dirent)) : 0;
   req->ptr2 = names = malloc (namesalloc);


### PR DESCRIPTION
Apply fix to libeio/eio.c as suggested by Marc Lehmann and stress tested
as resolving the memory leak.  This change parallels the fix he has merged
into the mainline libeio CVS.
    http://cvs.schmorp.de/libeio/eio.c?r1=1.73&r2=1.74

(Do I need to do more to ensure this gets into 0.5 ?)
