### PR TITLE
Fix for issue #1710 : aborts from new Buffer(too_large)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -24,6 +24,7 @@ var assert = require('assert');
 
 exports.INSPECT_MAX_BYTES = 50;
 
+var v8ExternalArraykMaxLength = 0x3fffffff;
 
 function toHex(n) {
   if (n < 16) return '0' + n.toString(16);
@@ -230,7 +231,9 @@ function Buffer(subject, encoding, offset) {
                         'array or string.');
     }
 
-    if (this.length > Buffer.poolSize) {
+    if (this.length > v8ExternalArraykMaxLength) {
+        throw new Error('Invalid array length');
+    } else if (this.length > Buffer.poolSize) {
       // Big buffer, just alloc one.
       this.parent = new SlowBuffer(this.length);
       this.offset = 0;

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -689,3 +689,27 @@ buf.write('123456', 'base64');
 assert.equal(Buffer._charsWritten, 6);
 buf.write('00010203040506070809', 'hex');
 assert.equal(Buffer._charsWritten, 18);
+
+// request size too large (0x3fffffff)
+var kMaxLength = 0x3fffffff;
+var bigbuffa;
+caught_error = null;
+
+try {
+  bigbuffa = new Buffer(kMaxLength+1);
+} catch (err) {
+  caught_error = err;
+}
+assert.strictEqual(caught_error.message, 'Invalid array length');
+
+// request size large but not too large
+caught_error = null;
+
+try {
+  // XXX Can't handle non-integral values?
+//bigbuffa = new Buffer(kMaxLength/2);
+  bigbuffa = new Buffer(Math.floor(kMaxLength/2));
+} catch (err) {
+  caught_error = err;
+}
+assert.strictEqual(caught_error, null);


### PR DESCRIPTION
"std::bad_alloc exception if a too big buffer is allocated"

Add check against for upper limit size for ExternalArray within v8.
