### PR TITLE
Fix memory consumption in excess of options.maxBuffer in child_process.exec()

### DIFF
--- a/lib/child_process_uv.js
+++ b/lib/child_process_uv.js
@@ -177,6 +177,7 @@ exports.execFile = function(file /* args, options, callback */) {
     if (stdout.length > options.maxBuffer) {
       err = new Error('maxBuffer exceeded.');
       kill();
+      child.stdout.destroy()
     }
   });
 
@@ -185,6 +186,7 @@ exports.execFile = function(file /* args, options, callback */) {
     if (stderr.length > options.maxBuffer) {
       err = new Error('maxBuffer exceeded.');
       kill();
+      child.stderr.destroy()
     }
   });
 


### PR DESCRIPTION
If the program does not die on the signal and continues to write to stdout, then the buffer is growing uncontrollably, until program is completed

Source:

```
var cp = require('child_process')

cp.exec(
    'dd if=/dev/zero bs=1M count=4096',
    {
        killSignal: 'SIGCONT' // ignored by `dd`
    },
    function(err, stdout, stderr) {
        console.log(err)
    }
)
```

Result:

```
# node test.js
{ arguments: undefined,
  type: undefined,
  message: 'maxBuffer exceeded.',
  stack: [Getter/Setter] }
FATAL ERROR: CALL_AND_RETRY_2 Allocation failed - process out of memory
```
