### PR TITLE
sys has been moved to util

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -412,7 +412,7 @@
     'unwatchFile': 'process.unwatchFile() has moved to fs.unwatchFile()',
     'mixin': 'process.mixin() has been removed.',
     'createChildProcess': 'childProcess API has changed. See doc/api.txt.',
-    'inherits': 'process.inherits() has moved to sys.inherits.',
+    'inherits': 'process.inherits() has moved to util.inherits()',
     '_byteLength': 'process._byteLength() has moved to Buffer.byteLength'
   };
 


### PR DESCRIPTION
Updated the message so it referrers to the correct library, instead of a deprecated one. 
