### PR TITLE
possibly test GH-1719

### DIFF
--- a/test/pummel/test-regress-GH-1719.js
+++ b/test/pummel/test-regress-GH-1719.js
@@ -1,0 +1,31 @@
+var fs = require('fs'),
+    http = require('http'),
+    https = require('https'),
+    common = require('../common'),
+    options = {
+        host: 'localhost',
+        port: 4443,
+        path: '/'
+    };
+
+https.createServer({
+    key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+    cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+}, function (req, res) {
+    res.end('\n');
+}).listen(4443);
+
+// the error from the previous request should not affect a valid request
+function http_error() {
+    https.get(options, function (res) {
+        // normal behavior
+        process.exit();
+    }).on('error', function (e) {
+        console.assert(false, e.message + ' on a valid request');
+    });
+}
+
+// an http get to an https server will trigger an ssl error
+http.get(options, function (res) {
+    console.assert(false, 'server should never accept http over https');
+}).on('error', http_error);

--- a/test/pummel/test-regress-GH-1719.js
+++ b/test/pummel/test-regress-GH-1719.js
@@ -17,6 +17,7 @@ https.createServer({
 
 // the error from the previous request should not affect a valid request
 function http_error() {
+    options.agent = false;
     https.get(options, function (res) {
         // normal behavior
         process.exit();


### PR DESCRIPTION
In trying to reduce the test case from https://gist.github.com/1220229 to be as simple / fast as possible I came up with this.

The problem is that I don't know if this test is valid. It fails both 0.4.11 and 0.4.12, where the scenario in the gist "works" with 0.4.12. Maybe it fails because everything is happening in the same process? It still seems like this _should_ pass.

You will notice that with 0.4.12 the error `(node SSL) error:1407609C:SSL routines:SSL23_GET_CLIENT_HELLO:http request` gets printed twice.

I'll create another test that spawns separate processes, but I didn't want to throw this away without getting some feedback.
