### PR TITLE
Child process options should not override env

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -219,7 +219,7 @@ ChildProcess.prototype.spawn = function(path, args, options, customFds) {
       options.uid === undefined) {
     // Deprecated API: (path, args, options, env, customFds)
     cwd = '';
-    env = options || process.env;
+    env = process.env;
     customFds = customFds || [-1, -1, -1];
     setsid = false;
     uid = -1;

--- a/test/simple/test-child-process-env.js
+++ b/test/simple/test-child-process-env.js
@@ -42,7 +42,19 @@ child.stdout.addListener('data', function(chunk) {
   response += chunk;
 });
 
+var child2 = spawn('/usr/bin/env', [], {});
+var response2 = '';
+
+child2.stdout.setEncoding('utf8');
+
+child2.stdout.addListener('data', function(chunk) {
+  console.log('stdout2: ' + chunk);
+  response2 += chunk;
+});
+
 process.addListener('exit', function() {
   assert.ok(response.indexOf('HELLO=WORLD') >= 0);
   assert.ok(response.indexOf('FOO=BAR') >= 0);
+
+  assert.ok(response2.indexOf('PATH=') >= 0);
 });


### PR DESCRIPTION
This is a simple patch for an issue I've run into. The short of it is, if you pass an empty object as the options to child_process#spawn, That object will become the env instead of defaulting to process.env. The result is running the command with an empty environment. The included test just spawns a child with an empty options object and confirms that some env was present by checking for 'PATH='. Feel free to add something more sophisticated.

The reason I ran into this is because I'm building a lib around child processes and I'm passing through an options object. Something like the following.

```
function myLib(cmd, args, options) {
  options = options || {}
  // do some other stuff
  spawn(cmd, args, options);
}
```

You can work around this problem entirely by ensuring that the env property is set.

```
function myLib(cmd, args, options) {
  options = options || {}
  // do some other stuff

  if(!options.env) { options.env = process.env }
  spawn(cmd, args, options);
}
```

Since child_process is being overhauled as we speak, if this didn't go into an 0.4.x release, it wouldn't bother me. Consider it a note to double check 0.6.x.
