### PR TITLE
Don't eval the command in the REPL twice when an Error is thrown.

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -160,7 +160,11 @@ function REPLServer(prompt, stream) {
                                   'repl');
             if (typeof ret !== 'function') success = true;
           } catch (e) {
-            success = false;
+            if (!(e && e.constructor && e.constructor.name === 'SyntaxError')) {
+              throw e;
+            } else {
+              success = false;
+            }
           }
 
           if (!success) {


### PR DESCRIPTION
Another rather obscure one that nobody but me will probably ever care about ;)

I _really_ tried for the past hour to integrate this into a test case, but I simply don't think it's possible with the way that `vm` handles contexts when an error happens (it seems nothing in the context is changed, so keeping a counter doesn't work). Sorry @bnoordhuis.

Basically, if a function is called in the REPL, and that function throws an Error, then the resulting command is executed twice! This happens because the command is first invoked on line 158, with added ( ) parens around the command, and if that throws, then it is invoked again on line 168 (assuming it was a SyntaxError because of the added parens) "for real" this time.

So the fix is to not assume the initial invokation's error is a SyntaxError and check first. 

Here's a REPL dump of what this is fixing:
### Before:

``` javascript
> function test () { console.trace(); throw new Error(); }
> test()
Trace: 
    at test (repl:1:28)
    at repl:1:2
    at Interface.<anonymous> (repl.js:158:22)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:153:10)
    at Interface._line (readline.js:408:8)
    at Interface._ttyWrite (readline.js:585:14)
    at ReadStream.<anonymous> (readline.js:73:12)
    at ReadStream.emit (events.js:88:20)
    at ReadStream._emitKey (tty_posix.js:306:10)
Trace: 
    at test (repl:1:28)
    at repl:1:1
    at Interface.<anonymous> (repl.js:168:22)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:153:10)
    at Interface._line (readline.js:408:8)
    at Interface._ttyWrite (readline.js:585:14)
    at ReadStream.<anonymous> (readline.js:73:12)
    at ReadStream.emit (events.js:88:20)
    at ReadStream._emitKey (tty_posix.js:306:10)
Error
    at test (repl:1:43)
    at repl:1:1
    at Interface.<anonymous> (repl.js:168:22)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:153:10)
    at Interface._line (readline.js:408:8)
    at Interface._ttyWrite (readline.js:585:14)
    at ReadStream.<anonymous> (readline.js:73:12)
    at ReadStream.emit (events.js:88:20)
    at ReadStream._emitKey (tty_posix.js:306:10)
```
### After:

``` javascript
> function test () { console.trace(); throw new Error(); }
> test()
Trace: 
    at test (repl:1:28)
    at repl:1:2
    at Interface.<anonymous> (repl.js:158:22)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:153:10)
    at Interface._line (readline.js:408:8)
    at Interface._ttyWrite (readline.js:585:14)
    at ReadStream.<anonymous> (readline.js:73:12)
    at ReadStream.emit (events.js:88:20)
    at ReadStream._emitKey (tty_posix.js:306:10)
Error
    at test (repl:1:43)
    at repl:1:2
    at Interface.<anonymous> (repl.js:158:22)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:153:10)
    at Interface._line (readline.js:408:8)
    at Interface._ttyWrite (readline.js:585:14)
    at ReadStream.<anonymous> (readline.js:73:12)
    at ReadStream.emit (events.js:88:20)
    at ReadStream._emitKey (tty_posix.js:306:10)
```

Thanks in advance!
