### PR TITLE
Requested for "Natives' Syntax-Issues & Implementation Laziness." (Issue #1774)

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -110,7 +110,7 @@ fs.readFile = function(path, encoding_) {
 };
 
 fs.readFileSync = function(path, encoding) {
-  var fd = fs.openSync(path, constants.O_RDONLY, 666);
+  var fd = fs.openSync(path, constants.O_RDONLY, parseInt('0666', 8));
   var buffer = new Buffer(4048);
   var buffers = [];
   var nread = 0;
@@ -563,7 +563,7 @@ function writeAll(fd, buffer, offset, length, callback) {
 fs.writeFile = function(path, data, encoding_, callback) {
   var encoding = (typeof(encoding_) == 'string' ? encoding_ : 'utf8');
   callback = (typeof(callback) == 'function' ? callback : null);
-  fs.open(path, 'w', 666, function(openErr, fd) {
+  fs.open(path, 'w', parseInt('0666', 8), function(openErr, fd) {
     if (openErr) {
       if (callback) callback(openErr);
     } else {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -105,12 +105,12 @@ fs.readFile = function(path, encoding_) {
         return callback(er);
       }
     }
-    callback(null, buffer);
+    return callback(null, buffer);
   });
 };
 
 fs.readFileSync = function(path, encoding) {
-  var fd = fs.openSync(path, constants.O_RDONLY, 0666);
+  var fd = fs.openSync(path, constants.O_RDONLY, 666);
   var buffer = new Buffer(4048);
   var buffers = [];
   var nread = 0;
@@ -411,8 +411,7 @@ fs.readlinkSync = function(path) {
 
 fs.symlink = function(destination, path, mode_, callback) {
   var mode = (typeof(mode_) == 'string' ? mode_ : null);
-  var callback_ = arguments[arguments.length - 1];
-  var callback = (typeof(callback_) == 'function' ? callback_ : null);
+  callback = (typeof(callback) == 'function' ? callback : null);
   binding.symlink(destination, path, mode, callback);
 };
 
@@ -563,9 +562,8 @@ function writeAll(fd, buffer, offset, length, callback) {
 
 fs.writeFile = function(path, data, encoding_, callback) {
   var encoding = (typeof(encoding_) == 'string' ? encoding_ : 'utf8');
-  var callback_ = arguments[arguments.length - 1];
-  var callback = (typeof(callback_) == 'function' ? callback_ : null);
-  fs.open(path, 'w', 0666, function(openErr, fd) {
+  callback = (typeof(callback) == 'function' ? callback : null);
+  fs.open(path, 'w', 666, function(openErr, fd) {
     if (openErr) {
       if (callback) callback(openErr);
     } else {
@@ -746,7 +744,7 @@ if (isWindows) {
 
   // windows version
   fs.realpathSync = function realpathSync(p, cache) {
-    var p = path.resolve(p);
+    p = path.resolve(p);
     if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
       return cache[p];
     }
@@ -761,7 +759,7 @@ if (isWindows) {
       cb = cache;
       cache = null;
     }
-    var p = path.resolve(p);
+    p = path.resolve(p);
     if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
       return cb(null, cache[p]);
     }
@@ -770,6 +768,7 @@ if (isWindows) {
       if (cache) cache[p] = p;
       cb(null, p);
     });
+    return null;
   };
 
 
@@ -933,7 +932,9 @@ if (isWindows) {
         fs.readlink(base, function(err, target) {
           gotTarget(err, seenLinks[id] = target);
         });
+        return null;
       });
+      return null;
     }
 
     function gotTarget(err, target, base) {
@@ -941,7 +942,7 @@ if (isWindows) {
 
       var resolvedLink = path.resolve(previous, target);
       if (cache) cache[base] = resolvedLink;
-      gotResolvedLink(resolvedLink);
+      return gotResolvedLink(resolvedLink);
     }
 
     function gotResolvedLink(resolvedLink) {
@@ -953,6 +954,7 @@ if (isWindows) {
 
       return process.nextTick(LOOP);
     }
+    return null;
   };
 
 }
@@ -1011,7 +1013,7 @@ var ReadStream = fs.ReadStream = function(path, options) {
   }
 
   if (this.fd !== null) {
-    return;
+    return null;
   }
 
   fs.open(this.path, this.flags, this.mode, function(err, fd) {
@@ -1025,6 +1027,7 @@ var ReadStream = fs.ReadStream = function(path, options) {
     self.emit('open', fd);
     self._read();
   });
+  return null;
 };
 util.inherits(ReadStream, Stream);
 
@@ -1334,4 +1337,5 @@ WriteStream.prototype.destroy = function(cb) {
 
 // There is no shutdown() for files.
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;
+
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -604,7 +604,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
   if (this.chunkedEncoding) {
     if (typeof(chunk) === 'string') {
       len = Buffer.byteLength(chunk, encoding);
-      var chunk = len.toString(16) + CRLF + chunk + CRLF;
+      chunk = len.toString(16) + CRLF + chunk + CRLF;
       ret = this._send(chunk, encoding);
     } else {
       // buffer
@@ -1726,7 +1726,7 @@ exports.cat = function(url, encoding_, headers_) {
     }
   }
 
-  var url = require('url').parse(url);
+  url = require('url').parse(url);
 
   var hasHost = false;
   if (Array.isArray(headers)) {

--- a/lib/http2.js
+++ b/lib/http2.js
@@ -604,7 +604,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
   if (this.chunkedEncoding) {
     if (typeof(chunk) === 'string') {
       len = Buffer.byteLength(chunk, encoding);
-      var chunk = len.toString(16) + CRLF + chunk + CRLF;
+      chunk = len.toString(16) + CRLF + chunk + CRLF;
       ret = this._send(chunk, encoding);
     } else {
       // buffer

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -316,7 +316,7 @@ Interface.prototype._tabComplete = function() {
 
         // If there is a common prefix to all matches, then apply that
         // portion.
-        var f = completions.filter(function(e) { if (e) return e; });
+        var f = completions.filter(function(e) { if (e) return e; else return null; });
         var prefix = commonPrefix(f);
         if (prefix.length > completeOn.length) {
           self._insertString(prefix.slice(completeOn.length));

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -183,6 +183,7 @@ function REPLServer(prompt, stream, eval) {
         } else {
           finish(null, ret);
         }
+        return null;
       });
 
     } else {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -916,6 +916,7 @@ Server.prototype.SNICallback = function(servername) {
       ctx = elem[1];
       return true;
     }
+    return null;
   });
 
   return ctx;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -93,12 +93,12 @@ exports.createUnzip = function(o) {
 // minimal 2-byte header
 function Deflate(opts) {
   if (!(this instanceof Deflate)) return new Deflate(opts);
-  Zlib.call(this, opts, binding.Deflate);
+  return Zlib.call(this, opts, binding.Deflate);
 }
 
 function Inflate(opts) {
   if (!(this instanceof Inflate)) return new Inflate(opts);
-  Zlib.call(this, opts, binding.Inflate);
+  return Zlib.call(this, opts, binding.Inflate);
 }
 
 
@@ -106,12 +106,12 @@ function Inflate(opts) {
 // gzip - bigger header, same deflate compression
 function Gzip(opts) {
   if (!(this instanceof Gzip)) return new Gzip(opts);
-  Zlib.call(this, opts, binding.Gzip);
+  return Zlib.call(this, opts, binding.Gzip);
 }
 
 function Gunzip(opts) {
   if (!(this instanceof Gunzip)) return new Gunzip(opts);
-  Zlib.call(this, opts, binding.Gunzip);
+  return Zlib.call(this, opts, binding.Gunzip);
 }
 
 
@@ -119,19 +119,19 @@ function Gunzip(opts) {
 // raw - no header
 function DeflateRaw(opts) {
   if (!(this instanceof DeflateRaw)) return new DeflateRaw(opts);
-  Zlib.call(this, opts, binding.DeflateRaw);
+  return Zlib.call(this, opts, binding.DeflateRaw);
 }
 
 function InflateRaw(opts) {
   if (!(this instanceof InflateRaw)) return new InflateRaw(opts);
-  Zlib.call(this, opts, binding.InflateRaw);
+  return Zlib.call(this, opts, binding.InflateRaw);
 }
 
 
 // auto-detect header.
 function Unzip(opts) {
   if (!(this instanceof Unzip)) return new Unzip(opts);
-  Zlib.call(this, opts, binding.Unzip);
+  return Zlib.call(this, opts, binding.Unzip);
 }
 
 


### PR DESCRIPTION
Hey, 

this is a fix for Issue #1774 for NodeJS is unable to start when called with latest-build V8 arguments "--harmony_typeof --harmony_weakmaps --harmony_block_scoping". This has been fixed, the JS-compliance has been "re"-implemented.

Cheers,
Kenan.
