### PR TITLE
allow console.log to completely drain before node exits normally

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -58,7 +58,17 @@ function format(f) {
 
 
 exports.log = function() {
-  process.stdout.write(format.apply(this, arguments) + '\n');
+  var res = process.stdout.write(format.apply(this, arguments) + '\n');
+  
+  // this is the first time stdout got backed up
+  if (!res && !process.stdout.pendingWrite) {
+     process.stdout.pendingWrite = true;
+
+     // magic sauce: keep node alive until stdout has flushed
+     process.stdout.once('drain', function () {
+       process.stdout.draining = false;
+     });
+  }
 };
 
 


### PR DESCRIPTION
This patch adds an even listener to `process.stdout` when appropriate, causing node to stay alive until all of the data has been written to stdout.
