### PR TITLE
REPL sources file from NODE_STARTUP env var

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -107,8 +107,26 @@
       var Module = NativeModule.require('module');
 
       if (NativeModule.require('tty').isatty(fd)) {
+
         // REPL
-        Module.requireRepl().start();
+        var ctx = Module.requireRepl().start().context;
+
+        var startup = process.env.NODE_STARTUP;
+        if (startup) {
+          var path = NativeModule.require('path');
+          var fs = NativeModule.require('fs');
+          var vm = NativeModule.require('vm');
+
+          path.exists(startup, function(exists) {
+            if (exists) {
+              fs.readFile(startup, function(err, data) {
+                if (! err) {
+                  vm.runInContext(data.toString('utf8'), ctx);
+                }
+              });
+            }
+          });
+        }
 
       } else {
         // Read all of stdin - execute it.

--- a/src/node.js
+++ b/src/node.js
@@ -111,15 +111,15 @@
         // REPL
         var ctx = Module.requireRepl().start().context;
 
-        var startup = process.env.NODE_STARTUP;
-        if (startup) {
+        var stup = process.env.NODE_STARTUP;
+        if (stup) {
           var path = NativeModule.require('path');
           var fs = NativeModule.require('fs');
           var vm = NativeModule.require('vm');
 
-          path.exists(startup, function(exists) {
+          path.exists(stup, function(exists) {
             if (exists) {
-              fs.readFile(startup, function(err, data) {
+              fs.readFile(stup, function(err, data) {
                 if (! err) {
                   vm.runInContext(data.toString('utf8'), ctx);
                 }


### PR DESCRIPTION
This is a small patch.  If the NODE_STARTUP env var is defined and is a file when the user enters the node REPL, then the file will be executed in the REPL's context.

This is nice b/c it allows the user to set up things like a ~/.node_history file, automatic imports, etc.
