### PR TITLE
Assert as a function

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -7,7 +7,7 @@ access it with `require('assert')`.
 
 Throws an exception that displays the values for `actual` and `expected` separated by the provided operator.
 
-### assert.ok(value, [message])
+### assert(value, message), assert.ok(value, [message])
 
 Tests if value is a `true` value, it is equivalent to `assert.equal(true, value, message);`
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -30,7 +30,7 @@ var pSlice = Array.prototype.slice;
 // AssertionError's when particular conditions are not met. The
 // assert module must conform to the following interface.
 
-var assert = exports;
+var assert = module.exports = ok;
 
 // 2. The AssertionError is defined in assert.
 // new assert.AssertionError({ message: message,
@@ -120,9 +120,10 @@ assert.fail = fail;
 // message_opt);. To test strictly for the value true, use
 // assert.strictEqual(true, guard, message_opt);.
 
-assert.ok = function ok(value, message) {
+function ok(value, message) {
   if (!!!value) fail(value, true, message, '==', assert.ok);
 };
+assert.ok = ok;
 
 // 5. The equality assertion tests shallow, coercive equality with
 // ==.

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -33,6 +33,12 @@ function makeBlock(f) {
 assert.ok(common.indirectInstanceOf(a.AssertionError.prototype, Error),
           'a.AssertionError instanceof Error');
 
+assert.throws(makeBlock(a, false), a.AssertionError, 'ok(false)');
+
+assert.doesNotThrow(makeBlock(a, true), a.AssertionError, 'ok(true)');
+
+assert.doesNotThrow(makeBlock(a, 'test', 'ok(\'test\')'));
+
 assert.throws(makeBlock(a.ok, false),
               a.AssertionError, 'ok(false)');
 


### PR DESCRIPTION
Make `assert` module an `assert.ok` function

Code can be written like:

```
var assert = require('assert');
assert(true);
```

instead of:

```
var assert = require('assert');
assert.ok(true);
```
