### PR TITLE
Fix broken os.totalmem() on FreeBSD amd64

### DIFF
--- a/src/platform_freebsd.cc
+++ b/src/platform_freebsd.cc
@@ -181,13 +181,9 @@ double Platform::GetFreeMemory() {
 }
 
 double Platform::GetTotalMemory() {
-#if defined(HW_PHYSMEM64)
-  uint64_t info;
-  static int which[] = {CTL_HW, HW_PHYSMEM64};
-#else
-  unsigned int info;
+  unsigned long info;
   static int which[] = {CTL_HW, HW_PHYSMEM};
-#endif
+
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {


### PR DESCRIPTION
sysctl(CTL_HW, HW_PHYSMEM) always returns unsigned long. Will work fine for 32 and 64 bit systems
