### PR TITLE
V0.4

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -363,7 +363,13 @@ OutgoingMessage.prototype._send = function(data, encoding) {
   if (!this._headerSent) {
     if (typeof data === 'string') {
       data = this._header + data;
-    } else {
+    } else if ( typeof data === 'object' ) {
+			var headerLength = Buffer.byteLength( this._header );
+			var full = new Buffer( data.length + headerLength );
+			full.write( this._header, 0, 'ascii' );
+			data.copy( full, headerLength );
+			data = full;
+		} else {
       this.output.unshift(this._header);
       this.outputEncodings.unshift('ascii');
     }


### PR DESCRIPTION
_send() writes headers along with first chunk of data even if the type of data is Buffer.

This is  based on the behavior of _send() when data  is of type string. This way the http response is not segmented into header and body in this particular case.
