### PR TITLE
fixed fork() not to overwrite passed environment variables

### DIFF
--- a/lib/child_process_uv.js
+++ b/lib/child_process_uv.js
@@ -140,7 +140,10 @@ exports.fork = function(modulePath, args, options) {
 
   // Just need to set this - child process won't actually use the fd.
   // For backwards compat - this can be changed to 'NODE_CHANNEL' before v0.6.
-  options.env = { NODE_CHANNEL_FD: 42 };
+  if (!options.env) {
+    options.env = {};
+  }
+  options.env.NODE_CHANNEL_FD = 42;
 
   // stdin is the IPC channel.
   options.stdinStream = createPipe(true);


### PR DESCRIPTION
options.env should be passed to spawn() without getting overwritten.
thx in advance
