### PR TITLE
A more robust util.isDate() function.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -332,11 +332,8 @@ function isRegExp(re) {
 
 
 function isDate(d) {
-  if (d instanceof Date) return true;
-  if (typeof d !== 'object') return false;
-  var properties = Date.prototype && Object.getOwnPropertyNames(Date.prototype);
-  var proto = d.__proto__ && Object.getOwnPropertyNames(d.__proto__);
-  return JSON.stringify(proto) === JSON.stringify(properties);
+  return d instanceof Date ||
+    (typeof d === 'object' && Object.prototype.toString.call(d) === '[object Date]');
 }
 
 

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -1,0 +1,35 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// libuv-broken
+
+
+var common = require('../common');
+var assert = require('assert');
+var util = require('util');
+
+// test the internal isDate implementation
+var Date2 = require('vm').runInNewContext('Date');
+var d = new Date2();
+var orig = util.inspect(d);
+Date2.prototype.foo = 'bar';
+var after = util.inspect(d);
+assert.equal(orig, after);

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -19,8 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// libuv-broken
-
 
 var common = require('../common');
 var assert = require('assert');


### PR DESCRIPTION
The old implementation was fragile. i.e. [node-time](https://github.com/TooTallNate/node-time) is an example of a user-land
module that exports an extended Date object (with a few added functions on it's
own Date object's prototype). In that case, the old check ends up comparing the prototype of the `util` module's Date object to the prototype of node-time's extended Date, and ends up failing...

It's a rather small edge case but we'd might as well nab it to make it as bulletproof as possible. Thanks in advance!
