### PR TITLE
OutgoingMessage.socket and OutgoingMessage.connection are both Streams

### DIFF
--- a/lib/http2.js
+++ b/lib/http2.js
@@ -385,7 +385,10 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
       }
       var c = this.output.shift();
       var e = this.outputEncodings.shift();
-      this.connection.write(c, e);
+      if (this.connection.write(c, e) === false) {
+        this._buffer(data, encoding);
+        return false;
+      };
     }
 
     // Directly write to socket.
@@ -758,6 +761,13 @@ OutgoingMessage.prototype._flush = function() {
     var encoding = this.outputEncodings.shift();
 
     ret = this.socket.write(data, encoding);
+    if (ret === false) {
+      var self = this;
+      this.socket.once('drain', function () {
+        self._flush();
+      });
+      return false;
+    }
   }
 
   if (this.finished) {


### PR DESCRIPTION
If a .write returns === false they should both wait for 'drain'

@mikeal I was not sure of the best way to post this to you.  I am also unsure as to how to write a test (always a bad sign).

I don't want to add to the signal to noise... but as long as the code was up in the air.
