### PR TITLE
Fixes #1229

### DIFF
--- a/tools/wafadmin/Tools/node_addon.py
+++ b/tools/wafadmin/Tools/node_addon.py
@@ -31,7 +31,6 @@ def detect(conf):
   conf.env['CPPPATH_NODE'] = join(prefix, 'include', 'node')
 
   conf.env.append_value('CPPFLAGS_NODE', '-D_GNU_SOURCE')
-  conf.env.append_value('CPPFLAGS_NODE', '-DEV_MULTIPLICITY=0')
 
   conf.env.append_value('CCFLAGS_NODE', '-D_LARGEFILE_SOURCE')
   conf.env.append_value('CCFLAGS_NODE', '-D_FILE_OFFSET_BITS=64')


### PR DESCRIPTION
This prevents addons that use ev_*_start() and similar methods from segfaulting on node 0.5.x. See issue #1229.
