### PR TITLE
[script] remove obsolete 'using v8::Null'

### DIFF
--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -37,7 +37,6 @@ using v8::TryCatch;
 using v8::String;
 using v8::Exception;
 using v8::Local;
-using v8::Null;
 using v8::Array;
 using v8::Persistent;
 using v8::Integer;


### PR DESCRIPTION
While reviewing node_script.cc code I found that this statement isn't used anywhere now.
