### PR TITLE
Fix issue #752. Remove http getHeader check for sent headers.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -540,10 +540,6 @@ OutgoingMessage.prototype.getHeader = function(name) {
     throw new Error("`name` is required for getHeader().");
   }
 
-  if (this._header) {
-    throw new Error("Can't use mutable header APIs after sent.");
-  }
-
   if (!this._headers) return;
 
   var key = name.toLowerCase();

--- a/test/simple/test-http-header-read.js
+++ b/test/simple/test-http-header-read.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+// Verify that ServerResponse.getHeader() works correctly even after
+// the response header has been sent. Issue 752 on github.
+
+var s = http.createServer(function(req, res) {
+  var contentType = 'Content-Type';
+  var plain = 'text/plain';
+  res.setHeader(contentType, plain);
+  res.writeHead(200);
+  res.end('hello world\n');
+  //This checks that after the headers have been sent, getHeader works
+  //and does not throw an exception (Issue 752)
+  assert.doesNotThrow(
+    function() {
+      assert.equal(plain, res.getHeader(contentType));
+    },
+    function(err) {
+      if ( (err instanceof Error) && /mutable header APIs/.test(err) ) {
+        return true;
+      }
+    },
+    'getHeader should not raise an error about mutable APIs'
+  );
+});
+
+s.listen(common.PORT, runTest);
+
+function runTest() {
+  http.get({ port: common.PORT }, function(response) {
+    response.on('end', function() {
+      s.close();
+    });
+  });
+}


### PR DESCRIPTION
Simple delete of an unnecessary conditional that will not allow getHeader to return a header value after the headers have been sent.  @creationix commented on issue #752 saying the check was not necessary.
