### PR TITLE
add positioned writing feature to fs.WriteStream

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -493,3 +493,8 @@ Returns a new WriteStream object (See `Writable Stream`).
     { flags: 'w',
       encoding: null,
       mode: 0666 }
+
+`options` may also include a `start` option to allow writing data at 
+some position past the beginning of the file.  Modifying a file rather 
+than replacing it may require a `flags` mode of `r+` rather than the 
+default mode `w`.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1109,6 +1109,14 @@ var WriteStream = fs.WriteStream = function(path, options) {
     this[key] = options[key];
   }
 
+  if (this.start !== undefined) {
+    if (this.start < 0) {
+      throw new Error('start must be >= zero');
+    }
+
+    this.pos = this.start;
+  }
+
   this.busy = false;
   this._queue = [];
 
@@ -1150,24 +1158,23 @@ WriteStream.prototype.flush = function() {
 
     if (method == fs.write) {
       self.bytesWritten += arguments[1];
-    }
+      if (cb) {
+        // write callback
+        cb(null, arguments[1]);
+      }
 
-    // stop flushing after close
-    if (method === fs.close) {
+    } else if (method === fs.open) {
+      // save reference for file pointer
+      self.fd = arguments[1];
+      self.emit('open', self.fd);
+
+    } else if (method === fs.close) {
+      // stop flushing after close
       if (cb) {
         cb(null);
       }
       self.emit('close');
       return;
-    }
-
-    // save reference for file pointer
-    if (method === fs.open) {
-      self.fd = arguments[1];
-      self.emit('open', self.fd);
-    } else if (cb) {
-      // write callback
-      cb(null, arguments[1]);
     }
 
     self.flush();
@@ -1194,14 +1201,17 @@ WriteStream.prototype.write = function(data) {
     cb = arguments[arguments.length - 1];
   }
 
-  if (Buffer.isBuffer(data)) {
-    this._queue.push([fs.write, data, 0, data.length, null, cb]);
-  } else {
+  if (!Buffer.isBuffer(data)) {
     var encoding = 'utf8';
     if (typeof(arguments[1]) == 'string') encoding = arguments[1];
-    this._queue.push([fs.write, data, undefined, encoding, cb]);
+    data = new Buffer('' + data, encoding);
   }
 
+  this._queue.push([fs.write, data, 0, data.length, this.pos, cb]);
+
+  if (this.pos !== undefined) {
+    this.pos += data.length;
+  }
 
   this.flush();
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -928,10 +928,10 @@ var ReadStream = fs.ReadStream = function(path, options) {
     }
 
     if (this.start > this.end) {
-      this.emit('error', new Error('start must be <= end'));
-    } else {
-      this._firstRead = true;
+      throw new Error('start must be <= end');
     }
+    
+    this.pos = this.start;
   }
 
   if (this.fd !== null) {
@@ -962,20 +962,15 @@ ReadStream.prototype.setEncoding = function(encoding) {
 
 ReadStream.prototype._read = function() {
   var self = this;
-  if (!self.readable || self.paused || self.reading) return;
+  if (!this.readable || this.paused || this.reading) return;
 
-  self.reading = true;
+  this.reading = true;
 
   if (!pool || pool.length - pool.used < kMinPoolSpace) {
     // discard the old pool. Can't add to the free list because
     // users might have refernces to slices on it.
     pool = null;
     allocNewPool();
-  }
-
-  if (self.start !== undefined && self._firstRead) {
-    self.pos = self.start;
-    self._firstRead = false;
   }
 
   // Grab another reference to the pool in the case that while we're in the
@@ -1022,10 +1017,10 @@ ReadStream.prototype._read = function() {
     self._read();
   }
 
-  fs.read(self.fd, pool, pool.used, toRead, self.pos, afterRead);
+  fs.read(this.fd, pool, pool.used, toRead, this.pos, afterRead);
 
-  if (self.pos !== undefined) {
-    self.pos += toRead;
+  if (this.pos !== undefined) {
+    this.pos += toRead;
   }
   pool.used += toRead;
 };
@@ -1132,7 +1127,7 @@ WriteStream.prototype.flush = function() {
 
   var args = this._queue.shift();
   if (!args) {
-    if (this.drainable) { self.emit('drain'); }
+    if (this.drainable) { this.emit('drain'); }
     return;
   }
 
@@ -1140,8 +1135,6 @@ WriteStream.prototype.flush = function() {
 
   var method = args.shift(),
       cb = args.pop();
-
-  var self = this;
 
   args.push(function(err) {
     self.busy = false;
@@ -1182,7 +1175,7 @@ WriteStream.prototype.flush = function() {
 
   // Inject the file pointer
   if (method !== fs.open) {
-    args.unshift(self.fd);
+    args.unshift(this.fd);
   }
 
   method.apply(this, args);
@@ -1190,7 +1183,7 @@ WriteStream.prototype.flush = function() {
 
 WriteStream.prototype.write = function(data) {
   if (!this.writable) {
-    this.emit("error", new Error('stream not writable'));
+    this.emit('error', new Error('stream not writable'));
     return false;
   }
 

--- a/test/simple/test-file-write-stream2.js
+++ b/test/simple/test-file-write-stream2.js
@@ -1,0 +1,98 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var path = require('path'),
+    fs = require('fs'),
+    util = require('util');
+
+
+var filepath = path.join(common.tmpDir, 'write.txt'),
+    file;
+
+var EXPECTED = '012345678910';
+
+var cb_expected = 'write open drain write drain close error ',
+    cb_occurred = '';
+
+var countDrains = 0;
+
+
+process.on('exit', function() {
+  removeTestFile();
+  if ( cb_occurred !== cb_expected) {
+    console.log('  Test callback events missing or out of order:');
+    console.log('    expected: %j', cb_expected);
+    console.log('    occurred: %j', cb_occurred);
+    assert.strictEqual(cb_occurred, cb_expected,
+          'events missing or out of order: "' +
+          cb_occurred + '" !== "' + cb_expected + '"');
+  }
+});
+
+function removeTestFile() {
+  try {
+    fs.unlinkSync(filepath);
+  } catch (e) {}
+}
+
+
+removeTestFile();
+
+file = fs.createWriteStream(filepath);
+
+file.on('open', function(fd) {
+  cb_occurred += 'open ';
+  assert.equal(typeof fd, 'number');
+});
+
+file.on('drain', function() {
+  cb_occurred += 'drain ';
+  ++countDrains;
+  if (countDrains === 1) {
+    assert.equal(fs.readFileSync(filepath), EXPECTED);
+    file.write(EXPECTED);
+    cb_occurred += 'write ';
+  } else if (countDrains == 2) {
+    assert.equal(fs.readFileSync(filepath), EXPECTED + EXPECTED);
+    file.end();
+  }
+});
+
+file.on('close', function() {
+  cb_occurred += 'close ';
+  assert.strictEqual(file.bytesWritten, EXPECTED.length * 2);
+  file.write('should not work anymore');
+});
+
+
+file.on('error', function(err) {
+  cb_occurred += 'error ';
+  assert.ok(err.message.indexOf('not writable') >= 0);
+});
+
+
+for (var i = 0; i < 11; i++) {
+  assert.strictEqual(file.write(i), false);
+}
+cb_occurred += 'write ';

--- a/test/simple/test-file-write-stream3.js
+++ b/test/simple/test-file-write-stream3.js
@@ -1,0 +1,187 @@
+
+var common = require('../common');
+var assert = require('assert');
+
+var path = require('path'),
+    fs = require('fs'),
+    util = require('util');
+
+
+var filepath = path.join(common.tmpDir, 'write_pos.txt');
+
+
+var cb_expected = 'write open close write open close write open close ',
+    cb_occurred = '';
+
+var fileDataInitial = 'abcdefghijklmnopqrstuvwxyz';
+
+var fileDataExpected_1 = 'abcdefghijklmnopqrstuvwxyz';
+var fileDataExpected_2 = 'abcdefghij123456qrstuvwxyz';
+var fileDataExpected_3 = 'abcdefghij\u2026\u2026qrstuvwxyz';
+
+
+process.on('exit', function() {
+  removeTestFile();
+  if ( cb_occurred !== cb_expected) {
+    console.log('  Test callback events missing or out of order:');
+    console.log('    expected: %j', cb_expected);
+    console.log('    occurred: %j', cb_occurred);
+    assert.strictEqual(cb_occurred, cb_expected,
+          'events missing or out of order: "' +
+          cb_occurred + '" !== "' + cb_expected + '"');
+  }
+});
+
+function removeTestFile() {
+  try {
+    fs.unlinkSync(filepath);
+  } catch (ex) { }
+}
+
+
+removeTestFile();
+
+
+function run_test_1() {
+  var file, buffer, options;
+
+  options = {};
+  file = fs.createWriteStream(filepath, options);
+  console.log('    (debug: start         ', file.start);
+  console.log('    (debug: pos           ', file.pos);
+
+  file.on('open', function(fd) {
+    cb_occurred += 'open ';
+  });
+
+  file.on('close', function() {
+    cb_occurred += 'close ';
+    console.log('    (debug: bytesWritten  ', file.bytesWritten);
+    console.log('    (debug: start         ', file.start);
+    console.log('    (debug: pos           ', file.pos);
+    assert.strictEqual(file.bytesWritten, buffer.length);
+    var fileData = fs.readFileSync(filepath, 'utf8');
+    console.log('    (debug: file data   ', fileData);
+    console.log('    (debug: expected    ', fileDataExpected_1);
+    assert.equal(fileData, fileDataExpected_1);
+
+    run_test_2();
+  });
+
+  file.on('error', function(err) {
+    cb_occurred += 'error ';
+    console.log('    (debug: err event ', err);
+    throw err;
+  });
+
+  buffer = new Buffer(fileDataInitial);
+  file.write(buffer);
+  cb_occurred += 'write ';
+
+  file.end();
+}
+
+
+function run_test_2() {
+  var file, buffer, options;
+
+  buffer = new Buffer('123456');
+
+  options = { start: 10,
+              flags: 'r+' };
+  file = fs.createWriteStream(filepath, options);
+  console.log('    (debug: start         ', file.start);
+  console.log('    (debug: pos           ', file.pos);
+
+  file.on('open', function(fd) {
+    cb_occurred += 'open ';
+  });
+
+  file.on('close', function() {
+    cb_occurred += 'close ';
+    console.log('    (debug: bytesWritten  ', file.bytesWritten);
+    console.log('    (debug: start         ', file.start);
+    console.log('    (debug: pos           ', file.pos);
+    assert.strictEqual(file.bytesWritten, buffer.length);
+    var fileData = fs.readFileSync(filepath, 'utf8');
+    console.log('    (debug: file data   ', fileData);
+    console.log('    (debug: expected    ', fileDataExpected_2);
+    assert.equal(fileData, fileDataExpected_2);
+
+    run_test_3();
+  });
+
+  file.on('error', function(err) {
+    cb_occurred += 'error ';
+    console.log('    (debug: err event ', err);
+    throw err;
+  });
+
+  file.write(buffer);
+  cb_occurred += 'write ';
+
+  file.end();
+}
+
+
+function run_test_3() {
+  var file, buffer, options;
+
+  var data = '\u2026\u2026',    // 3 bytes * 2 = 6 bytes in UTF-8
+      fileData;
+
+  options = { start: 10,
+              flags: 'r+' };
+  file = fs.createWriteStream(filepath, options);
+  console.log('    (debug: start         ', file.start);
+  console.log('    (debug: pos           ', file.pos);
+
+  file.on('open', function(fd) {
+    cb_occurred += 'open ';
+  });
+
+  file.on('close', function() {
+    cb_occurred += 'close ';
+    console.log('    (debug: bytesWritten  ', file.bytesWritten);
+    console.log('    (debug: start         ', file.start);
+    console.log('    (debug: pos           ', file.pos);
+    assert.strictEqual(file.bytesWritten, data.length * 3);
+    fileData = fs.readFileSync(filepath, 'utf8');
+    console.log('    (debug: file data   ', fileData);
+    console.log('    (debug: expected    ', fileDataExpected_3);
+    assert.equal(fileData, fileDataExpected_3);
+
+    run_test_4();
+  });
+
+  file.on('error', function(err) {
+    cb_occurred += 'error ';
+    console.log('    (debug: err event ', err);
+    throw err;
+  });
+
+  file.write(data, 'utf8');
+  cb_occurred += 'write ';
+
+  file.end();
+}
+
+
+function run_test_4() {
+  var file, options;
+
+  options = { start: -5,
+              flags: 'r+' };
+
+  //  Error: start must be >= zero
+  assert.throws(
+    function() {
+      file = fs.createWriteStream(filepath, options);
+    },
+    /start must be/
+  );
+
+}
+
+run_test_1();
+


### PR DESCRIPTION
While one is able to specify where writes should update a file when
using fs.write directly, if one wanted to use file streams there was
no way to set a starting position.  This change implements a 'start'
option to createWriteStream() along with code to handle positioned
writing, allowing partial update of files while taking advantage of
the existing file stream handler.

A similar feature was implemented July 2010 by tuxychandru that allowed
positioned reading with createReadStream.
  Support for reading byte ranges from files using fs.createReadStream   July 20, 2010
  https://github.com/joyent/node/commit/f5f7cb92646169a7096360506cef79a7a45571fa#lib/fs.js

That feature corresponded to the HTTP GET request with Range: header specifying
a byte range.

The feature implemented by this change would correspond to HTTP PUT requests
that specify the Content-Range: header.

This change does _not_ implement an 'end' parameter.  Unlike the situation
with ReadStream, where continued reading is controlled by the stream code,
with WriteStream the user is controlling how much to write, and may end
the writing at any point of their choice.

Files fs.js and doc/api/fs.markdown are updated and two test files added.
These may be the first tests for pwrite-style write requests?

Narrative:

Minor changes:

While examining the previous implementation for read (in order to better
conform to user expectations) a couple rough spots were seen.  In more than
a couple places 'self' and 'this' were exchanged, with the usual discipline
of using 'self' only inside closures not being observed.  The code was thus
a little more difficult to read.  Purely out of over-fastidiousness, 'self'
was replaced with 'this' where appropriate.  No change to execution, and
not strictly needed.

In createReadStream, while trying to understand the initialization code
that set 'this.pos' from 'this.start', it was realized that the extra code
in ._read() was not needed.  'this.pos' could be set initially in the
constructor.  The extra 'if' could be removed from this hot code.

One lint change of double-quotes to single.

Major changes:

WriteStream.write is the correct place to queue the fs.write request with
the next file write position 'this.pos'.  But where to update 'this.pos'?

In the previous code it was possible to queue an fs.write with either
Buffer or string data.  Of course, a string might encode into some
not-yet-known number of bytes.  While a write completion will know
exactly how many bytes were written, we can't wait until then.  Multiple
writes can be queued before any writes finish, and we must update
'this.pos' before they finish.  So we _must_ discover how many bytes any
particular write will occupy as we are queueing writes.

Now since the "fs.write of string data feature" isn't supposed to be known
(undocumented), but WriteStream.write _is_ documented to handle both Buffer
and string data, there should be little shock if encoding was done at
the stream level.  Encoding from string to Buffer inside WriteStream.write
would not increase the work done, merely move the work.

The fs.write queueing code is rewritten, encoding possible strings to
Buffers, then queueing only buffers.  The always available 'buffer.length'
then gives the byte count needed to update 'this.pos'.

Lastly, noticing that there were two places in the WriteStream.flush
code where fs.write was being handled, the code was re-ordered to put
fs.write handling (hot) first after error handling.  (And the extra
"var self = this;" was removed)

New test file test-file-write-stream2.js is not entirely needed.  It is
a variation on test-file-write-stream.js.  It differs by not using some
of the undocumented callbacks that may be legacy code, but rather _only_
events.  It also attempts to check for success by not only 'counting'
the number of events seen, but also the _order_ of events seen.  I think
this then has more information for the reader, and might catch a bug
not otherwise detectable?

New test file test-file-write-stream3.js tests the new positioned writes
with WriteStream.
