### PR TITLE
Interface for getting and setting socket options 

### DIFF
--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -500,6 +500,38 @@ struct uv_getaddrinfo_s {
                     const char* service,
                     const struct addrinfo* hints);
 
+
+/*
+ * Currently supported socket options.
+ * Used by getsockopt and setsockopt.
+ */
+typedef enum {
+  UV_SO_RCVBUF = 0,
+  UV_SO_SNDBUF
+} uv_so_opt_name;
+
+typedef enum {
+  UV_SOL_SOCKET = 0xffff
+} uv_so_opt_level;
+
+
+/* uv_setsockopt
+ * Returns zero if no error occured.
+ * Otherwise a value of -1 is returned.
+ *
+ */
+int uv_setsockopt(uv_stream_t*, int level, int optname, const char *optval,
+    int optlen);
+
+
+/* uv_getsockopt
+ * Returns zero if no error occured.
+ * Otherwise a value of -1 is returned.
+ *
+ */
+int uv_getsockopt(uv_stream_t*, int level, int optname, int optlen);
+
+
 /*
  * Child process. Subclass of uv_handle_t.
  */


### PR DESCRIPTION
Some socket options like no delay and keep alive are present in node.
However, I need access to SO_RCVBUF to enforce the TCP standard receive window size (65,535) per socket. 
I have noted that Twisted enforce this attribute for each socket at 65,535 with the possibility to configure it globally for new sockets, which would solve my problem in node. However, I believe setting this parameter for each socket instead follows nodes conventions.

Maybe we could use socket.setReceiveWindowSize(int).
SO_SNDBUF might also be interesting.

I've added an initial interface for setting and getting socket options.
This still needs os specific implementation code, tests and javascript bindings. Unfortunately I don't know how to proceed with that.
