### PR TITLE
SendTo/SendMsg expect a buffer only, not a string; fix error message

### DIFF
--- a/src/node_net.cc
+++ b/src/node_net.cc
@@ -1111,7 +1111,7 @@ static Handle<Value> SendMsg(const Arguments& args) {
   // Grab the actul data to be written, stuffing it into iov
   if (!Buffer::HasInstance(args[1])) {
     return ThrowException(Exception::TypeError(
-      String::New("Expected either a string or a buffer")));
+      String::New("Expected a buffer")));
   }
 
   Local<Object> buffer_obj = args[1]->ToObject();
@@ -1237,7 +1237,7 @@ static Handle<Value> SendTo(const Arguments& args) {
   // Grab the actul data to be written
   if (!Buffer::HasInstance(args[1])) {
     return ThrowException(Exception::TypeError(
-      String::New("Expected either a string or a buffer")));
+      String::New("Expected a buffer")));
   }
 
   Local<Object> buffer_obj = args[1]->ToObject();


### PR DESCRIPTION
Came across an error message that confused me, since I was passing a string and not a buffer into dgram.send().

Simple repro case:

```
var dgram = require('dgram');
var socket = dgram.createSocket("udp4");
var message = "foo";
socket.send(message, 0, message.length, 5580, "localhost", function(err) {
    if (err) throw err;
    console.log("here's the callback");
});
```

yields:

```
/private/tmp/sender.js:5
    if (err) throw err;
             ^
TypeError: Expected either a string or a buffer
    at Socket.sendto (dgram.js:259:25)
    at dgram.js:246:14
    at dgram.js:40:5
    at dns.js:159:33
    at Object.lookup (dns.js:154:13)
    at dnsLookup (dgram.js:35:7)
    at Socket.send (dgram.js:238:37)
    at Object.<anonymous> (/private/tmp/sender.js:4:8)
    at Module._compile (module.js:373:26)
    at Object..js (module.js:379:10)
```

So this PR just fixes the error message.  I could hack something up to actually accept strings if that's preferred.
