### PR TITLE
fix crash on bt command in the debugger.

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -497,6 +497,11 @@ Client.prototype.fullTrace = function(cb) {
   this.reqBacktrace(function(trace) {
     var refs = [];
 
+    if (trace.totalFrames == 0) {
+      if (cb) cb(trace);
+      return;
+    }
+
     for (var i = 0; i < trace.frames.length; i++) {
       var frame = trace.frames[i];
       // looks like this:


### PR DESCRIPTION
When you send 'backtrace' request by typing 'bt' in the debugger,
you could receive a response that its body.totalFrames equals 0(zero).
This response has no body.frames array, but a callback function accesses body.frames.length without checking if body.totalFrames equals 0 or not.
Thus if body.totalFrames equals 0, the node process will crash like below.

debug> bt
There was an internal error in Node's debugger. Please report this bug.
Cannot read property 'length' of undefined
TypeError: Cannot read property 'length' of undefined
    at _debugger.js:500:37
    at _debugger.js:352:13
    at Client._onResponse (_debugger.js:226:5)
    at Protocol.onResponse (native)
    at Protocol.execute (_debugger.js:116:14)
    at Client.<anonymous> (_debugger.js:154:14)
    at Client.emit (events.js:64:17)
    at Client._onReadable (net_legacy.js:673:31)
    at IOWatcher.onReadable [as callback](net_legacy.js:177:10)

This callback function is used as an argument to reqBacktrace in Client.prototype.fullTrace method.

So I've added a check to prevent it from the crash.
This fix simply show (empty stack) in such situation.

debug> bt
(empty stack)

Please check it.
