### PR TITLE
Support ssl session get/set in tls.  Useful for client side session resume.

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -192,6 +192,14 @@ CryptoStream.prototype.getSession = function() {
   return null;
 };
 
+CryptoStream.prototype.isSessionReused = function() {
+  if (this.pair.ssl) {
+    return this.pair.ssl.isSessionReused();
+  }
+
+  return null;
+};
+
 CryptoStream.prototype.getCipher = function(err) {
   if (this.pair.ssl) {
     return this.pair.ssl.getCurrentCipher();

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -184,6 +184,13 @@ CryptoStream.prototype.getPeerCertificate = function() {
   return null;
 };
 
+CryptoStream.prototype.getSession = function() {
+  if (this.pair.ssl) {
+    return this.pair.ssl.getSession();
+  }
+
+  return null;
+};
 
 CryptoStream.prototype.getCipher = function(err) {
   if (this.pair.ssl) {
@@ -956,6 +963,10 @@ exports.connect = function(port /* host, options, cb */) {
                               servername: options.servername || host
                             });
 
+  if (options.session) {
+    pair.ssl.setSession(options.session);
+  }
+  
   var cleartext = pipe(pair, socket);
 
   socket.connect(port, host);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -580,6 +580,8 @@ void Connection::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "clearPending", Connection::ClearPending);
   NODE_SET_PROTOTYPE_METHOD(t, "encPending", Connection::EncPending);
   NODE_SET_PROTOTYPE_METHOD(t, "getPeerCertificate", Connection::GetPeerCertificate);
+  NODE_SET_PROTOTYPE_METHOD(t, "getSession", Connection::GetSession);
+  NODE_SET_PROTOTYPE_METHOD(t, "setSession", Connection::SetSession);
   NODE_SET_PROTOTYPE_METHOD(t, "isInitFinished", Connection::IsInitFinished);
   NODE_SET_PROTOTYPE_METHOD(t, "verifyError", Connection::VerifyError);
   NODE_SET_PROTOTYPE_METHOD(t, "getCurrentCipher", Connection::GetCurrentCipher);
@@ -1129,6 +1131,82 @@ Handle<Value> Connection::GetPeerCertificate(const Arguments& args) {
   }
   return scope.Close(info);
 }
+
+Handle<Value> Connection::GetSession(const Arguments& args) {
+  HandleScope scope;
+  
+  Connection *ss = Connection::Unwrap(args);
+
+  if (ss->ssl_ == NULL) return Undefined();
+  
+  SSL_SESSION* sess = SSL_get_session(ss->ssl_);
+  if (!sess) return Undefined();
+
+  int slen = i2d_SSL_SESSION(sess, NULL);
+  assert(slen > 0);
+  
+  Local<Value> s;
+  
+  if (slen > 0)
+  {
+    void* pp = ::malloc(slen);
+    if (pp)
+    {
+      unsigned char* p = (unsigned char*)pp;
+      i2d_SSL_SESSION(sess, &p);
+      s = Encode(pp, slen, BINARY);
+      ::free(pp);
+    }
+    else
+      return False();
+  }
+  else
+    return False();
+  
+  return scope.Close(s);
+}
+
+Handle<Value> Connection::SetSession(const Arguments& args) {
+  HandleScope scope;
+  
+  Connection *ss = Connection::Unwrap(args);
+
+  if (args.Length() < 1 || !args[0]->IsString()) {
+    Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
+    return ThrowException(exception);
+  }
+
+  ASSERT_IS_STRING_OR_BUFFER(args[0]);
+  ssize_t slen = DecodeBytes(args[0], BINARY);
+
+  if (slen < 0) {
+    Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
+    return ThrowException(exception);
+  }
+
+  char* sbuf = new char[slen];
+  
+  ssize_t wlen = DecodeWrite(sbuf, slen, args[0], BINARY);
+  assert(wlen == slen);
+
+  const unsigned char* p = (unsigned char*) sbuf;
+  SSL_SESSION* sess = d2i_SSL_SESSION(NULL, &p, wlen);
+
+  delete [] sbuf;
+
+  if (!sess)
+    return Undefined();
+
+  int r = SSL_set_session(ss->ssl_, sess);
+  SSL_SESSION_free(sess);
+
+  if (!r) {
+    return ThrowException(Exception::Error(String::New("SSL_set_session error")));
+  }
+
+  return True();
+}
+
 
 Handle<Value> Connection::Start(const Arguments& args) {
   HandleScope scope;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -119,6 +119,8 @@ class Connection : ObjectWrap {
   static v8::Handle<v8::Value> EncOut(const v8::Arguments& args);
   static v8::Handle<v8::Value> ClearIn(const v8::Arguments& args);
   static v8::Handle<v8::Value> GetPeerCertificate(const v8::Arguments& args);
+  static v8::Handle<v8::Value> GetSession(const v8::Arguments& args);
+  static v8::Handle<v8::Value> SetSession(const v8::Arguments& args);
   static v8::Handle<v8::Value> IsInitFinished(const v8::Arguments& args);
   static v8::Handle<v8::Value> VerifyError(const v8::Arguments& args);
   static v8::Handle<v8::Value> GetCurrentCipher(const v8::Arguments& args);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -121,6 +121,7 @@ class Connection : ObjectWrap {
   static v8::Handle<v8::Value> GetPeerCertificate(const v8::Arguments& args);
   static v8::Handle<v8::Value> GetSession(const v8::Arguments& args);
   static v8::Handle<v8::Value> SetSession(const v8::Arguments& args);
+  static v8::Handle<v8::Value> IsSessionReused(const v8::Arguments& args);
   static v8::Handle<v8::Value> IsInitFinished(const v8::Arguments& args);
   static v8::Handle<v8::Value> VerifyError(const v8::Arguments& args);
   static v8::Handle<v8::Value> GetCurrentCipher(const v8::Arguments& args);

--- a/test/simple/test-tls-client-resume.js
+++ b/test/simple/test-tls-client-resume.js
@@ -1,0 +1,76 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Create an ssl server.  First connection, validate that not resume.
+// Cache session and close connection.  Use session on second connection.
+// ASSERT resumption.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+};
+
+var connections = 0;
+
+// create server
+var server = tls.Server(options, function(socket) {
+  socket.end("Goodbye");
+  connections++;
+});
+
+// start listening
+server.listen(common.PORT, function() {
+
+  var session1 = null;
+  var client1 = tls.connect(common.PORT, function () {
+    console.log('connect1');
+    assert.ok(!client1.isSessionReused(), "Session *should not* be reused.");
+    session1 = client1.getSession();
+  });
+
+  client1.on('close', function() {
+    console.log('close1');
+    
+    var client2 = tls.connect(common.PORT, {'session':session1}, function () {
+      console.log('connect2');
+      assert.ok(client2.isSessionReused(), "Session *should* be reused.");
+    });
+    
+    client2.on('close', function() {
+      console.log('close2');
+      server.close();
+    });
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(2, connections);
+});


### PR DESCRIPTION
Support ssl session get/set in tls.  Useful for client side session resume, particularly RFC 5077.

Not clear how this should bubble up to https Agent support.
