### PR TITLE
Refactor http test

### DIFF
--- a/test/disabled/test-http-big-proxy-responses.js
+++ b/test/disabled/test-http-big-proxy-responses.js
@@ -43,21 +43,24 @@ chargen.listen(9000, ready);
 
 // Proxy to the chargen server.
 var proxy = http.createServer(function(req, res) {
-  var c = http.createClient(9000, 'localhost');
-
   var len = parseInt(req.headers['x-len'], 10);
   assert.ok(len > 0);
 
   var sent = 0;
 
 
-  c.addListener('error', function(e) {
+  function onError(e) {
     console.log('proxy client error. sent ' + sent);
     throw e;
-  });
+  }
 
-  var proxy_req = c.request(req.method, req.url, req.headers);
-  proxy_req.addListener('response', function(proxy_res) {
+  var proxy_req = http.request({
+    host:    'localhost',
+    port:    9000,
+    method:  req.method,
+    path:    req.url,
+    headers: req.headers
+  }, function(proxy_res) {
     res.writeHead(proxy_res.statusCode, proxy_res.headers);
 
     var count = 0;
@@ -74,7 +77,7 @@ var proxy = http.createServer(function(req, res) {
     });
 
   });
-
+  proxy_req.on('error', onError);
   proxy_req.end();
 });
 proxy.listen(9001, ready);
@@ -89,9 +92,12 @@ function call_chargen(list) {
 
     var recved = 0;
 
-    var req = http.createClient(9001, 'localhost').request('/', {'x-len': len});
-
-    req.addListener('response', function(res) {
+    var req = http.request({
+      port:    9001,
+      host:    'localhost',
+      path:    '/',
+      headers: {'x-len': len}
+    }, function(res) {
 
       res.addListener('data', function(d) {
         recved += d.length;
@@ -115,7 +121,7 @@ function call_chargen(list) {
   }
 }
 
-serversRunning = 0;
+var serversRunning = 0;
 function ready() {
   if (++serversRunning < 2) return;
   call_chargen([100, 1000, 10000, 100000, 1000000]);
@@ -124,3 +130,4 @@ function ready() {
 process.addListener('exit', function() {
   assert.ok(done);
 });
+

--- a/test/disabled/test-http-head-request.js
+++ b/test/disabled/test-http-head-request.js
@@ -42,9 +42,11 @@ server.listen(common.PORT);
 var gotEnd = false;
 
 server.addListener('listening', function() {
-  var client = http.createClient(common.PORT);
-  var request = client.request('HEAD', '/');
-  request.addListener('response', function(response) {
+  var request = http.request({
+    port:   common.PORT,
+    method: 'HEAD',
+    path:   '/'
+  }, function(response) {
     console.log('got response');
     response.addListener('data', function() {
       process.exit(2);
@@ -60,3 +62,4 @@ server.addListener('listening', function() {
 setTimeout(function() {
   process.exit(1);
 }, 2000);
+

--- a/test/pummel/test-http-upload-timeout.js
+++ b/test/pummel/test-http-upload-timeout.js
@@ -48,8 +48,11 @@ server.listen(common.PORT, '127.0.0.1', function() {
     connections++;
 
     setTimeout(function() {
-      var client = http.createClient(common.PORT),
-          request = client.request('POST', '/');
+      var request = http.request({
+        port: common.PORT,
+        method: 'POST',
+        path:   '/'
+      });
 
       function ping() {
         var nextPing = (Math.random() * 900).toFixed();

--- a/test/simple/test-http-allow-req-after-204-res.js
+++ b/test/simple/test-http-allow-req-after-204-res.js
@@ -38,14 +38,15 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
-var client = http.createClient(common.PORT);
-
 function nextRequest() {
   var method = methods.shift();
   console.error('writing request: %s', method);
 
-  var request = client.request(method, '/');
-  request.on('response', function(response) {
+  var request = http.request({
+    port:   common.PORT,
+    method: method,
+    path:   '/'
+  }, function(response) {
     response.on('end', function() {
       if (methods.length == 0) {
         console.error('close server');
@@ -62,3 +63,4 @@ function nextRequest() {
 }
 
 server.listen(common.PORT, nextRequest);
+

--- a/test/simple/test-http-buffer-sanity.js
+++ b/test/simple/test-http-buffer-sanity.js
@@ -68,11 +68,12 @@ var gotThanks = false;
 web.listen(common.PORT, function() {
   console.log('Making request');
 
-  var client = http.createClient(common.PORT);
-  var req = client.request('GET', '/', { 'content-length': buffer.length });
-  req.end(buffer);
-
-  req.on('response', function(res) {
+  var req = http.request({
+    port:    common.PORT,
+    method:  'GET',
+    path:    '/',
+    headers: { 'content-length': buffer.length }
+  }, function(res) {
     console.log('Got response');
     res.setEncoding('utf8');
     res.on('data', function(string) {
@@ -80,6 +81,7 @@ web.listen(common.PORT, function() {
       gotThanks = true;
     });
   });
+  req.end(buffer);
 });
 
 
@@ -87,3 +89,4 @@ process.on('exit', function() {
   assert.equal(bufferSize, measuredSize);
   assert.ok(gotThanks);
 });
+

--- a/test/simple/test-http-client-parse-error.js
+++ b/test/simple/test-http-client-parse-error.js
@@ -37,10 +37,14 @@ var srv = net.createServer(function(c) {
 var parseError = false;
 
 srv.listen(common.PORT, '127.0.0.1', function() {
-  var hc = http.createClient(common.PORT, '127.0.0.1');
-  hc.request('GET', '/').end();
+  var req = http.request({
+    host:   '127.0.0.1',
+    port:   common.PORT,
+    method: 'GET',
+    path:   '/'});
+  req.end();
 
-  hc.on('error', function(e) {
+  req.on('error', function(e) {
     console.log('got error from client');
     srv.close();
     assert.ok(e.message.indexOf('Parse Error') >= 0);
@@ -52,5 +56,4 @@ srv.listen(common.PORT, '127.0.0.1', function() {
 process.addListener('exit', function() {
   assert.ok(parseError);
 });
-
 

--- a/test/simple/test-http-client-race.js
+++ b/test/simple/test-http-client-race.js
@@ -39,9 +39,7 @@ var body1 = '';
 var body2 = '';
 
 server.addListener('listening', function() {
-  var client = http.createClient(common.PORT);
-
-  var req1 = client.request('/1');
+  var req1 = http.request({ port: common.PORT, path: '/1' });
   req1.end();
   req1.addListener('response', function(res1) {
     res1.setEncoding('utf8');
@@ -51,7 +49,7 @@ server.addListener('listening', function() {
     });
 
     res1.addListener('end', function() {
-      var req2 = client.request('/2');
+      var req2 = http.request({ port: common.PORT, path: '/2' });
       req2.end();
       req2.addListener('response', function(res2) {
         res2.setEncoding('utf8');
@@ -66,3 +64,4 @@ process.addListener('exit', function() {
   assert.equal(body1_s, body1);
   assert.equal(body2_s, body2);
 });
+

--- a/test/simple/test-http-client-upload-buf.js
+++ b/test/simple/test-http-client-upload-buf.js
@@ -46,15 +46,11 @@ var server = http.createServer(function(req, res) {
 server.listen(common.PORT);
 
 server.addListener('listening', function() {
-  var client = http.createClient(common.PORT);
-  var req = client.request('POST', '/');
-
-  req.write(new Buffer(N));
-  req.end();
-
-  common.error('client finished sending request');
-
-  req.addListener('response', function(res) {
+  var req = http.request({
+    port:   common.PORT,
+    method: 'POST',
+    path:   '/'
+  }, function(res) {
     res.setEncoding('utf8');
     res.addListener('data', function(chunk) {
       console.log(chunk);
@@ -64,6 +60,11 @@ server.addListener('listening', function() {
       server.close();
     });
   });
+
+  req.write(new Buffer(N));
+  req.end();
+
+  common.error('client finished sending request');
 });
 
 process.addListener('exit', function() {
@@ -71,3 +72,4 @@ process.addListener('exit', function() {
   assert.equal(true, server_req_complete);
   assert.equal(true, client_res_complete);
 });
+

--- a/test/simple/test-http-client-upload.js
+++ b/test/simple/test-http-client-upload.js
@@ -47,16 +47,11 @@ var server = http.createServer(function(req, res) {
 server.listen(common.PORT);
 
 server.addListener('listening', function() {
-  var client = http.createClient(common.PORT);
-  var req = client.request('POST', '/');
-  req.write('1\n');
-  req.write('2\n');
-  req.write('3\n');
-  req.end();
-
-  common.error('client finished sending request');
-
-  req.addListener('response', function(res) {
+  var req = http.request({
+    port:   common.PORT,
+    method: 'POST',
+    path:   '/'
+  }, function(res) {
     res.setEncoding('utf8');
     res.addListener('data', function(chunk) {
       console.log(chunk);
@@ -66,6 +61,13 @@ server.addListener('listening', function() {
       server.close();
     });
   });
+
+  req.write('1\n');
+  req.write('2\n');
+  req.write('3\n');
+  req.end();
+
+  common.error('client finished sending request');
 });
 
 process.addListener('exit', function() {
@@ -73,3 +75,4 @@ process.addListener('exit', function() {
   assert.equal(true, server_req_complete);
   assert.equal(true, client_res_complete);
 });
+

--- a/test/simple/test-http-contentLength0.js
+++ b/test/simple/test-http-contentLength0.js
@@ -33,13 +33,11 @@ var s = http.createServer(function(req, res) {
 });
 s.listen(common.PORT, function() {
 
-  var r = http.createClient(common.PORT);
-  var request = r.request('GET', '/');
-
-  request.on('response', function(response) {
+  var request = http.request({ port: common.PORT }, function(response) {
     console.log('STATUS: ' + response.statusCode);
     s.close();
   });
 
   request.end();
 });
+

--- a/test/simple/test-http-exceptions.js
+++ b/test/simple/test-http-exceptions.js
@@ -33,8 +33,7 @@ var server = http.createServer(function(req, res) {
 server.listen(common.PORT, function() {
   var req;
   for (var i = 0; i < 4; i += 1) {
-    req = http.createClient(common.PORT).request('GET', '/busy/' + i);
-    req.end();
+    req = http.get({ port: common.PORT, path: '/busy/' + i });
   }
 });
 

--- a/test/simple/test-http-expect-continue.js
+++ b/test/simple/test-http-expect-continue.js
@@ -51,9 +51,11 @@ server.listen(common.PORT);
 
 
 server.addListener('listening', function() {
-  var client = http.createClient(common.PORT);
-  var req = client.request('POST', '/world', {
-    'Expect': '100-continue'
+  var req = http.request({
+    port:    common.PORT,
+    method:  'POST',
+    path:    '/world',
+    headers: { 'Expect': '100-continue' }
   });
   common.debug('Client sending request...');
   outstanding_reqs++;
@@ -82,3 +84,4 @@ server.addListener('listening', function() {
     });
   });
 });
+

--- a/test/simple/test-http-head-request.js
+++ b/test/simple/test-http-head-request.js
@@ -37,18 +37,21 @@ var server = http.createServer(function(req, res) {
 var gotEnd = false;
 
 server.listen(common.PORT, function() {
-  var client = http.createClient(common.PORT);
-  var request = client.request('HEAD', '/');
-  request.end();
-  request.addListener('response', function(response) {
+  var request = http.request({
+    port:   common.PORT,
+    method: 'HEAD',
+    path:   '/'
+  }, function(response) {
     common.error('response start');
     response.addListener('end', function() {
       common.error('response end');
       gotEnd = true;
     });
   });
+  request.end();
 });
 
 process.addListener('exit', function() {
   assert.ok(gotEnd);
 });
+

--- a/test/simple/test-http-head-response-has-no-body-end.js
+++ b/test/simple/test-http-head-response-has-no-body-end.js
@@ -37,10 +37,11 @@ server.listen(common.PORT);
 var responseComplete = false;
 
 server.addListener('listening', function() {
-  var req = http.createClient(common.PORT).request('HEAD', '/');
-  common.error('req');
-  req.end();
-  req.addListener('response', function(res) {
+  var req = http.request({
+    port:   common.PORT,
+    method: 'HEAD',
+    path:   '/'
+  }, function(res) {
     common.error('response');
     res.addListener('end', function() {
       common.error('response end');
@@ -48,8 +49,11 @@ server.addListener('listening', function() {
       responseComplete = true;
     });
   });
+  common.error('req');
+  req.end();
 });
 
 process.addListener('exit', function() {
   assert.ok(responseComplete);
 });
+

--- a/test/simple/test-http-head-response-has-no-body.js
+++ b/test/simple/test-http-head-response-has-no-body.js
@@ -37,10 +37,11 @@ server.listen(common.PORT);
 var responseComplete = false;
 
 server.addListener('listening', function() {
-  var req = http.createClient(common.PORT).request('HEAD', '/');
-  common.error('req');
-  req.end();
-  req.addListener('response', function(res) {
+  var req = http.request({
+    port: common.PORT,
+    method: 'HEAD',
+    path: '/'
+  }, function(res) {
     common.error('response');
     res.addListener('end', function() {
       common.error('response end');
@@ -48,8 +49,11 @@ server.addListener('listening', function() {
       responseComplete = true;
     });
   });
+  common.error('req');
+  req.end();
 });
 
 process.addListener('exit', function() {
   assert.ok(responseComplete);
 });
+

--- a/test/simple/test-http-proxy.js
+++ b/test/simple/test-http-proxy.js
@@ -43,12 +43,12 @@ var backend = http.createServer(function(req, res) {
   res.end();
 });
 
-var proxy_client = http.createClient(BACKEND_PORT);
 var proxy = http.createServer(function(req, res) {
   common.debug('proxy req headers: ' + JSON.stringify(req.headers));
-  var proxy_req = proxy_client.request(url.parse(req.url).pathname);
-  proxy_req.end();
-  proxy_req.addListener('response', function(proxy_res) {
+  var proxy_req = http.get({
+    port: BACKEND_PORT,
+    path: url.parse(req.url).pathname
+  }, function(proxy_res) {
 
     common.debug('proxy res headers: ' + JSON.stringify(proxy_res.headers));
 
@@ -76,10 +76,10 @@ function startReq() {
   nlistening++;
   if (nlistening < 2) return;
 
-  var client = http.createClient(PROXY_PORT);
-  var req = client.request('/test');
-  common.debug('client req');
-  req.addListener('response', function(res) {
+  var client = http.get({
+    port: PROXY_PORT,
+    path: '/test'
+  }, function(res) {
     common.debug('got res');
     assert.equal(200, res.statusCode);
 
@@ -95,7 +95,7 @@ function startReq() {
       common.debug('closed both');
     });
   });
-  req.end();
+  common.debug('client req');
 }
 
 common.debug('listen proxy');
@@ -107,3 +107,4 @@ backend.listen(BACKEND_PORT, startReq);
 process.addListener('exit', function() {
   assert.equal(body, 'hello world\n');
 });
+

--- a/test/simple/test-http-server-multiheaders.js
+++ b/test/simple/test-http-server-multiheaders.js
@@ -40,18 +40,21 @@ var srv = http.createServer(function(req, res) {
 });
 
 srv.listen(common.PORT, function() {
-  var hc = http.createClient(common.PORT, 'localhost');
-  var hr = hc.request('/',
-      [
-        ['accept', 'abc'],
-        ['accept', 'def'],
-        ['Accept', 'ghijklmnopqrst'],
-        ['host', 'foo'],
-        ['Host', 'bar'],
-        ['hOst', 'baz'],
-        ['x-foo', 'bingo'],
-        ['x-bar', 'banjo'],
-        ['x-bar', 'bango']
-      ]);
-  hr.end();
+  http.get({
+    host: 'localhost',
+    port: common.PORT,
+    path: '/',
+    headers: [
+      ['accept', 'abc'],
+      ['accept', 'def'],
+      ['Accept', 'ghijklmnopqrst'],
+      ['host', 'foo'],
+      ['Host', 'bar'],
+      ['hOst', 'baz'],
+      ['x-foo', 'bingo'],
+      ['x-bar', 'banjo'],
+      ['x-bar', 'bango']
+    ]
+  });
 });
+

--- a/test/simple/test-http-set-cookies.js
+++ b/test/simple/test-http-set-cookies.js
@@ -43,11 +43,7 @@ server.addListener('listening', function() {
   //
   // one set-cookie header
   //
-  var client = http.createClient(common.PORT);
-  var req = client.request('GET', '/one');
-  req.end();
-
-  req.addListener('response', function(res) {
+  http.get({ port: common.PORT, path: '/one' }, function(res) {
     // set-cookie headers are always return in an array.
     // even if there is only one.
     assert.deepEqual(['A'], res.headers['set-cookie']);
@@ -66,11 +62,7 @@ server.addListener('listening', function() {
 
   // two set-cookie headers
 
-  var client = http.createClient(common.PORT);
-  var req = client.request('GET', '/two');
-  req.end();
-
-  req.addListener('response', function(res) {
+  http.get({ port: common.PORT, path: '/two' }, function(res) {
     assert.deepEqual(['A', 'B'], res.headers['set-cookie']);
     assert.equal('text/plain', res.headers['content-type']);
 
@@ -90,3 +82,4 @@ server.addListener('listening', function() {
 process.addListener('exit', function() {
   assert.equal(2, nresponses);
 });
+

--- a/test/simple/test-http-set-trailers.js
+++ b/test/simple/test-http-set-trailers.js
@@ -96,11 +96,7 @@ server.addListener('listening', function() {
 
 // now, see if the client sees the trailers.
 server.addListener('listening', function() {
-  var client = http.createClient(common.PORT);
-  var req = client.request('/hello', {});
-  req.end();
-  outstanding_reqs++;
-  req.addListener('response', function(res) {
+  http.get({ port: common.PORT, path: '/hello', headers: {} }, function(res) {
     res.addListener('end', function() {
       //console.log(res.trailers);
       assert.ok('x-foo' in res.trailers, 'Client doesn\'t see trailers.');
@@ -111,4 +107,6 @@ server.addListener('listening', function() {
       }
     });
   });
+  outstanding_reqs++;
 });
+

--- a/test/simple/test-http-upgrade-client.js
+++ b/test/simple/test-http-upgrade-client.js
@@ -52,8 +52,8 @@ var gotUpgrade = false;
 
 srv.listen(common.PORT, '127.0.0.1', function() {
 
-  var hc = http.createClient(common.PORT, '127.0.0.1').request('GET', '/');
-  hc.addListener('upgrade', function(res, socket, upgradeHead) {
+  var req = http.get({ port: common.PORT });
+  req.addListener('upgrade', function(res, socket, upgradeHead) {
     // XXX: This test isn't fantastic, as it assumes that the entire response
     //      from the server will arrive in a single data callback
     assert.equal(upgradeHead, 'nurtzo');
@@ -69,9 +69,9 @@ srv.listen(common.PORT, '127.0.0.1', function() {
 
     gotUpgrade = true;
   });
-  hc.end();
 });
 
 process.addListener('exit', function() {
   assert.ok(gotUpgrade);
 });
+

--- a/test/simple/test-http-upgrade-client2.js
+++ b/test/simple/test-http-upgrade-client2.js
@@ -42,29 +42,28 @@ server.listen(common.PORT, function() {
   function upgradeRequest(fn) {
     console.log("req");
     var header = { 'Connection': 'Upgrade', 'Upgrade': 'Test' };
-    var request = http.createClient(common.PORT).request('GET', '/', header);
-    var client = request;
+    var request = http.request({ port: common.PORT, headers: header });
     var wasUpgrade = false;
 
     function onUpgrade(res, socket, head) {
       console.log("client upgraded");
       wasUpgrade = true;
 
-      client.removeListener('upgrade', onUpgrade);
+      request.removeListener('upgrade', onUpgrade);
       socket.end();
     }
-    client.on('upgrade', onUpgrade);
+    request.on('upgrade', onUpgrade);
 
     function onEnd() {
       console.log("client end");
-      client.removeListener('end', onEnd);
+      request.removeListener('end', onEnd);
       if (!wasUpgrade) {
         throw new Error('hasn\'t received upgrade event');
       } else {
         fn && process.nextTick(fn);
       }
     }
-    client.on('close', onEnd);
+    request.on('close', onEnd);
 
     request.write('head');
 
@@ -85,3 +84,4 @@ server.listen(common.PORT, function() {
 process.on('exit', function() {
   assert.equal(2, successCount);
 });
+

--- a/test/simple/test-http-write-empty-string.js
+++ b/test/simple/test-http-write-empty-string.js
@@ -45,10 +45,7 @@ process.addListener('exit', function() {
 
 
 server.listen(common.PORT, function() {
-  var client = http.createClient(common.PORT);
-  var req = client.request('/');
-  req.end();
-  req.addListener('response', function(res) {
+  http.get({ port: common.PORT }, function(res) {
     assert.equal(200, res.statusCode);
     res.setEncoding('ascii');
     res.addListener('data', function(chunk) {

--- a/test/simple/test-listen-fd.js
+++ b/test/simple/test-listen-fd.js
@@ -44,10 +44,10 @@ netBinding.listen(fd, 128);
 srv.listenFD(fd);
 
 // Make an HTTP request to the server above
-var hc = http.createClient(common.PORT, '127.0.0.1');
-hc.request('/').end();
+http.get({ port: common.PORT, host: '127.0.0.1', path: '/'});
 
 // Verify that we're exiting after having received an HTTP  request
 process.addListener('exit', function() {
   assert.ok(gotRequest);
 });
+

--- a/test/simple/test-pipe.js
+++ b/test/simple/test-pipe.js
@@ -107,12 +107,12 @@ function startClient() {
 
   console.log('Making request');
 
-  var client = http.createClient(common.PORT);
-  var req = client.request('GET', '/', { 'content-length': buffer.length });
-  req.write(buffer);
-  req.end();
-
-  req.on('response', function(res) {
+  var req = http.request({
+    port:    common.PORT,
+    method:  'GET',
+    path:    '/',
+    headers: { 'content-length': buffer.length }
+  }, function(res) {
     console.log('Got response');
     res.setEncoding('utf8');
     res.on('data', function(string) {
@@ -120,6 +120,8 @@ function startClient() {
       gotThanks = true;
     });
   });
+  req.write(buffer);
+  req.end();
 }
 
 process.on('exit', function() {

--- a/test/simple/test-zerolengthbufferbug.js
+++ b/test/simple/test-zerolengthbufferbug.js
@@ -37,12 +37,7 @@ var gotResponse = false;
 var resBodySize = 0;
 
 server.listen(common.PORT, function() {
-  var client = http.createClient(common.PORT);
-
-  var req = client.request('GET', '/');
-  req.end();
-
-  req.on('response', function(res) {
+  http.get({ port: common.PORT }, function(res) {
     gotResponse = true;
 
     res.on('data', function(d) {
@@ -59,5 +54,4 @@ process.on('exit', function() {
   assert.ok(gotResponse);
   assert.equal(0, resBodySize);
 });
-
 


### PR DESCRIPTION
Many http tests had used legacy `http.Client`.
This refactored it to use modern API.
