### PR TITLE
No longer disable output colourization on NODE_NO_READLINE

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -117,7 +117,7 @@ function REPLServer(prompt, stream, eval, useGlobal) {
   this.commands = {};
   defineDefaultCommands(this);
 
-  if (rli.enabled && !exports.disableColors &&
+  if (!exports.disableColors &&
       exports.writer === util.inspect) {
     // Turn on ANSI coloring.
     exports.writer = function(obj, showHidden, depth) {


### PR DESCRIPTION
The REPL mistakenly assumed that NODE_NO_READLINE should also disable colourization of output; now,
if you completely want to disable all “intelligence” of the output, you’ll need both of the
following:

```
env NODE_NO_READLINE=1 NODE_DISABLE_COLORS=1 node
```
