### PR TITLE
Fix test-child-process-exec-env on Win32.

### DIFF
--- a/test/simple/test-child-process-exec-env.js
+++ b/test/simple/test-child-process-exec-env.js
@@ -26,6 +26,8 @@ var success_count = 0;
 var error_count = 0;
 var response = '';
 
+var isWindows = process.platform === 'win32';
+
 function after(err, stdout, stderr) {
   if (err) {
     error_count++;
@@ -39,7 +41,14 @@ function after(err, stdout, stderr) {
   }
 }
 
-var child = exec('/usr/bin/env', { env: { 'HELLO': 'WORLD' } }, after);
+var env = { 'HELLO': 'WORLD' };
+
+if (isWindows) {
+  var child = spawn('cmd.exe', ['/c', 'set'], {env: env}, after);
+} else {
+  var child = spawn('/usr/bin/env', [], {env: env}, after);
+}
+
 
 child.stdout.setEncoding('utf8');
 child.stdout.addListener('data', function(chunk) {


### PR DESCRIPTION
A simple test fix; the test currently fails on Win32 because spawning /usr/bin/env is the wrong thing to do.
