### PR TITLE
Only register once for listening when passing a callback to Server.listen

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -686,7 +686,7 @@ Server.prototype.listen = function() {
 
   var lastArg = arguments[arguments.length - 1];
   if (typeof lastArg == 'function') {
-    self.addListener('listening', lastArg);
+    self.once('listening', lastArg);
   }
 
   var port = toPort(arguments[0]);

--- a/test/simple/test-net-server-listen-remove-callback.js
+++ b/test/simple/test-net-server-listen-remove-callback.js
@@ -1,0 +1,19 @@
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+// Server should only fire listen callback once
+var server = net.createServer();
+
+server.on('close', function() {
+  var listeners = server.listeners('listening');
+  console.log('Closed, listeners:', listeners.length);
+  assert.equal(0, listeners.length);
+});
+
+server.listen(3000, function() {
+    server.close();
+    server.listen(3001, function() {
+        server.close();
+    });
+});


### PR DESCRIPTION
Only register once for listening when passing a callback to Server.listen(), this prevents servers recycled using close() from invoking the callback when Server.listen() is called later.

This very simple example exposes the problem:

``` javascript
var http = require('http');
var server = http.createServer();
server.on('close', function() {
    console.log('Closed, listeners:', server.listeners('listening').length);
});

server.listen(3000, function() {
    server.close();
    server.listen(3001, function() {
        server.close();
    });
});
```

Output:

```
Closed, listeners: 1
Closed, listeners: 2
Closed, listeners: 3
```
