### PR TITLE
Directly export the Stream constructor.

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -26,7 +26,9 @@ function Stream() {
   events.EventEmitter.call(this);
 }
 util.inherits(Stream, events.EventEmitter);
-exports.Stream = Stream;
+module.exports = Stream;
+// Backwards-compat with node 0.4.x
+Stream.Stream = Stream;
 
 Stream.prototype.pipe = function(dest, options) {
   var source = this;


### PR DESCRIPTION
Also setting up a circular reference back to the stream as `Stream.Stream`, for backwards-compatibility.

@visionmedia and I were talking about this. I don't see why we shouldn't do this, since this is the only thing exported from the `stream` module. On the other hand, I'm not sure if it's very _node-core-y_ since I don't think any other core module directly exports anything.

Pull request here for discussion :)
