### PR TITLE
Fix for url.parse() leaving trailing ":" on the protocol/scheme

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -28,7 +28,7 @@ exports.format = urlFormat;
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-var protocolPattern = /^([a-z0-9]+:)/i,
+var protocolPattern = /^([a-z0-9]+):/i,
     portPattern = /:[0-9]+$/,
     // RFC 2396: characters reserved for delimiting URLs.
     delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
@@ -99,7 +99,7 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
 
   var proto = protocolPattern.exec(rest);
   if (proto) {
-    proto = proto[0];
+    proto = proto[1];
     var lowerProto = proto.toLowerCase();
     out.protocol = lowerProto;
     rest = rest.substr(proto.length);


### PR DESCRIPTION
Before:
    % node -e 'require("url").parse("http://www.google.com/").protocol'
    http:

After:
    % node -e 'require("url").parse("http://www.google.com/").protocol'
    http
