### PR TITLE
Fix wrong error handling at Open() after open(2) in sync mode

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -664,8 +664,8 @@ static Handle<Value> Open(const Arguments& args) {
     ASYNC_CALL(open, args[3], *path, flags, mode)
   } else {
     int fd = open(*path, flags, mode);
-    SetCloseOnExec(fd);
     if (fd < 0) return ThrowException(ErrnoException(errno, NULL, "", *path));
+    SetCloseOnExec(fd);
     return scope.Close(Integer::New(fd));
   }
 }


### PR DESCRIPTION
For example, for any open(2)-error was:

> require('fs').openSync('/notpermitted', 'w')
> Error: EBADF, Bad file descriptor '/notpermitted'
>     at Object.openSync (fs.js:221:18) ...

Now:

> require('fs').openSync('/notpermitted', 'w')
> Error: EACCES, Permission denied '/notpermitted'
>     at Object.openSync (fs.js:221:18) ....
