### PR TITLE
Implement os.uptime(), os.cpus(), os.totalmem(), and os.freemem() for mingw

### DIFF
--- a/src/platform_win32.cc
+++ b/src/platform_win32.cc
@@ -279,14 +279,7 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
   unsigned int i = 0, numcpus, j, max_ext_funcs;
   unsigned int regs[4];
   char CPUName[64];
-  char CPUVendor[32];
   SYSTEM_INFO si;
-
-  memset(CPUVendor, 0, sizeof(CPUVendor));
-  __get_cpuid(0, &regs[0], &regs[1], &regs[2], &regs[3]);
-  *((int*)CPUVendor) = regs[1];
-  *((int*)(CPUVendor+4)) = regs[3];
-  *((int*)(CPUVendor+8)) = regs[2];
 
   memset(CPUName, 0, sizeof(CPUName));
   __get_cpuid(0x80000000, &regs[0], &regs[1], &regs[2], &regs[3]);

--- a/wscript
+++ b/wscript
@@ -476,6 +476,7 @@ def configure(conf):
   if sys.platform.startswith("win32"):
     conf.env.append_value('LIB', 'ws2_32')
     conf.env.append_value('LIB', 'winmm')
+    conf.env.append_value('LIB', 'powrprof');
 
   conf.env.append_value('CPPFLAGS', '-Wno-unused-parameter');
   conf.env.append_value('CPPFLAGS', '-D_FORTIFY_SOURCE=2');


### PR DESCRIPTION
One note: I'm not 100% certain of the conversion of Windows' units for user/sys/idle/etc to ticks, but it looks right to me.
