### PR TITLE
Create explicit v8 lock

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2566,6 +2566,7 @@ int Start(int argc, char *argv[]) {
   argv = Init(argc, argv);
 
   v8::V8::Initialize();
+  v8::Locker locker;
   v8::HandleScope handle_scope;
 
   // Create the one and only Context.


### PR DESCRIPTION
v8 requires a lock of each thread using the vm, but if none is explicitly is created it will implicitly create one for you. This creates issues when trying to build modules which use v8's multi-threading features because there's no lock to unlock.
