### PR TITLE
refactored cluster module

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -10,7 +10,7 @@ which share server ports.
   var cluster = require('cluster');
   var http = require('http');
 
-  if (!cluster.isWorker()) {
+  if (cluster.isMaster()) {
     // Start the master process, fork workers.
     cluster.startMaster({ workers: 2 });
   } else {

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -27,3 +27,14 @@ Running node will now share port 8000 between the workers:
     Worker 2438 online
     Worker 2437 online
 
+The following is an example of worker resuscitation, spawning
+a new worker process when another exits.
+
+  if (cluster.isMaster) {
+    cluster.startMaster();
+    process.on('SIGCHLD', function(){
+      console.log('worker killed');
+      cluster.spawnWorker();
+    });
+  }
+  ... 

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -21,11 +21,9 @@ which share server ports.
     }).listen(8000);
   }
 
-If we start it like this
+Running node will now share port 8000 between the workers:
 
-    % node cluster server.js 
-    Detected 2 cpus
+    % node server.js 
     Worker 2438 online
     Worker 2437 online
 
-Node will automatically share port 8000 between the multiple instances.

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -10,7 +10,7 @@ which share server ports.
   var cluster = require('cluster');
   var http = require('http');
 
-  if (cluster.isMaster()) {
+  if (cluster.isMaster) {
     // Start the master process, fork workers.
     cluster.startMaster({ workers: 2 });
   } else {

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -38,3 +38,25 @@ a new worker process when another exits.
     });
   }
   ... 
+
+Cluster ids the servers internally, allowing multiple
+servers to work as you would expect:
+
+  var cluster = require('cluster');
+  var http = require('http');
+
+  if (cluster.isMaster) {
+    cluster.startMaster();
+  } else {
+    http.Server(function(req, res) {
+      res.end("hello world 1\n");
+    }).listen(3000);
+
+    http.Server(function(req, res) {
+      res.end("hello world 2\n");
+    }).listen(3001);
+
+    http.Server(function(req, res) {
+      res.end("hello world 3\n");
+    }).listen(3002);
+  }

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -27,8 +27,29 @@ Running node will now share port 8000 between the workers:
     Worker 2438 online
     Worker 2437 online
 
-The following is an example of worker resuscitation, spawning
-a new worker process when another exits.
+### exports.startMaster([options])
+
+  Spawns the initial worker processes, one per CPU by default.
+
+  The following options are supported:
+  
+  - `filename`: script to execute in the worker process, defaults to `process.argv[1]`
+  - `args`: worker program arguments, defaulting to `process.argv.slice(2)`
+  - `workers`: the number of workers, defaulting to `os.cpus().length`
+
+### exports.spawnWorker([options])
+
+   Spawn a new worker process. This is called within `cluster.startMaster()`,
+   however it is useful to implement worker resuscitation as described below
+   in the "Common patterns" section.
+   
+   The `options` available are identical to `cluster.startMaster()`.
+
+## Common patterns
+
+## Worker resuscitation
+
+The following is an example of how you may implement worker resuscitation, spawning a new worker process when another exits.
 
   if (cluster.isMaster) {
     cluster.startMaster();
@@ -38,25 +59,3 @@ a new worker process when another exits.
     });
   }
   ... 
-
-Cluster ids the servers internally, allowing multiple
-servers to work as you would expect:
-
-  var cluster = require('cluster');
-  var http = require('http');
-
-  if (cluster.isMaster) {
-    cluster.startMaster();
-  } else {
-    http.Server(function(req, res) {
-      res.end("hello world 1\n");
-    }).listen(3000);
-
-    http.Server(function(req, res) {
-      res.end("hello world 2\n");
-    }).listen(3001);
-
-    http.Server(function(req, res) {
-      res.end("hello world 3\n");
-    }).listen(3002);
-  }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -52,7 +52,7 @@ exports.isMaster = ! exports.isWorker;
 
 // Call this from the master process. It will start child workers.
 //
-// options.workerFilename
+// options.filename
 // Specifies the script to execute for the child processes. Default is
 // process.argv[1]
 //
@@ -65,12 +65,12 @@ exports.isMaster = ! exports.isWorker;
 exports.startMaster = function(options) {
   amMaster = true;
   options = options || {};
-  options.workerFilename = options.workerFilename || process.argv[1];
+  options.filename = options.filename || process.argv[1];
   options.args = options.args || process.argv.slice(2);
   options.workers = options.workers || require('os').cpus().length;
 
   for (var i = 0; i < options.workers; i++) {
-    forkWorker(options.workerFilename, options.args);
+    forkWorker(options.filename, options.args);
   }
 
   process.on('uncaughtException', function(e) {
@@ -92,9 +92,9 @@ exports.startMaster = function(options) {
 
 exports.spawnWorker = function(options){
   options = options || {};
-  options.workerFilename = options.workerFilename || process.argv[1];
+  options.filename = options.filename || process.argv[1];
   options.args = options.args || process.argv.slice(2);
-  forkWorker(options.workerFilename, options.args);
+  forkWorker(options.filename, options.args);
 };
 
 function handleWorkerMessage(worker, message) {
@@ -131,7 +131,7 @@ function handleWorkerMessage(worker, message) {
 }
 
 
-function forkWorker(workerFilename, args) {
+function forkWorker(filename, args) {
   var id = ++ids;
   var env = {};
 
@@ -141,7 +141,7 @@ function forkWorker(workerFilename, args) {
 
   env.NODE_WORKER_ID = id;
 
-  var worker = fork(workerFilename, args, { env: env });
+  var worker = fork(filename, args, { env: env });
 
   worker.on('message', function(message) {
     handleWorkerMessage(worker, message);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -189,7 +189,7 @@ function queryMaster(msg, cb) {
   debug('send ' + JSON.stringify(msg));
 
   // Grab some random queryId
-  msg._queryId = (++queryIds);
+  msg._queryId = ++queryIds;
   msg._workerId = workerId;
 
   // Store callback for later. Callback called in startWorker.

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -55,6 +55,10 @@ exports.isWorker = function() {
   return 'NODE_WORKER_ID' in process.env;
 };
 
+exports.isMaster = function() {
+  return ! exports.isWorker();
+};
+
 
 // Call this from the master process. It will start child workers.
 //

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -90,6 +90,12 @@ exports.startMaster = function(options) {
   });
 }
 
+exports.spawnWorker = function(options){
+  options = options || {};
+  options.workerFilename = options.workerFilename || process.argv[1];
+  options.args = options.args || process.argv.slice(2);
+  forkWorker(options.workerFilename, options.args);
+};
 
 function handleWorkerMessage(worker, message) {
   assert.ok(amMaster);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -97,31 +97,29 @@ exports.spawnWorker = function(options){
   forkWorker(options.filename, options.args);
 };
 
-function handleWorkerMessage(worker, message) {
+function handleWorkerMessage(worker, msg) {
   assert.ok(amMaster);
 
-  debug("recv " + JSON.stringify(message));
+  debug("recv " + JSON.stringify(msg));
 
-  switch (message.cmd) {
+  switch (msg.cmd) {
     case 'online': 
       console.log("Worker " + worker.pid + " online");
-      workers[message._workerId] = worker;
+      workers[msg._workerId] = worker;
       break;
 
     case 'queryServer':
-      var key = message.address + ":" +
-                message.port + ":" +
-                message.addressType;
-      var response = { _queryId: message._queryId };
+      var key = [msg.address, msg.port, msg.addressType].join(':')
 
-      if (key in servers == false) {
+      if (!servers[key]) {
         // Create a new server.
         debug('create new server ' + key);
-        servers[key] = net._createServerHandle(message.address,
-                                               message.port,
-                                               message.addressType);
+        servers[key] = net._createServerHandle(msg.address,
+                                               msg.port,
+                                               msg.addressType);
       }
-      worker.send(response, servers[key]);
+
+      worker.send({ _queryId: msg._queryId }, servers[key]);
       break;
 
     default:
@@ -143,8 +141,8 @@ function forkWorker(filename, args) {
 
   var worker = fork(filename, args, { env: env });
 
-  worker.on('message', function(message) {
-    handleWorkerMessage(worker, message);
+  worker.on('message', function(msg) {
+    handleWorkerMessage(worker, msg);
   });
 
   worker.on('exit', function() {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -47,18 +47,8 @@ var workerId = 0;
 var queryIds = 0;
 var queryCallbacks = {};
 
-
-
-// Used to check if this process is a worker or not.
-// Returns boolean.
-exports.isWorker = function() {
-  return 'NODE_WORKER_ID' in process.env;
-};
-
-exports.isMaster = function() {
-  return ! exports.isWorker();
-};
-
+exports.isWorker = 'NODE_WORKER_ID' in process.env;
+exports.isMaster = ! exports.isWorker;
 
 // Call this from the master process. It will start child workers.
 //

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -74,22 +74,10 @@ exports.isMaster = function() {
 // The number of workers to start. Defaults to os.cpus().length.
 exports.startMaster = function(options) {
   amMaster = true;
-
-  if (!options) {
-    options = {};
-  }
-
-  if (!options.workerFilename) {
-    options.workerFilename = process.argv[1];
-  }
-
-  if (!options.args) {
-    options.args = process.argv.slice(2);
-  }
-
-  if (!options.workers) {
-    options.workers = require('os').cpus().length;
-  }
+  options = options || {};
+  options.workerFilename = options.workerFilename || process.argv[1];
+  options.args = options.args || process.argv.slice(2);
+  options.workers = options.workers || require('os').cpus().length;
 
   for (var i = 0; i < options.workers; i++) {
     forkWorker(options.workerFilename, options.args);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -127,17 +127,15 @@ function handleWorkerMessage(worker, message) {
 
 function forkWorker(workerFilename, args) {
   var id = ++ids;
-  var envCopy = {};
+  var env = {};
 
   for (var x in process.env) {
-    envCopy[x] = process.env[x];
+    env[x] = process.env[x];
   }
 
-  envCopy['NODE_WORKER_ID'] = id;
+  env.NODE_WORKER_ID = id;
 
-  var worker = fork(workerFilename, args, {
-    env: envCopy
-  });
+  var worker = fork(workerFilename, args, { env: env });
 
   worker.on('message', function(message) {
     handleWorkerMessage(worker, message);


### PR DESCRIPTION
- improved extensibility
- added -n, --workers <n>
- added -r, --require <file>
- added worker incr / decr functionality
- added worker removal functionality
- refactored / exposed worker spawning
- delegate arbitrary messages
- message master when listening

The main goal of this commit is to make cluster.js
extensible. not to make assumptions with re-spawning
logic etc, but to facilitate it. logging and other 
related tasks are then delegated as well.

To "plugin" in master logic you use `--require`, as `$ node cluster`
will not exec the script for the master process. ex:

```
  $ node cluster app
```

vs:

```
  $ node cluster -r master app
```

where _./master.js_ contains `process.on()` event
listeners for logging, logic for re-spawning etc.

I'm not 100% sold on `--require`, but it would be more
abstract than cluster-specific module loading etc.
The one benefit of doing something cluster-specific,
is that you could truly encapsulate cluster "plugins"
which may contain both master and worker logic. For example
suppose you have a plugin _./stats.js_ which may aggregate/relay/display
request/connection statistics etc in master, and send messages to master
from the worker(s). perhaps it would look something like this:

``` js
  exports.master = function(){
    process.on('message', function(){ // socket.io UI blah blah  })
  };
```

``` js
  exports.worker = function(server){
    server.on('connection', function(){
      ... process.send(whatever)
    });
  };
```

 these `--require`d scripts would be useful as mentioned for restart logic
 and other tasks as well, ex:

``` js
  process.on('worker killed', function(worker){
    console.log('  worker %d killed', worker.id);
    require('cluster').spawn();
  });
```

or things like REPLs which can manipulate the cluster with the
methods I've exposed in this patch.

cheers!
