### PR TITLE
http: `JSON.stringify` objects in OutgoingMessage.write

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -599,7 +599,11 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
 
   if (typeof chunk !== 'string' && !Buffer.isBuffer(chunk) &&
       !Array.isArray(chunk)) {
-    throw new TypeError('first argument must be a string, Array, or Buffer');
+    if (typeof chunk == 'object') {
+      chunk = JSON.stringify(chunk);
+    } else {
+      throw new TypeError('first argument must be a string, Array, Buffer or object');
+    }
   }
 
   if (chunk.length === 0) return false;

--- a/test/simple/test-http-json-response.js
+++ b/test/simple/test-http-json-response.js
@@ -1,0 +1,54 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var http = require('http');
+var common = require('../common');
+
+var body = {
+  hello: 'world',
+  feature: ['like', 'that', 'is', 'pretty', 'cool'],
+  outputtingJsonIs: 1337
+};
+
+var response = '';
+
+var server = http.createServer(function (res, req) {
+  req.writeHead(200, {'content-type': 'application/json'});
+  req.end(body);
+});
+
+server.listen(common.PORT, function () {
+  http.get({ port: common.PORT }, function (res) {
+    res.on('data', function (chunk) {
+      response += chunk;
+    });
+    res.on('end', function () {
+      server.close();
+    });
+  });
+});
+
+process.on('exit', function () {
+  console.log('Received response: ' + response);
+  assert.deepEqual(body, JSON.parse(response));
+});
+


### PR DESCRIPTION
This allows user to do, for example:

```
http.createServer(function (req, res) {
  res.writeHead(200, {'content-type': 'application/json'});
  res.end({ hello: 'world' });
});
```

Which will end up being outputted as:

```
{"hello": "world"}
```

Test included.
