### PR TITLE
Fix #836 in branch V0.4

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -704,7 +704,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
 
   // There is the first message on the outgoing queue, and we've sent
   // everything to the socket.
-  if (this.output.length === 0 && this.connection._httpMessage === this) {
+  if (this.output.length === 0 && this.connection && this.connection._httpMessage === this) {
     debug('outgoing message end.');
     this._finish();
   }


### PR DESCRIPTION
Without this, the process would occasionally throw a TypeError on a nulled this.connection
