### PR TITLE
Fixes #1304, #1085

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1325,7 +1325,10 @@ Agent.prototype._establishNewConnection = function() {
         debug('AGENT socket keep-alive');
       }
 
-      req.detachSocket(socket);
+      // The socket may already be detached and destroyed by an abort call
+      if (socket._httpMessage) {
+        req.detachSocket(socket);
+      }
 
       assert(!socket._httpMessage);
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -530,7 +530,10 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
   this.encrypted = new EncryptedStream(this);
 
   process.nextTick(function() {
-    self.ssl.start();
+    /* The Connection may be destroyed by an abort call */
+    if (self.ssl) {
+      self.ssl.start();
+    }
     self.cycle();
   });
 }

--- a/test/simple/test-regress-GH-1085.js
+++ b/test/simple/test-regress-GH-1085.js
@@ -1,12 +1,26 @@
-// Regression test for GH-1085
-// https://github.com/joyent/node/issues/1085
+// Copyright Joyent, Inc. and other Node contributors.
 //
-// This test works by requestig a small file over HTTP and aborting the request
-// into the data listener of the response. The purpose of this test is to make
-// an abort call into the response data listner thou shalt not throw assertion
-// errors in detachSocket().
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var common = require('../common');
+var assert = require('assert');
 var http = require('http');
 
 var opt = {

--- a/test/simple/test-regress-GH-1085.js
+++ b/test/simple/test-regress-GH-1085.js
@@ -1,0 +1,21 @@
+// Regression test for GH-1085
+// https://github.com/joyent/node/issues/1085
+//
+// This test works by requestig a small file over HTTP and aborting the request
+// into the data listener of the response. The purpose of this test is to make
+// an abort call into the response data listner thou shalt not throw assertion
+// errors in detachSocket().
+
+var common = require('../common');
+var http = require('http');
+
+var opt = {
+  host: 'nodejs.org',
+  path: '/favicon.ico'
+};
+
+var req = http.get(opt, function (res) {
+  res.addListener('data', function (chunk) {
+    req.abort();
+  });
+});

--- a/test/simple/test-regress-GH-1304.js
+++ b/test/simple/test-regress-GH-1304.js
@@ -1,0 +1,19 @@
+// Regression test for GH-1304
+// https://github.com/joyent/node/issues/1304
+//
+// This test works by creating a HTTPS connection to a server, then aborting
+// it. The purpose of this test is to have a tls module thou shalt not fail if
+// the request is aborted.
+
+var common = require('../common');
+var https = require('https');
+
+var opt = {
+	host: 'encrypted.google.com',
+	path: '/'
+};
+
+var req = https.get(opt, function (res) {
+});
+
+req.abort();

--- a/test/simple/test-regress-GH-1304.js
+++ b/test/simple/test-regress-GH-1304.js
@@ -1,11 +1,26 @@
-// Regression test for GH-1304
-// https://github.com/joyent/node/issues/1304
+// Copyright Joyent, Inc. and other Node contributors.
 //
-// This test works by creating a HTTPS connection to a server, then aborting
-// it. The purpose of this test is to have a tls module thou shalt not fail if
-// the request is aborted.
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var common = require('../common');
+var assert = require('assert');
 var https = require('https');
 
 var opt = {

--- a/test/simple/test-regress-GH-1304.js
+++ b/test/simple/test-regress-GH-1304.js
@@ -9,8 +9,8 @@ var common = require('../common');
 var https = require('https');
 
 var opt = {
-	host: 'encrypted.google.com',
-	path: '/'
+  host: 'encrypted.google.com',
+  path: '/'
 };
 
 var req = https.get(opt, function (res) {


### PR DESCRIPTION
#1304: The Connection instance may be destroyed by abort() when process.nextTick is executed.
#1085: The agent end event may call detachSocket() after the socket is detached and destroyed by abort(). This patch avoids that behavior.
