### PR TITLE
doc: fix links

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1318,7 +1318,7 @@ koichik, Maciej Małecki, Guglielmo Ferri, isaacs)
 2010.04.29, Version 0.1.93, 557ba6bd97bad3afe0f9bd3ac07efac0a39978c1
 
   * Fixed no 'end' event on long chunked HTTP messages
-    http://github.com/ry/node/issues/#issue/77
+    https://github.com/joyent/node/issues/77
 
   * Remove legacy modules http_old and tcp_old
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Windows:
 
 Resources for Newcomers
 ---
-  - [The Wiki](https://github.com/ry/node/wiki)
+  - [The Wiki](https://github.com/joyent/node/wiki)
   - [nodejs.org](http://nodejs.org/)
   - [how to install node.js and npm (node package manager)](http://joyeur.com/2010/12/10/installing-node-and-npm/)
-  - [list of modules](https://github.com/ry/node/wiki/modules)
+  - [list of modules](https://github.com/joyent/node/wiki/modules)
   - [searching the npm registry](http://search.npmjs.org/)
-  - [list of companies and projects using node](http://github.com/ry/node/wiki)
+  - [list of companies and projects using node](https://github.com/joyent/node/wiki/Projects,-Applications,-and-Companies-Using-Node)
   - [node.js mailing list](http://groups.google.com/group/nodejs)
   - irc chatroom, [#node.js on freenode.net](http://webchat.freenode.net?channels=node.js&uio=d4)
-  - [community](https://github.com/ry/node/wiki/Community)
-  - [contributing](https://github.com/ry/node/wiki/Contributing)
-  - [big list of all the helpful wiki pages](https://github.com/ry/node/wiki/_pages)
+  - [community](https://github.com/joyent/node/wiki/Community)
+  - [contributing](https://github.com/joyent/node/wiki/Contributing)
+  - [big list of all the helpful wiki pages](https://github.com/joyent/node/wiki/_pages)

--- a/doc/api/appendix_1.markdown
+++ b/doc/api/appendix_1.markdown
@@ -2,43 +2,43 @@
 
 There are many third party modules for Node. At the time of writing, August
 2010, the master repository of modules is
-[the wiki page](http://github.com/joyent/node/wiki/modules).
+[the wiki page](https://github.com/joyent/node/wiki/modules).
 
 This appendix is intended as a SMALL guide to new-comers to help them
 quickly find what are considered to be quality modules. It is not intended
 to be a complete list.  There may be better more complete modules found
 elsewhere.
 
-- Module Installer: [npm](http://github.com/isaacs/npm)
+- Module Installer: [npm](https://github.com/isaacs/npm)
 
-- HTTP Middleware: [Connect](http://github.com/senchalabs/connect)
+- HTTP Middleware: [Connect](https://github.com/senchalabs/connect)
 
-- Web Framework: [Express](http://github.com/visionmedia/express)
+- Web Framework: [Express](https://github.com/visionmedia/express)
 
 - Web Sockets: [Socket.IO](https://github.com/learnboost/socket.io)
 
-- HTML Parsing: [HTML5](http://github.com/aredridel/html5)
+- HTML Parsing: [HTML5](https://github.com/aredridel/html5)
 
-- [mDNS/Zeroconf/Bonjour](http://github.com/agnat/node_mdns)
+- [mDNS/Zeroconf/Bonjour](https://github.com/agnat/node_mdns)
 
 - [RabbitMQ, AMQP](https://github.com/postwait/node-amqp)
 
-- [mysql](http://github.com/felixge/node-mysql)
+- [mysql](https://github.com/felixge/node-mysql)
 
-- Serialization: [msgpack](http://github.com/pgriess/node-msgpack)
+- Serialization: [msgpack](https://github.com/pgriess/node-msgpack)
 
-- Scraping: [Apricot](http://github.com/silentrob/Apricot)
+- Scraping: [Apricot](https://github.com/silentrob/Apricot)
 
-- Debugger: [ndb](http://github.com/smtlaissezfaire/ndb) is a CLI debugger
-  [inspector](http://github.com/dannycoates/node-inspector) is a web based
+- Debugger: [ndb](https://github.com/smtlaissezfaire/ndb) is a CLI debugger
+  [inspector](https://github.com/dannycoates/node-inspector) is a web based
   tool.
 
-- [pcap binding](http://github.com/mranney/node_pcap)
+- [pcap binding](https://github.com/mranney/node_pcap)
 
-- [ncurses](http://github.com/mscdex/node-ncurses)
+- [ncurses](https://github.com/mscdex/node-ncurses)
 
 - Testing/TDD/BDD: [vows](http://vowsjs.org/),
-  [expresso](http://github.com/visionmedia/expresso),
-  [mjsunit.runner](http://github.com/tmpvar/mjsunit.runner)
+  [expresso](https://github.com/visionmedia/expresso),
+  [mjsunit.runner](https://github.com/tmpvar/mjsunit.runner)
 
 Patches to this list are welcome.

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -135,5 +135,5 @@ line interface:
 
 Take a look at this slightly more complicated
 [example](https://gist.github.com/901104), and
-[http-console](http://github.com/cloudhead/http-console) for a real-life use
+[http-console](https://github.com/cloudhead/http-console) for a real-life use
 case.

--- a/doc/index.html
+++ b/doc/index.html
@@ -107,7 +107,7 @@ server.listen(1337, "127.0.0.1");
       <h2 id="download">Download</h2>
 
       <p>
-        <a href="http://github.com/joyent/node/tree/master">git repo</a>
+        <a href="https://github.com/joyent/node/tree/master">git repo</a>
       </p>
 
       <p>2011.09.15 v0.4.12 (stable)
@@ -184,7 +184,7 @@ server.listen(1337, "127.0.0.1");
         grown out of the author's experiences developing and working with
         web servers. For example, streaming data through most web frameworks
         is impossible.  Node attempts to correct these problems in its HTTP
-        <a href="http://github.com/ry/http-parser/tree/master">parser</a>
+        <a href="https://github.com/joyent/http-parser/tree/master">parser</a>
         and API. Coupled with Node's purely evented infrastructure, it makes
         a good foundation for web libraries or frameworks.
       </p>

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Inspiration for this code comes from Salvatore Sanfilippo's linenoise.
-// http://github.com/antirez/linenoise
+// https://github.com/antirez/linenoise
 // Reference:
 // * http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 // * http://www.3waylabs.com/nw/WWW/products/wizcon/vt220.html

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -35,7 +35,7 @@
 #endif
 #include <stdlib.h>  /* free() */
 
-// This is a binding to http_parser (http://github.com/ry/http-parser)
+// This is a binding to http_parser (https://github.com/joyent/http-parser)
 // The goal is to decouple sockets from parsing for more javascript-level
 // agility. A Buffer is read from a socket and passed to parser.execute().
 // The parser then issues callbacks with slices of the data

--- a/test/pummel/test-next-tick-loops-quick.js
+++ b/test/pummel/test-next-tick-loops-quick.js
@@ -25,7 +25,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-// Regression test GH-511: https://github.com/ry/node/issues/issue/511
+// Regression test GH-511: https://github.com/joyent/node/issues/issue/511
 // Make sure nextTick loops quickly
 
 setTimeout(function() {

--- a/test/simple/test-http-eof-on-connect.js
+++ b/test/simple/test-http-eof-on-connect.js
@@ -24,7 +24,7 @@ var assert = require('assert');
 var net = require('net');
 var http = require('http');
 
-// This is a regression test for http://github.com/ry/node/issues/#issue/44
+// This is a regression test for https://github.com/joyent/node/issues/44
 // It is separate from test-http-malformed-request.js because it is only
 // reproduceable on the first packet on the first connection to a server.
 

--- a/test/simple/test-http-extra-response.js
+++ b/test/simple/test-http-extra-response.js
@@ -26,7 +26,7 @@ var net = require('net');
 
 // If an HTTP server is broken and sends data after the end of the response,
 // node should ignore it and drop the connection.
-// Demos this bug: https://github.com/ry/node/issues/680
+// Demos this bug: https://github.com/joyent/node/issues/680
 
 var body = 'hello world\r\n';
 var fullResponse =

--- a/test/simple/test-http-parser.js
+++ b/test/simple/test-http-parser.js
@@ -30,7 +30,7 @@ var RESPONSE = HTTPParser.RESPONSE;
 
 // The purpose of this test is not to check HTTP compliance but to test the
 // binding. Tests for pathological http messages should be submitted
-// upstream to http://github.com/ry/http-parser for inclusion into
+// upstream to https://github.com/joyent/http-parser for inclusion into
 // deps/http-parser/test.c
 
 


### PR DESCRIPTION
_Low priority_.

Changes:
- 'http://github.com' => 'https://github.com'
- 'https://github.com/ry/node' => 'https://github.com/joyent/node'
- 'https://github.com/ry/http-parser' =>
  'https://github.com/joyent/http-parser'
- old issue links
- wiki link
