### PR TITLE
Fix path methods for filenames that include control chars.

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -249,7 +249,7 @@ if (isWindows) {
 
   // Regex to split a filename into [*, dir, basename, ext]
   // posix version
-  var splitPathRe = /^(.+\/(?!$)|\/)?((?:.+?)?(\.[^.]*)?)$/;
+  var splitPathRe = /^([\s\S]+\/(?!$)|\/)?((?:[\s\S]+?)?(\.[^.]*)?)$/;
 
   // path.resolve([from ...], to)
   // posix version

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -30,6 +30,14 @@ var f = __filename;
 
 assert.equal(path.basename(f), 'test-path.js');
 assert.equal(path.basename(f, '.js'), 'test-path');
+
+// POSIX filenames may include control characters
+// c.f. http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html
+if (!isWindows) {
+  var controlCharFilename = 'Icon' + String.fromCharCode(13); 
+  assert.equal(path.basename('/a/b/' + controlCharFilename), controlCharFilename);
+}
+
 assert.equal(path.extname(f), '.js');
 assert.equal(path.dirname(f).substr(-11), isWindows ? 'test\\simple' : 'test/simple');
 assert.equal(path.dirname('/a/b/'), '/a');


### PR DESCRIPTION
Use [\s\S] instead of . to match any char, including newlines.
