### PR TITLE
Remove duplicated section in doc/api/module.markdown

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -341,22 +341,6 @@ The example module above could be structured like so:
   accordingly.
 
 
-### Accessing the main module
-
-When a file is run directly from Node, `require.main` is set to its
-`module`. That means that you can determine whether a file has been run
-directly by testing
-
-    require.main === module
-
-For a file `foo.js`, this will be `true` if run via `node foo.js`, but
-`false` if run by `require('./foo')`.
-
-Because `module` provides a `filename` property (normally equivalent to
-`__filename`), the entry point of the current application can be obtained
-by checking `require.main.filename`.
-
-
 ## Addenda: Package Manager Tips
 
 The semantics of Node's `require()` function were designed to be general


### PR DESCRIPTION
The section "Accessing the main module" appeared twice in doc/api/module.markdown.
