### PR TITLE
Raise an error when a malformed package.json file is found

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -109,7 +109,7 @@ function readPackage(requestPath) {
   try {
     var pkg = packageCache[requestPath] = JSON.parse(json)
   } catch (e) {
-    e.path = jsonPath
+    e.path = jsonPath;
     e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
     throw e;
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -102,11 +102,16 @@ function readPackage(requestPath) {
   try {
     var jsonPath = path.resolve(requestPath, 'package.json');
     var json = fs.readFileSync(jsonPath, 'utf8');
-    var pkg = packageCache[requestPath] = JSON.parse(json);
-    return pkg;
-  } catch (e) {}
+  } catch (e) {
+    return false
+  }
 
-  return false;
+  try {
+    var pkg = packageCache[requestPath] = JSON.parse(json)
+  } catch (e) {
+    throw new Error('Error parsing ' + jsonPath + ': ' + e.message)
+  }
+  return pkg;
 }
 
 function tryPackage(requestPath, exts) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -109,7 +109,9 @@ function readPackage(requestPath) {
   try {
     var pkg = packageCache[requestPath] = JSON.parse(json)
   } catch (e) {
-    throw new Error('Error parsing ' + jsonPath + ': ' + e.message)
+    e.path = jsonPath
+    e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
+    throw e;
   }
   return pkg;
 }


### PR DESCRIPTION
The current behaviour will silently ignore any parsing errors
that may occur when loading a package.json file. This makes
debugging errors in the package.json file very difficult.

This changes the behaviour that that errors opening and reading
the file package.json file continue to be ignored, but errors
in parsing will throw an exception.
