### PR TITLE
Disable some problem on compilation with warning

### DIFF
--- a/deps/v8/SConstruct
+++ b/deps/v8/SConstruct
@@ -282,9 +282,7 @@ V8_EXTRA_FLAGS = {
   'gcc': {
     'all': {
       'WARNINGFLAGS': ['-Wall',
-                       '-Werror',
                        '-W',
-                       '-Wno-unused-parameter',
                        '-Wnon-virtual-dtor']
     },
     'os:win32': {


### PR DESCRIPTION
-Werror and -Wno-unused-parameter break compilation... It seems that a lot of messages are send on V8 mailing list about this option.

I removed this 3 parameters to compile node, and it works.
