### PR TITLE
Performance Increase: child_process.fork() reading of JSON

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -77,14 +77,15 @@ function setupChannel(target, channel) {
     if (pool) {
       jsonBuffer += pool.toString('ascii', offset, offset + length);
 
-      var i;
-      while ((i = jsonBuffer.indexOf('\n')) >= 0) {
-        var json = jsonBuffer.slice(0, i);
+      var i, start = 0;
+      while ((i = jsonBuffer.indexOf('\n', start)) >= 0) {
+        var json = jsonBuffer.slice(start, i);
         var message = JSON.parse(json);
-        jsonBuffer = jsonBuffer.slice(i + 1);
 
         target.emit('message', message, recvHandle);
+        start = i+1;
       }
+      jsonBuffer = jsonBuffer.slice(start);
 
     } else {
       channel.close();


### PR DESCRIPTION
Improves how data is read from the buffer for child_process.fork() so that the jsonBuffer is not actually modified until all data that can be read from it is read.

Running the benchmark listed in this issue: https://github.com/joyent/node/issues/1863
found at https://github.com/aikar/wormhole/blob/5xperfdegrade/testperf.js

I'm seeing a 10-15% increase in performance, from 185-190k messages/sec to 215-220k/sec.
