### PR TITLE
Buffer.write() should always set Buffer._charsWritten

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -555,6 +555,10 @@ Handle<Value> Buffer::AsciiWrite(const Arguments &args) {
                               0,
                               max_length,
                               String::HINT_MANY_WRITES_EXPECTED);
+
+  constructor_template->GetFunction()->Set(chars_written_sym,
+                                           Integer::New(written));
+
   return scope.Close(Integer::New(written));
 }
 
@@ -642,6 +646,9 @@ Handle<Value> Buffer::Base64Write(const Arguments &args) {
     *dst++ = ((c & 0x03) << 6) | (d & 0x3F);
   }
 
+  constructor_template->GetFunction()->Set(chars_written_sym,
+                                           Integer::New(s.length()));
+
   return scope.Close(Integer::New(dst - start));
 }
 
@@ -672,6 +679,10 @@ Handle<Value> Buffer::BinaryWrite(const Arguments &args) {
   max_length = MIN(s->Length(), MIN(buffer->length_ - offset, max_length));
 
   int written = DecodeWrite(p, max_length, s, BINARY);
+
+  constructor_template->GetFunction()->Set(chars_written_sym,
+                                           Integer::New(written));
+
   return scope.Close(Integer::New(written));
 }
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -559,3 +559,16 @@ var sub = buf.slice(0, 4);         // length: 4
 written = sub.write('12345', 'binary');
 assert.equal(written, 4);
 assert.equal(buf[4], 0);
+
+// test for _charsWritten
+buf = new Buffer(9);
+buf.write('あいうえ', 'utf8'); // 3bytes * 4
+assert.equal(Buffer._charsWritten, 3);
+buf.write('あいうえお', 'ucs2'); // 2bytes * 5
+assert.equal(Buffer._charsWritten, 4);
+buf.write('0123456789', 'ascii');
+assert.equal(Buffer._charsWritten, 9);
+buf.write('0123456789', 'binary');
+assert.equal(Buffer._charsWritten, 9);
+buf.write('123456', 'base64');
+assert.equal(Buffer._charsWritten, 6);


### PR DESCRIPTION
With `'utf8'` and `'ucs2'`, `Buffer.write()` sets `Buffer._charsWritten` property.
But with `'ascii'`, `'base64'`, `'binary'` and `'hex'` (only v0.5), `write()` doesn't set the property.

This patch for v0.4 branch.
I will fix for `'hex'` encoding after v0.4 branch is merged to the master.

Please review.
