### PR TITLE
Don't use `instanceof` in lib/util.js "is" checks.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -379,30 +379,26 @@ function reduceToSingleString(output, base, braces) {
 
 
 function isArray(ar) {
-  return ar instanceof Array ||
-         Array.isArray(ar) ||
-         (ar && ar !== Object.prototype && isArray(ar.__proto__));
+  return Array.isArray(ar) ||
+         (typeof ar === 'object' && objectToString(ar) === '[object Array]');
 }
 exports.isArray = isArray;
 
 
 function isRegExp(re) {
-  return re instanceof RegExp ||
-      (typeof re === 'object' && objectToString(re) === '[object RegExp]');
+  return typeof re === 'object' && objectToString(re) === '[object RegExp]';
 }
 exports.isRegExp = isRegExp;
 
 
 function isDate(d) {
-  return d instanceof Date ||
-      (typeof d === 'object' && objectToString(d) === '[object Date]');
+  return typeof d === 'object' && objectToString(d) === '[object Date]';
 }
 exports.isDate = isDate;
 
 
 function isError(e) {
-  return e instanceof Error ||
-      (typeof e === 'object' && objectToString(e) === '[object Error]');
+  return typeof e === 'object' && objectToString(e) === '[object Error]';
 }
 exports.isError = isError;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -378,6 +378,8 @@ function reduceToSingleString(output, base, braces) {
 }
 
 
+// NOTE: These type checking functions intentionally don't use `instanceof`
+// because it is fragile and can be easily faked with `Object.create()`.
 function isArray(ar) {
   return Array.isArray(ar) ||
          (typeof ar === 'object' && objectToString(ar) === '[object Array]');

--- a/test/simple/test-sys.js
+++ b/test/simple/test-sys.js
@@ -37,7 +37,7 @@ assert.equal('Sun, 14 Feb 2010 11:48:40 GMT',
 assert.equal("'\\n\\u0001'", common.inspect('\n\u0001'));
 
 assert.equal('[]', common.inspect([]));
-assert.equal('[]', common.inspect(Object.create([])));
+assert.equal('{}', common.inspect(Object.create([])));
 assert.equal('[ 1, 2 ]', common.inspect([1, 2]));
 assert.equal('[ 1, [ 2, 3 ] ]', common.inspect([1, [2, 3]]));
 
@@ -91,9 +91,6 @@ assert.equal('{ writeonly: [Setter] }',
 var value = {};
 value['a'] = value;
 assert.equal('{ a: [Circular] }', common.inspect(value));
-value = Object.create([]);
-value.push(1);
-assert.equal('[ 1, length: 1 ]', common.inspect(value));
 
 // Array with dynamic properties
 value = [1, 2, 3];

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -58,3 +58,7 @@ assert.ok(ex.indexOf('[stack]') != -1);
 assert.ok(ex.indexOf('[message]') != -1);
 assert.ok(ex.indexOf('[arguments]') != -1);
 assert.ok(ex.indexOf('[type]') != -1);
+
+// GH-1941
+// should not throw:
+assert.equal(util.inspect(Object.create(Date.prototype)), '{}')

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -53,7 +53,6 @@ try {
   assert.equal(util.inspect(e), '[ReferenceError: undef is not defined]');
 }
 var ex = util.inspect(new Error('FAIL'), true);
-console.log(ex);
 assert.ok(ex.indexOf('[Error: FAIL]') != -1);
 assert.ok(ex.indexOf('[stack]') != -1);
 assert.ok(ex.indexOf('[message]') != -1);

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -36,6 +36,7 @@ assert.equal(false, util.isArray({}))
 assert.equal(false, util.isArray({ push: function () {} }))
 assert.equal(false, util.isArray(/regexp/))
 assert.equal(false, util.isArray(new Error))
+assert.equal(false, util.isArray(Object.create(Array.prototype)))
 
 // isRegExp
 assert.equal(true, util.isRegExp(/regexp/))
@@ -45,6 +46,7 @@ assert.equal(true, util.isRegExp(context('RegExp')()))
 assert.equal(false, util.isRegExp({}))
 assert.equal(false, util.isRegExp([]))
 assert.equal(false, util.isRegExp(new Date()))
+assert.equal(false, util.isRegExp(Object.create(RegExp.prototype)))
 
 // isDate
 assert.equal(true, util.isDate(new Date()))
@@ -54,6 +56,7 @@ assert.equal(false, util.isDate(Date()))
 assert.equal(false, util.isDate({}))
 assert.equal(false, util.isDate([]))
 assert.equal(false, util.isDate(new Error))
+assert.equal(false, util.isDate(Object.create(Date.prototype)))
 
 // isError
 assert.equal(true, util.isError(new Error))
@@ -65,3 +68,4 @@ assert.equal(true, util.isError(new (context('SyntaxError'))))
 assert.equal(false, util.isError({}))
 assert.equal(false, util.isError({ name: 'Error', message: '' }))
 assert.equal(false, util.isError([]))
+assert.equal(false, util.isError(Object.create(Error.prototype)))


### PR DESCRIPTION
While using `instanceof`, these functions could easily be faked with something
like:  Object.create(Date.prototype)

So let's just not use it at all. A little slower, but these functions are only
used in the REPL / for debugging so it's OK.

This fixes #1941.
