### PR TITLE
Improve startup time for "process.stdin;process.stdout" by 0.7%

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -214,19 +214,19 @@
       if (stdout) return stdout;
 
       var binding = process.binding('stdio'),
-          // FIXME Remove conditional when net is supported again on windows.
-          net = (process.platform !== "win32")
-                ? NativeModule.require('net_legacy') // fixme!
-                : undefined,
-          fs = NativeModule.require('fs'),
-          tty = NativeModule.require('tty'),
           fd = binding.stdoutFD;
 
       if (binding.isatty(fd)) {
+        var tty = NativeModule.require('tty');
         stdout = new tty.WriteStream(fd);
       } else if (binding.isStdoutBlocking()) {
+        var fs = NativeModule.require('fs');
         stdout = new fs.WriteStream(null, {fd: fd});
       } else {
+        // FIXME Remove conditional when net is supported again on windows.
+        var net = (process.platform !== "win32")
+                ? NativeModule.require('net_legacy') // fixme!
+                : undefined;
         stdout = new net.Stream(fd);
         // FIXME Should probably have an option in net.Stream to create a
         // stream from an existing fd which is writable only. But for now
@@ -248,16 +248,16 @@
       if (stdin) return stdin;
 
       var binding = process.binding('stdio'),
-          net = NativeModule.require('net'),
-          fs = NativeModule.require('fs'),
-          tty = NativeModule.require('tty'),
           fd = binding.openStdin();
 
       if (binding.isatty(fd)) {
+        var tty = NativeModule.require('tty');
         stdin = new tty.ReadStream(fd);
       } else if (binding.isStdinBlocking()) {
+        var fs = NativeModule.require('fs');
         stdin = new fs.ReadStream(null, {fd: fd});
       } else {
+        var net = NativeModule.require('net');
         stdin = new net.Stream(fd);
         stdin.readable = true;
       }


### PR DESCRIPTION
Just load needed stuff in the getters, not everything.
**WARNING: this makes `simple/test-module-load-list` and `simple/test-child-process-kill` fail!**

```
[jann@Jann-PC tmp]$ date; for i in {1..1000}; do node-053-bkp test.js; done; date
Di 16. Aug 15:41:34 CEST 2011
Di 16. Aug 15:42:45 CEST 2011
[jann@Jann-PC tmp]$ date; for i in {1..1000}; do node-053-bkp test.js; done; date
Di 16. Aug 15:42:54 CEST 2011
Di 16. Aug 15:44:05 CEST 2011
[jann@Jann-PC tmp]$ date; for i in {1..1000}; do node test.js; done; date
Di 16. Aug 15:44:41 CEST 2011
Di 16. Aug 15:45:50 CEST 2011
[jann@Jann-PC tmp]$ date; for i in {1..1000}; do node test.js; done; date
Di 16. Aug 15:45:54 CEST 2011
Di 16. Aug 15:47:04 CEST 2011
[jann@Jann-PC tmp]$ cat test.js
process.stdin; process.stdout;
[jann@Jann-PC tmp]$
```

I really can't see how this change can cause test failures, especially in test-child-process-kill - is this just some race condition or did I really break something?
