### PR TITLE
Add '.' '+' and '-' in url protocol pattern

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -30,7 +30,7 @@ exports.format = urlFormat;
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-var protocolPattern = /^([a-z0-9]+:)/i,
+var protocolPattern = /^([a-z0-9.+-]+:)/i,
     portPattern = /:[0-9]+$/,
     // RFC 2396: characters reserved for delimiting URLs.
     delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -335,6 +335,39 @@ var parseTests = {
     hostname: 'bucket_name.s3.amazonaws.com',
     pathname: '/image.jpg',
     href: 'http://bucket_name.s3.amazonaws.com/image.jpg'
+  },
+  'svn+ssh://foo/bar': {
+    'href': 'svn+ssh://foo/bar',
+    'hostname': 'foo',
+    'protocol': 'svn+ssh:',
+    'pathname': '/bar',
+    'slashes': true
+  },
+  'dash-test://foo/bar': {
+    'href': 'dash-test://foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dash-test:',
+    'pathname': '/bar',
+    'slashes': true
+  },
+  'dash-test:foo/bar': {
+    'href': 'dash-test:foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dash-test:',
+    'pathname': '/bar'
+  },
+  'dot.test://foo/bar': {
+    'href': 'dot.test://foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dot.test:',
+    'pathname': '/bar',
+    'slashes': true
+  },
+  'dot.test:foo/bar': {
+    'href': 'dot.test:foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dot.test:',
+    'pathname': '/bar'
   }
 };
 

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -514,6 +514,39 @@ var formatTests = {
     'hostname': 'foo',
     'protocol': 'http:',
     'pathname': '/'
+  },
+  'svn+ssh://foo/bar': {
+    'href': 'svn+ssh://foo/bar',
+    'hostname': 'foo',
+    'protocol': 'svn+ssh:',
+    'pathname': '/bar',
+    'slashes': true
+  },
+  'dash-test://foo/bar': {
+    'href': 'dash-test://foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dash-test:',
+    'pathname': '/bar',
+    'slashes': true
+  },
+  'dash-test:foo/bar': {
+    'href': 'dash-test:foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dash-test:',
+    'pathname': '/bar'
+  },
+  'dot.test://foo/bar': {
+    'href': 'dot.test://foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dot.test:',
+    'pathname': '/bar',
+    'slashes': true
+  },
+  'dot.test:foo/bar': {
+    'href': 'dot.test:foo/bar',
+    'hostname': 'foo',
+    'protocol': 'dot.test:',
+    'pathname': '/bar'
   }
 };
 for (var u in formatTests) {


### PR DESCRIPTION
- Based on BNF from RFC 1738 section 5.
- Added tests to cover svn+ssh and some other examples

Adding this would allow future node releases to parse svn+ssh and other non-alphanumeric url protocols. This is in line with RFC 1738 and also supported by major web browsers.

The tests I've added should help guard against regressions. The url tesst pass from my branch.
