### PR TITLE
master, added an option to "request" of http.js to enable to choose the protocol version

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -913,9 +913,11 @@ function ClientRequest(options, defaultPort) {
   this._last = true;
 
   if (Array.isArray(headers)) {
-    this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + httpVersion + '\r\n', headers);
+    this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + 
+      httpVersion + '\r\n', headers);
   } else if (this.getHeader('expect')) {
-    this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + httpVersion + '\r\n', this._renderHeaders());
+    this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + 
+      httpVersion + '\r\n', this._renderHeaders());
   }
 
 }
@@ -925,7 +927,8 @@ util.inherits(ClientRequest, OutgoingMessage);
 exports.ClientRequest = ClientRequest;
 
 ClientRequest.prototype._implicitHeader = function() {
-  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + this.httpVersion + '\r\n', this._renderHeaders());
+  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + 
+    this.httpVersion + '\r\n', this._renderHeaders());
 }
 
 ClientRequest.prototype.abort = function() {
@@ -1691,7 +1694,7 @@ Client.prototype.request = function(method, url, headers, httpVersion) {
 
   var self = this;
 
-  if(httpVersion != "1.1" && httpVersion != "1.0") {
+  if(httpVersion !== "1.1" && httpVersion !== "1.0") {
     httpVersion = "1.1";
   }
 
@@ -1707,7 +1710,7 @@ Client.prototype.request = function(method, url, headers, httpVersion) {
   this._cycle();
 
   return req;
-}
+};
 
 exports.cat = function(url, encoding_, headers_) {
   var encoding = 'utf8',

--- a/lib/http.js
+++ b/lib/http.js
@@ -877,6 +877,10 @@ function ClientRequest(options, defaultPort) {
 
   var method = this.method = (options.method || 'GET').toUpperCase();
   this.path = options.path || '/';
+  var httpVersion = this.httpVersion = options.httpVersion || "1.1";
+  info = httpVersion.split('.');
+  this.httpVersionMajor = info[0];
+  this.httpVersionMinor = info[1];
 
   if (!Array.isArray(headers)) {
     if (options.headers) {
@@ -898,7 +902,7 @@ function ClientRequest(options, defaultPort) {
   }
 
   this.shouldKeepAlive = false;
-  if (method === 'GET' || method === 'HEAD') {
+  if (method === 'GET' || method === 'HEAD' || version === "1.0") {
     this.useChunkedEncodingByDefault = false;
   } else {
     this.useChunkedEncodingByDefault = true;
@@ -909,9 +913,9 @@ function ClientRequest(options, defaultPort) {
   this._last = true;
 
   if (Array.isArray(headers)) {
-    this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n', headers);
+    this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + httpVersion + '\r\n', headers);
   } else if (this.getHeader('expect')) {
-    this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n', this._renderHeaders());
+    this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + httpVersion + '\r\n', this._renderHeaders());
   }
 
 }
@@ -921,7 +925,7 @@ util.inherits(ClientRequest, OutgoingMessage);
 exports.ClientRequest = ClientRequest;
 
 ClientRequest.prototype._implicitHeader = function() {
-  this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n', this._renderHeaders());
+  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + this.httpVersion + '\r\n', this._renderHeaders());
 }
 
 ClientRequest.prototype.abort = function() {
@@ -1676,9 +1680,10 @@ Client.prototype._ensureConnection = function() {
 };
 
 
-Client.prototype.request = function(method, url, headers) {
+Client.prototype.request = function(method, url, headers, httpVersion) {
   if (typeof(url) != 'string') {
     // assume method was omitted, shift arguments
+    httpVersion = headers;
     headers = url;
     url = method;
     method = 'GET';
@@ -1686,10 +1691,15 @@ Client.prototype.request = function(method, url, headers) {
 
   var self = this;
 
+  if(httpVersion != "1.1" && httpVersion != "1.0") {
+    httpVersion = "1.1";
+  }
+
   var options = {
     method: method || 'GET',
     path: url || '/',
-    headers: headers
+    headers: headers,
+    httpVersion: httpVersion
   };
 
   var req = new ClientRequest(options);
@@ -1697,8 +1707,7 @@ Client.prototype.request = function(method, url, headers) {
   this._cycle();
 
   return req;
-};
-
+}
 
 exports.cat = function(url, encoding_, headers_) {
   var encoding = 'utf8',

--- a/lib/http.js
+++ b/lib/http.js
@@ -902,7 +902,7 @@ function ClientRequest(options, defaultPort) {
   }
 
   this.shouldKeepAlive = false;
-  if (method === 'GET' || method === 'HEAD' || version === "1.0") {
+  if (method === 'GET' || method === 'HEAD' || httpVersion === "1.0") {
     this.useChunkedEncodingByDefault = false;
   } else {
     this.useChunkedEncodingByDefault = true;

--- a/lib/http2.js
+++ b/lib/http2.js
@@ -979,6 +979,9 @@ function ClientRequest(options, cb) {
 
   options.port = options.port || options.defaultPort;
   options.host = options.host || 'localhost';
+  options.httpVersion = options.httpVersion || '1.1';
+  
+  self.httpVersion = options.httpVersion;
 
   if (options.setHost === undefined) {
     options.setHost = true;
@@ -1009,16 +1012,16 @@ function ClientRequest(options, cb) {
     }
   }
 
-  if (method === 'GET' || method === 'HEAD') {
+  if (method === 'GET' || method === 'HEAD' || httpVersion === "1.0") {
     self.useChunkedEncodingByDefault = false;
   } else {
     self.useChunkedEncodingByDefault = true;
   }
 
   if (Array.isArray(options.headers)) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n', options.headers);
+    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + option.httpVersion + '\r\n', options.headers);
   } else if (self.getHeader('expect')) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n', self._renderHeaders());
+    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + option.httpVersion + '\r\n', self._renderHeaders());
   }
   if (self.socketPath) {
     self._last = true;
@@ -1054,7 +1057,7 @@ util.inherits(ClientRequest, OutgoingMessage);
 exports.ClientRequest = ClientRequest;
 
 ClientRequest.prototype._implicitHeader = function() {
-  this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n', this._renderHeaders());
+  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + this.httpVersion + '\r\n', this._renderHeaders());
 };
 
 ClientRequest.prototype.abort = function() {
@@ -1465,17 +1468,24 @@ function Client(port, host) {
   this.agent = new Agent({ host: host, port: port, maxSockets: 1 });
 }
 util.inherits(Client, EventEmitter);
-Client.prototype.request = function(method, path, headers) {
+Client.prototype.request = function(method, path, headers, httpVersion) {
   var self = this;
   var options = {};
   options.host = self.host;
   options.port = self.port;
   if (method[0] === '/') {
+    httpVersion = headers;
     headers = path;
     path = method;
     method = 'GET';
   }
+
+  if(httpVersion != "1.1" && httpVersion != "1.0") {
+    httpVersion = "1.1";
+  }
+
   options.method = method;
+  options.httpVersion = httpVersion;
   options.path = path;
   options.headers = headers;
   options.agent = self.agent;

--- a/lib/http2.js
+++ b/lib/http2.js
@@ -1019,9 +1019,11 @@ function ClientRequest(options, cb) {
   }
 
   if (Array.isArray(options.headers)) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + option.httpVersion + '\r\n', options.headers);
+    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + 
+      option.httpVersion + '\r\n', options.headers);
   } else if (self.getHeader('expect')) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + option.httpVersion + '\r\n', self._renderHeaders());
+    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + 
+      option.httpVersion + '\r\n', self._renderHeaders());
   }
   if (self.socketPath) {
     self._last = true;
@@ -1057,7 +1059,8 @@ util.inherits(ClientRequest, OutgoingMessage);
 exports.ClientRequest = ClientRequest;
 
 ClientRequest.prototype._implicitHeader = function() {
-  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + this.httpVersion + '\r\n', this._renderHeaders());
+  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + 
+    this.httpVersion + '\r\n', this._renderHeaders());
 };
 
 ClientRequest.prototype.abort = function() {
@@ -1480,7 +1483,7 @@ Client.prototype.request = function(method, path, headers, httpVersion) {
     method = 'GET';
   }
 
-  if(httpVersion != "1.1" && httpVersion != "1.0") {
+  if(httpVersion !== "1.1" && httpVersion !== "1.0") {
     httpVersion = "1.1";
   }
 


### PR DESCRIPTION
Hi again,

I came to an issue while trying to proxy requests from wget: it understands only HTTP 1.0. While the current version of the code is able to answer him with the right version, it doesn't enable the user to choose protocol version for the proxyed request.

With this pull request, i try to introduce this feature as smoothly as possible in the code.

thanks
