### PR TITLE
process.memoryUsage returns memory usage measured in bytes

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -287,7 +287,7 @@ What platform you're running on. `'linux2'`, `'darwin'`, etc.
 
 ### process.memoryUsage()
 
-Returns an object describing the memory usage of the Node process.
+Returns an object describing the memory usage of the Node process measured in bytes.
 
     var util = require('util');
 


### PR DESCRIPTION
It should be mentioned in docs to avoid confusion.
