### PR TITLE
Getters/Setters in VM's Context

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -21,19 +21,6 @@
 
 var binding = process.binding('evals');
 
-binding.NodeScript._setCloneMethod(function(source, target) {
-  Object.getOwnPropertyNames(source).forEach(function(key) {
-    try {
-      var desc = Object.getOwnPropertyDescriptor(source, key);
-      if (desc.value === source) desc.value = target;
-
-      Object.defineProperty(target, key, desc);
-    } catch (e) {
-      // Catch sealed properties errors
-    }
-  });
-});
-
 exports.Script = binding.NodeScript;
 exports.createScript = function(code, ctx, name) {
   return new exports.Script(code, ctx, name);

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -23,12 +23,14 @@ var binding = process.binding('evals');
 
 binding.NodeScript._setCloneMethod(function(source, target) {
   Object.getOwnPropertyNames(source).forEach(function(key) {
-    delete target[key];
+    try {
+      var desc = Object.getOwnPropertyDescriptor(source, key);
+      if (desc.value === source) desc.value = target;
 
-    var desc = Object.getOwnPropertyDescriptor(source, key);
-    if (desc.value === source) desc.value = target;
-
-    Object.defineProperty(target, key, desc);
+      Object.defineProperty(target, key, desc);
+    } catch (e) {
+      // Catch sealed properties errors
+    }
   });
 });
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -21,6 +21,17 @@
 
 var binding = process.binding('evals');
 
+binding.NodeScript._setCloneMethod(function(source, target) {
+  Object.getOwnPropertyNames(source).forEach(function(key) {
+    delete target[key];
+
+    var desc = Object.getOwnPropertyDescriptor(source, key);
+    if (desc.value === source) desc.value = target;
+
+    Object.defineProperty(target, key, desc);
+  });
+});
+
 exports.Script = binding.NodeScript;
 exports.createScript = function(code, ctx, name) {
   return new exports.Script(code, ctx, name);

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -106,6 +106,8 @@ Persistent<Function> cloneObjectMethod;
 
 void CloneObject(Handle<Object> recv,
                  Handle<Object> source, Handle<Object> target) {
+  HandleScope scope;
+
   Handle<Value> args[] = {source, target};
   cloneObjectMethod->Call(recv, 2, args);
 }

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -37,9 +37,11 @@ using v8::TryCatch;
 using v8::String;
 using v8::Exception;
 using v8::Local;
+using v8::Null;
 using v8::Array;
 using v8::Persistent;
 using v8::Integer;
+using v8::Function;
 using v8::FunctionTemplate;
 
 
@@ -94,8 +96,19 @@ class WrappedScript : ObjectWrap {
   static Handle<Value> CompileRunInThisContext(const Arguments& args);
   static Handle<Value> CompileRunInNewContext(const Arguments& args);
 
+  static Handle<Value> SetCloneMethod(const Arguments& args);
+
   Persistent<Script> script_;
 };
+
+
+Persistent<Function> cloneObjectMethod;
+
+void CloneObject(Handle<Object> recv,
+                 Handle<Object> source, Handle<Object> target) {
+  Handle<Value> args[] = {source, target};
+  cloneObjectMethod->Call(recv, 2, args);
+}
 
 
 void WrappedContext::Initialize(Handle<Object> target) {
@@ -177,6 +190,10 @@ void WrappedScript::Initialize(Handle<Object> target) {
                             "runInNewContext",
                             WrappedScript::RunInNewContext);
 
+  NODE_SET_PROTOTYPE_METHOD(constructor_template,
+                            "_setCloneMethod",
+                            WrappedScript::SetCloneMethod);
+
   NODE_SET_METHOD(constructor_template,
                   "createContext",
                   WrappedScript::CreateContext);
@@ -192,6 +209,10 @@ void WrappedScript::Initialize(Handle<Object> target) {
   NODE_SET_METHOD(constructor_template,
                   "runInNewContext",
                   WrappedScript::CompileRunInNewContext);
+
+  NODE_SET_METHOD(constructor_template,
+                  "_setCloneMethod",
+                  WrappedScript::SetCloneMethod);
 
   target->Set(String::NewSymbol("NodeScript"),
               constructor_template->GetFunction());
@@ -225,14 +246,8 @@ Handle<Value> WrappedScript::CreateContext(const Arguments& args) {
 
   if (args.Length() > 0) {
     Local<Object> sandbox = args[0]->ToObject();
-    Local<Array> keys = sandbox->GetPropertyNames();
 
-    for (uint32_t i = 0; i < keys->Length(); i++) {
-      Handle<String> key = keys->Get(Integer::New(i))->ToString();
-      Handle<Value> value = sandbox->Get(key);
-      if(value == sandbox) { value = context; }
-      context->Set(key, value);
-    }
+    CloneObject(args.This(), sandbox, context);
   }
 
 
@@ -273,6 +288,15 @@ Handle<Value> WrappedScript::CompileRunInThisContext(const Arguments& args) {
 Handle<Value> WrappedScript::CompileRunInNewContext(const Arguments& args) {
   return
     WrappedScript::EvalMachine<compileCode, newContext, returnResult>(args);
+}
+
+Handle<Value> WrappedScript::SetCloneMethod(const Arguments& args) {
+  HandleScope scope;
+
+  Local<Function> cloneObjectMethod_ = Local<Function>::Cast(args[0]);
+  cloneObjectMethod = Persistent<Function>::New(cloneObjectMethod_);
+
+  return scope.Close(Null());
 }
 
 
@@ -343,14 +367,7 @@ Handle<Value> WrappedScript::EvalMachine(const Arguments& args) {
 
     // Copy everything from the passed in sandbox (either the persistent
     // context for runInContext(), or the sandbox arg to runInNewContext()).
-    keys = sandbox->GetPropertyNames();
-
-    for (i = 0; i < keys->Length(); i++) {
-      Handle<String> key = keys->Get(Integer::New(i))->ToString();
-      Handle<Value> value = sandbox->Get(key);
-      if (value == sandbox) { value = context->Global(); }
-      context->Global()->Set(key, value);
-    }
+    CloneObject(args.This(), sandbox, context->Global());
   }
 
   // Catch errors
@@ -408,13 +425,7 @@ Handle<Value> WrappedScript::EvalMachine(const Arguments& args) {
 
   if (context_flag == userContext || context_flag == newContext) {
     // success! copy changes back onto the sandbox object.
-    keys = context->Global()->GetPropertyNames();
-    for (i = 0; i < keys->Length(); i++) {
-      Handle<String> key = keys->Get(Integer::New(i))->ToString();
-      Handle<Value> value = context->Global()->Get(key);
-      if (value == context->Global()) { value = sandbox; }
-      sandbox->Set(key, value);
-    }
+    CloneObject(args.This(), context->Global(), sandbox);
   }
 
   if (context_flag == newContext) {

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -105,7 +105,7 @@ class WrappedScript : ObjectWrap {
 Persistent<Function> cloneObjectMethod;
 
 void CloneObject(Handle<Object> recv,
-                 Handle<Object> source, Handle<Object> target) {
+                 Handle<Value> source, Handle<Value> target) {
   HandleScope scope;
 
   Handle<Value> args[] = {source, target};
@@ -369,7 +369,7 @@ Handle<Value> WrappedScript::EvalMachine(const Arguments& args) {
 
     // Copy everything from the passed in sandbox (either the persistent
     // context for runInContext(), or the sandbox arg to runInNewContext()).
-    CloneObject(args.This(), sandbox, context->Global());
+    CloneObject(args.This(), sandbox, context->Global()->GetPrototype());
   }
 
   // Catch errors
@@ -427,7 +427,7 @@ Handle<Value> WrappedScript::EvalMachine(const Arguments& args) {
 
   if (context_flag == userContext || context_flag == newContext) {
     // success! copy changes back onto the sandbox object.
-    CloneObject(args.This(), context->Global(), sandbox);
+    CloneObject(args.This(), context->Global()->GetPrototype(), sandbox);
   }
 
   if (context_flag == newContext) {

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -112,16 +112,16 @@ void CloneObject(Handle<Object> recv,
   if (cloneObjectMethod.IsEmpty()) {
     Local<Function> cloneObjectMethod_ = Local<Function>::Cast(
       Script::Compile(String::New(
-        "(function(source, target) {\
-           Object.getOwnPropertyNames(source).forEach(function(key) {\
-           try {\
-             var desc = Object.getOwnPropertyDescriptor(source, key);\
-             if (desc.value === source) desc.value = target;\
-             Object.defineProperty(target, key, desc);\
-           } catch (e) {\
+        "(function(source, target) {\n\
+           Object.getOwnPropertyNames(source).forEach(function(key) {\n\
+           try {\n\
+             var desc = Object.getOwnPropertyDescriptor(source, key);\n\
+             if (desc.value === source) desc.value = target;\n\
+             Object.defineProperty(target, key, desc);\n\
+           } catch (e) {\n\
             // Catch sealed properties errors\n\
-           }\
-         });\
+           }\n\
+         });\n\
         })"
       ), String::New("binding:script"))->Run()
     );

--- a/test/simple/test-vm-create-context-accessors.js
+++ b/test/simple/test-vm-create-context-accessors.js
@@ -1,0 +1,26 @@
+var common = require('../common');
+var assert = require('assert');
+var vm = require('vm');
+
+var ctx = {};
+
+Object.defineProperty(ctx, 'getter', {
+  get: function() {
+    return 'ok';
+  }
+});
+
+var val;
+Object.defineProperty(ctx, 'setter', {
+  set: function(_val) {
+    val = _val;
+  },
+  get: function() {
+    return 'ok=' + val;
+  }
+});
+
+ctx = vm.createContext(ctx);
+
+var result = vm.runInContext('setter = "test";[getter,setter]', ctx);
+assert.deepEqual(result, ['ok', 'ok=test']);


### PR DESCRIPTION
With this change it's possible to have getters and setters in global object for `repl` and `vm` module.

Please review this before #1667 (I'll made some changes to it if that land in master)
