### PR TITLE
path.js: correct three harmless .length typos (off-by-one)

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -30,7 +30,7 @@ var isWindows = process.platform === 'win32';
 function normalizeArray(parts, allowAboveRoot) {
   // if the path tries to go above the root, `up` ends up > 0
   var up = 0;
-  for (var i = parts.length; i >= 0; i--) {
+  for (var i = parts.length-1; i >= 0; i--) {
     var last = parts[i];
     if (last == '.') {
       parts.splice(i, 1);
@@ -72,7 +72,7 @@ if (isWindows) {
         resolvedTail = '',
         resolvedAbsolute = false;
 
-    for (var i = arguments.length; i >= -1; i--) {
+    for (var i = arguments.length-1; i >= -1; i--) {
       var path = (i >= 0) ? arguments[i] : process.cwd();
 
       // Skip empty and invalid entries
@@ -255,7 +255,7 @@ if (isWindows) {
     var resolvedPath = '',
         resolvedAbsolute = false;
 
-    for (var i = arguments.length; i >= -1 && !resolvedAbsolute; i--) {
+    for (var i = arguments.length-1; i >= -1 && !resolvedAbsolute; i--) {
       var path = (i >= 0) ? arguments[i] : process.cwd();
 
       // Skip empty and invalid entries


### PR DESCRIPTION
lib/path.js routines normalizeArray() and resolve() have for loops that
count down from end of an array.  The loop indexes are initialized using
"array.length" rather than "array.length-1".  The initial array element
accessed is always beyond the end of array and the value is 'undefined'.
Strangely, code exists that acts to ignore undefined values so that the
typos are unnoticeable.

Existing tests emit no errors either before or after changing to "length-1".
Tests _do_ start failing at "length-2". (Actually it is node that starts
to fail at "length-2" - that's a valid enough test...)
