### PR TITLE
Added an option to child_process.spawn

### DIFF
--- a/src/node_child_process.h
+++ b/src/node_child_process.h
@@ -91,9 +91,8 @@ class ChildProcess : ObjectWrap {
             int custom_fds[3],
             bool do_setsid,
             int custom_uid,
-            char *custom_uname,
-            int custom_gid,
-            char *custom_gname,
+            int num_custom_gids,
+			const gid_t *custom_gids,
             int* channel);
 
   // Simple syscall wrapper. Does not disable the watcher. onexit will be


### PR DESCRIPTION
child_process.spawn now accepts an array of group ids (or group names),
in addition to the numerical group id or group name.

The signature for the internal method ChildProcess::Spawn was also changed.
It now receives an user id and an array of group ids, instead of a
single user id/name and a single group id/name.
