### PR TITLE
Fix repl test

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -163,9 +163,9 @@ function REPLServer(prompt, stream, eval) {
                 self.context,
                 'repl',
                 function(e, ret) {
-        if (e) return finish(e);
+        if (e && !isSyntaxError(e)) return finish(e);
 
-        if (ret === 'function' || e) {
+        if (typeof ret === 'function' || e) {
           // Now as statement without parens.
           self.eval(self.bufferedCommand, self.context, 'repl', finish);
         } else {
@@ -177,14 +177,18 @@ function REPLServer(prompt, stream, eval) {
       finish(null);
     }
 
-    function finish(e, ret) {
+    function isSyntaxError(e) {
       // Convert error to string
       e = e && (e.stack || e.toString());
+      return e && e.match(/^SyntaxError/) &&
+             !(e.match(/^SyntaxError: Unexpected token .*\n/) &&
+             e.match(/\n    at Object.parse \(native\)\n/));
+    }
+
+    function finish(e, ret) {
 
       // If error was SyntaxError and not JSON.parse error
-      if (e && e.match(/^SyntaxError/) &&
-          !(e.match(/^SyntaxError: Unexpected token .*\n/) &&
-            e.match(/\n    at Object.parse \(native\)\n/))) {
+      if (isSyntaxError(e)) {
         // Start buffering data like that:
         // {
         // ...  x: 1
@@ -192,7 +196,7 @@ function REPLServer(prompt, stream, eval) {
         self.displayPrompt();
         return;
       } else if (e) {
-        self.outputStream.write(e + '\n');
+        self.outputStream.write((e.stack || e) + '\n');
       }
 
       // Clear buffer if no SyntaxErrors


### PR DESCRIPTION
Fix syntax error handling for 'throw ...', fix return value assertion ( when typing `function blah() {}` )
