### PR TITLE
Fix broken os.freemem() on FreeBSD amd64

### DIFF
--- a/src/platform_freebsd.cc
+++ b/src/platform_freebsd.cc
@@ -156,7 +156,7 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
 
 double Platform::GetFreeMemory() {
   double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  unsigned long info;
+  unsigned int info = 0;
   size_t size = sizeof(info);
 
   if (sysctlbyname("vm.stats.vm.v_free_count", &info, &size, NULL, 0) < 0) {


### PR DESCRIPTION
v_free_count defined as u_int v_free_count (struct vmmeter sys/vmmeter.h:87), but variable info defined as unsigned long, that cause error on 64-bits systems because higher 32 bits remain uninitialized.

Example:

> require('os').freemem()
> 140737549713408
