### PR TITLE
More accurate error messages when writing beyond the length of a Buffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -760,7 +760,7 @@ Buffer.prototype.writeUInt8 = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset < buffer.length,
-    'trying to read beyond buffer length');
+    'trying to write beyond buffer length');
 
   verifuint(value, 0xff);
   buffer[offset] = value;
@@ -783,7 +783,7 @@ Buffer.prototype.writeUInt16 = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset + 1 < buffer.length,
-    'trying to read beyond buffer length');
+    'trying to write beyond buffer length');
 
   verifuint(value, 0xffff);
 
@@ -813,7 +813,7 @@ Buffer.prototype.writeUInt32 = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset + 3 < buffer.length,
-    'trying to read beyond buffer length');
+    'trying to write beyond buffer length');
 
   verifuint(value, 0xffffffff);
   if (endian == 'big') {
@@ -908,7 +908,7 @@ Buffer.prototype.writeInt8 = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset < buffer.length,
-    'Trying to read beyond buffer length');
+    'Trying to write beyond buffer length');
 
   verifsint(value, 0x7f, -0xf0);
 
@@ -936,7 +936,7 @@ Buffer.prototype.writeInt16 = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset + 1 < buffer.length,
-    'Trying to read beyond buffer length');
+    'Trying to write beyond buffer length');
 
   verifsint(value, 0x7fff, -0xf000);
 
@@ -964,7 +964,7 @@ Buffer.prototype.writeInt32 = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset + 3 < buffer.length,
-    'Trying to read beyond buffer length');
+    'Trying to write beyond buffer length');
 
   verifsint(value, 0x7fffffff, -0xf0000000);
   if (value >= 0) {
@@ -991,7 +991,7 @@ Buffer.prototype.writeFloat = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset + 3 < buffer.length,
-    'Trying to read beyond buffer length');
+    'Trying to write beyond buffer length');
 
   verifIEEE754(value, 3.4028234663852886e+38, -3.4028234663852886e+38);
   IEEE754.writeIEEE754(buffer, value, offset, endian, 23, 4);
@@ -1014,7 +1014,7 @@ Buffer.prototype.writeDouble = function(value, offset, endian) {
     'missing offset');
 
   assert.ok(offset + 7 < buffer.length,
-    'Trying to read beyond buffer length');
+    'Trying to write beyond buffer length');
 
   verifIEEE754(value, 1.7976931348623157E+308, -1.7976931348623157E+308);
   IEEE754.writeIEEE754(buffer, value, offset, endian, 52, 8);


### PR DESCRIPTION
Changed `trying to read beyond buffer length` to `trying to write beyond buffer length` error message in data writing methods.
