### PR TITLE
Fix module loading order, add test cases and document for requre() of .json

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -44,10 +44,12 @@ return the built in HTTP module, even if there is a file by that name.
 ### File Modules
 
 If the exact filename is not found, then node will attempt to load the
-required filename with the added extension of `.js`, and then `.node`.
+required filename with the added extension in order of `.js`, `.node` 
+and `.json`.
 
 `.js` files are interpreted as JavaScript text files, and `.node` files
-are interpreted as compiled addon modules loaded with `dlopen`.
+are interpreted as compiled addon modules loaded with `dlopen`. `.json` 
+files are interpreted as JavaScript objects loaded with `JSON.parse()`.
 
 A module prefixed with `'/'` is an absolute path to the file.  For
 example, `require('/home/marco/foo.js')` will load the file at

--- a/lib/module.js
+++ b/lib/module.js
@@ -143,6 +143,18 @@ Module._findPath = function(request, paths) {
   var fs = NativeModule.require('fs');
   var exts = Object.keys(Module._extensions);
 
+// specify the default search order of file extensions
+  var exts_order = ['.js', '.node', '.json'];
+
+// Since Object.key() returns key elements in an arbitary
+// order, check and reorder them if they are violated.
+  if(exts.slice(0,exts_order.length).join() !== exts_order.join()){
+    for(var i = 0, EOL = exts_order.length; i < EOL; i++){
+      exts.splice(exts.indexOf(exts_order[i]),1);
+      exts.splice(i,0,exts_order[i]);
+    }
+  }
+
   if (request.charAt(0) === '/') {
     paths = [''];
   }

--- a/test/fixtures/module-load-order/file10/index.js
+++ b/test/fixtures/module-load-order/file10/index.js
@@ -1,0 +1,22 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.file10 = 'file10/index.js';

--- a/test/fixtures/module-load-order/file10/index.json
+++ b/test/fixtures/module-load-order/file10/index.json
@@ -1,0 +1,1 @@
+{"file10":"file10/index.json"}

--- a/test/fixtures/module-load-order/file10/index.node
+++ b/test/fixtures/module-load-order/file10/index.node
@@ -1,0 +1,1 @@
+exports.file10 = 'file10/index.node';

--- a/test/fixtures/module-load-order/file10/index.reg
+++ b/test/fixtures/module-load-order/file10/index.reg
@@ -1,0 +1,1 @@
+exports.file10 = 'file10/index.reg';

--- a/test/fixtures/module-load-order/file10/index.reg2
+++ b/test/fixtures/module-load-order/file10/index.reg2
@@ -1,0 +1,1 @@
+exports.file10 = 'file10/index.reg2';

--- a/test/fixtures/module-load-order/file11/index.js
+++ b/test/fixtures/module-load-order/file11/index.js
@@ -1,0 +1,22 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.file11 = 'file11/index.js';

--- a/test/fixtures/module-load-order/file11/index.json
+++ b/test/fixtures/module-load-order/file11/index.json
@@ -1,0 +1,1 @@
+{"file11":"file11/index.json"}

--- a/test/fixtures/module-load-order/file11/index.reg
+++ b/test/fixtures/module-load-order/file11/index.reg
@@ -1,0 +1,1 @@
+exports.file11 = 'file11/index.reg';

--- a/test/fixtures/module-load-order/file11/index.reg2
+++ b/test/fixtures/module-load-order/file11/index.reg2
@@ -1,0 +1,1 @@
+exports.file11 = 'file11/index.reg2';

--- a/test/fixtures/module-load-order/file12/index.json
+++ b/test/fixtures/module-load-order/file12/index.json
@@ -1,0 +1,1 @@
+{"file12":"file12/index.json"}

--- a/test/fixtures/module-load-order/file12/index.node
+++ b/test/fixtures/module-load-order/file12/index.node
@@ -1,0 +1,1 @@
+exports.file12 = 'file12/index.node';

--- a/test/fixtures/module-load-order/file12/index.reg
+++ b/test/fixtures/module-load-order/file12/index.reg
@@ -1,0 +1,1 @@
+exports.file12 = 'file12/index.reg';

--- a/test/fixtures/module-load-order/file12/index.reg2
+++ b/test/fixtures/module-load-order/file12/index.reg2
@@ -1,0 +1,1 @@
+exports.file12 = 'file12/index.reg2';

--- a/test/fixtures/module-load-order/file13/index.json
+++ b/test/fixtures/module-load-order/file13/index.json
@@ -1,0 +1,1 @@
+{"file13":"file13/index.json"}

--- a/test/fixtures/module-load-order/file13/index.reg
+++ b/test/fixtures/module-load-order/file13/index.reg
@@ -1,0 +1,1 @@
+exports.file13 = 'file13/index.reg';

--- a/test/fixtures/module-load-order/file13/index.reg2
+++ b/test/fixtures/module-load-order/file13/index.reg2
@@ -1,0 +1,1 @@
+exports.file13 = 'file13/index.reg2';

--- a/test/fixtures/module-load-order/file14/index.js
+++ b/test/fixtures/module-load-order/file14/index.js
@@ -1,0 +1,22 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.file14 = 'file14/index.js';

--- a/test/fixtures/module-load-order/file14/index.json
+++ b/test/fixtures/module-load-order/file14/index.json
@@ -1,0 +1,1 @@
+{"file14":"file14/index.json"}

--- a/test/fixtures/module-load-order/file14/index.node
+++ b/test/fixtures/module-load-order/file14/index.node
@@ -1,0 +1,1 @@
+exports.file14 = 'file14/index.node';

--- a/test/fixtures/module-load-order/file14/index.reg
+++ b/test/fixtures/module-load-order/file14/index.reg
@@ -1,0 +1,1 @@
+exports.file14 = 'file14/index.reg';

--- a/test/fixtures/module-load-order/file14/index.reg2
+++ b/test/fixtures/module-load-order/file14/index.reg2
@@ -1,0 +1,1 @@
+exports.file14 = 'file14/index.reg2';

--- a/test/fixtures/module-load-order/file14/index0
+++ b/test/fixtures/module-load-order/file14/index0
@@ -1,0 +1,1 @@
+exports.file14 = 'file14/index0';

--- a/test/simple/test-module-loading.js
+++ b/test/simple/test-module-loading.js
@@ -186,6 +186,23 @@ try {
 assert.equal(require(loadOrder + 'file8').file8, 'file8/index.reg', msg);
 assert.equal(require(loadOrder + 'file9').file9, 'file9/index.reg2', msg);
 
+// add test cases of module loading order for .json 
+assert.equal(require(loadOrder + 'file10').file10, 'file10/index.js', msg);
+assert.equal(require(loadOrder + 'file11').file11, 'file11/index.js', msg);
+try {
+  require(loadOrder + 'file12');
+} catch (e) {
+  assert.ok(e.message.match(/file12\/index\.node/));
+}
+assert.equal(require(loadOrder + 'file13').file13, 'file13/index.json', msg);
+
+// Check the case that the file extension is defined as number.
+// Object.keys() in V8 always returns number keys at first so that we must 
+// reorder the extention array to search module files in order of ".js",
+// ".node" and ".json"
+// http://code.google.com/p/chromium/issues/detail?id=20270
+require.extensions['0'] = require.extensions['.js'];
+assert.equal(require(loadOrder + 'file14').file14, 'file14/index.js', msg);
 
 // make sure that module.require() is the same as
 // doing require() inside of that module.


### PR DESCRIPTION
Fix module loading order of the file extension and add several test cases.

In the case that the file extension is defined as number, however it seems to be very rare, 
 its possible to fail the test while searching file extensions as in this request.

This is because that Object.keys() in V8 always returns number keys at first so that 
we must reorder the extension array to search module files in order of  ".js",".node" and ".json"

 http://code.google.com/p/chromium/issues/detail?id=20270

Also, the description of rquire() of .json is added to the document.
