### PR TITLE
Fixed a typo in definition HAVE_PIPE2

### DIFF
--- a/deps/uv/src/uv-unix.c
+++ b/deps/uv/src/uv-unix.c
@@ -47,8 +47,9 @@
 #ifdef __linux__
 #include <linux/version.h>
 /* pipe2() requires linux >= 2.6.27 and glibc >= 2.9 */
-#define HAVE_PIPE2 \
-  defined(LINUX_VERSION_CODE) && defined(__GLIBC_PREREQ) && LINUX_VERSION_CODE >= 0x2061B && __GLIBC_PREREQ(2, 9))
+#if defined(LINUX_VERSION_CODE) && defined(__GLIBC_PREREQ) && LINUX_VERSION_CODE >= 0x2061B && __GLIBC_PREREQ(2, 9)
+#define HAVE_PIPE2
+#endif
 #endif
 
 #ifdef __sun


### PR DESCRIPTION
The define HAVE_PIPE2 was always being set, even when the requisites
were not met.
