### PR TITLE
Added EventEmitter#stopPropagation()

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -43,6 +43,29 @@ it is removed.
       console.log('Ah, we have our first user!');
     });
 
+#### emitter.stopPropagation()
+
+ When called the emitter will immediately stop invoking any
+ additional listeners that are present.
+
+     var calls = [];
+     emitter.on('foo', function(){
+       calls.push('one');
+     });
+
+     emitter.on('foo', function(){
+       calls.push('two');
+       emitter.stopPropagation();
+     });
+
+     emitter.on('foo', function(){
+       calls.push('three');
+     });
+
+     emitter.emit('foo');
+     console.log(calls);
+     // => ['one', 'two']
+
 #### emitter.removeListener(event, listener)
 
 Remove a listener from the listener array for the specified event.

--- a/lib/events.js
+++ b/lib/events.js
@@ -36,9 +36,14 @@ EventEmitter.prototype.setMaxListeners = function(n) {
   this._events.maxListeners = n;
 };
 
+EventEmitter.prototype.stopPropagation = function(){
+  this.propagate = false;
+  return this;
+};
 
 EventEmitter.prototype.emit = function() {
   var type = arguments[0];
+  this.propagate = true;
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events || !this._events.error ||
@@ -84,7 +89,7 @@ EventEmitter.prototype.emit = function() {
     for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
 
     var listeners = handler.slice();
-    for (var i = 0, l = listeners.length; i < l; i++) {
+    for (var i = 0, l = listeners.length; this.propagate && i < l; i++) {
       listeners[i].apply(this, args);
     }
     return true;

--- a/test/simple/test-event-emitter-propagation.js
+++ b/test/simple/test-event-emitter-propagation.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var e = new events.EventEmitter;
+
+var calls = []
+  , n = 0;
+
+e.on('foo', function(){
+  calls.push('one');
+});
+
+e.on('foo', function(){
+  calls.push('two');
+  if (!n++) e.stopPropagation();
+});
+
+e.on('foo', function(){
+  calls.push('three');
+});
+
+e.on('foo', function(){
+  calls.push('four');
+});
+
+e.emit('foo');
+e.emit('foo');
+
+process.on('exit', function(){
+  assert.deepEqual(calls, ['one', 'two', 'one', 'two', 'three', 'four']);
+});


### PR DESCRIPTION
there have been a few times where I wanted to short-circuit the event in emission, but couldn't even hack it in since we cache the `.length`. Doesn't matter to me what it's called, `emitter.cancel()` or something would be more concise but this is more browser-like. Thoughts? if I'm the only one who has wanted this please ignore :)
