### PR TITLE
Adding documentation for the 'agent' option in http.request().

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -394,6 +394,10 @@ Options:
 - `path`: Request path. Should include query string and fragments if any.
    E.G. `'/index.html?page=12'`
 - `headers`: An object containing request headers.
+- `agent`: Controls `Agent` behavior. Possible values:
+ - `undefined` (default): use default `Agent` for this host and port.
+ - `Agent` object: explicitly use the passed in `Agent`.
+ - `false`: explicitly generate a new `Agent` for this host and port. `Agent` will not be re-used.
 
 `http.request()` returns an instance of the `http.ClientRequest`
 class. The `ClientRequest` instance is a writable stream. If one needs to


### PR DESCRIPTION
Options.agent wasn't documented.
