### PR TITLE
tiny fix in http.js

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -956,8 +956,11 @@ Agent.prototype.createSocket = function(name, host, port) {
   return s;
 };
 Agent.prototype.removeSocket = function(s, name, host, port) {
-  if (this.sockets[name] && this.sockets[name].indexOf(s) !== -1) {
-    this.sockets[name].splice(this.sockets[name].indexOf(s), 1);
+  if (this.sockets[name]) {
+    var index = this.sockets[name].indexOf(s);
+    if (index !== -1) {
+      this.sockets[name].splice(index, 1);
+    }
   } else if (this.sockets[name] && this.sockets[name].length === 0) {
     // don't leak
     delete this.sockets[name];

--- a/lib/http.js
+++ b/lib/http.js
@@ -957,7 +957,7 @@ Agent.prototype.createSocket = function(name, host, port) {
 };
 Agent.prototype.removeSocket = function(s, name, host, port) {
   if (this.sockets[name] && this.sockets[name].indexOf(s) !== -1) {
-    this.sockets[name].shift(this.sockets[name].indexOf(s));
+    this.sockets[name].splice(this.sockets[name].indexOf(s), 1);
   } else if (this.sockets[name] && this.sockets[name].length === 0) {
     // don't leak
     delete this.sockets[name];


### PR DESCRIPTION
I found a tiny bug in removeSocket method in http.js.
I think this method wants to remove a socket specified as the first argument from this.sockets[name].
But the current implemtntation removes the first socket from this.sockets[name].
shift method of Array class doesn't take an argument. So I'll fix it to use splice method.
