### PR TITLE
add global listener support

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -36,7 +36,7 @@ EventEmitter.prototype.setMaxListeners = function(n) {
   this._events.maxListeners = n;
 };
 
-
+var globalType = '*';
 EventEmitter.prototype.emit = function() {
   var type = arguments[0];
   // If there is no 'error' event listener then throw.
@@ -55,6 +55,18 @@ EventEmitter.prototype.emit = function() {
 
   if (!this._events) return false;
   var handler = this._events[type];
+
+  // global event, emit even if there are no type specific handlers
+  if (type !== globalType) {
+    if (this._events[globalType]) {
+      var l = arguments.length;
+      var args = new Array(l+1); // make room to push globalType on the front
+      args[0] = globalType;
+      for (var i = 0; i < l; i++) args[i+1] = arguments[i];
+      this.emit.apply(this, args);
+    }
+  }
+
   if (!handler) return false;
 
   if (typeof handler == 'function') {

--- a/test/simple/test-event-emitter-add-listeners.js
+++ b/test/simple/test-event-emitter-add-listeners.js
@@ -25,12 +25,13 @@ var events = require('events');
 
 var e = new events.EventEmitter();
 
-var events_new_listener_emited = [];
+var events_new_listener_emitted = [];
+var events_global_listener_emitted = [];
 var times_hello_emited = 0;
 
 e.addListener('newListener', function(event, listener) {
   console.log('newListener: ' + event);
-  events_new_listener_emited.push(event);
+  events_new_listener_emitted.push(event);
 });
 
 e.on('hello', function(a, b) {
@@ -38,6 +39,13 @@ e.on('hello', function(a, b) {
   times_hello_emited += 1;
   assert.equal('a', a);
   assert.equal('b', b);
+});
+
+e.on('*', function(event) {
+  console.log('global');
+  events_global_listener_emitted.push(event);
+  assert.equal('a', arguments[1]);
+  assert.equal('b', arguments[2]);
 });
 
 console.log('start');
@@ -51,7 +59,8 @@ f.setMaxListeners(0);
 
 
 process.addListener('exit', function() {
-  assert.deepEqual(['hello'], events_new_listener_emited);
+  assert.deepEqual(['hello', '*'], events_new_listener_emitted);
+  assert.deepEqual(['hello'], events_global_listener_emitted);
   assert.equal(1, times_hello_emited);
 });
 

--- a/test/simple/test-event-emitter-num-args.js
+++ b/test/simple/test-event-emitter-num-args.js
@@ -24,12 +24,19 @@ var assert = require('assert');
 var events = require('events');
 
 var e = new events.EventEmitter(),
-    num_args_emited = [];
+    num_args_emitted = [],
+    num_global_args_emitted = [];
 
 e.on('numArgs', function() {
   var numArgs = arguments.length;
   console.log('numArgs: ' + numArgs);
-  num_args_emited.push(numArgs);
+  num_args_emitted.push(numArgs);
+});
+
+e.on('*', function() {
+  var numArgs = arguments.length;
+  console.log('numGlobalArgs: ' + numArgs);
+  num_global_args_emitted.push(numArgs);
 });
 
 console.log('start');
@@ -42,7 +49,6 @@ e.emit('numArgs', null, null, null, null);
 e.emit('numArgs', null, null, null, null, null);
 
 process.addListener('exit', function() {
-  assert.deepEqual([0, 1, 2, 3, 4, 5], num_args_emited);
+  assert.deepEqual([0, 1, 2, 3, 4, 5], num_args_emitted);
+  assert.deepEqual([1, 2, 3, 4, 5, 6], num_global_args_emitted);
 });
-
-

--- a/test/simple/test-event-emitter-remove-all-listeners.js
+++ b/test/simple/test-event-emitter-remove-all-listeners.js
@@ -25,6 +25,8 @@ var events = require('events');
 
 
 function listener() {}
+function gListener1() {}
+function gListener2() {}
 
 var e1 = new events.EventEmitter();
 e1.addListener('foo', listener);
@@ -37,7 +39,14 @@ assert.deepEqual([listener], e1.listeners('bar'));
 var e2 = new events.EventEmitter();
 e2.addListener('foo', listener);
 e2.addListener('bar', listener);
+e2.addListener('*', gListener1);
 e2.removeAllListeners();
-console.error(e2);
 assert.deepEqual([], e2.listeners('foo'));
 assert.deepEqual([], e2.listeners('bar'));
+assert.deepEqual([], e2.listeners('*'));
+
+var e3 = new events.EventEmitter();
+e3.addListener('*', gListener1);
+e3.addListener('*', gListener2);
+e3.removeAllListeners('*');
+assert.deepEqual([], e2.listeners('*'));

--- a/test/simple/test-event-emitter-remove-listeners.js
+++ b/test/simple/test-event-emitter-remove-listeners.js
@@ -25,6 +25,7 @@ var events = require('events');
 
 
 var count = 0;
+var gcount = 0;
 
 function listener1() {
   console.log('listener1');
@@ -39,6 +40,16 @@ function listener2() {
 function listener3() {
   console.log('listener3');
   count++;
+}
+
+function globalListener1() {
+  console.log('globalListener1');
+  gcount++;
+}
+
+function globalListener2() {
+  console.log('globalListener2');
+  gcount++;
 }
 
 var e1 = new events.EventEmitter();
@@ -57,5 +68,13 @@ e3.addListener('hello', listener2);
 e3.removeListener('hello', listener1);
 assert.deepEqual([listener2], e3.listeners('hello'));
 
+var e4 = new events.EventEmitter();
+e4.on('*', globalListener1);
+e4.removeListener('*', globalListener1);
+assert.deepEqual([], e4.listeners('*'));
 
-
+var e5 = new events.EventEmitter();
+e5.on('*', globalListener1);
+e5.on('*', globalListener2);
+e5.removeListener('*', globalListener1);
+assert.deepEqual([globalListener2], e5.listeners('*'));


### PR DESCRIPTION
Adds support for a global event listener using "*".

```
var ee = new EventEmitter();
ee.on('*', function(event) {
   console.log('global event for ' + event);
});

ee.on('foo', function() {
   console.log('foo');       
})
.on('bar', function() {
   console.log('bar');
});

ee.emit('foo');

setTimeout(function() {
   console.log('after 10 secs');
   ee.emit('bar');
}, 10000);

// output
global event for foo
foo
after 10 secs
global event for baz
baz
```

This patch is very minimal and uses the same EventEmitter infrastructure. It simply makes "*" a special event name. See this thread for some background. The branch linked there is gone. Replaced by this one (g_event_short).

https://groups.google.com/forum/#!searchin/nodejs/marco$20onevent/nodejs/y3MbKZUKbSU/al89RUn4gfsJ
