### PR TITLE
Fix/dont call to string unnecessarily

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -284,15 +284,7 @@ function isArray(ar) {
 
 
 function isRegExp(re) {
-  var s = '' + re;
-  return re instanceof RegExp || // easy case
-         // duck-type for context-switching evalcx case
-         typeof(re) === 'function' &&
-         re.constructor.name === 'RegExp' &&
-         re.compile &&
-         re.test &&
-         re.exec &&
-         s.match(/^\/.*\/[gim]{0,3}$/);
+  return Object.prototype.toString.call(re) == '[object RegExp]';
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -284,7 +284,8 @@ function isArray(ar) {
 
 
 function isRegExp(re) {
-  return Object.prototype.toString.call(re) == '[object RegExp]';
+  return re instanceof RegExp ||
+    (typeof re === 'object' && Object.prototype.toString.call(re) === '[object RegExp]');
 }
 
 

--- a/test/simple/test-console-not-call-toString.js
+++ b/test/simple/test-console-not-call-toString.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var func = function () {};
+var toStringCalled = false;
+func.toString = function () {
+  toStringCalled = true;
+};
+
+console.log(func);
+
+assert.ok(!toStringCalled);

--- a/test/simple/test-console-not-call-toString.js
+++ b/test/simple/test-console-not-call-toString.js
@@ -28,6 +28,6 @@ func.toString = function () {
   toStringCalled = true;
 };
 
-console.log(func);
+require('util').inspect(func);
 
 assert.ok(!toStringCalled);


### PR DESCRIPTION
This is sort of a narrow edge-case but it doesn't cause any harm so, nor API changes, so it should be ok for the 0.4.x branch.

Basically, calling `util.inspect()` on a `Function` object calls toString on the object [here](https://github.com/joyent/node/blob/028b33b18ae16c52cb5eda879d92c20bf5b99c13/lib/util.js#L287). I have a case where I'm overriding a Function's toString function to something else, and was confused why I was getting debug statements (from my custom `toString`) while just logging in the REPL and via `console.log`.

So attached is a test case for what I am talking about, and a simple fix. Thanks in advance!
