### PR TITLE
Allow Net options to be passed through HTTP.createServer()

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -958,12 +958,23 @@ function httpSocketSetup(socket) {
 }
 
 
-function Server(requestListener) {
+function Server() {
   if (!(this instanceof Server)) return new Server(requestListener);
-  net.Server.call(this, { allowHalfOpen: true });
-
-  if (requestListener) {
-    this.addListener('request', requestListener);
+  
+  var options = {};
+  
+  // I'm sure there is a more beautiful way to do this, but...
+  if (typeof arguments[0] == 'function') {
+    options['allowHalfOpen'] = true;
+    net.Server.call(this, options);
+    this.addListener('request', arguments[0]);
+  } else {
+    options = arguments[0] || {};
+    options['allowHalfOpen'] = true;
+    net.Server.call(this, options);
+    if (typeof arguments[1] == 'function') {
+        this.addListener('request', arguments[1]);
+    }
   }
 
   // Similar option to this. Too lazy to write my own docs.
@@ -979,8 +990,8 @@ util.inherits(Server, net.Server);
 exports.Server = Server;
 
 
-exports.createServer = function(requestListener) {
-  return new Server(requestListener);
+exports.createServer = function() {
+  return new Server(arguments[0], argument[1]);
 };
 
 


### PR DESCRIPTION
var s = require('http').createServer({'opt':'ions'}, callBack(...) { });
