### PR TITLE
Socket write encoding case sensitivity

### DIFF
--- a/lib/net_legacy.js
+++ b/lib/net_legacy.js
@@ -411,6 +411,11 @@ Socket.prototype._writeOut = function(data, encoding, fd, cb) {
       pool = null;
       allocNewPool();
     }
+    
+    if (encoding)
+    {
+      encoding = String(encoding).toLowerCase();
+    }
 
     if (!encoding || encoding == 'utf8' || encoding == 'utf-8') {
       // default to utf8


### PR DESCRIPTION
Just spent ages debugging a problem with Node failing an assertion when sending messages along a socket - it turns out that I was specifying "UTF8" as the encoding value, which was not being recognised because it's uppercase.

So I've just added a line to lowercase the encoding value and maybe save someone else some pain!
