### PR TITLE
Add Socket::bytesRead, Socket::bytesWritten for amount of sent/received data tracking

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -323,6 +323,14 @@ The string representation of the remote IP address. For example,
 The numeric representation of the remote port. For example,
 `80` or `21`.
 
+#### socket.bytesRead
+
+The amount of received bytes.
+
+#### socket.bytesWritten
+
+The amount of bytes sent.
+
 
 
 #### Event: 'connect'

--- a/lib/net_legacy.js
+++ b/lib/net_legacy.js
@@ -207,6 +207,9 @@ function initSocket(self) {
   self._writeWatcher.socket = self;
   self._writeWatcher.callback = onWritable;
   self.writable = false;
+
+  self.bytesRead = 0;
+  self.bytesWritten = 0;
 }
 
 // Deprecated API: Socket(fd, type)
@@ -454,6 +457,8 @@ Socket.prototype._writeOut = function(data, encoding, fd, cb) {
     return false;
   }
 
+  this.bytesWritten += bytesWritten;
+
   debug('wrote ' + bytesWritten + ' bytes to socket.')
   debug('[fd, off, len] = ' + JSON.stringify([this.fd, off, len]));
 
@@ -664,6 +669,7 @@ Socket.prototype._onReadable = function() {
     var start = pool.used;
     var end = pool.used + bytesRead;
     pool.used += bytesRead;
+    self.bytesRead += bytesRead;
 
     debug('socket ' + self.fd + ' received ' + bytesRead + ' bytes');
 

--- a/lib/net_uv.js
+++ b/lib/net_uv.js
@@ -51,6 +51,8 @@ function initSocketHandle(self) {
   self._flags = 0;
   self._connectQueueSize = 0;
   self.destroyed = false;
+  self.bytesRead = 0;
+  self.bytesWritten = 0;
 
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {
@@ -255,6 +257,8 @@ function onread(buffer, offset, length) {
       }
     }
 
+    self.bytesRead += length;
+
     // Optimization: emit the original buffer with end points
     if (self.ondata) self.ondata(buffer, offset, end);
 
@@ -307,6 +311,8 @@ Socket.prototype.write = function(data /* [encoding], [fd], [cb] */) {
       fd = arguments[2];
     }
   }
+
+  this.bytesWritten += data.length;
 
   // Change strings to buffers. SLOW
   if (typeof data == 'string') {

--- a/test/simple/test-net-bytes-stats.js
+++ b/test/simple/test-net-bytes-stats.js
@@ -1,0 +1,71 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var tcpPort = common.PORT;
+var bytesRead = 0;
+var bytesWritten = 0;
+var count = 0;
+
+var tcp = net.Server(function(s) {
+  console.log('tcp server connection');
+
+  s.on('end', function() {
+    bytesRead += s.bytesRead;
+    console.log('tcp socket disconnect #' + count);
+  });
+});
+
+tcp.listen(common.PORT, function () {
+  var socket = net.createConnection(tcpPort);
+
+  socket.on('connect', function() {
+    count++;
+    console.log('tcp client connection #' + count);
+
+    socket.write('foo', function () {
+      socket.end('bar');
+    });
+  });
+
+  socket.on('end', function() {
+    bytesWritten += socket.bytesWritten;
+    console.log('tcp client disconnect #' + count);
+  });
+
+  socket.on('close', function() {
+    console.log('Bytes read: ' + bytesRead);
+    console.log('Bytes written: ' + bytesWritten);
+    if (count < 2) {
+      socket.connect(tcpPort);
+    } else {
+      tcp.close();
+    };
+  });
+});
+
+process.on('exit', function () {
+  assert.equal(bytesRead, 12);
+  assert.equal(bytesWritten, 12);
+});


### PR DESCRIPTION
Currently, it's impossible to track amount of sent/received data (or probably I don't know how to do that). I found it useful for http clients and servers, because http(s) 'data' event does not include headers, also it's too expensive operation. If makes sense, please apply.
