### PR TITLE
Added URL support for .get() in lib/http2.js; Added .valid() in lib/url.js

### DIFF
--- a/lib/http2.js
+++ b/lib/http2.js
@@ -1269,6 +1269,13 @@ exports.request = function(options, cb) {
 };
 
 exports.get = function(options, cb) {
+  if ((url = require('url').valid(options)) !== false) {
+    options = {};
+    if (url.hostname) options.host = url.hostname;
+    else return false;
+    options.port = url.port || 80;
+    options.path = url.pathname || '/';
+  } else return false;
   options.method = 'GET';
   var req = exports.request(options, cb);
   req.end();

--- a/lib/url.js
+++ b/lib/url.js
@@ -553,3 +553,8 @@ function parseHost(host) {
   if (host) out.hostname = host;
   return out;
 }
+
+exports.valid = function (url) {
+  if (url.match(/^(([^:]+):\/\/([^:\/]+)(:([0-9]+))*(\/.+)*|javascript:.+)$/)) return urlParse(url);
+  return false;
+};


### PR DESCRIPTION
.get example:

```
require('http').get('http://www.google.com',function(res) {
    console.log(res);
});
```

.valid example:

```
if ((url = require('url').valid('http://www.google.com')) !== false) {
    console.log(url);
} else console.log('Invalid URL.');
```
