### PR TITLE
doc patch for 1676, path.normalize no longer works for URLs

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -3,6 +3,9 @@
 This module contains utilities for handling and transforming file
 paths.  Almost all these methods perform only string transformations.
 The file system is not consulted to check whether paths are valid.
+The behavior of the methods of this module is platform dependent, 
+they expect and returns forward slashes for Unix systems and back 
+slashes for Windows.
 
 `path.exists` and `path.existsSync` are the exceptions, and should
 logically be found in the fs module as they do access the file system.

--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -74,3 +74,10 @@ Take a parsed URL object, and return a formatted URL string.
 ### url.resolve(from, to)
 
 Take a base URL, and a href URL, and resolve them as a browser would for an anchor tag.
+The pathname returned has ./ and ../ resolved to an absolute path.
+
+### url.resolveObject(from, to)
+
+Take a base URL, and a href URL, and resolve them as a browser would for an anchor tag.
+The to and from parameters should be parsed objects representing URLs, and not strings.
+The pathname returned has ./ and ../ resolved to an absolute path.


### PR DESCRIPTION
make OS differences between path implementations clearer
indicate that the url module can resolve relative URLs

N.B. documenting url.resolveObject() exported function, which I'm using. 
I assume exported functions should be documented?  Or are there reasons to export functions that are not really a part of the API?
