### PR TITLE
Fixed Socket.write callbacks incorrectly being called twice

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -442,6 +442,10 @@ Socket.prototype._writeOut = function(data, encoding, fd, cb) {
       this._writeQueueCallbacks.unshift(cb);
       this._writeWatcher.start();
       this._onBufferChange();
+      // Callback will be called when the second half
+      //   of this buffer is sent, don't associated a
+      //   callback with the first half.
+      cb = null;
       queuedData = true;
     }
   }


### PR DESCRIPTION
Fixed Socket.write callbacks incorrectly being called twice (once when first half of a split packet is written, and again with the second half), under extreme load conditions.
