### PR TITLE
add autoDiscovery of ports to servers

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -11,13 +11,17 @@ automatically set as a listener for the `'connection'` event.
 
 `options` is an object with the following defaults:
 
-    { allowHalfOpen: false
+    { allowHalfOpen: false,
+      autoDiscovery: false
     }
 
 If `allowHalfOpen` is `true`, then the socket won't automatically send FIN
 packet when the other end of the socket sends a FIN packet. The socket becomes
 non-readable, but still writable. You should call the end() method explicitly.
 See `'end'` event for more information.
+
+If `autoDiscovery` is `true`, then the socket will bind to the closest
+available address when listening rather than throwing an EADDRINUSE error.
 
 ### net.createConnection(arguments...)
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -898,6 +898,7 @@ function Server(/* [ options, ] listener */) {
   self.connections = 0;
 
   self.allowHalfOpen = options.allowHalfOpen || false;
+  self.autoDiscovery = options.autoDiscovery || false;
 
   self.watcher = new IOWatcher();
   self.watcher.host = self;
@@ -1033,11 +1034,9 @@ Server.prototype.listen = function() {
     // Don't bind(). OS will assign a port with INADDR_ANY.
     // The port can be found with server.address()
     self.type = 'tcp4';
-    self.fd = socket(self.type);
     self._doListen(port);
   } else if (port === false) {
     // the first argument specifies a path
-    self.fd = socket('unix');
     self.type = 'unix';
     var path = arguments[0];
     self.path = path;
@@ -1067,7 +1066,6 @@ Server.prototype.listen = function() {
         self.emit('error', err);
       } else {
         self.type = addressType == 4 ? 'tcp4' : 'tcp6';
-        self.fd = socket(self.type);
         self._doListen(port, ip);
       }
     });
@@ -1092,16 +1090,29 @@ Server.prototype._startWatcher = function() {
 
 Server.prototype._doListen = function() {
   var self = this;
+  self.fd = socket(self.type);
 
   // Ensure we have a dummy fd for EMFILE conditions.
   getDummyFD();
 
-  try {
-    bind(self.fd, arguments[0], arguments[1]);
-  } catch (err) {
-    self.close();
-    self.emit('error', err);
-    return;
+  var port = arguments[0];
+  var ip = arguments[1];
+  
+  for(;;) {
+    try {
+      console.dir(arguments)
+      bind(self.fd, port, ip);
+      break;
+    } catch (err) {
+      if (self.autoDiscovery && err.code === 'EADDRINUSE') {
+        port++;
+      }
+      else {
+        self.close();
+        self.emit('error', err);
+        return;
+      }
+    }
   }
 
   // Need to the listening in the nextTick so that people potentially have
@@ -1115,8 +1126,13 @@ Server.prototype._doListen = function() {
     try {
       listen(self.fd, self._backlog || 128);
     } catch (err) {
-      self.close();
-      self.emit('error', err);
+      if (self.autoDiscovery && err.code === 'EADDRINUSE') {
+        self._doListen(port+1, ip);
+      }
+      else {
+        self.close();
+        self.emit('error', err);
+      }
       return;
     }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1100,7 +1100,6 @@ Server.prototype._doListen = function() {
   
   for(;;) {
     try {
-      console.dir(arguments)
       bind(self.fd, port, ip);
       break;
     } catch (err) {

--- a/test/simple/test-net-autodiscovery.js
+++ b/test/simple/test-net-autodiscovery.js
@@ -1,0 +1,44 @@
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+server1 = net.createServer();
+server2 = net.createServer({autoDiscovery: true});
+
+var i = 0;
+function check() {
+  i++;
+  if (i != 2) {
+    return;
+  }
+  
+  var addr1 = server1.address();
+  var addr2 = server2.address();
+  
+  server1.close();
+  server2.close();
+  
+  assert.equal(addr1.port, common.PORT);
+  assert.notEqual(addr2, null);
+  assert.notEqual(addr2.port, common.PORT);
+  
+}
+
+server1.on('listening', check);
+server2.on('listening', check);
+
+server1.on('error', function(err) {
+  assert.ifError(err);
+  
+  if(server1.fd) server1.close();
+  if(server2.fd) server2.close();
+});
+server2.on('error', function(err) {
+  assert.ifError(err);
+  
+  if(server1.fd) server1.close();
+  if(server2.fd) server2.close();
+});
+
+server1.listen(common.PORT);
+server2.listen(common.PORT);


### PR DESCRIPTION
Adds a {autoDiscovery: true} option to servers. This will prevent EADDRINUSE when listening on the same port by incrementing the port being bound/listened to.

IE:

```
server1=net.createServer()
server2=net.createServer({autoDiscovery: true})

server1.listen(8888)
server2.listen(8888)
```

server2 will end up listening on 8889
