### PR TITLE
child_process.fork: don't modify args

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -124,7 +124,7 @@ function nop() { }
 exports.fork = function(modulePath, args, options) {
   if (!options) options = {};
 
-  if (!args) args = [];
+  args = args ? args.slice(0) : [];
   args.unshift(modulePath);
 
   if (options.stdinStream) {

--- a/test/simple/test-child-process-fork.js
+++ b/test/simple/test-child-process-fork.js
@@ -1,8 +1,10 @@
 var assert = require('assert');
 var common = require('../common');
 var fork = require('child_process').fork;
+var args = ['foo', 'bar'];
 
-var n = fork(common.fixturesDir + '/child-process-spawn-node.js');
+var n = fork(common.fixturesDir + '/child-process-spawn-node.js', args);
+assert.deepEqual(args, ['foo', 'bar']);
 
 var messageCount = 0;
 


### PR DESCRIPTION
Because `child_process.fork()` modify `args` argument, the worker processes after the second cannot get right arguments with `cluster`.
example:

`a.js`

``` javascript
console.log(process.env.NODE_WORKER_ID, process.argv);
```

result:

```
$ node cluster a.js foo bar
Detected 2 cpus
Worker 5097 online
Worker 5098 online
1 [ '/home/koichik/git/joyent/node/out/Release/node',
  '/tmp/a.js',
  'foo',
  'bar' ]
2 [ '/home/koichik/git/joyent/node/out/Release/node',
  '/tmp/a.js',
  '/tmp/a.js',
  'foo',
  'bar' ]
```
