### PR TITLE
Fix net.Socket.connect argument parsing

### DIFF
--- a/lib/net_legacy.js
+++ b/lib/net_legacy.js
@@ -700,9 +700,15 @@ Socket.prototype.connect = function() {
   self._connecting = true; // set false in doConnect
   self.writable = true;
 
-  var lastArg = arguments[arguments.length - 1];
-  if (typeof lastArg == 'function') {
-    self.addListener('connect', lastArg);
+  var host;
+  if (typeof arguments[1] === 'string') {
+    host = arguments[1];
+  }
+
+  if (typeof arguments[1] === 'function') {
+    self.on('connect', arguments[1]);
+  } else if (typeof arguments[2] === 'function') {
+    self.on('connect', arguments[2]);
   }
 
   var port = toPort(arguments[0]);
@@ -715,7 +721,7 @@ Socket.prototype.connect = function() {
     doConnect(self, arguments[0]);
   } else {
     // TCP
-    require('dns').lookup(arguments[1], function(err, ip, addressType) {
+    require('dns').lookup(host, function(err, ip, addressType) {
       if (err) {
         self.emit('error', err);
       } else {

--- a/lib/net_uv.js
+++ b/lib/net_uv.js
@@ -24,9 +24,9 @@ exports.createServer = function() {
 };
 
 
-exports.connect = exports.createConnection = function(port, host /* [cb] */ ) {
+exports.connect = exports.createConnection = function(port /* [host], [cb] */) {
   var s = new Socket();
-  s.connect(port, host, arguments[2]);
+  s.connect(port, arguments[1], arguments[2]);
   return s;
 };
 
@@ -304,10 +304,17 @@ function connectip(self, port, ip) {
 }
 
 
-Socket.prototype.connect = function(port, host /* [cb] */) {
+Socket.prototype.connect = function(port /* [host], [cb] */) {
   var self = this;
 
-  if (typeof arguments[2] === 'function') {
+  var host;
+  if (typeof arguments[1] === 'string') {
+    host = arguments[1];
+  }
+
+  if (typeof arguments[1] === 'function') {
+    self.on('connect', arguments[1]);
+  } else if (typeof arguments[2] === 'function') {
     self.on('connect', arguments[2]);
   }
 

--- a/test/simple/test-net-create-connection.js
+++ b/test/simple/test-net-create-connection.js
@@ -24,19 +24,27 @@ var assert = require('assert');
 var net = require('net');
 
 var tcpPort = common.PORT;
-var connectHappened = false;
+var clientConnected = 0;
+var serverConnected = 0;
 
 var server = net.createServer(function(socket) {
-  server.close();
   socket.end();
+  if (++serverConnected === 4) {
+    server.close();
+  }
 });
 server.listen(tcpPort, 'localhost', function() {
-  var client = net.createConnection(tcpPort, 'localhost', function() {
-    connectHappened = true;
-  });
+  function cb() {
+    ++clientConnected;
+  }
+
+  net.createConnection(tcpPort).on('connect', cb);
+  net.createConnection(tcpPort, 'localhost').on('connect', cb);
+  net.createConnection(tcpPort, cb);
+  net.createConnection(tcpPort, 'localhost', cb);
 });
 
 process.on('exit', function () {
-  assert.ok(connectHappened);
+  assert.equal(clientConnected, 4);
 });
 


### PR DESCRIPTION
My old patch (#1208) was wrong when I omitted a host.
example: `net.createConnection(port, cb)`
