### PR TITLE
Fix Socket.write callbacks being delayed until long after the data was sent

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -341,20 +341,15 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
     if (typeof data == 'string' &&
         this._writeQueue.length &&
         typeof this._writeQueue[last] === 'string' &&
-        this._writeQueueEncoding[last] === encoding) {
+        this._writeQueueEncoding[last] === encoding &&
+        !this._writeQueueCallbacks[last]) {
       // optimization - concat onto last
+      // not valid if the last had a callback, or the callback may never
+      // get called (keep on getting chained)
       this._writeQueue[last] += data;
 
       if (cb) {
-        if (!this._writeQueueCallbacks[last]) {
-          this._writeQueueCallbacks[last] = cb;
-        } else {
-          // awful
-          this._writeQueueCallbacks[last] = function() {
-            this._writeQueueCallbacks[last]();
-            cb();
-          };
-        }
+        this._writeQueueCallbacks[last] = cb;
       }
     } else {
       this._writeQueue.push(data);


### PR DESCRIPTION
Fix Socket.write callbacks being delayed until long after the data was actually sent, in cases of high load.  These were often getting called after the data has been sent, received on the other end, had a response generated, and the response sent back, causing applications to get a response data packet before they've had a chance to realize the data has been sent.
