### PR TITLE
Fix with --harmony-weakmaps

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -466,9 +466,8 @@ exports.inherits = function(ctor, superCtor) {
   ctor.super_ = superCtor;
   ctor.prototype = Object.create(superCtor.prototype, {
     constructor: {
-      value: ctor,
+      get: function() { return ctor; },
       enumerable: false,
-      writable: true,
       configurable: true
     }
   });

--- a/test/simple/test-util-inherits.js
+++ b/test/simple/test-util-inherits.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var util = require('util');
+
+function Foo() {
+  this.foo = 'foo';
+}
+
+Foo.prototype.getFoo = function() {
+  return this.foo;
+};
+
+function Bar() {
+  Foo.call(this);
+  this.bar = 'bar';
+}
+util.inherits(Bar, Foo);
+
+Bar.prototype.getBar = function() {
+  return this.bar;
+};
+
+var bar = new Bar();
+assert.equal(bar.getFoo(), 'foo');
+assert.equal(bar.getBar(), 'bar');
+assert.equal(bar.constructor, Bar);
+assert.equal(Bar.super_, Foo);
+

--- a/test/simple/test-with-weakmaps.js
+++ b/test/simple/test-with-weakmaps.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var path = require('path');
+var fs = require('fs');
+
+var child = spawn(process.execPath,
+                  ['--harmony-weakmaps', '-e', 'new WeakMap()']);
+child.on('exit', function(code) {
+  assert.equal(code, 0);
+});
+
+var options = {
+  cwd: __dirname
+};
+var child2 = spawn(process.execPath,
+                   ['--harmony-weakmaps', 'test-util-inherits.js'],
+                   options);
+child2.on('exit', function(code) {
+  assert.equal(code, 0);
+});
+


### PR DESCRIPTION
With `--harmony-weakmaps` command line option, `util.inherits` throws `TypeError`.
reproduce:

```
$ node --harmony-weakmaps

util.js:467
  ctor.prototype = Object.create(superCtor.prototype, {
                          ^
TypeError: Invalid property.  A property cannot both have accessors and be writable or have a value: #<WeakMap>
    at Function.create (native)
    at WeakMap.inherits (util.js:467:27)
    at assert.js:52:6
    at NativeModule.compile (node.js:502:5)
    at node.js:467:18
    at buffer.js:23:14
    at NativeModule.compile (node.js:502:5)
    at Function.require (node.js:467:18)
    at Function.globalVariables (node.js:137:34)
    at startup (node.js:48:13)
```
