### PR TITLE
Avoid buffer overrun with 'binary' encoding

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -667,9 +667,11 @@ Handle<Value> Buffer::BinaryWrite(const Arguments &args) {
 
   char *p = (char*)buffer->data_ + offset;
 
-  size_t towrite = MIN((unsigned long) s->Length(), buffer->length_ - offset);
+  size_t max_length = args[2]->IsUndefined() ? buffer->length_ - offset
+                                             : args[2]->Uint32Value();
+  max_length = MIN(s->Length(), MIN(buffer->length_ - offset, max_length));
 
-  int written = DecodeWrite(p, towrite, s, BINARY);
+  int written = DecodeWrite(p, max_length, s, BINARY);
   return scope.Close(Integer::New(written));
 }
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -553,3 +553,9 @@ assert.equal(written, 9);
 written = buf.write('あいう\0'); // 3bytes * 3 + 1byte
 assert.equal(written, 10);
 
+// test for buffer overrun
+buf = new Buffer([0, 0, 0, 0, 0]); // length: 5
+var sub = buf.slice(0, 4);         // length: 4
+written = sub.write('12345', 'binary');
+assert.equal(written, 4);
+assert.equal(buf[4], 0);


### PR DESCRIPTION
With `'binary'` encoding, `Buffer.write()` overruns the buffer's length.
reproduce:

```
> buf = new Buffer([0, 0, 0, 0, 0]);
<Buffer 00 00 00 00 00>
> sub = buf.slice(0, 4);
<Buffer 00 00 00 00>
> sub.write('12345', 'binary')
5
> buf
<Buffer 31 32 33 34 35>
```

Please review.
