### PR TITLE
Fix a typo in the documented fchown signature

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -85,12 +85,12 @@ to the completion callback.
 
 Synchronous chown(2).
 
-### fs.fchown(path, uid, gid, [callback])
+### fs.fchown(fd, uid, gid, [callback])
 
 Asynchronous fchown(2). No arguments other than a possible exception are given
 to the completion callback.
 
-### fs.fchownSync(path, uid, gid)
+### fs.fchownSync(fd, uid, gid)
 
 Synchronous fchown(2).
 


### PR DESCRIPTION
Just a tiny change: This way it should convey that a number should be passed, not a string.
