### PR TITLE
Feature uv os round 1

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -153,10 +153,6 @@ static Handle<Value> GetLoadAvg(const Arguments& args) {
   double loadavg[3];
   uv_loadavg(loadavg);
 
-  if (loadavg[0] < 0) {
-    return Undefined();
-  }
-
   Local<Array> loads = Array::New(3);
   loads->Set(0, Number::New(loadavg[0]));
   loads->Set(1, Number::New(loadavg[1]));

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -117,7 +117,7 @@ static Handle<Value> GetCPUInfo(const Arguments& args) {
 
 static Handle<Value> GetFreeMemory(const Arguments& args) {
   HandleScope scope;
-  double amount = Platform::GetFreeMemory();
+  double amount = uv_get_free_memory();
 
   if (amount < 0) {
     return Undefined();
@@ -128,7 +128,7 @@ static Handle<Value> GetFreeMemory(const Arguments& args) {
 
 static Handle<Value> GetTotalMemory(const Arguments& args) {
   HandleScope scope;
-  double amount = Platform::GetTotalMemory();
+  double amount = uv_get_total_memory();
 
   if (amount < 0) {
     return Undefined();
@@ -150,12 +150,17 @@ static Handle<Value> GetUptime(const Arguments& args) {
 
 static Handle<Value> GetLoadAvg(const Arguments& args) {
   HandleScope scope;
-  Local<Array> loads = Array::New(3);
-  int r = Platform::GetLoadAvg(&loads);
+  double loadavg[3];
+  uv_loadavg(loadavg);
 
-  if (r < 0) {
+  if (loadavg[0] < 0) {
     return Undefined();
   }
+
+  Local<Array> loads = Array::New(3);
+  loads->Set(0, Number::New(loadavg[0]));
+  loads->Set(1, Number::New(loadavg[1]));
+  loads->Set(2, Number::New(loadavg[2]));
 
   return scope.Close(loads);
 }

--- a/src/platform.h
+++ b/src/platform.h
@@ -34,13 +34,10 @@ class Platform {
 
   static int GetMemory(size_t *rss, size_t *vsize);
   static int GetCPUInfo(v8::Local<v8::Array> *cpus);
-  static double GetFreeMemory();
-  static double GetTotalMemory();
   static double GetUptime(bool adjusted = false)
   {
     return adjusted ? GetUptimeImpl() - prog_start_time : GetUptimeImpl();
   }
-  static int GetLoadAvg(v8::Local<v8::Array> *loads);
   static v8::Handle<v8::Value> GetInterfaceAddresses();
  private:
   static double GetUptimeImpl();

--- a/src/platform_cygwin.cc
+++ b/src/platform_cygwin.cc
@@ -321,20 +321,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
   return 0;
 }
 
-double Platform::GetFreeMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  double pages = static_cast<double>(sysconf(_SC_AVPHYS_PAGES));
-
-  return static_cast<double>(pages * pagesize);
-}
-
-double Platform::GetTotalMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  double pages = static_cast<double>(sysconf(_SC_PHYS_PAGES));
-
-  return pages * pagesize;
-}
-
 double Platform::GetUptimeImpl() {
   double amount;
   char line[512];
@@ -351,12 +337,6 @@ double Platform::GetUptimeImpl() {
 
   return amount;
 }
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  // Unsupported as of cygwin 1.7.7
-  return -1;
-}
-
 
 Handle<Value> Platform::GetInterfaceAddresses() {
   HandleScope scope;

--- a/src/platform_darwin.cc
+++ b/src/platform_darwin.cc
@@ -140,31 +140,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
   return 0;
 }
 
-double Platform::GetFreeMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  vm_statistics_data_t info;
-  mach_msg_type_number_t count = sizeof(info) / sizeof(integer_t);
-
-  if (host_statistics(mach_host_self(), HOST_VM_INFO,
-                      (host_info_t)&info, &count) != KERN_SUCCESS) {
-    return -1;
-  }
-
-  return (static_cast<double>(info.free_count)) * pagesize;
-}
-
-double Platform::GetTotalMemory() {
-  uint64_t info;
-  static int which[] = {CTL_HW, HW_MEMSIZE};
-  size_t size = sizeof(info);
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-
-  return static_cast<double>(info);
-}
-
 double Platform::GetUptimeImpl() {
   time_t now;
   struct timeval info;
@@ -177,24 +152,6 @@ double Platform::GetUptimeImpl() {
   now = time(NULL);
 
   return static_cast<double>(now - info.tv_sec);
-}
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  struct loadavg info;
-  size_t size = sizeof(info);
-  static int which[] = {CTL_VM, VM_LOADAVG};
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-  (*loads)->Set(0, Number::New(static_cast<double>(info.ldavg[0])
-                               / static_cast<double>(info.fscale)));
-  (*loads)->Set(1, Number::New(static_cast<double>(info.ldavg[1])
-                               / static_cast<double>(info.fscale)));
-  (*loads)->Set(2, Number::New(static_cast<double>(info.ldavg[2])
-                               / static_cast<double>(info.fscale)));
-
-  return 0;
 }
 
 

--- a/src/platform_freebsd.cc
+++ b/src/platform_freebsd.cc
@@ -154,31 +154,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
   return 0;
 }
 
-double Platform::GetFreeMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  unsigned int info = 0;
-  size_t size = sizeof(info);
-
-  if (sysctlbyname("vm.stats.vm.v_free_count", &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-
-  return (static_cast<double>(info)) * pagesize;
-}
-
-double Platform::GetTotalMemory() {
-  unsigned long info;
-  static int which[] = {CTL_HW, HW_PHYSMEM};
-
-  size_t size = sizeof(info);
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-
-  return static_cast<double>(info);
-}
-
 double Platform::GetUptimeImpl() {
   time_t now;
   struct timeval info;
@@ -191,24 +166,6 @@ double Platform::GetUptimeImpl() {
   now = time(NULL);
 
   return static_cast<double>(now - info.tv_sec);
-}
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  struct loadavg info;
-  size_t size = sizeof(info);
-  static int which[] = {CTL_VM, VM_LOADAVG};
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-  (*loads)->Set(0, Number::New(static_cast<double>(info.ldavg[0])
-                               / static_cast<double>(info.fscale)));
-  (*loads)->Set(1, Number::New(static_cast<double>(info.ldavg[1])
-                               / static_cast<double>(info.fscale)));
-  (*loads)->Set(2, Number::New(static_cast<double>(info.ldavg[2])
-                               / static_cast<double>(info.fscale)));
-
-  return 0;
 }
 
 

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -25,8 +25,6 @@
 #include <v8.h>
 
 #include <sys/param.h> // for MAXPATHLEN
-#include <sys/sysctl.h>
-#include <sys/sysinfo.h>
 #include <unistd.h> // getpagesize, sysconf
 #include <stdio.h> // sscanf, snprintf
 
@@ -257,20 +255,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
   return 0;
 }
 
-double Platform::GetFreeMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  double pages = static_cast<double>(sysconf(_SC_AVPHYS_PAGES));
-
-  return static_cast<double>(pages * pagesize);
-}
-
-double Platform::GetTotalMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  double pages = static_cast<double>(sysconf(_SC_PHYS_PAGES));
-
-  return pages * pagesize;
-}
-
 double Platform::GetUptimeImpl() {
 #if HAVE_MONOTONIC_CLOCK
   struct timespec now;
@@ -287,19 +271,6 @@ double Platform::GetUptimeImpl() {
   }
   return static_cast<double>(info.uptime);
 #endif
-}
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  struct sysinfo info;
-
-  if (sysinfo(&info) < 0) {
-    return -1;
-  }
-  (*loads)->Set(0, Number::New(static_cast<double>(info.loads[0]) / 65536.0));
-  (*loads)->Set(1, Number::New(static_cast<double>(info.loads[1]) / 65536.0));
-  (*loads)->Set(2, Number::New(static_cast<double>(info.loads[2]) / 65536.0));
-
-  return 0;
 }
 
 

--- a/src/platform_openbsd.cc
+++ b/src/platform_openbsd.cc
@@ -153,36 +153,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
   return 0;
 }
 
-double Platform::GetFreeMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  struct uvmexp info;
-  size_t size = sizeof(info);
-  static int which[] = {CTL_VM, VM_UVMEXP};
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-
-  return static_cast<double>(info.free) * pagesize;
-}
-
-double Platform::GetTotalMemory() {
-#if defined(HW_PHYSMEM64)
-  uint64_t info;
-  static int which[] = {CTL_HW, HW_PHYSMEM64};
-#else
-  unsigned int info;
-  static int which[] = {CTL_HW, HW_PHYSMEM};
-#endif
-  size_t size = sizeof(info);
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-
-  return static_cast<double>(info);
-}
-
 double Platform::GetUptimeImpl() {
   time_t now;
   struct timeval info;
@@ -195,24 +165,6 @@ double Platform::GetUptimeImpl() {
   now = time(NULL);
 
   return static_cast<double>(now - info.tv_sec);
-}
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  struct loadavg info;
-  size_t size = sizeof(info);
-  static int which[] = {CTL_VM, VM_LOADAVG};
-
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) {
-    return -1;
-  }
-  (*loads)->Set(0, Number::New(static_cast<double>(info.ldavg[0])
-                               / static_cast<double>(info.fscale)));
-  (*loads)->Set(1, Number::New(static_cast<double>(info.ldavg[1])
-                               / static_cast<double>(info.fscale)));
-  (*loads)->Set(2, Number::New(static_cast<double>(info.ldavg[2])
-                               / static_cast<double>(info.fscale)));
-
-  return 0;
 }
 
 

--- a/src/platform_sunos.cc
+++ b/src/platform_sunos.cc
@@ -207,40 +207,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
 }
 
 
-double Platform::GetFreeMemory() {
-  kstat_ctl_t   *kc;
-  kstat_t       *ksp;
-  kstat_named_t *knp;
-
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  ulong_t freemem;
-
-  if((kc = kstat_open()) == NULL)
-    throw "could not open kstat";
-
-  ksp = kstat_lookup(kc, (char *)"unix", 0, (char *)"system_pages");
-
-  if(kstat_read(kc, ksp, NULL) == -1){
-    throw "could not read kstat";
-  }
-  else {
-    knp = (kstat_named_t *) kstat_data_lookup(ksp, (char *)"freemem");
-    freemem = knp->value.ul;
-  }
-
-  kstat_close(kc);
-
-  return static_cast<double>(freemem)*pagesize;
-}
-
-
-double Platform::GetTotalMemory() {
-  double pagesize = static_cast<double>(sysconf(_SC_PAGESIZE));
-  double pages = static_cast<double>(sysconf(_SC_PHYS_PAGES));
-
-  return pagesize*pages;
-}
-
 double Platform::GetUptimeImpl() {
   kstat_ctl_t   *kc;
   kstat_t       *ksp;
@@ -264,18 +230,6 @@ double Platform::GetUptimeImpl() {
   kstat_close(kc);
 
   return static_cast<double>( clk_intr / hz );
-}
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  HandleScope scope;
-  double loadavg[3];
-
-  (void) getloadavg(loadavg, 3);
-  (*loads)->Set(0, Number::New(loadavg[LOADAVG_1MIN]));
-  (*loads)->Set(1, Number::New(loadavg[LOADAVG_5MIN]));
-  (*loads)->Set(2, Number::New(loadavg[LOADAVG_15MIN]));
-
-  return 0;
 }
 
 

--- a/src/platform_win32.cc
+++ b/src/platform_win32.cc
@@ -214,34 +214,6 @@ int Platform::GetMemory(size_t *rss, size_t *vsize) {
   return 0;
 }
 
-
-double Platform::GetFreeMemory() {
-
-  MEMORYSTATUSEX memory_status;
-  memory_status.dwLength = sizeof(memory_status);
-
-  if(!GlobalMemoryStatusEx(&memory_status))
-  {
-     winapi_perror("GlobalMemoryStatusEx");
-  }
-
-  return (double)memory_status.ullAvailPhys;
-}
-
-double Platform::GetTotalMemory() {
-
-  MEMORYSTATUSEX memory_status;
-  memory_status.dwLength = sizeof(memory_status);
-
-  if(!GlobalMemoryStatusEx(&memory_status))
-  {
-    winapi_perror("GlobalMemoryStatusEx");
-  }
-
-  return (double)memory_status.ullTotalPhys;
-}
-
-
 int Platform::GetCPUInfo(Local<Array> *cpus) {
   return -1;
 }
@@ -250,11 +222,6 @@ int Platform::GetCPUInfo(Local<Array> *cpus) {
 double Platform::GetUptimeImpl() {
   return (double)GetTickCount()/1000.0;
 }
-
-int Platform::GetLoadAvg(Local<Array> *loads) {
-  return -1;
-}
-
 
 Handle<Value> Platform::GetInterfaceAddresses() {
   HandleScope scope;


### PR DESCRIPTION
Use available uv os functions (freemem, totalmem, loadavg).

This pull request is incomplete, going to remove useless headers from all os (not just linux)
