### PR TITLE
Include <errno.h> only once.

### DIFF
--- a/deps/libeio/eio.c
+++ b/deps/libeio/eio.c
@@ -53,7 +53,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <limits.h>


### PR DESCRIPTION
errno.h was included twice
