### PR TITLE
Add missing parentheses in buffer docs.

### DIFF
--- a/doc/api/buffers.markdown
+++ b/doc/api/buffers.markdown
@@ -188,8 +188,8 @@ Example:
     buf[3] = 0x42;
 
     for (ii = 0; ii < buf.length; ii++) {
-      console.log(buf.readUInt8(ii, 'big');
-      console.log(buf.readUInt8(ii, 'little');
+      console.log(buf.readUInt8(ii, 'big'));
+      console.log(buf.readUInt8(ii, 'little'));
     }
 
     // 0x3
@@ -216,12 +216,12 @@ Example:
     buf[2] = 0x23;
     buf[3] = 0x42;
 
-    console.log(buf.readUInt16(0, 'big');
-    console.log(buf.readUInt16(0, 'little');
-    console.log(buf.readUInt16(1, 'big');
-    console.log(buf.readUInt16(1, 'little');
-    console.log(buf.readUInt16(2, 'big');
-    console.log(buf.readUInt16(2, 'little');
+    console.log(buf.readUInt16(0, 'big'));
+    console.log(buf.readUInt16(0, 'little'));
+    console.log(buf.readUInt16(1, 'big'));
+    console.log(buf.readUInt16(1, 'little'));
+    console.log(buf.readUInt16(2, 'big'));
+    console.log(buf.readUInt16(2, 'little'));
 
     // 0x0304
     // 0x0403
@@ -245,8 +245,8 @@ Example:
     buf[2] = 0x23;
     buf[3] = 0x42;
 
-    console.log(buf.readUInt32(0, 'big');
-    console.log(buf.readUInt32(0, 'little');
+    console.log(buf.readUInt32(0, 'big'));
+    console.log(buf.readUInt32(0, 'little'));
 
     // 0x03042342
     // 0x42230403
@@ -293,7 +293,7 @@ Example:
     buf[2] = 0x80;
     buf[3] = 0x3f;
 
-    console.log(buf.readFloat(0, 'little');
+    console.log(buf.readFloat(0, 'little'));
 
     // 0x01
 
@@ -316,7 +316,7 @@ Example:
     buf[6] = 0xd5;
     buf[7] = 0x3f;
 
-    console.log(buf.readDouble(0, 'little');
+    console.log(buf.readDouble(0, 'little'));
 
     // 0.3333333333333333
 


### PR DESCRIPTION
In buffer docs some examples had mismatched parentheses.
