### PR TITLE
Removed --use-legacy from node --help

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2300,7 +2300,6 @@ static void PrintHelp() {
          "  --v8-options         print v8 command line options\n"
          "  --vars               print various compiled-in variables\n"
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
-         "  --use-legacy         use the legacy backend (default: libuv)\n"
          "\n"
          "Enviromental variables:\n"
          "NODE_PATH              ':'-separated list of directories\n"


### PR DESCRIPTION
I noticed that the --use-legacy option was still in node --help, though it's no longer valid. Removed.
