### PR TITLE
Gyp: use target defaults and fix consequences

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -104,7 +104,8 @@
         ],
       }],
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
-        'cflags': [ '-Wall', '-pthread', '-fno-rtti', '-fno-exceptions' ],
+        'cflags': [ '-Wall', '-pthread', ],
+        'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
         'ldflags': [ '-pthread', ],
         'conditions': [
           [ 'target_arch=="ia32"', {

--- a/common.gypi
+++ b/common.gypi
@@ -104,62 +104,58 @@
         ],
       }],
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
-       'target_defaults': {
-         'cflags': [ '-Wall', '-pthread', '-fno-rtti', '-fno-exceptions' ],
-         'ldflags': [ '-pthread', ],
-         'conditions': [
-           [ 'target_arch=="ia32"', {
-             'cflags': [ '-m32' ],
-             'ldflags': [ '-m32' ],
-           }],
-           [ 'OS=="linux"', {
-             'cflags': [ '-ansi' ],
-           }],
-           [ 'visibility=="hidden"', {
-             'cflags': [ '-fvisibility=hidden' ],
-           }],
-         ],
-       },
+        'cflags': [ '-Wall', '-pthread', '-fno-rtti', '-fno-exceptions' ],
+        'ldflags': [ '-pthread', ],
+        'conditions': [
+          [ 'target_arch=="ia32"', {
+            'cflags': [ '-m32' ],
+            'ldflags': [ '-m32' ],
+          }],
+          [ 'OS=="linux"', {
+            'cflags': [ '-ansi' ],
+          }],
+          [ 'visibility=="hidden"', {
+            'cflags': [ '-fvisibility=hidden' ],
+          }],
+        ],
       }],
       ['OS=="mac"', {
-        'target_defaults': {
-          'xcode_settings': {
-            'ALWAYS_SEARCH_USER_PATHS': 'NO',
-            'GCC_C_LANGUAGE_STANDARD': 'ansi',        # -ansi
-            'GCC_CW_ASM_SYNTAX': 'NO',                # No -fasm-blocks
-            'GCC_DYNAMIC_NO_PIC': 'NO',               # No -mdynamic-no-pic
-                                                      # (Equivalent to -fPIC)
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
-            'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
-            'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
-            # GCC_INLINES_ARE_PRIVATE_EXTERN maps to -fvisibility-inlines-hidden
-            'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
-            'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',      # -fvisibility=hidden
-            'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
-            'GCC_TREAT_WARNINGS_AS_ERRORS': 'YES',    # -Werror
-            'GCC_VERSION': '4.2',
-            'GCC_WARN_ABOUT_MISSING_NEWLINE': 'YES',  # -Wnewline-eof
-            'MACOSX_DEPLOYMENT_TARGET': '10.4',       # -mmacosx-version-min=10.4
-            'PREBINDING': 'NO',                       # No -Wl,-prebind
-            'USE_HEADERMAP': 'NO',
-            'OTHER_CFLAGS': [
-              '-fno-strict-aliasing',
-            ],
-            'WARNING_CFLAGS': [
-              '-Wall',
-              '-Wendif-labels',
-              '-W',
-              '-Wno-unused-parameter',
-              '-Wnon-virtual-dtor',
-            ],
-          },
-          'target_conditions': [
-            ['_type!="static_library"', {
-              'xcode_settings': {'OTHER_LDFLAGS': ['-Wl,-search_paths_first']},
-            }],
+        'xcode_settings': {
+          'ALWAYS_SEARCH_USER_PATHS': 'NO',
+          'GCC_C_LANGUAGE_STANDARD': 'ansi',        # -ansi
+          'GCC_CW_ASM_SYNTAX': 'NO',                # No -fasm-blocks
+          'GCC_DYNAMIC_NO_PIC': 'NO',               # No -mdynamic-no-pic
+                                                    # (Equivalent to -fPIC)
+          'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
+          'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
+          'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
+          # GCC_INLINES_ARE_PRIVATE_EXTERN maps to -fvisibility-inlines-hidden
+          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',      # -fvisibility=hidden
+          'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
+          'GCC_TREAT_WARNINGS_AS_ERRORS': 'YES',    # -Werror
+          'GCC_VERSION': '4.2',
+          'GCC_WARN_ABOUT_MISSING_NEWLINE': 'YES',  # -Wnewline-eof
+          'MACOSX_DEPLOYMENT_TARGET': '10.4',       # -mmacosx-version-min=10.4
+          'PREBINDING': 'NO',                       # No -Wl,-prebind
+          'USE_HEADERMAP': 'NO',
+          'OTHER_CFLAGS': [
+            '-fno-strict-aliasing',
+          ],
+          'WARNING_CFLAGS': [
+            '-Wall',
+            '-Wendif-labels',
+            '-W',
+            '-Wno-unused-parameter',
+            '-Wnon-virtual-dtor',
           ],
         },
+        'target_conditions': [
+          ['_type!="static_library"', {
+            'xcode_settings': {'OTHER_LDFLAGS': ['-Wl,-search_paths_first']},
+          }],
+        ],
       }],
     ],
-  },
+  }
 }

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -16,6 +16,10 @@
         '_REENTRANT',
       ],
 
+      'cflags!': [
+        '-ansi'
+      ],
+
       'conditions': [
         ['OS=="win"', {
           'defines': [


### PR DESCRIPTION
The first patch makes node use the target_defaults on mac and linux, mostly a reindent.

The second one fixes some of the consequences of actually using these flags.
