### PR TITLE
fix fs.watchFile to prevent the node from crash when callback is omitted

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -375,7 +375,7 @@ Example:
 
 The synchronous version of `fs.writeFile`.
 
-### fs.watchFile(filename, [options], listener)
+### fs.watchFile(filename, [options], [listener])
 
 Watch for changes on `filename`. The callback `listener` will be called each
 time the file is accessed.

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -375,7 +375,7 @@ Example:
 
 The synchronous version of `fs.writeFile`.
 
-### fs.watchFile(filename, [options], [listener])
+### fs.watchFile(filename, [options], listener)
 
 Watch for changes on `filename`. The callback `listener` will be called each
 time the file is accessed.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -596,10 +596,10 @@ fs.watchFile = function(filename) {
 
   if ('object' == typeof arguments[1]) {
     options = arguments[1];
-    listener = arguments[2] || noop;
+    listener = arguments[2];
   } else {
     options = {};
-    listener = arguments[1] || noop;
+    listener = arguments[1];
   }
 
   if (options.persistent === undefined) options.persistent = true;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -602,6 +602,10 @@ fs.watchFile = function(filename) {
     listener = arguments[1];
   }
 
+  if (!listener) {
+    throw new Error('watchFile requires a listener function');
+  }
+
   if (options.persistent === undefined) options.persistent = true;
   if (options.interval === undefined) options.interval = 0;
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -596,10 +596,10 @@ fs.watchFile = function(filename) {
 
   if ('object' == typeof arguments[1]) {
     options = arguments[1];
-    listener = arguments[2];
+    listener = arguments[2] || noop;
   } else {
     options = {};
-    listener = arguments[1];
+    listener = arguments[1] || noop;
   }
 
   if (options.persistent === undefined) options.persistent = true;

--- a/test/simple/test-fs-watch-file.js
+++ b/test/simple/test-fs-watch-file.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var fs = require('fs');
+
+
+var filename = path.join(common.fixturesDir, 'watch.txt');
+fs.writeFileSync(filename, "hello");
+
+try {
+  fs.watchFile(filename);
+} catch (e) {
+  assert.equal(e.message, 'watchFile requires a listener function');
+}
+
+try {
+  fs.watchFile(filename, function(curr, prev) {
+    fs.unwatchFile(filename);
+    fs.unlinkSync(filename);
+  });
+} catch (e) {
+  assert.ok(false);
+}
+
+setTimeout(function() {
+  fs.writeFileSync(filename, "world");
+}, 1000);
+

--- a/test/simple/test-fs-watch-file.js
+++ b/test/simple/test-fs-watch-file.js
@@ -28,20 +28,23 @@ var fs = require('fs');
 var filename = path.join(common.fixturesDir, 'watch.txt');
 fs.writeFileSync(filename, "hello");
 
-try {
-  fs.watchFile(filename);
-} catch (e) {
-  assert.equal(e.message, 'watchFile requires a listener function');
-}
+assert.throws(
+  function() {
+    fs.watchFile(filename);
+  },
+  function(e) {
+    return e.message === 'watchFile requires a listener function';
+  }
+);
 
-try {
-  fs.watchFile(filename, function(curr, prev) {
-    fs.unwatchFile(filename);
-    fs.unlinkSync(filename);
-  });
-} catch (e) {
-  assert.ok(false);
-}
+assert.doesNotThrow(
+  function() {
+    fs.watchFile(filename, function(curr, prev) {
+      fs.unwatchFile(filename);
+      fs.unlinkSync(filename);
+    });
+  }
+);
 
 setTimeout(function() {
   fs.writeFileSync(filename, "world");


### PR DESCRIPTION
callback argument in fs.js is usually optional.
When you don't specify callback argument, noop funciton is used as callback.
noop is empty funciton and does nothing.

But why does ONLY fs.watchFile method require callback argument?
I think it should be applied the same rule in the same module.
Besides if you omit callback argument to watchFile, the node process crashes.
This is very ugly.

[ykikuchi@ykikuchi-sc440 boo]$ cat ~/watch.js
var fs = require("fs");
fs.watchFile("/home/ykikuchi/ttxt");

[ykikuchi@ykikuchi-sc440 boo]$ ./node ~/watch.js

node.js:189
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
Error: addListener only takes instances of Function
    at StatWatcher.<anonymous> (events.js:99:11)
    at Object.watchFile (fs.js:615:8)
    at Object.<anonymous> (/home/ykikuchi/watch.js:12:4)
    at Module._compile (module.js:406:26)
    at Object..js (module.js:445:10)
    at Module.load (module.js:334:31)
    at Function._load (module.js:293:12)
    at Array.<anonymous> (module.js:458:10)
    at EventEmitter._tickCallback (node.js:181:26)

So I've fixed the method to use noop function as callback if you omit the argument.
Please check it.
