### PR TITLE
add a safer (and slower, and worse) runInNewContext (see #1469)

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -30,3 +30,48 @@ exports.createContext = binding.NodeScript.createContext;
 exports.runInContext = binding.NodeScript.runInContext;
 exports.runInThisContext = binding.NodeScript.runInThisContext;
 exports.runInNewContext = binding.NodeScript.runInNewContext;
+
+exports.runInNewSafeContext = function(code, context) {
+  var middleContext = {};
+  middleContext.middleContext = middleContext;
+  middleContext.subGlobal = context;
+  middleContext.g_code = code;
+  middleContext.runInNewContext = binding.NodeScript.runInNewContext;
+  var copyingClosure = (function() {
+    function deepClone(obj) {
+      var type = typeof obj;
+      if (type==='undefined' || obj===null || type==='boolean' || type==='number' || type==='string') {
+        return obj;
+      }
+      if (type==='function') {
+        return function() {
+          obj.apply(this, arguments);
+        };
+      }
+      if (type==='object') {
+        var toReturn = Array.isArray(obj) ? [] : {};
+        var objKeys = Object.getOwnPropertyNames(obj);
+        for (var i=0; i<objKeys.length; i++) {
+          toReturn[objKeys[i]] = deepClone(obj[objKeys[i]]);
+        }
+        return toReturn;
+      }
+      throw new Error('unknown typeof result: "'+type+'"');
+    }
+    subGlobal = deepClone(subGlobal);
+  }).toString();
+  var newCode = "("+copyingClosure+")();"
+  var protectiveRecursion = (function() {
+    if (!this || !this.goOn) {
+      return arguments.callee.call({goOn: true});
+    }
+    var code = g_code;
+    delete middleContext.g_code;
+    var run = runInNewContext;
+    delete middleContext.runInNewContext;
+    delete middleContext.middleContext;
+    return run(code, subGlobal);
+  }).toString();
+  newCode += "("+protectiveRecursion+")()";
+  return binding.NodeScript.runInNewContext(newCode, middleContext);
+}


### PR DESCRIPTION
This adds a function `vm.runInNewSafeContext` that takes the same arguments as `vm.runInNewContext` but is more secure:
- it prevents crawling up the caller chain using recursion
- it deep-clones everything in the global object and replaces functions with wrapper functions so that `console.log.constructor` is the `Function` from the eval-context, not the one from the global context (`new Function(code)` constructs a function that behaves like it was run in the context the `Function` thing comes from, so it's like a leaked `eval`)

I didn't just put this in `vm.runInNewContext` because some people maybe won't like the auto-deep-clone.

```
> vm.runInNewSafeContext('function f(){return f.caller===f.caller.caller};f()',{print:console.log})
true
> vm.runInNewContext('print.constructor',{print:function(){}})===Function
true
> vm.runInNewSafeContext('print.constructor',{print:function(){}})===Function
false
```
