### PR TITLE
fix 'info breakpoints' debugger command to show useful information.

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -825,7 +825,11 @@ Interface.prototype.handleCommand = function(cmd) {
       return;
     }
     client.listbreakpoints(function(res) {
-      console.log(res);
+      for (var i = 0; i < res.body.breakpoints.length; i++) {
+        var bp = res.body.breakpoints[i];
+        var name = bp.script_name || client.scripts[bp.script_id].name;
+        console.log("#" + bp.number + " " + name + ":" + (bp.line+1));
+      }
       term.prompt();
     });
 


### PR DESCRIPTION
In debugger, 'info breakpoints' command obviously shows useless information.

Here is an example of the result.
debug> info breakpoints
{ seq: 7,
  request_seq: 1,
  type: 'response',
  command: 'listbreakpoints',
  success: true,
  body: { breakpoints: [ [Object] ], breakOnExceptions: false, breakOnUncaughtExceptions: false },
  refs: [],
  running: false }
debug>

Who can get information about breakpoints from this?
We should want information like this.

debug> info breakpoints
#1 /Users/xenyou/toybox/node/basic.js:1

So I've fixed this to show the above.
Please check it.

There may be a misunderstanding in this fix because
I don't really know about the debugger protocol. :-P
