### PR TITLE
Debugger improvements [Allow user to set a breakpoint using the debbuger interface, also export the Interface class]

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -541,6 +541,7 @@ Client.prototype.fullTrace = function(cb) {
 
 var commands = [
   'backtrace',
+  'breakpoint',
   'continue',
   'help',
   'info breakpoints',

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -647,6 +647,21 @@ function Interface() {
   });
 }
 
+Client.prototype.setBreakpoint = function(target, line, callback) {
+  var req = {
+    command: 'setbreakpoint',
+    arguments: { type: 'script',
+                 target: target,
+                 line: line
+    }
+  };
+
+  this.req(req, function(res) {
+    if (callback) {
+      callback(res);
+    }
+  });
+};
 
 Interface.prototype.complete = function(line) {
   // Match me with a command.
@@ -660,9 +675,35 @@ Interface.prototype.complete = function(line) {
     }
   }
 
+  // Breakpoint script name completion
+  if ((this.client) && line.indexOf('breakpoint') === 0 ||
+      line.indexOf('bp') === 0) {
+    var left = line.replace(/^breakpoint/, '').replace(/^bp/, '').trim();
+    matches = this._completeScripts(left);
+  }
+
   return [matches, line];
 };
 
+Interface.prototype._completeScripts = function(line) {
+  var client = this.client;
+  var matches = [];
+
+  if (!client || !client.scripts) {
+    return [];
+  }
+
+  for (var id in client.scripts) {
+    var script = client.scripts[id];
+    if (typeof script == 'object' && script.name) {
+      if (script.name.indexOf(line) === 0) {
+        matches.push(script.name);
+      }
+    }
+  }
+
+  return matches;
+}
 
 Interface.prototype.handleSIGINT = function() {
   if (this.paused) {
@@ -671,7 +712,6 @@ Interface.prototype.handleSIGINT = function() {
     this.tryQuit();
   }
 };
-
 
 Interface.prototype.quit = function() {
   if (this.quitting) return;
@@ -773,6 +813,27 @@ function leftPad(n) {
   }
   return s;
 }
+
+/*
+ * Return object with different information for the provided script.
+ * @return {Object} Script object if script is found, false otherwise.
+ */
+Interface.prototype._getScript = function(scriptName) {
+  var scripts, script;
+  scripts = this.client.scripts;
+
+  for (var key in scripts) {
+    if (scripts.hasOwnProperty(key)) {
+      script = scripts[key];
+
+      if (script && script.name.indexOf(scriptName) !== -1) {
+        return script;
+      }
+    }
+  }
+
+  return false;
+};
 
 
 Interface.prototype.handleCommand = function(cmd) {
@@ -896,8 +957,37 @@ Interface.prototype.handleCommand = function(cmd) {
       }
       term.prompt();
     });
+  } else if (matches = /^(breakpoint|bp)(\s.*?)? (\d+)/.exec(cmd)) {
+    var scriptName, script, lineNo;
+    if (!client) {
+      self.printNotConnected();
+      return;
+    }
 
-  } else if (cmd == 'scripts' || cmd == 'scripts full') {
+    if (!matches[2]) {
+      // No script name provided, use current file name
+      scriptName = this.client.currentScript;
+      script = this._getScript(scriptName);
+    }
+    else {
+      scriptName = matches[2].trim();
+      script = null;
+    }
+
+    // Line numbers in debugger are 0 based
+    lineNo = (parseInt(matches[3], 10) - 1);
+
+    if (script && (lineNo < 1 || lineNo > (script.lineCount - 1))) {
+      console.log('Invalid line number (must be between 1 and ' + script.lineCount + ')');
+      self.term.prompt();
+      return;
+    }
+
+    this.client.setBreakpoint(scriptName, lineNo, function(res) {
+      self.term.prompt();
+    });
+  }
+  else if (cmd == 'scripts' || cmd == 'scripts full') {
     if (!client) {
       self.printNotConnected();
       return;

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -648,7 +648,7 @@ function Interface() {
   });
 }
 
-Client.prototype.setBreakpoint = function(target, line, callback) {
+Client.prototype.setbreakpoint = function(target, line, callback) {
   var req = {
     command: 'setbreakpoint',
     arguments: { type: 'script',
@@ -984,7 +984,7 @@ Interface.prototype.handleCommand = function(cmd) {
       return;
     }
 
-    this.client.setBreakpoint(scriptName, lineNo, function(res) {
+    this.client.setbreakpoint(scriptName, lineNo, function(res) {
       self.term.prompt();
     });
   }

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1212,5 +1212,4 @@ Interface.prototype.printScripts = function(displayNatives) {
   process.stdout.write(text);
 };
 
-
-
+exports.Interface = Interface;

--- a/test/simple/test-debugger-client.js
+++ b/test/simple/test-debugger-client.js
@@ -118,7 +118,7 @@ addTest(function (client, done) {
 addTest(function (client, done) {
   console.error("setbreakpoint");
 
-  client.setBreakpoint("some-file.js", 1, function(res) {
+  client.setbreakpoint("some-file.js", 1, function(res) {
     assert.ok(res.success);
 
 

--- a/test/simple/test-debugger-client.js
+++ b/test/simple/test-debugger-client.js
@@ -105,6 +105,34 @@ addTest(function (client, done) {
 });
 
 addTest(function (client, done) {
+  console.error("eval 2+2");
+  client.reqEval("2+2", function (res) {
+    assert.ok(res.success);
+    console.error(res);
+    assert.equal('4', res.body.text);
+    assert.equal(4, res.body.value);
+    done();
+  });
+});
+
+addTest(function (client, done) {
+  console.error("setbreakpoint");
+
+  client.setBreakpoint("some-file.js", 1, function(res) {
+    assert.ok(res.success);
+
+
+    // Verify that the breakpoint has been set
+    client.listbreakpoints(function(res) {
+      assert.equal(res.body.breakpoints.length, 1);
+      assert.equal(res.body.breakpoints[0].line, 1);
+      assert.equal(res.body.breakpoints[0].script_name, "some-file.js");
+      done();
+    });
+  });
+});
+
+addTest(function (client, done) {
   console.error("requesting scripts");
   client.reqScripts(function () {
     console.error("got %d scripts", Object.keys(client.scripts).length);
@@ -118,17 +146,6 @@ addTest(function (client, done) {
       }
     }
     assert.ok(foundMainScript);
-    done();
-  });
-});
-
-addTest(function (client, done) {
-  console.error("eval 2+2");
-  client.reqEval("2+2", function (res) {
-    assert.ok(res.success);
-    console.error(res);
-    assert.equal('4', res.body.text);
-    assert.equal(4, res.body.value);
     done();
   });
 });
@@ -168,7 +185,7 @@ function doTest(cb, done) {
             done();
           });
         });
-      }, 100);
+      }, 200);
     }
   });
 }


### PR DESCRIPTION
With this patch users can also set a breakpoint using a debugger client interface.

The command syntax is: `breakpoint|bp [script path] [line number]`

If the script path is omitted, currently running script is used as a target.
