### PR TITLE
Fixed chained callbacks calling the wrong callback or crashing calling a 

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -350,8 +350,9 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
           this._writeQueueCallbacks[last] = cb;
         } else {
           // awful
+          var last_cb = this._writeQueueCallbacks[last];
           this._writeQueueCallbacks[last] = function() {
-            this._writeQueueCallbacks[last]();
+            last_cb();
             cb();
           };
         }

--- a/lib/net.js
+++ b/lib/net.js
@@ -443,6 +443,10 @@ Socket.prototype._writeOut = function(data, encoding, fd, cb) {
       this._writeQueueCallbacks.unshift(cb);
       this._writeWatcher.start();
       this._onBufferChange();
+      // Callback will be called when the second half
+      //   of this buffer is sent, don't associated a
+      //   callback with the first half.
+      cb = null;
       queuedData = true;
     }
   }


### PR DESCRIPTION
Fixed chained callbacks calling the wrong callback or crashing calling a non-existent callback.  This fixes errors of the form:
net.js:354
            this._writeQueueCallbacks[last]();
TypeError: Cannot call method '0' of undefined
