### PR TITLE
tls: make `tls.connect` accept port and host in `options`

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -103,9 +103,15 @@ You can test this server by connecting to it with `openssl s_client`:
 
 
 #### tls.connect(port, [host], [options], [secureConnectListener])
+#### tls.connect(options, [secureConnectListener])
 
-Creates a new client connection to the given `port` and `host`. (If `host`
-defaults to `localhost`.) `options` should be an object which specifies
+Creates a new client connection to the given `port` and `host` (old API) or
+`options.port` and `options.host`. (If `host` defaults to `localhost`.)
+`options` should be an object which specifies
+
+  - `host`: Host which client should connect to
+
+  - `port`: Port which client should connect to
 
   - `key`: A string or `Buffer` containing the private key of the client in
     PEM format.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -106,12 +106,12 @@ You can test this server by connecting to it with `openssl s_client`:
 #### tls.connect(options, [secureConnectListener])
 
 Creates a new client connection to the given `port` and `host` (old API) or
-`options.port` and `options.host`. (If `host` defaults to `localhost`.)
-`options` should be an object which specifies
+`options.port` and `options.host`. (If `host` is omitted, it defaults to
+`localhost`.) `options` should be an object which specifies
 
-  - `host`: Host which client should connect to
+  - `host`: Host the client should connect to
 
-  - `port`: Port which client should connect to
+  - `port`: Port the client should connect to
 
   - `key`: A string or `Buffer` containing the private key of the client in
     PEM format.

--- a/lib/https.js
+++ b/lib/https.js
@@ -52,7 +52,9 @@ exports.createServer = function(opts, requestListener) {
 // HTTPS agents.
 
 function createConnection(port, host, options) {
-  return tls.connect(port, host, options);
+  options.port = port;
+  options.host = host;
+  return tls.connect(options);
 };
 
 function Agent(options) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -982,7 +982,7 @@ Server.prototype.SNICallback = function(servername) {
 
 // Target API:
 //
-//  var s = tls.connect(8000, "google.com", options, function() {
+//  var s = tls.connect({port: 8000, host: "google.com"}, function() {
 //    if (!s.authorized) {
 //      s.destroy();
 //      return;
@@ -994,24 +994,10 @@ Server.prototype.SNICallback = function(servername) {
 //  });
 //
 //
-// TODO:  make port, host part of options!
-exports.connect = function(port /* host, options, cb */) {
-  // parse args
-  var host, options = {}, cb;
-  for (var i = 1; i < arguments.length; i++) {
-    switch (typeof arguments[i]) {
-      case 'string':
-        host = arguments[i];
-        break;
-
-      case 'object':
-        options = arguments[i];
-        break;
-
-      case 'function':
-        cb = arguments[i];
-        break;
-    }
+exports.connect = function(options, cb) {
+  if (typeof options == 'function') {
+    cb = options;
+    options = {};
   }
 
   var socket = new net.Stream();
@@ -1023,7 +1009,7 @@ exports.connect = function(port /* host, options, cb */) {
   var pair = new SecurePair(sslcontext, false, true, false,
                             {
                               NPNProtocols: this.NPNProtocols,
-                              servername: options.servername || host
+                              servername: options.servername || options.host
                             });
 
   if (options.session) {
@@ -1035,7 +1021,7 @@ exports.connect = function(port /* host, options, cb */) {
     cleartext.on('secureConnect', cb);
   }
 
-  socket.connect(port, host);
+  socket.connect(options.port, options.host);
 
   pair.on('secure', function() {
     var verifyError = pair.ssl.verifyError();

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1003,6 +1003,7 @@ exports.connect = function(/* [port, host], options, cb */) {
     // having to merge properties. This is just faster and cleaner solution.
     if (typeof arguments[i] == 'object') {
       options = arguments[i];
+      break;
     }
   }
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -994,10 +994,32 @@ Server.prototype.SNICallback = function(servername) {
 //  });
 //
 //
-exports.connect = function(options, cb) {
-  if (typeof options == 'function') {
-    cb = options;
-    options = {};
+exports.connect = function(/* [port, host], options, cb */) {
+  var options = {}, cb;
+
+  for (var i = 0; i < arguments.length; i++) {
+    // Finding `options` object first is the better way (tm) to solve this
+    // issue. Trying to find it later would result in losing flexibility or
+    // having to merge properties. This is just faster and cleaner solution.
+    if (typeof arguments[i] == 'object') {
+      options = arguments[i];
+    }
+  }
+
+  for (var i = 0; i < arguments.length; i++) {
+    switch (typeof arguments[i]) {
+      case 'number':
+        options.port = arguments[i];
+        break;
+
+      case 'string':
+        options.host = arguments[i];
+        break;
+
+      case 'function':
+        cb = arguments[i];
+        break;
+    }
   }
 
   var socket = new net.Stream();

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -997,30 +997,31 @@ Server.prototype.SNICallback = function(servername) {
 exports.connect = function(/* [port, host], options, cb */) {
   var options = {}, cb;
 
-  for (var i = 0; i < arguments.length; i++) {
-    // Finding `options` object first is the better way (tm) to solve this
-    // issue. Trying to find it later would result in losing flexibility or
-    // having to merge properties. This is just faster and cleaner solution.
-    if (typeof arguments[i] == 'object') {
-      options = arguments[i];
-      break;
+  if (typeof arguments[0] == 'object') {
+    options = arguments[0];
+  }
+  else if (typeof arguments[1] == 'object') {
+    options = arguments[1];
+    options.port = arguments[0];
+  }
+  else if (typeof arguments[2] == 'object') {
+    options = arguments[2];
+    options.port = arguments[0];
+    options.host = arguments[1];
+  }
+  else {
+    // This is what happens when user passes no `options` argument, we can't
+    // throw `TypeError` here because it would be incompatible with old API
+    if (typeof arguments[0] == 'number') {
+      options.port = arguments[0];
+    }
+    if (typeof arguments[1] == 'string') {
+      options.host = arguments[1];
     }
   }
 
-  for (var i = 0; i < arguments.length; i++) {
-    switch (typeof arguments[i]) {
-      case 'number':
-        options.port = arguments[i];
-        break;
-
-      case 'string':
-        options.host = arguments[i];
-        break;
-
-      case 'function':
-        cb = arguments[i];
-        break;
-    }
+  if (typeof arguments[arguments.length - 1] == 'function') {
+    cb = arguments[arguments.length - 1];
   }
 
   var socket = new net.Stream();

--- a/test/simple/test-tls-client-abort.js
+++ b/test/simple/test-tls-client-abort.js
@@ -33,7 +33,7 @@ var path = require('path');
 var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-var conn = tls.connect(common.PORT, {cert: cert, key: key}, function() {
+var conn = tls.connect({cert: cert, key: key, port: common.PORT}, function() {
   assert.ok(false); // callback should never be executed
 });
 conn.on('error', function() {

--- a/test/simple/test-tls-client-resume.js
+++ b/test/simple/test-tls-client-resume.js
@@ -50,7 +50,7 @@ var server = tls.Server(options, function(socket) {
 server.listen(common.PORT, function() {
 
   var session1 = null;
-  var client1 = tls.connect(common.PORT, function() {
+  var client1 = tls.connect({port: common.PORT}, function() {
     console.log('connect1');
     assert.ok(!client1.isSessionReused(), 'Session *should not* be reused.');
     session1 = client1.getSession();
@@ -59,7 +59,7 @@ server.listen(common.PORT, function() {
   client1.on('close', function() {
     console.log('close1');
 
-    var client2 = tls.connect(common.PORT, {'session': session1}, function() {
+    var client2 = tls.connect({'session': session1, port: common.PORT}, function() {
       console.log('connect2');
       assert.ok(client2.isSessionReused(), 'Session *should* be reused.');
     });

--- a/test/simple/test-tls-client-verify.js
+++ b/test/simple/test-tls-client-verify.js
@@ -100,7 +100,7 @@ function testServers(index, servers, clientOptions, cb) {
     var b = '';
 
     console.error('connecting...');
-    var client = tls.connect(common.PORT, clientOptions, function() {
+    var client = tls.connect(clientOptions, function() {
 
       console.error('expected: ' + ok + ' authed: ' + client.authorized);
 
@@ -128,6 +128,7 @@ function runTest(testIndex) {
   if (!tcase) return;
 
   var clientOptions = {
+    port: common.PORT,
     ca: tcase.ca.map(loadPEM),
     key: loadPEM(tcase.key),
     cert: loadPEM(tcase.cert)

--- a/test/simple/test-tls-connect-simple.js
+++ b/test/simple/test-tls-connect-simple.js
@@ -39,12 +39,12 @@ var server = tls.Server(options, function(socket) {
 });
 
 server.listen(common.PORT, function() {
-  var client1 = tls.connect(common.PORT, function() {
+  var client1 = tls.connect({port: common.PORT}, function() {
     ++clientConnected;
     client1.end();
   });
 
-  var client2 = tls.connect(common.PORT);
+  var client2 = tls.connect({port: common.PORT});
   client2.on('secureConnect', function() {
     ++clientConnected;
     client2.end();

--- a/test/simple/test-tls-connect.js
+++ b/test/simple/test-tls-connect.js
@@ -42,7 +42,7 @@ var path = require('path');
     assert.ok(errorEmitted);
   });
 
-  var conn = tls.connect(common.PORT, {cert: cert, key: key}, function() {
+  var conn = tls.connect({cert: cert, key: key, port: common.PORT}, function() {
     assert.ok(false); // callback should never be executed
   });
 

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -45,24 +45,27 @@ var serverOptions = {
   NPNProtocols: ['a', 'b', 'c']
 };
 
+var serverPort = common.PORT;
+
 var clientsOptions = [{
+  port: serverPort,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
   NPNProtocols: ['a', 'b', 'c']
 },{
+  port: serverPort,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
   NPNProtocols: ['c', 'b', 'e']
 },{
+  port: serverPort,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
   NPNProtocols: ['first-priority-unsupported', 'x', 'y']
 }];
-
-var serverPort = common.PORT;
 
 var serverResults = [],
     clientsResults = [];
@@ -74,7 +77,7 @@ server.listen(serverPort, startTest);
 
 function startTest() {
   function connectClient(options, callback) {
-    var client = tls.connect(serverPort, 'localhost', options, function() {
+    var client = tls.connect(options, function() {
       clientsResults.push(client.npnProtocol);
       client.destroy();
 

--- a/test/simple/test-tls-passphrase.js
+++ b/test/simple/test-tls-passphrase.js
@@ -46,7 +46,8 @@ var server = tls.Server({
 
 var connectCount = 0;
 server.listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+  var c = tls.connect({
+    port: common.PORT,
     key: key,
     passphrase: 'passphrase',
     cert: cert
@@ -59,7 +60,8 @@ server.listen(common.PORT, function() {
 });
 
 assert.throws(function() {
-  tls.connect(common.PORT, {
+  tls.connect({
+    port: common.PORT,
     key: key,
     passphrase: 'invalid',
     cert: cert

--- a/test/simple/test-tls-pause-close.js
+++ b/test/simple/test-tls-pause-close.js
@@ -66,7 +66,7 @@ var server = tls.createServer(options, function(s) {
 });
 
 server.listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, function() {
+  var c = tls.connect({port: common.PORT}, function() {
     console.log('client connected');
     c.socket.on('end', function() {
       console.log('client socket ended');

--- a/test/simple/test-tls-pause.js
+++ b/test/simple/test-tls-pause.js
@@ -45,7 +45,7 @@ var server = tls.Server(options, function(socket) {
 
 server.listen(common.PORT, function() {
   var resumed = false;
-  var client = tls.connect(common.PORT, function() {
+  var client = tls.connect({port: common.PORT}, function() {
     client.pause();
     common.debug('paused');
     send();

--- a/test/simple/test-tls-peer-certificate.js
+++ b/test/simple/test-tls-peer-certificate.js
@@ -42,7 +42,7 @@ var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
 server.listen(common.PORT, function() {
-  var socket = tls.connect(common.PORT, function() {
+  var socket = tls.connect({port: common.PORT}, function() {
     var peerCert = socket.getPeerCertificate();
     common.debug(util.inspect(peerCert));
     assert.equal(peerCert.subject.subjectAltName,

--- a/test/simple/test-tls-remote.js
+++ b/test/simple/test-tls-remote.js
@@ -48,7 +48,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
   assert.equal(server.address().address, '127.0.0.1');
   assert.equal(server.address().port, common.PORT);
 
-  var c = tls.connect(common.PORT, '127.0.0.1', function() {
+  var c = tls.connect({port: common.PORT, host: '127.0.0.1'}, function() {
     assert.equal(c.address().address, c.socket.address().address);
     assert.equal(c.address().port, c.socket.address().port);
 

--- a/test/simple/test-tls-request-timeout.js
+++ b/test/simple/test-tls-request-timeout.js
@@ -42,7 +42,7 @@ var server = tls.Server(options, function(socket) {
 });
 
 server.listen(common.PORT, function() {
-  var socket = tls.connect(common.PORT);
+  var socket = tls.connect({port: common.PORT});
 });
 
 process.on('exit', function() {

--- a/test/simple/test-tls-set-encoding.js
+++ b/test/simple/test-tls-set-encoding.js
@@ -41,7 +41,7 @@ var server = tls.Server(options, function(socket) {
 
 
 server.listen(common.PORT, function() {
-  var client = tls.connect(common.PORT);
+  var client = tls.connect({port: common.PORT});
 
   var buffer = '';
 

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -57,25 +57,27 @@ var SNIContexts = {
   }
 };
 
+var serverPort = common.PORT;
 
 var clientsOptions = [{
+  port: serverPort,
   key: loadPEM('agent1-key'),
   cert: loadPEM('agent1-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com'
 },{
+  port: serverPort,
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   ca: [loadPEM('ca2-cert')],
   servername: 'b.test.com'
 },{
+  port: serverPort,
   key: loadPEM('agent3-key'),
   cert: loadPEM('agent3-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'c.wrong.com'
 }];
-
-var serverPort = common.PORT;
 
 var serverResults = [],
     clientResults = [];
@@ -91,7 +93,7 @@ server.listen(serverPort, startTest);
 
 function startTest() {
   function connectClient(options, callback) {
-    var client = tls.connect(serverPort, 'localhost', options, function() {
+    var client = tls.connect(options, function() {
       clientResults.push(client.authorized);
       client.destroy();
 


### PR DESCRIPTION
Previous API used form:

```
tls.connect(443, "google.com", options, ...)
```

now it's replaced with:

```
tls.connect({port: 443, host: "google.com", ...}, ...)
```

It simplifies argument parsing in `tls.connect` and makes the API consistent with other parts.
