### PR TITLE
Corrected fs.watchFile documentation

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -420,7 +420,7 @@ stat object:
 These stat objects are instances of `fs.Stat`.
 
 If you want to be notified when the file was modified, not just accessed
-you need to compare `curr.mtime` and `prev.mtime`.
+you need to compare `curr.mtime.getTime()` and `prev.mtime.getTime()`.
 
 
 ### fs.unwatchFile(filename)


### PR DESCRIPTION
to specify that getTime() methods needs
to be used, because the expression
`curr.mtime !== prev.mtime` appears to
be always true for some reason.
