### PR TITLE
New assertions and util checks

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -323,3 +323,80 @@ assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
 };
 
 assert.ifError = function(err) { if (err) {throw err;}};
+
+// 12. isArray assertion
+// assert.isArray(value, message)
+
+assert.isArray = function isArray(value, message) {
+  if(!util.isArray(value)) fail(util.typeOf(value), 'array', message, '==', assert.isArray);
+};
+
+// 13. isBoolean assertion
+// assert.isBoolean(value, message)
+
+assert.isBoolean = function isBoolean(value, message) {
+  if(!util.isBoolean(value)) fail(util.typeOf(value), 'boolean', message, '==', assert.isBoolean);
+};
+
+// 14. isDate assertion
+// assert.isDate(value, message)
+
+assert.isDate = function isDate(value, message) {
+  if(!util.isDate(value)) fail(util.typeOf(value), 'date', message, '==', assert.isDate);
+};
+
+// 15. isFunction assertion
+// assert.isFunction(value, message)
+
+assert.isFunction = function isFunction(value, message) {
+  if(!util.isFunction(value)) fail(util.typeOf(value), 'function', message, '==', assert.isFunction);
+};
+
+// 16. isInstanceOf assertion
+// assert.isInstanceOf(obj1, obj2, message)
+
+assert.isInstanceOf = function isInstanceOf(obj1, obj2, message) {
+  if(!util.isInstanceOf(obj1, obj2)) fail('not a instanceof', 'instanceof', message, '==', assert.isInstanceOf);
+};
+
+// 17. isNull assertion
+// assert.isNull(value, message)
+
+assert.isNull = function isNull(value, message) {
+  if(!util.isNull(value)) fail(util.typeOf(value), 'null', message, '==', assert.isNull);
+};
+
+// 18. isNumber assertion
+// assert.isNumber(value, message)
+
+assert.isNumber = function isNumber(value, message) {
+  if(!util.isNumber(value)) fail(util.typeOf(value), 'number', message, '==', assert.isNumber);
+};
+
+// 19. isObject assertion
+// assert.isObject(value, message)
+
+assert.isObject = function isObject(value, message) {
+  if(!util.isObject(value)) fail(util.typeOf(value), 'object', message, '==', assert.isObject);
+};
+
+// 20. isRegExp assertion
+// assert.isRegExp(value, message)
+
+assert.isRegExp = function isRegExp(value, message) {
+  if(!util.isRegExp(value)) fail(util.typeOf(value), 'regexp', message, '==', assert.isRegExp);
+};
+
+// 21. isString assertion
+// assert.isString(value, message)
+
+assert.isString = function isString(value, message) {
+  if(!util.isString(value)) fail(util.typeOf(value), 'string', message, '==', assert.isString);
+};
+
+// 22. isUndefined assertion
+// assert.isUndefined(value, message)
+
+assert.isUndefined = function isUndefined(value, message) {
+  if(!util.isUndefined(value)) fail(util.typeOf(value), 'undefined', message, '==', assert.isUndefined);
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -139,7 +139,7 @@ function inspect(obj, showHidden, depth, colors) {
   function format(value, recurseTimes) {
     // Provide a hook for user-specified inspect functions.
     // Check that value is an object with an inspect function on it
-    if (value && typeof value.inspect === 'function' &&
+    if (value && isFunction(value.inspect) &&
         // Filter out the util module, it's inspect function is special
         value !== exports &&
         // Also filter out any prototype objects using the circular check.
@@ -165,7 +165,7 @@ function inspect(obj, showHidden, depth, colors) {
         return stylize('' + value, 'boolean');
     }
     // For some reason typeof null is "object", so special case here.
-    if (value === null) {
+    if (isNull(value)) {
       return stylize('null', 'null');
     }
 
@@ -174,7 +174,7 @@ function inspect(obj, showHidden, depth, colors) {
     var keys = showHidden ? Object.getOwnPropertyNames(value) : visible_keys;
 
     // Functions without properties can be shortcutted.
-    if (typeof value === 'function' && keys.length === 0) {
+    if (isFunction(value) && keys.length === 0) {
       var name = value.name ? ': ' + value.name : '';
       return stylize('[Function' + name + ']', 'special');
     }
@@ -200,7 +200,7 @@ function inspect(obj, showHidden, depth, colors) {
     }
 
     // Make functions say that they are functions
-    if (typeof value === 'function') {
+    if (isFunction(value)) {
       var n = value.name ? ': ' + value.name : '';
       base = ' [Function' + n + ']';
     } else {
@@ -251,7 +251,7 @@ function inspect(obj, showHidden, depth, colors) {
       }
       if (!str) {
         if (seen.indexOf(value[key]) < 0) {
-          if (recurseTimes === null) {
+          if (isNull(null)) {
             str = format(value[key]);
           } else {
             str = format(value[key], recurseTimes - 1);
@@ -271,7 +271,7 @@ function inspect(obj, showHidden, depth, colors) {
           str = stylize('[Circular]', 'special');
         }
       }
-      if (typeof name === 'undefined') {
+      if (isUndefined(name)) {
         if (type === 'Array' && key.match(/^\d+$/)) {
           return str;
         }
@@ -313,25 +313,22 @@ function inspect(obj, showHidden, depth, colors) {
 
     return output;
   }
-  return format(obj, (typeof depth === 'undefined' ? 2 : depth));
+  return format(obj, (isUndefined(depth) ? 2 : depth));
 }
 exports.inspect = inspect;
 
 
-function isArray(ar) {
+var isArray = exports.isArray = function(ar) {
   return ar instanceof Array ||
          Array.isArray(ar) ||
          (ar && ar !== Object.prototype && isArray(ar.__proto__));
 }
 
-
-function isRegExp(re) {
-  return re instanceof RegExp ||
-    (typeof re === 'object' && Object.prototype.toString.call(re) === '[object RegExp]');
+var isBoolean = exports.isBoolean = function(bool) {
+  return typeof bool == "boolean";
 }
 
-
-function isDate(d) {
+var isDate = exports.isDate = function(d) {
   if (d instanceof Date) return true;
   if (typeof d !== 'object') return false;
   var properties = Date.prototype && Object.getOwnPropertyNames(Date.prototype);
@@ -339,6 +336,53 @@ function isDate(d) {
   return JSON.stringify(proto) === JSON.stringify(properties);
 }
 
+var isFunction = exports.isFunction = function(fn) {
+  return typeof fn == "function";
+}
+
+var isInstanceOf = exports.isInstanceOf = function(cls1, cls2) {
+  return cls1 instanceof cls2;
+}
+
+var isNull = exports.isNull = function(val) {
+  return val === null;
+}
+
+var isNumber = exports.isNumber = function(nr) {
+  return typeof nr == "number";
+}
+
+var isObject = exports.isObject = function(obj) {
+	return obj !== null && typeof obj == "object" && Object.prototype.toString.call(obj) == '[object Object]'/*obj.constructor == Object*/;
+}
+
+var isRegExp = exports.isRegExp = function(re) {
+  return re instanceof RegExp ||
+    (typeof re === 'object' && Object.prototype.toString.call(re) === '[object RegExp]');
+}
+
+var isString = exports.isString = function(str) {
+  return typeof str == "string";
+}
+
+var isUndefined = exports.isUndefined = function(val) {
+ return typeof val == "undefined";
+}
+
+var typeOf = exports.typeOf = function(obj) {
+  if(isArray(obj)) return 'array';
+  if(isBoolean(obj)) return 'boolean';
+  if(isDate(obj)) return 'date';
+  if(isFunction(obj)) return 'function';
+  if(isNull(obj)) return 'null';
+  if(isNumber(obj)) return 'number';
+  if(isObject(obj)) return 'object';
+  if(isRegExp(obj)) return 'regexp';
+  if(isString(obj)) return 'string';
+  if(isUndefined(obj)) return 'undefined';
+
+  return 'unknown';
+}
 
 var pWarning;
 

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -260,3 +260,123 @@ testAssertionMessage({a:undefined, b:null}, '{"a":"undefined","b":null}');
 testAssertionMessage({a:NaN, b:Infinity, c:-Infinity},
     '{"a":"NaN","b":"Infinity","c":"-Infinity"}');
 
+var undef;
+
+assert.doesNotThrow(makeBlock(a.isArray, []), "array == array");
+assert.throws(makeBlock(a.isArray, false), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, new Date()), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, function(){}), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, null), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, 123), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, {}), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, /[A-Z]/), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, "str"), a.AssertionError, 'isArray');
+assert.throws(makeBlock(a.isArray, undef), a.AssertionError, 'isArray');
+
+assert.throws(makeBlock(a.isBoolean, []), a.AssertionError, 'isBoolean');
+assert.doesNotThrow(makeBlock(a.isBoolean, false), "boolean == boolean");
+assert.throws(makeBlock(a.isBoolean, new Date()), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, function(){}), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, null), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, 123), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, {}), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, /[A-Z]/), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, "str"), a.AssertionError, 'isBoolean');
+assert.throws(makeBlock(a.isBoolean, undef), a.AssertionError, 'isBoolean');
+
+assert.throws(makeBlock(a.isDate, []), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, false), a.AssertionError, 'isDate');
+assert.doesNotThrow(makeBlock(a.isDate, new Date()), "date == date");
+assert.throws(makeBlock(a.isDate, function(){}), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, null), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, 123), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, {}), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, /[A-Z]/), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, "str"), a.AssertionError, 'isDate');
+assert.throws(makeBlock(a.isDate, undef), a.AssertionError, 'isDate');
+
+assert.throws(makeBlock(a.isFunction, []), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, false), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, new Date()), a.AssertionError, 'isFunction');
+assert.doesNotThrow(makeBlock(a.isFunction, function(){}), "function == function");
+assert.throws(makeBlock(a.isFunction, null), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, 123), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, {}), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, /[A-Z]/), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, "str"), a.AssertionError, 'isFunction');
+assert.throws(makeBlock(a.isFunction, undef), a.AssertionError, 'isFunction');
+
+var x = function(){};
+var xx = new x();
+var y = function(){};
+var yy = new y();
+
+assert.doesNotThrow(makeBlock(a.isInstanceOf, xx, x), "instance == instance");
+assert.throws(makeBlock(a.isInstanceOf, xx, y), a.AssertionError, 'isInstanceOf');
+
+
+assert.throws(makeBlock(a.isNull, []), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, false), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, new Date()), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, function(){}), a.AssertionError, 'isNull');
+assert.doesNotThrow(makeBlock(a.isNull, null), "null == null");
+assert.throws(makeBlock(a.isNull, 123), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, {}), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, /[A-Z]/), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, "str"), a.AssertionError, 'isNull');
+assert.throws(makeBlock(a.isNull, undef), a.AssertionError, 'isNull');
+
+assert.throws(makeBlock(a.isNumber, []), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, false), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, new Date()), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, function(){}), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, null), a.AssertionError, 'isNumber');
+assert.doesNotThrow(makeBlock(a.isNumber, 123), "number == number");
+assert.throws(makeBlock(a.isNumber, {}), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, /[A-Z]/), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, "str"), a.AssertionError, 'isNumber');
+assert.throws(makeBlock(a.isNumber, undef), a.AssertionError, 'isNumber');
+
+assert.throws(makeBlock(a.isObject, []), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, false), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, new Date()), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, function(){}), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, null), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, 123), a.AssertionError, 'isObject');
+assert.doesNotThrow(makeBlock(a.isObject, {}), "object == object");
+assert.throws(makeBlock(a.isObject, /[A-Z]/), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, "str"), a.AssertionError, 'isObject');
+assert.throws(makeBlock(a.isObject, undef), a.AssertionError, 'isObject');
+
+assert.throws(makeBlock(a.isRegExp, []), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, false), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, new Date()), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, function(){}), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, null), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, 123), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, {}), a.AssertionError, 'isRegExp');
+assert.doesNotThrow(makeBlock(a.isRegExp, /[A-Z]/), "regexp == regexp");
+assert.throws(makeBlock(a.isRegExp, "str"), a.AssertionError, 'isRegExp');
+assert.throws(makeBlock(a.isRegExp, undef), a.AssertionError, 'isRegExp');
+
+assert.throws(makeBlock(a.isString, []), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, false), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, new Date()), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, function(){}), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, null), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, 123), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, {}), a.AssertionError, 'isString');
+assert.throws(makeBlock(a.isString, /[A-Z]/), a.AssertionError, 'isString');
+assert.doesNotThrow(makeBlock(a.isString, "str"), "string == string");
+assert.throws(makeBlock(a.isString, undef), a.AssertionError, 'isString');
+
+assert.throws(makeBlock(a.isUndefined, []), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, false), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, new Date()), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, function(){}), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, null), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, 123), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, {}), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, /[A-Z]/), a.AssertionError, 'isUndefined');
+assert.throws(makeBlock(a.isUndefined, "str"), a.AssertionError, 'isUndefined');
+assert.doesNotThrow(makeBlock(a.isUndefined, undef), "undefined == undefined");

--- a/test/simple/test-util-types.js
+++ b/test/simple/test-util-types.js
@@ -1,0 +1,154 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var util = require('util');
+
+var undef;
+
+assert.ok(util.isArray([]));
+assert.ifError(util.isArray(false));
+assert.ifError(util.isArray(new Date()));
+assert.ifError(util.isArray(function(){}));
+assert.ifError(util.isArray(null));
+assert.ifError(util.isArray(123));
+assert.ifError(util.isArray({}));
+assert.ifError(util.isArray(/[A-Z]/));
+assert.ifError(util.isArray("str"));
+assert.ifError(util.isArray(undef));
+
+assert.ifError(util.isBoolean([]));
+assert.ok(util.isBoolean(false));
+assert.ifError(util.isBoolean(new Date()));
+assert.ifError(util.isBoolean(function(){}));
+assert.ifError(util.isBoolean(null));
+assert.ifError(util.isBoolean(123));
+assert.ifError(util.isBoolean({}));
+assert.ifError(util.isBoolean(/[A-Z]/));
+assert.ifError(util.isBoolean("str"));
+assert.ifError(util.isBoolean(undef));
+
+assert.ifError(util.isDate([]));
+assert.ifError(util.isDate(false));
+assert.ok(util.isDate(new Date()));
+assert.ifError(util.isDate(function(){}));
+assert.ifError(util.isDate(null));
+assert.ifError(util.isDate(123));
+assert.ifError(util.isDate({}));
+assert.ifError(util.isDate(/[A-Z]/));
+assert.ifError(util.isDate("str"));
+assert.ifError(util.isDate(undef));
+
+assert.ifError(util.isFunction([]));
+assert.ifError(util.isFunction(false));
+assert.ifError(util.isFunction(new Date()));
+assert.ok(util.isFunction(function(){}));
+assert.ifError(util.isFunction(null));
+assert.ifError(util.isFunction(123));
+assert.ifError(util.isFunction({}));
+assert.ifError(util.isFunction(/[A-Z]/));
+assert.ifError(util.isFunction("str"));
+assert.ifError(util.isFunction(undef));
+
+var fn1 = function(){}
+var obj1 = new fn1();
+var fn2 = function(){};
+var obj2 = new fn2();
+
+assert.ok(util.isInstanceOf(obj1, fn1));
+assert.ifError(util.isInstanceOf(obj2, fn1));
+
+assert.ifError(util.isNull([]));
+assert.ifError(util.isNull(false));
+assert.ifError(util.isNull(new Date()));
+assert.ifError(util.isNull(function(){}));
+assert.ok(util.isNull(null));
+assert.ifError(util.isNull(123));
+assert.ifError(util.isNull({}));
+assert.ifError(util.isNull(/[A-Z]/));
+assert.ifError(util.isNull("str"));
+assert.ifError(util.isNull(undef));
+
+assert.ifError(util.isNumber([]));
+assert.ifError(util.isNumber(false));
+assert.ifError(util.isNumber(new Date()));
+assert.ifError(util.isNumber(function(){}));
+assert.ifError(util.isNumber(null));
+assert.ok(util.isNumber(123));
+assert.ifError(util.isNumber({}));
+assert.ifError(util.isNumber(/[A-Z]/));
+assert.ifError(util.isNumber("str"));
+assert.ifError(util.isNumber(undef));
+
+assert.ifError(util.isObject([]));
+assert.ifError(util.isObject(false));
+assert.ifError(util.isObject(new Date()));
+assert.ifError(util.isObject(function(){}));
+assert.ifError(util.isObject(null));
+assert.ifError(util.isObject(123));
+assert.ok(util.isObject({}));
+assert.ifError(util.isObject(/[A-Z]/));
+assert.ifError(util.isObject("str"));
+assert.ifError(util.isObject(undef));
+
+assert.ifError(util.isRegExp([]));
+assert.ifError(util.isRegExp(false));
+assert.ifError(util.isRegExp(new Date()));
+assert.ifError(util.isRegExp(function(){}));
+assert.ifError(util.isRegExp(null));
+assert.ifError(util.isRegExp(123));
+assert.ifError(util.isRegExp({}));
+assert.ok(util.isRegExp(/[A-Z]/));
+assert.ifError(util.isRegExp("str"));
+assert.ifError(util.isRegExp(undef));
+
+assert.ifError(util.isString([]));
+assert.ifError(util.isString(false));
+assert.ifError(util.isString(new Date()));
+assert.ifError(util.isString(function(){}));
+assert.ifError(util.isString(null));
+assert.ifError(util.isString(123));
+assert.ifError(util.isString({}));
+assert.ifError(util.isString(/[A-Z]/));
+assert.ok(util.isString("str"));
+assert.ifError(util.isString(undef));
+
+assert.ifError(util.isUndefined([]));
+assert.ifError(util.isUndefined(false));
+assert.ifError(util.isUndefined(new Date()));
+assert.ifError(util.isUndefined(function(){}));
+assert.ifError(util.isUndefined(null));
+assert.ifError(util.isUndefined(123));
+assert.ifError(util.isUndefined({}));
+assert.ifError(util.isUndefined(/[A-Z]/));
+assert.ifError(util.isUndefined("str"));
+assert.ok(util.isUndefined(undef));
+
+assert.equal(util.typeOf(undef), 'undefined');
+assert.equal(util.typeOf("str"), 'string');
+assert.equal(util.typeOf(/[A-Z]/), 'regexp');
+assert.equal(util.typeOf({}), 'object');
+assert.equal(util.typeOf(123), 'number');
+assert.equal(util.typeOf(null), 'null');
+assert.equal(util.typeOf(function(){}), 'function');
+assert.equal(util.typeOf(new Date()), 'date');
+assert.equal(util.typeOf(false), 'boolean');
+assert.equal(util.typeOf([]), 'array');


### PR DESCRIPTION
Implemented new type of assertions and type checks

util:
- added new checks: isArray, isBoolean, isFunction, isInstanceOf, isNull, isNumber, isObject, isString, isUndefined - which returns true/false
- added typeOf - which returns type of given value
- exported all of above

assert:
- new assertions based on the checks in util

This pull request requires changes in util.isDate which are going to be merged from https://github.com/joyent/node/pull/1615

Tests included.
