### PR TITLE
Fix issues building on Mac OSX 10.5

### DIFF
--- a/deps/uv/src/eio/config_darwin.h
+++ b/deps/uv/src/eio/config_darwin.h
@@ -8,7 +8,11 @@
 /* #undef HAVE_FALLOCATE */
 
 /* fdatasync(2) is available */
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1060
 #define HAVE_FDATASYNC 1
+#else
+#define HAVE_FDATASYNC 0
+#endif
 
 /* futimes(2) is available */
 #define HAVE_FUTIMES 1

--- a/deps/v8/src/elements.cc
+++ b/deps/v8/src/elements.cc
@@ -590,7 +590,6 @@ ElementsAccessor* ElementsAccessor::ForArray(FixedArrayBase* array) {
     default:
       UNREACHABLE();
       return NULL;
-      break;
   }
 }
 


### PR DESCRIPTION
This fixes two issues with 10.5, one with the gcc compiler barfing on some perfectly good code in v8, and one with the configuration setting for fdatasync.
