### PR TITLE
Fix typo for fs.write docs for v0.4 branch

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -296,7 +296,7 @@ current position.
 See pwrite(2).
 
 The callback will be given three arguments `(err, written, buffer)` where `written`
-specifies how many _bytes_ were written into `buffer`.
+specifies how many _bytes_ were written from `buffer`.
 
 Note that it is unsafe to use `fs.write` multiple times on the same file
 without waiting for the callback. For this scenario,


### PR DESCRIPTION
I saw this was already fixed in master but not for the v0.4 branch.
