### PR TITLE
Fix html links to documentation.

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -86,7 +86,7 @@ server.listen(1337, "127.0.0.1");
 </pre>
 
       <p>
-        See the <a href="/docs">API documentation</a> for more
+        See the <a href="/docs/latest/api/index.html">API documentation</a> for more
         examples.
       </p>
 
@@ -113,7 +113,7 @@ server.listen(1337, "127.0.0.1");
         (<a href="http://nodejs.org/docs/v0.4.8/api/index.html">Documentation</a>)
       </p>
 
-      <p>Historical: <a href="http://nodejs.org/dist">versions</a>, <a href="http://nodejs.org/docs">docs</a></p>
+      <p>Historical: <a href="http://nodejs.org/dist">versions</a>, <a href="http://nodejs.org/docs/latest/api/index.html">docs</a></p>
 
       <p>
         For build instructions see


### PR DESCRIPTION
The current html documentation links to itself.  The proposed should fix 2 links to go to the correct location.
