### PR TITLE
Test for https2 compatibility (issue #1531)

### DIFF
--- a/test/simple/test-https2-compatibility.js
+++ b/test/simple/test-https2-compatibility.js
@@ -1,0 +1,64 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+
+var https = require('https');
+var assert = require('assert');
+var fs = require('fs');
+var common = require('../common');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var got_callback = false;
+
+var server = https.createServer(options, function(req, res) {
+  res.writeHead(200);
+  res.end("hello world\n");
+});
+
+server.listen(common.PORT, function() {
+  https.get({ 
+    path: '/', 
+    port: common.PORT, 
+    host: 'localhost',
+    secure: true, 
+    agent: false
+  }, function (res) {
+    console.log(res.statusCode);
+    got_callback = true;
+    server.close();
+  }).on('error', function (e) {
+    console.log(e.message);
+    process.exit(1);
+  });
+});
+
+process.on('exit', function() {
+  assert.ok(got_callback);
+});
+


### PR DESCRIPTION
As requested in #1531, tests for http2 compatibility.

Test sets up a simple HTTPS server and checks if https2 is able to connect using `agent: false` setting.
Current node master fails, @mikeal's https2-fix branch passes (checked with commit mikeal@aa149b6).
