### PR TITLE
Fix MSVS building.

### DIFF
--- a/generate-projects.bat
+++ b/generate-projects.bat
@@ -1,2 +1,2 @@
 @echo off
-python tools\gyp_node -f msvs -D msvs_multi_core_compile=true
+python tools\gyp_node -f msvs -G msvs_version=2010 -D msvs_multi_core_compile=true

--- a/node.gyp
+++ b/node.gyp
@@ -74,7 +74,7 @@
       'dependencies': [
         'deps/http_parser/http_parser.gyp:http_parser',
         'deps/v8/tools/gyp/v8.gyp:v8',
-        'deps/uv/build/all.gyp:uv',
+        'deps/uv/all.gyp:uv',
         'node_js2c#host',
       ],
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -49,6 +49,9 @@
 #define getcwd _getcwd
 #include <process.h>
 #define getpid _getpid
+#include <io.h>
+#define umask _umask
+typedef int mode_t;
 #endif
 #include <errno.h>
 #include <sys/types.h>
@@ -1442,11 +1445,6 @@ static Handle<Value> Cwd(const Arguments& args) {
 
   return scope.Close(cwd);
 }
-
-
-#ifndef __POSIX__
-# define umask _umask
-#endif
 
 static Handle<Value> Umask(const Arguments& args) {
   HandleScope scope;

--- a/tools/gyp_node
+++ b/tools/gyp_node
@@ -42,7 +42,6 @@ if __name__ == '__main__':
     # Tell make to write its output into the same dir
     args.extend(['-Goutput_dir=' + output_dir])
 
-  args.append('-S-nodegyp')
   args.append('-Dtarget_arch=ia32')
   args.append('-Dcomponent=static_library')
   args.append('-Dlibrary=static_library')


### PR DESCRIPTION
gyp got broken with a uv upgrade, and there are some minor fixes needed for `umask()`.

Also, using gyp with -S breaks mksnapshot, so disable that for now.
