### PR TITLE
OpenSSL EVP API Fix (ECB mode failing)

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -780,7 +780,7 @@ int Connection::SelectNextProtoCallback_(SSL *s,
   }
 
   return SSL_TLSEXT_ERR_OK;
-}                                  
+}
 #endif
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1830,12 +1830,13 @@ class Cipher : public ObjectWrap {
     int key_len = EVP_BytesToKey(cipher, EVP_md5(), NULL, (unsigned char*) key_buf, key_buf_len, 1, key, iv);
 
     EVP_CIPHER_CTX_init(&ctx);
-    EVP_CipherInit(&ctx,cipher,(unsigned char *)key,(unsigned char *)iv, true);
-    if (!EVP_CIPHER_CTX_set_key_length(&ctx,key_len)) {
+    EVP_CipherInit_ex(&ctx, cipher, NULL, NULL, NULL, true);
+    if (!EVP_CIPHER_CTX_set_key_length(&ctx, key_len)) {
       fprintf(stderr, "node-crypto : Invalid key length %d\n", key_len);
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
+    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, true);
     initialised_ = true;
     return true;
   }
@@ -1856,12 +1857,13 @@ class Cipher : public ObjectWrap {
       return false;
     }
     EVP_CIPHER_CTX_init(&ctx);
-    EVP_CipherInit(&ctx,cipher,(unsigned char *)key,(unsigned char *)iv, true);
-    if (!EVP_CIPHER_CTX_set_key_length(&ctx,key_len)) {
+    EVP_CipherInit_ex(&ctx, cipher, NULL, NULL, NULL, true);
+    if (!EVP_CIPHER_CTX_set_key_length(&ctx, key_len)) {
       fprintf(stderr, "node-crypto : Invalid key length %d\n", key_len);
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
+    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, true);
     initialised_ = true;
     return true;
   }
@@ -1879,7 +1881,7 @@ class Cipher : public ObjectWrap {
   int CipherFinal(unsigned char** out, int *out_len) {
     if (!initialised_) return 0;
     *out = new unsigned char[EVP_CIPHER_CTX_block_size(&ctx)];
-    EVP_CipherFinal(&ctx,*out,out_len);
+    EVP_CipherFinal_ex(&ctx,*out,out_len);
     EVP_CIPHER_CTX_cleanup(&ctx);
     initialised_ = false;
     return 1;
@@ -2198,16 +2200,13 @@ class Decipher : public ObjectWrap {
                                  iv);
 
     EVP_CIPHER_CTX_init(&ctx);
-    EVP_CipherInit(&ctx,
-                   cipher_,
-                   (unsigned char*)(key),
-                   (unsigned char *)(iv),
-                   false);
-    if (!EVP_CIPHER_CTX_set_key_length(&ctx,key_len)) {
+    EVP_CipherInit_ex(&ctx, cipher_, NULL, NULL, NULL, false);
+    if (!EVP_CIPHER_CTX_set_key_length(&ctx, key_len)) {
       fprintf(stderr, "node-crypto : Invalid key length %d\n", key_len);
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
+    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, false);
     initialised_ = true;
     return true;
   }
@@ -2228,16 +2227,13 @@ class Decipher : public ObjectWrap {
       return false;
     }
     EVP_CIPHER_CTX_init(&ctx);
-    EVP_CipherInit(&ctx,
-                   cipher_,
-                   (unsigned char*)(key),
-                   (unsigned char *)(iv),
-                   false);
-    if (!EVP_CIPHER_CTX_set_key_length(&ctx,key_len)) {
+    EVP_CipherInit_ex(&ctx, cipher_, NULL, NULL, NULL, false);
+    if (!EVP_CIPHER_CTX_set_key_length(&ctx, key_len)) {
       fprintf(stderr, "node-crypto : Invalid key length %d\n", key_len);
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
+    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, false);
     initialised_ = true;
     return true;
   }
@@ -2258,7 +2254,7 @@ class Decipher : public ObjectWrap {
     if (tolerate_padding) {
       local_EVP_DecryptFinal_ex(&ctx,*out,out_len);
     } else {
-      EVP_CipherFinal(&ctx,*out,out_len);
+      EVP_CipherFinal_ex(&ctx,*out,out_len);
     }
     EVP_CIPHER_CTX_cleanup(&ctx);
     initialised_ = false;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1852,7 +1852,8 @@ class Cipher : public ObjectWrap {
       fprintf(stderr, "node-crypto : Unknown cipher %s\n", cipherType);
       return false;
     }
-    if (EVP_CIPHER_iv_length(cipher)!=iv_len) {
+    /* OpenSSL versions up to 0.9.8l failed to return the correct iv_length (0) for ECB ciphers */
+    if (EVP_CIPHER_iv_length(cipher) != iv_len && !(EVP_CIPHER_mode(cipher) == EVP_CIPH_ECB_MODE && iv_len == 0)) {
       fprintf(stderr, "node-crypto : Invalid IV length %d\n", iv_len);
       return false;
     }
@@ -2222,7 +2223,8 @@ class Decipher : public ObjectWrap {
       fprintf(stderr, "node-crypto : Unknown cipher %s\n", cipherType);
       return false;
     }
-    if (EVP_CIPHER_iv_length(cipher_) != iv_len) {
+    /* OpenSSL versions up to 0.9.8l failed to return the correct iv_length (0) for ECB ciphers */
+    if (EVP_CIPHER_iv_length(cipher_) != iv_len && !(EVP_CIPHER_mode(cipher_) == EVP_CIPH_ECB_MODE && iv_len == 0)) {
       fprintf(stderr, "node-crypto : Invalid IV length %d\n", iv_len);
       return false;
     }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2214,7 +2214,9 @@ class Decipher : public ObjectWrap {
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
-    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, false);
+    EVP_CipherInit_ex(&ctx, NULL, NULL,
+      (unsigned char *)key,
+      (unsigned char *)iv, false);
     initialised_ = true;
     return true;
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1827,7 +1827,8 @@ class Cipher : public ObjectWrap {
     }
 
     unsigned char key[EVP_MAX_KEY_LENGTH],iv[EVP_MAX_IV_LENGTH];
-    int key_len = EVP_BytesToKey(cipher, EVP_md5(), NULL, (unsigned char*) key_buf, key_buf_len, 1, key, iv);
+    int key_len = EVP_BytesToKey(cipher, EVP_md5(), NULL,
+      (unsigned char*) key_buf, key_buf_len, 1, key, iv);
 
     EVP_CIPHER_CTX_init(&ctx);
     EVP_CipherInit_ex(&ctx, cipher, NULL, NULL, NULL, true);
@@ -1836,7 +1837,9 @@ class Cipher : public ObjectWrap {
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
-    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, true);
+    EVP_CipherInit_ex(&ctx, NULL, NULL,
+      (unsigned char *)key,
+      (unsigned char *)iv, true);
     initialised_ = true;
     return true;
   }
@@ -1852,8 +1855,10 @@ class Cipher : public ObjectWrap {
       fprintf(stderr, "node-crypto : Unknown cipher %s\n", cipherType);
       return false;
     }
-    /* OpenSSL versions up to 0.9.8l failed to return the correct iv_length (0) for ECB ciphers */
-    if (EVP_CIPHER_iv_length(cipher) != iv_len && !(EVP_CIPHER_mode(cipher) == EVP_CIPH_ECB_MODE && iv_len == 0)) {
+    /* OpenSSL versions up to 0.9.8l failed to return the correct
+       iv_length (0) for ECB ciphers */
+    if (EVP_CIPHER_iv_length(cipher) != iv_len &&
+      !(EVP_CIPHER_mode(cipher) == EVP_CIPH_ECB_MODE && iv_len == 0)) {
       fprintf(stderr, "node-crypto : Invalid IV length %d\n", iv_len);
       return false;
     }
@@ -1864,7 +1869,9 @@ class Cipher : public ObjectWrap {
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
-    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, true);
+    EVP_CipherInit_ex(&ctx, NULL, NULL,
+      (unsigned char *)key,
+      (unsigned char *)iv, true);
     initialised_ = true;
     return true;
   }
@@ -2223,8 +2230,10 @@ class Decipher : public ObjectWrap {
       fprintf(stderr, "node-crypto : Unknown cipher %s\n", cipherType);
       return false;
     }
-    /* OpenSSL versions up to 0.9.8l failed to return the correct iv_length (0) for ECB ciphers */
-    if (EVP_CIPHER_iv_length(cipher_) != iv_len && !(EVP_CIPHER_mode(cipher_) == EVP_CIPH_ECB_MODE && iv_len == 0)) {
+    /* OpenSSL versions up to 0.9.8l failed to return the correct
+      iv_length (0) for ECB ciphers */
+    if (EVP_CIPHER_iv_length(cipher_) != iv_len &&
+      !(EVP_CIPHER_mode(cipher_) == EVP_CIPH_ECB_MODE && iv_len == 0)) {
       fprintf(stderr, "node-crypto : Invalid IV length %d\n", iv_len);
       return false;
     }
@@ -2235,7 +2244,9 @@ class Decipher : public ObjectWrap {
       EVP_CIPHER_CTX_cleanup(&ctx);
       return false;
     }
-    EVP_CipherInit_ex(&ctx, NULL, NULL, (unsigned char *)key, (unsigned char *)iv, false);
+    EVP_CipherInit_ex(&ctx, NULL, NULL,
+      (unsigned char *)key,
+      (unsigned char *)iv, false);
     initialised_ = true;
     return true;
   }

--- a/test/simple/test-crypto-ecb.js
+++ b/test/simple/test-crypto-ecb.js
@@ -33,6 +33,7 @@ try {
 }
 
 // Testing whether EVP_CipherInit_ex is functioning correctly.
+// Reference: bug#1997
 
 (function()
 {
@@ -49,4 +50,3 @@ try {
   msg += decrypt.final('ascii');
   assert.equal(msg, 'Hello World!');
 }());
-

--- a/test/simple/test-crypto-ecb.js
+++ b/test/simple/test-crypto-ecb.js
@@ -36,17 +36,17 @@ try {
 
 (function()
 {
-	var encrypt = crypto.createCipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
-	var hex = encrypt.update('Hello World!', 'ascii', 'hex');
-	hex += encrypt.final('hex');
-	assert.equal(hex.toUpperCase(), '6D385F424AAB0CFBF0BB86E07FFB7D71');
+  var encrypt = crypto.createCipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
+  var hex = encrypt.update('Hello World!', 'ascii', 'hex');
+  hex += encrypt.final('hex');
+  assert.equal(hex.toUpperCase(), '6D385F424AAB0CFBF0BB86E07FFB7D71');
 }());
 
 (function()
 {
-	var decrypt = crypto.createDecipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
-	var msg = decrypt.update('6D385F424AAB0CFBF0BB86E07FFB7D71', 'hex', 'ascii');
-	msg += decrypt.final('ascii');
-	assert.equal(msg, 'Hello World!');
+  var decrypt = crypto.createDecipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
+  var msg = decrypt.update('6D385F424AAB0CFBF0BB86E07FFB7D71', 'hex', 'ascii');
+  msg += decrypt.final('ascii');
+  assert.equal(msg, 'Hello World!');
 }());
 

--- a/test/simple/test-crypto-ecb.js
+++ b/test/simple/test-crypto-ecb.js
@@ -1,0 +1,52 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+try {
+  var crypto = require('crypto');
+} catch (e) {
+  console.log('Not compiled with OPENSSL support.');
+  process.exit();
+}
+
+// Testing whether EVP_CipherInit_ex is functioning correctly.
+
+(function()
+{
+	var encrypt = crypto.createCipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
+	var hex = encrypt.update('Hello World!', 'ascii', 'hex');
+	hex += encrypt.final('hex');
+	assert.equal(hex.toUpperCase(), '6D385F424AAB0CFBF0BB86E07FFB7D71');
+}());
+
+(function()
+{
+	var decrypt = crypto.createDecipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
+	var msg = decrypt.update('6D385F424AAB0CFBF0BB86E07FFB7D71', 'hex', 'ascii');
+	msg += decrypt.final('ascii');
+	assert.equal(msg, 'Hello World!');
+}());
+


### PR DESCRIPTION
Hey there.
I was trying to decrypt some Blowfish-ECB-mode encrypted strings with node.js, but all I got was weird characters. After making an isolated test case, I discovered that node.js is not using OpenSSL's EVP_CIPHER_CTX_set_key_length correctly.

It's called _after_ EVP_CipherInit, so it will just silently do nothing (won't return any error code either). However, unless you're using a cipher with a variable key length (such as Blowfish ECB) it will go unnoticed. The fix is to use EVP_CipherInit_ex instead and to call it two times, as (dimly) described by EVP_CipherInit_ex's man page on openssl.org[1].

So here's a pull request and a test case.

I have also changed the code to use EVP_EncryptFinal_ex to go along with the _ex init call which should not have any side effects since at least in current OpenSSLs (haven't checked 0.x ones), Final is simply an alias to Final_ex.

Also here's a standalone cpp file I used for testing: https://gist.github.com/1335823 BF_ecb_encrypt is used to verify the output.

Looking forward to reading your comments.

[1] http://www.openssl.org/docs/crypto/EVP_EncryptInit.html
