### PR TITLE
fix an broken question

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -998,7 +998,7 @@ Interface.prototype.yesNoQuestion = function(prompt, cb) {
       cb(false);
     } else {
       console.log('Please answer y or n.');
-      self.restartQuestion(cb);
+      self.yesNoQuestion(prompt, cb);
     }
   });
 };


### PR DESCRIPTION
I found a bug about user interface in yesNoQuestion method in _debugger.js.

When you run "#node debug some.js" in command line and do the following steps, 
you will experience an weird semantics.
1. debug> run
2. stop at some breakpoint
3. press Ctrl+c to exit some.js
4. you will be asked that "A debugging session is active. Quit anyway? (y or n)"
5. press a key that NOT y or n. (e.g. press 'l')
6. this time, you will be asked that "The program being debugged has been started already. Start it from the beginning? (y or n)"
7. press y
8. the node process will be aborted.

It's weird. Do you think so?
I think if we type a non-y/n answer, the question shoud be repeated.
For example, like this,

debug> 
A debugging session is active. Quit anyway? (y or n) l
Please answer y or n.

A debugging session is active. Quit anyway? (y or n) l
Please answer y or n.

A debugging session is active. Quit anyway? (y or n) 

So, I've fixed this to repeat the question. Please check it.
