### PR TITLE
Print out `undefined` on the REPL when returned.

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -228,7 +228,7 @@ function REPLServer(prompt, stream, eval) {
       self.bufferedCommand = '';
 
       // If we got any output - print it (if no error)
-      if (!e && ret !== undefined) {
+      if (!e) {
         global._ = ret;
         self.outputStream.write(exports.writer(ret) + '\n');
       }


### PR DESCRIPTION
`util.inspect()` has a special case for "undefined" (grey), so it would be nice to be able to distinguish visually that undefined is the result of an expression.
