### PR TITLE
[sni] code and test

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -23,12 +23,10 @@ var tls = require('tls');
 var http = require('http');
 var inherits = require('util').inherits;
 
-var NPN_ENABLED = process.binding('constants').NPN_ENABLED;
-
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
-  if (NPN_ENABLED && !opts.NPNProtocols) {
+  if (process.features.npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 
@@ -64,7 +62,7 @@ Agent.prototype.defaultPort = 443;
 
 
 Agent.prototype._getConnection = function(options, cb) {
-  if (NPN_ENABLED && !this.options.NPNProtocols) {
+  if (process.features.npn && !this.options.NPNProtocols) {
     this.options.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -26,7 +26,7 @@ var inherits = require('util').inherits;
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
-  if (process.features.npn && !opts.NPNProtocols) {
+  if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 
@@ -62,7 +62,7 @@ Agent.prototype.defaultPort = 443;
 
 
 Agent.prototype._getConnection = function(options, cb) {
-  if (process.features.npn && !this.options.NPNProtocols) {
+  if (process.features.tls_npn && !this.options.NPNProtocols) {
     this.options.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 

--- a/lib/https2.js
+++ b/lib/https2.js
@@ -26,7 +26,7 @@ var inherits = require('util').inherits;
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
-  if (process.features.npn && !opts.NPNProtocols) {
+  if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 

--- a/lib/https2.js
+++ b/lib/https2.js
@@ -23,12 +23,10 @@ var tls = require('tls');
 var http = require('http');
 var inherits = require('util').inherits;
 
-var NPN_ENABLED = process.binding('constants').NPN_ENABLED;
-
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
-  if (NPN_ENABLED && !opts.NPNProtocols) {
+  if (process.features.npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -71,6 +71,27 @@ function convertNPNProtocols(NPNProtocols, out) {
   }
 };
 
+// Create SSL Contexts for each object key
+function convertSNIContexts(SNIContexts, out) {
+  var result = {};
+
+  for (var key in SNIContexts) {
+    if (SNIContexts.hasOwnProperty(key)) {
+      var val = SNIContexts[key],
+          ctx = crypto.createCredentials({
+            key: val.key,
+            cert: val.cert,
+            ca: val.ca,
+            crl: val.crl
+          }).ctx;
+
+      result[key] = ctx;
+    }
+  }
+
+  return result;
+};
+
 // Base class of both CleartextStream and EncryptedStream
 function CryptoStream(pair) {
   stream.Stream.call(this);
@@ -478,16 +499,18 @@ EncryptedStream.prototype._pusher = function(pool, offset, length) {
  */
 
 function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
-                    NPNProtocols) {
+                    options) {
   if (!(this instanceof SecurePair)) {
     return new SecurePair(credentials,
                           isServer,
                           requestCert,
                           rejectUnauthorized,
-                          NPNProtocols);
+                          options);
   }
 
   var self = this;
+
+  options || (options = {});
 
   events.EventEmitter.call(this);
 
@@ -515,12 +538,18 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
 
   this.ssl = new Connection(this.credentials.context,
                              this._isServer ? true : false,
-                             this._requestCert,
+                             this._isServer ? this._requestCert :
+                                              options.servername,
                              this._rejectUnauthorized);
 
-  if (NPN_ENABLED && NPNProtocols) {
-    this.ssl.setNPNProtocols(NPNProtocols);
+  if (this.ssl.setSNIContexts) {
+    this.ssl.setSNIContexts(options.SNIContexts || {});
+  }
+
+  if (NPN_ENABLED && options.NPNProtocols) {
+    this.ssl.setNPNProtocols(options.NPNProtocols);
     this.npnProtocol = null;
+    this.servername = null;
   }
 
   /* Acts as a r/w stream to the cleartext side of the stream. */
@@ -633,6 +662,11 @@ SecurePair.prototype.maybeInitFinished = function() {
     if (NPN_ENABLED) {
       this.npnProtocol = this.ssl.getNegotiatedProtocol();
     }
+
+    if (this.ssl.getServername) {
+      this.servername = this.ssl.getServername();
+    }
+
     this._secureEstablished = true;
     debug('secure established');
     this.emit('secure');
@@ -790,7 +824,10 @@ function Server(/* [options], listener */) {
                               true,
                               self.requestCert,
                               self.rejectUnauthorized,
-                              self.NPNProtocols);
+                              {
+                                NPNProtocols: self.NPNProtocols,
+                                SNIContexts: self.SNIContexts
+                              });
 
     var cleartext = pipe(pair, socket);
     cleartext._controlReleased = false;
@@ -798,6 +835,8 @@ function Server(/* [options], listener */) {
     pair.on('secure', function() {
       pair.cleartext.authorized = false;
       pair.cleartext.npnProtocol = pair.npnProtocol;
+      pair.cleartext.servername = pair.servername;
+
       if (!self.requestCert) {
         cleartext._controlReleased = true;
         self.emit('secureConnection', pair.cleartext, pair.encrypted);
@@ -859,6 +898,7 @@ Server.prototype.setOptions = function(options) {
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
   if (options.secureOptions) this.secureOptions = options.secureOptions;
   if (options.NPNProtocols) convertNPNProtocols(options.NPNProtocols, this);
+  if (options.SNIContexts) convertSNIContexts(options.SNIContexts, this);
 };
 
 
@@ -903,7 +943,10 @@ exports.connect = function(port /* host, options, cb */) {
 
   convertNPNProtocols(options.NPNProtocols, this);
   var pair = new SecurePair(sslcontext, false, true, false,
-                            this.NPNProtocols);
+                            {
+                              NPNProtocols: this.NPNProtocols,
+                              servername: options.servername
+                            });
 
   var cleartext = pipe(pair, socket);
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -71,27 +71,6 @@ function convertNPNProtocols(NPNProtocols, out) {
   }
 };
 
-// Create SSL Contexts for each object key
-function convertSNIContexts(SNIContexts, out) {
-  var result = {};
-
-  for (var key in SNIContexts) {
-    if (SNIContexts.hasOwnProperty(key)) {
-      var val = SNIContexts[key],
-          ctx = crypto.createCredentials({
-            key: val.key,
-            cert: val.cert,
-            ca: val.ca,
-            crl: val.crl
-          }).ctx;
-
-      result[key] = ctx;
-    }
-  }
-
-  return result;
-};
-
 // Base class of both CleartextStream and EncryptedStream
 function CryptoStream(pair) {
   stream.Stream.call(this);
@@ -542,8 +521,8 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
                                               options.servername,
                              this._rejectUnauthorized);
 
-  if (this.ssl.setSNIContexts) {
-    this.ssl.setSNIContexts(options.SNIContexts || {});
+  if (this.ssl.setSNICallback && options.SNICallback) {
+    this.ssl.setSNICallback(options.SNICallback);
   }
 
   if (NPN_ENABLED && options.NPNProtocols) {
@@ -826,7 +805,7 @@ function Server(/* [options], listener */) {
                               self.rejectUnauthorized,
                               {
                                 NPNProtocols: self.NPNProtocols,
-                                SNIContexts: self.SNIContexts
+                                SNICallback: self.SNICallback
                               });
 
     var cleartext = pipe(pair, socket);
@@ -898,7 +877,7 @@ Server.prototype.setOptions = function(options) {
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
   if (options.secureOptions) this.secureOptions = options.secureOptions;
   if (options.NPNProtocols) convertNPNProtocols(options.NPNProtocols, this);
-  if (options.SNIContexts) convertSNIContexts(options.SNIContexts, this);
+  if (options.SNICallback) this.SNICallback = options.SNICallback;
 };
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -518,14 +518,14 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
                                               options.servername,
                              this._rejectUnauthorized);
 
-  if (process.features.sni) {
+  if (process.features.tls_sni) {
     if (this._isServer && options.SNICallback) {
       this.ssl.setSNICallback(options.SNICallback);
     }
     this.servername = null;
   }
 
-  if (process.features.npn && options.NPNProtocols) {
+  if (process.features.tls_npn && options.NPNProtocols) {
     this.ssl.setNPNProtocols(options.NPNProtocols);
     this.npnProtocol = null;
   }
@@ -637,11 +637,11 @@ SecurePair.prototype.cycle = function(depth) {
 
 SecurePair.prototype.maybeInitFinished = function() {
   if (this.ssl && !this._secureEstablished && this.ssl.isInitFinished()) {
-    if (process.features.npn) {
+    if (process.features.tls_npn) {
       this.npnProtocol = this.ssl.getNegotiatedProtocol();
     }
 
-    if (process.features.sni) {
+    if (process.features.tls_sni) {
       this.servername = this.ssl.getServername();
     }
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -521,7 +521,7 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
                                               options.servername,
                              this._rejectUnauthorized);
 
-  if (this.ssl.setSNICallback && options.SNICallback) {
+  if (this.ssl.setSNICallback && this._isServer) {
     this.ssl.setSNICallback(options.SNICallback);
   }
 
@@ -877,7 +877,38 @@ Server.prototype.setOptions = function(options) {
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
   if (options.secureOptions) this.secureOptions = options.secureOptions;
   if (options.NPNProtocols) convertNPNProtocols(options.NPNProtocols, this);
-  if (options.SNICallback) this.SNICallback = options.SNICallback;
+  if (options.SNICallback) {
+    this.SNICallback = options.SNICallback;
+  } else {
+    this.SNICallback = this.SNICallback.bind(this);
+  }
+};
+
+// SNI Contexts High-Level API
+Server.prototype._contexts = [];
+Server.prototype.addContext = function(servername, credentials) {
+  if (!servername) {
+    throw 'Servername is required parameter for Server.addContext';
+  }
+
+  var re = new RegExp('^' +
+                      servername.replace(/([\.^$+?\-\\[\]{}])/g, '\\$1')
+                                .replace(/\*/g, '.*') +
+                      '$');
+  this._contexts.push([re, crypto.createCredentials(credentials).context]);
+};
+
+Server.prototype.SNICallback = function(servername) {
+  var ctx;
+
+  this._contexts.some(function(elem) {
+    if (servername.match(elem[0]) !== null) {
+      ctx = elem[1];
+      return true;
+    }
+  });
+
+  return ctx;
 };
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -27,8 +27,6 @@ var stream = require('stream');
 var END_OF_FILE = 42;
 var assert = require('assert').ok;
 
-var NPN_ENABLED = process.binding('constants').NPN_ENABLED;
-
 var debug;
 if (process.env.NODE_DEBUG && /tls/.test(process.env.NODE_DEBUG)) {
   debug = function(a) { console.error('TLS:', a); };
@@ -40,7 +38,6 @@ if (process.env.NODE_DEBUG && /tls/.test(process.env.NODE_DEBUG)) {
 var Connection = null;
 try {
   Connection = process.binding('crypto').Connection;
-  exports.NPN_ENABLED = NPN_ENABLED;
 } catch (e) {
   throw new Error('node.js not compiled with openssl crypto support.');
 }
@@ -521,14 +518,16 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
                                               options.servername,
                              this._rejectUnauthorized);
 
-  if (this.ssl.setSNICallback && this._isServer) {
-    this.ssl.setSNICallback(options.SNICallback);
+  if (process.features.sni) {
+    if (this._isServer && options.SNICallback) {
+      this.ssl.setSNICallback(options.SNICallback);
+    }
+    this.servername = null;
   }
 
-  if (NPN_ENABLED && options.NPNProtocols) {
+  if (process.features.npn && options.NPNProtocols) {
     this.ssl.setNPNProtocols(options.NPNProtocols);
     this.npnProtocol = null;
-    this.servername = null;
   }
 
   /* Acts as a r/w stream to the cleartext side of the stream. */
@@ -638,11 +637,11 @@ SecurePair.prototype.cycle = function(depth) {
 
 SecurePair.prototype.maybeInitFinished = function() {
   if (this.ssl && !this._secureEstablished && this.ssl.isInitFinished()) {
-    if (NPN_ENABLED) {
+    if (process.features.npn) {
       this.npnProtocol = this.ssl.getNegotiatedProtocol();
     }
 
-    if (this.ssl.getServername) {
+    if (process.features.sni) {
       this.servername = this.ssl.getServername();
     }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -142,6 +142,18 @@ static bool use_uv = true;
 // disabled by default for now
 static bool use_http2 = false;
 
+#ifdef OPENSSL_NPN_NEGOTIATED
+static bool use_npn = true;
+#else
+static bool use_npn = false;
+#endif
+
+#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
+static bool use_sni = true;
+#else
+static bool use_sni = false;
+#endif
+
 // Buffer for getpwnam_r(), getgrpam_r() and other misc callers; keep this
 // scoped at file-level rather than method-level to avoid excess stack usage.
 static char getbuf[PATH_MAX + 1];
@@ -2031,6 +2043,8 @@ static Handle<Object> GetFeatures() {
   obj->Set(String::NewSymbol("uv"), Boolean::New(use_uv));
   obj->Set(String::NewSymbol("http2"), Boolean::New(use_http2));
   obj->Set(String::NewSymbol("ipv6"), True()); // TODO ping libuv
+  obj->Set(String::NewSymbol("npn"), Boolean::New(use_npn));
+  obj->Set(String::NewSymbol("sni"), Boolean::New(use_sni));
   obj->Set(String::NewSymbol("tls"),
       Boolean::New(get_builtin_module("crypto") != NULL));
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2043,8 +2043,8 @@ static Handle<Object> GetFeatures() {
   obj->Set(String::NewSymbol("uv"), Boolean::New(use_uv));
   obj->Set(String::NewSymbol("http2"), Boolean::New(use_http2));
   obj->Set(String::NewSymbol("ipv6"), True()); // TODO ping libuv
-  obj->Set(String::NewSymbol("npn"), Boolean::New(use_npn));
-  obj->Set(String::NewSymbol("sni"), Boolean::New(use_sni));
+  obj->Set(String::NewSymbol("tls_npn"), Boolean::New(use_npn));
+  obj->Set(String::NewSymbol("tls_sni"), Boolean::New(use_sni));
   obj->Set(String::NewSymbol("tls"),
       Boolean::New(get_builtin_module("crypto") != NULL));
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -753,6 +753,8 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
         SecureContext *sc = ObjectWrap::Unwrap<SecureContext>(
                                 Local<Object>::Cast(ret));
         SSL_set_SSL_CTX(s, sc->ctx_);
+      } else {
+        return SSL_TLSEXT_ERR_NOACK;
       }
     }
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -61,13 +61,13 @@ static Persistent<String> name_symbol;
 static Persistent<String> version_symbol;
 static Persistent<String> ext_key_usage_symbol;
 
-static Persistent<FunctionTemplate> SC_constructor;
+static Persistent<FunctionTemplate> secure_context_constructor;
 
 void SecureContext::Initialize(Handle<Object> target) {
   HandleScope scope;
 
   Local<FunctionTemplate> t = FunctionTemplate::New(SecureContext::New);
-  SC_constructor = Persistent<FunctionTemplate>::New(t);
+  secure_context_constructor = Persistent<FunctionTemplate>::New(t);
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("SecureContext"));
@@ -748,7 +748,7 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
       }
 
       // If ret is SecureContext
-      if (SC_constructor->HasInstance(ret)) {
+      if (secure_context_constructor->HasInstance(ret)) {
         p->sniContext_ = Persistent<Value>::New(ret);
         SecureContext *sc = ObjectWrap::Unwrap<SecureContext>(
                                 Local<Object>::Cast(ret));

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -740,7 +740,8 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
       TryCatch try_catch;
 
       // Call it
-      Local<Value> ret = callback->Call(Context::GetCurrent()->Global(), 1,
+      Local<Value> ret = callback->Call(Context::GetCurrent()->Global(),
+                                        1,
                                         argv);
 
       if (try_catch.HasCaught()) {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -104,6 +104,11 @@ class Connection : ObjectWrap {
   v8::Persistent<v8::Value> selectedNPNProto_;
 #endif
 
+#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
+  v8::Persistent<v8::Object> sniContexts_;
+  v8::Persistent<v8::String> servername_;
+#endif
+
  protected:
   static v8::Handle<v8::Value> New(const v8::Arguments& args);
   static v8::Handle<v8::Value> EncIn(const v8::Arguments& args);
@@ -135,6 +140,13 @@ class Connection : ObjectWrap {
                                       unsigned int inlen, void *arg);
 #endif
 
+#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
+  // SNI
+  static v8::Handle<v8::Value> GetServername(const v8::Arguments& args);
+  static v8::Handle<v8::Value> SetSNIContexts(const v8::Arguments& args);
+  static int SelectSNIContextCallback_(SSL *s, int *ad, void* arg);
+#endif
+
   int HandleBIOError(BIO *bio, const char* func, int rv);
   int HandleSSLError(const char* func, int rv);
 
@@ -161,6 +173,11 @@ class Connection : ObjectWrap {
 #ifdef OPENSSL_NPN_NEGOTIATED
     if (!npnProtos_.IsEmpty()) npnProtos_.Dispose();
     if (!selectedNPNProto_.IsEmpty()) selectedNPNProto_.Dispose();
+#endif
+
+#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
+   if (!sniContexts_.IsEmpty()) sniContexts_.Dispose();
+   if (!servername_.IsEmpty()) servername_.Dispose();
 #endif
   }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -105,7 +105,8 @@ class Connection : ObjectWrap {
 #endif
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-  v8::Persistent<v8::Object> sniContexts_;
+  v8::Persistent<v8::Function> sniCallback_;
+  v8::Persistent<v8::Value> sniContext_;
   v8::Persistent<v8::String> servername_;
 #endif
 
@@ -143,7 +144,7 @@ class Connection : ObjectWrap {
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   // SNI
   static v8::Handle<v8::Value> GetServername(const v8::Arguments& args);
-  static v8::Handle<v8::Value> SetSNIContexts(const v8::Arguments& args);
+  static v8::Handle<v8::Value> SetSNICallback(const v8::Arguments& args);
   static int SelectSNIContextCallback_(SSL *s, int *ad, void* arg);
 #endif
 
@@ -176,7 +177,8 @@ class Connection : ObjectWrap {
 #endif
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-   if (!sniContexts_.IsEmpty()) sniContexts_.Dispose();
+   if (!sniCallback_.IsEmpty()) sniCallback_.Dispose();
+   if (!sniContext_.IsEmpty()) sniContext_.Dispose();
    if (!servername_.IsEmpty()) servername_.Dispose();
 #endif
   }

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if (!process.versions.openssl || !process.features.npn) {
+if (!process.features.tls_npn) {
   console.error("Skipping because node compiled without OpenSSL or " +
                 "with old OpenSSL version.");
   process.exit(0);

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -19,9 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var NPN_ENABLED = process.binding('constants').NPN_ENABLED;
-
-if (!process.versions.openssl || !NPN_ENABLED) {
+if (!process.versions.openssl || !process.features.npn) {
   console.error("Skipping because node compiled without OpenSSL or " +
                 "with old OpenSSL version.");
   process.exit(0);

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if (!process.versions.openssl) {
+if (!process.versions.openssl || !process.features.sni) {
   console.error("Skipping because node compiled without OpenSSL or " +
                 "with old OpenSSL version.");
   process.exit(0);

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -1,0 +1,100 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL or " +
+                "with old OpenSSL version.");
+  process.exit(0);
+}
+
+var common = require('../common'),
+    assert = require('assert'),
+    fs = require('fs'),
+    tls = require('tls');
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + ".pem");
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverOptions = {
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert'),
+  crl: loadPEM('ca2-crl')
+};
+
+serverOptions.SNIContexts = {
+  'a.example.com': {
+    key: serverOptions.key,
+    cert: serverOptions.cert,
+    crl: serverOptions.crl
+  },
+  'b.example.com': {
+    key: serverOptions.key,
+    cert: serverOptions.cert,
+    crl: serverOptions.crl
+  }
+};
+
+
+var clientsOptions = [{
+  key: serverOptions.key,
+  cert: serverOptions.cert,
+  crl: serverOptions.crl,
+  servername: 'a.example.com'
+},{
+  key: serverOptions.key,
+  cert: serverOptions.cert,
+  crl: serverOptions.crl,
+  servername: 'b.example.com'
+}];
+
+var serverPort = common.PORT;
+
+var serverResults = [];
+
+var server = tls.createServer(serverOptions, function(c) {
+  serverResults.push(c.servername);
+});
+server.listen(serverPort, startTest);
+
+function startTest() {
+  function connectClient(options, callback) {
+    var client = tls.connect(serverPort, 'localhost', options, function() {
+      client.destroy();
+
+      callback();
+    });
+  };
+
+  connectClient(clientsOptions[0], function() {
+    connectClient(clientsOptions[1], function() {
+      server.close();
+    });
+  });
+};
+
+process.on('exit', function() {
+  assert.deepEqual(serverResults, ['a.example.com', 'b.example.com']);
+});

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -28,6 +28,7 @@ if (!process.versions.openssl) {
 var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),
+    crypto = require('crypto'),
     tls = require('tls');
 
 function filenamePEM(n) {
@@ -41,20 +42,23 @@ function loadPEM(n) {
 var serverOptions = {
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
-  crl: loadPEM('ca2-crl')
+  crl: loadPEM('ca2-crl'),
+  SNICallback: function(servername) {
+    return SNIContexts[servername];
+  }
 };
 
-serverOptions.SNIContexts = {
-  'a.example.com': {
+var SNIContexts = {
+  'a.example.com': crypto.createCredentials({
     key: serverOptions.key,
     cert: serverOptions.cert,
     crl: serverOptions.crl
-  },
-  'b.example.com': {
+  }).ctx,
+  'b.example.com': crypto.createCredentials({
     key: serverOptions.key,
     cert: serverOptions.cert,
     crl: serverOptions.crl
-  }
+  }).ctx
 };
 
 

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if (!process.versions.openssl || !process.features.sni) {
+if (!process.features.tls_sni) {
   console.error("Skipping because node compiled without OpenSSL or " +
                 "with old OpenSSL version.");
   process.exit(0);


### PR DESCRIPTION
Implemented SNI (Server Name Indication) TLS Extension support for node.js 0.5 branch.
See this for more information about SNI : http://www.ietf.org/rfc/rfc3546.txt

Basically, this should work even with old 0.9.8 openssl versions.

Added test which is itself a simple example.
