### PR TITLE
url.resolveObject should return the same object as url.parse

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -296,9 +296,8 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
   }
 
   // finally, reconstruct the href based on what has been validated.
-  out.href = urlFormat(out);
-
-  return out;
+  // and remove blank or null properties
+  return normalizeObject(out);
 }
 
 // format a parsed object into a url string
@@ -371,7 +370,12 @@ function urlResolveObject(source, relative) {
   // hrefs like //foo/bar always cut to the protocol.
   if (relative.slashes && !relative.protocol) {
     relative.protocol = source.protocol;
-    return relative;
+    //urlParse appends trailing / to urls like http://www.example.com
+    if (slashedProtocol[relative.protocol] &&
+        relative.hostname && !relative.pathname) {
+      relative.pathname = '/';
+    }
+    return normalizeObject(relative);
   }
 
   if (relative.protocol && relative.protocol !== source.protocol) {
@@ -383,14 +387,15 @@ function urlResolveObject(source, relative) {
     // if it is file:, then the host is dropped,
     // because that's known to be hostless.
     // anything else is assumed to be absolute.
-
-    if (!slashedProtocol[relative.protocol]) return relative;
-
+    if (!slashedProtocol[relative.protocol]) {
+      return normalizeObject(relative);
+    }
     source.protocol = relative.protocol;
     if (!relative.host && !hostlessProtocol[relative.protocol]) {
       var relPath = (relative.pathname || '').split('/');
       while (relPath.length && !(relative.host = relPath.shift()));
       if (!relative.host) relative.host = '';
+      if (!relative.hostname) relative.hostname = '';
       if (relPath[0] !== '') relPath.unshift('');
       if (relPath.length < 2) relPath.unshift('');
       relative.pathname = relPath.join('/');
@@ -399,10 +404,11 @@ function urlResolveObject(source, relative) {
     source.search = relative.search;
     source.query = relative.query;
     source.host = relative.host || '';
-    delete source.auth;
-    delete source.hostname;
+    source.auth = relative.auth;
+    source.hostname = relative.hostname || relative.host;
     source.port = relative.port;
-    return source;
+    source.slashes = source.slashes || relative.slashes;
+    return normalizeObject(source);
   }
 
   var isSourceAbs = (source.pathname && source.pathname.charAt(0) === '/'),
@@ -416,8 +422,7 @@ function urlResolveObject(source, relative) {
       srcPath = source.pathname && source.pathname.split('/') || [],
       relPath = relative.pathname && relative.pathname.split('/') || [],
       psychotic = source.protocol &&
-          !slashedProtocol[source.protocol] &&
-          source.host !== undefined;
+          !slashedProtocol[source.protocol];
 
   // if the url is a non-slashed url, then relative
   // links like ../.. should be able
@@ -452,6 +457,8 @@ function urlResolveObject(source, relative) {
     // it's absolute.
     source.host = (relative.host || relative.host === '') ?
                       relative.host : source.host;
+    source.hostname = (relative.hostname || relative.hostname === '') ?
+                      relative.hostname : source.hostname;
     source.search = relative.search;
     source.query = relative.query;
     srcPath = relPath;
@@ -469,19 +476,27 @@ function urlResolveObject(source, relative) {
     // like href='?foo'.
     // Put this after the other two cases because it simplifies the booleans
     if (psychotic) {
-      source.host = srcPath.shift();
+      source.hostname = source.host = srcPath.shift();
+      //occationaly the auth can get stuck only in host
+      //this especialy happens in cases like
+      //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+      var authInHost = source.host && source.host.indexOf('@') > 0 ?
+                       source.host.split('@') : false;
+      if (authInHost) {
+        source.auth = authInHost.shift();
+        source.hostname = authInHost.shift();
+      }
     }
     source.search = relative.search;
     source.query = relative.query;
-    return source;
+    return normalizeObject(source);
   }
   if (!srcPath.length) {
     // no path at all.  easy.
     // we've already handled the other stuff above.
     delete source.pathname;
-    return source;
+    return normalizeObject(source);
   }
-
   // if a url ENDs in . or .., then it must get a trailing slash.
   // however, if it ends in anything else non-slashy,
   // then it must NOT get a trailing slash.
@@ -527,7 +542,16 @@ function urlResolveObject(source, relative) {
 
   // put the host back
   if (psychotic) {
-    source.host = isAbsolute ? '' : srcPath.shift();
+    source.hostname = source.host = isAbsolute ? '' : srcPath.shift();
+    //occationaly the auth can get stuck only in host
+    //this especialy happens in cases like
+    //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+    var authInHost = source.host && source.host.indexOf('@') > 0 ?
+                     source.host.split('@') : false;
+    if (authInHost) {
+      relative.auth = authInHost.shift();
+      source.hostname = authInHost.shift();
+    }
   }
 
   mustEndAbs = mustEndAbs || (source.host && srcPath.length);
@@ -537,9 +561,22 @@ function urlResolveObject(source, relative) {
   }
 
   source.pathname = srcPath.join('/');
+  source.auth = relative.auth;
+  source.slashes = source.slashes || relative.slashes;
+  return normalizeObject(source);
+}
 
-
-  return source;
+/**
+ *  updates href and removes false-ish properties
+ */
+function normalizeObject(obj) {
+  obj.href = urlFormat(obj);
+  for (var i in obj) {
+    if (obj.hasOwnProperty(i) && !obj[i]) {
+      delete obj[i];
+    }
+  }
+  return obj;
 }
 
 function parseHost(host) {


### PR DESCRIPTION
url.resolveObject(url.parse(x), y) == url.parse(url.resove(x, y))

all the tests pass except for
['.//g', 'f:/a', 'f://g']
but this may be fundamental to the way url.parse works.  Because url.parse('f:/a') will not be slashed, but url.parse('f://g') will be slashed.  It is not clear to me which is right, or even if I could concoct a solution given the arbitrary nature of the problem.

I am particularly uncomfortable in my treatment of slashes, all I'm doing is pushing the value along the chain, and url.js:425 where I adjust what it means to be psychotic.  The reason I did this is:
1. ['local2@domain2', 'mailto:local1@domain1?query1', 'mailto:local2@domain2']
2.  that source.host is handled at url.js:437 which indicates that a source with no host may be psychotic
