### PR TITLE
Use __proto__ on the object in the REPL tab-completion.

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -412,7 +412,7 @@ REPLServer.prototype.complete = function(line) {
             memberGroups.push(Object.getOwnPropertyNames(obj));
           }
           // works for non-objects
-          var p = obj.constructor ? obj.constructor.prototype : null;
+          var p = obj.__proto__;
           try {
             var sentinel = 5;
             while (p !== null) {


### PR DESCRIPTION
Some people (me) use `__proto__` to augment an Object's prototype after it's been created.
This patch helps make the "new" prototype properties visible if necessary in the REPL's tab completion.

I would attach a test case but I'm not sure how to test for this tab-completion behavior. At least I couldn't find an existing one.

Thanks in advance!
