### PR TITLE
More bulletproof `util.inspect()` function.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -180,10 +180,10 @@ function formatValue(ctx, value, recurseTimes) {
       return ctx.stylize('[Function' + name + ']', 'special');
     }
     if (isRegExp(value)) {
-      return ctx.stylize('' + value, 'regexp');
+      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
     }
     if (isDate(value)) {
-      return ctx.stylize(value.toUTCString(), 'date');
+      return ctx.stylize(Date.prototype.toUTCString.call(value), 'date');
     }
     if (isError(value)) {
       return formatError(value);
@@ -206,12 +206,12 @@ function formatValue(ctx, value, recurseTimes) {
 
   // Make RegExps say that they are RegExps
   if (isRegExp(value)) {
-    base = ' ' + value;
+    base = ' ' + RegExp.prototype.toString.call(value);
   }
 
   // Make dates with properties first say the date
   if (isDate(value)) {
-    base = ' ' + value.toUTCString();
+    base = ' ' + Date.prototype.toUTCString.call(value);
   }
 
   // Make error with message first say the error
@@ -225,7 +225,7 @@ function formatValue(ctx, value, recurseTimes) {
 
   if (recurseTimes < 0) {
     if (isRegExp(value)) {
-      return ctx.stylize('' + value, 'regexp');
+      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
     } else {
       return ctx.stylize('[Object]', 'special');
     }

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -62,3 +62,16 @@ assert.ok(ex.indexOf('[type]') != -1);
 // GH-1941
 // should not throw:
 assert.equal(util.inspect(Object.create(Date.prototype)), '{}')
+
+// GH-1944
+assert.doesNotThrow(function () {
+  var d = new Date();
+  d.toUTCString = null;
+  util.inspect(d);
+});
+
+assert.doesNotThrow(function () {
+  var r = /regexp/;
+  r.toString = null;
+  util.inspect(r);
+});


### PR DESCRIPTION
Use the _real_ versions of the Date and RegExp functions, from the
prototype. This defends against code like:

``` js
var d = new Date()
d.toUTCString = null
util.inspect(d)
  // TypeError: toUTCString is not a function
```

Or:

``` js
var r = /a regexp/
r.toString = null
util.inspect(r)
  // TypeError: Cannot convert object to primitive value
```
