### PR TITLE
Fix a stack buffer overflow in ChildProcess custom_fd handling.

### DIFF
--- a/src/node_child_process.cc
+++ b/src/node_child_process.cc
@@ -47,6 +47,8 @@ extern char **environ;
 
 #include <limits.h> /* PATH_MAX */
 
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*(a)))
+
 namespace node {
 
 using namespace v8;
@@ -168,7 +170,7 @@ Handle<Value> ChildProcess::Spawn(const Arguments& args) {
     // Set the custom file descriptor values (if any) for the child process
     Local<Array> custom_fds_handle = Local<Array>::Cast(args[4]);
     int custom_fds_len = custom_fds_handle->Length();
-    for (int i = 0; i < custom_fds_len; i++) {
+    for (int i = 0; i < custom_fds_len && i < ARRAY_SIZE(custom_fds); i++) {
       if (custom_fds_handle->Get(i)->IsUndefined()) continue;
       Local<Integer> fd = custom_fds_handle->Get(i)->ToInteger();
       custom_fds[i] = fd->Value();


### PR DESCRIPTION
Previous there was an unbounded copy from a JavaScript array into a int[3] stack
array.  The copy is now bounded by the size of the stack array.

The following code would reproduce the issue:

var cp = require('child_process');
var bigish = Array(200);

for (var i = 0, il = bigish.length; i < il; ++i)
  bigish[i] = -1;

cp.spawn('/bin/echo', [ ], { customFds: bigish })
