### PR TITLE
documented behavior for arrays and unassigned parameters

### DIFF
--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -10,13 +10,13 @@ Optionally override the default separator and assignment characters.
 
 Example:
 
-    querystring.stringify({foo: 'bar'})
+    querystring.stringify({ foo: 'bar', baz: ['qux', 'quux'], corge: '' })
     // returns
-    'foo=bar'
+    'foo=bar&baz=qux&baz=quux&corge='
 
-    querystring.stringify({foo: 'bar', baz: 'bob'}, ';', ':')
+    querystring.stringify({foo: 'bar', baz: 'qux'}, ';', ':')
     // returns
-    'foo:bar;baz:bob'
+    'foo:bar;baz:qux'
 
 ### querystring.parse(str, sep='&', eq='=')
 
@@ -25,9 +25,9 @@ Optionally override the default separator and assignment characters.
 
 Example:
 
-    querystring.parse('a=b&b=c')
+    querystring.parse('foo=bar&baz=qux&baz=quux&corge')
     // returns
-    { a: 'b', b: 'c' }
+    { foo: 'bar', baz: ['qux', 'quux'], corge: '' }
 
 ### querystring.escape
 


### PR DESCRIPTION
documented behavior for arrays and unassigned parameters.

Also brought into spec with rfc 3092 by using 'qux' instead of 'bob'.

=|8^P
