### PR TITLE
Padding control for Crypto (v2)

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -106,6 +106,13 @@ the output format of the enciphered data, and can be `'binary'`, `'base64'` or `
 
 Returns the enciphered contents, and can be called many times with new data as it is streamed.
 
+### cipher.setAutoPadding(auto_padding=true)
+
+You can disable automatic padding of the input data to block size. If `auto_padding` is false,
+the length of the entire input data must be a multiple of the cipher's block size or `final` will fail.
+Useful for non-standard padding, e.g. using `0x0` instead of PKCS padding. You must call this before `cipher.final`.
+
+
 ### cipher.final(output_encoding='binary')
 
 Returns any remaining enciphered contents, with `output_encoding` being one of: `'binary'`, `'base64'` or `'hex'`.
@@ -122,6 +129,12 @@ This is the mirror of the [createCipher()](#crypto.createCipher) above.
 
 Creates and returns a decipher object, with the given algorithm, key and iv.
 This is the mirror of the [createCipheriv()](#crypto.createCipheriv) above.
+
+### decipher.setAutoPadding(auto_padding=true)
+
+You can disable auto padding if the data has been encrypted without standard block padding to prevent
+`decipher.final` from checking and removing it. Can only work if the input data's length is a multiple of the
+ciphers block size. You must call this before streaming data to `decipher.update`.
 
 ### decipher.update(data, input_encoding='binary', output_encoding='binary')
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1866,6 +1866,7 @@ class Cipher : public ObjectWrap {
     NODE_SET_PROTOTYPE_METHOD(t, "init", CipherInit);
     NODE_SET_PROTOTYPE_METHOD(t, "initiv", CipherInitIv);
     NODE_SET_PROTOTYPE_METHOD(t, "update", CipherUpdate);
+    NODE_SET_PROTOTYPE_METHOD(t, "setAutoPadding", SetAutoPadding);
     NODE_SET_PROTOTYPE_METHOD(t, "final", CipherFinal);
 
     target->Set(String::NewSymbol("Cipher"), t->GetFunction());
@@ -1929,7 +1930,6 @@ class Cipher : public ObjectWrap {
     return true;
   }
 
-
   int CipherUpdate(char* data, int len, unsigned char** out, int* out_len) {
     if (!initialised_) return 0;
     *out_len=len+EVP_CIPHER_CTX_block_size(&ctx);
@@ -1939,13 +1939,18 @@ class Cipher : public ObjectWrap {
     return 1;
   }
 
+  int SetAutoPadding(bool auto_padding) {
+    if (!initialised_) return 0;
+    return EVP_CIPHER_CTX_set_padding(&ctx, auto_padding ? 1 : 0);
+  }
+
   int CipherFinal(unsigned char** out, int *out_len) {
     if (!initialised_) return 0;
     *out = new unsigned char[EVP_CIPHER_CTX_block_size(&ctx)];
-    EVP_CipherFinal_ex(&ctx,*out,out_len);
+    int r = EVP_CipherFinal_ex(&ctx,*out,out_len);
     EVP_CIPHER_CTX_cleanup(&ctx);
     initialised_ = false;
-    return 1;
+    return r;
   }
 
 
@@ -2144,6 +2149,15 @@ class Cipher : public ObjectWrap {
     return scope.Close(outString);
   }
 
+  static Handle<Value> SetAutoPadding(const Arguments& args) {
+    HandleScope scope;
+    Cipher *cipher = ObjectWrap::Unwrap<Cipher>(args.This());
+
+    cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue());
+
+    return Undefined();
+  }
+
   static Handle<Value> CipherFinal(const Arguments& args) {
     Cipher *cipher = ObjectWrap::Unwrap<Cipher>(args.This());
 
@@ -2161,7 +2175,13 @@ class Cipher : public ObjectWrap {
     assert(out_len != -1);
 
     if (out_len == 0 || r == 0) {
-      return scope.Close(String::New(""));
+      delete[] out_value; // allocated even if out_len = 0
+      if (r == 0) {
+        Local<Value> exception = Exception::TypeError(String::New("CipherFinal fail"));
+        return ThrowException(exception);
+      } else {
+        return scope.Close(String::New(""));
+      }
     }
 
     if (args.Length() == 0 || !args[0]->IsString()) {
@@ -2239,8 +2259,9 @@ class Decipher : public ObjectWrap {
     NODE_SET_PROTOTYPE_METHOD(t, "init", DecipherInit);
     NODE_SET_PROTOTYPE_METHOD(t, "initiv", DecipherInitIv);
     NODE_SET_PROTOTYPE_METHOD(t, "update", DecipherUpdate);
+    NODE_SET_PROTOTYPE_METHOD(t, "setAutoPadding", SetAutoPadding);
     NODE_SET_PROTOTYPE_METHOD(t, "final", DecipherFinal);
-    NODE_SET_PROTOTYPE_METHOD(t, "finaltol", DecipherFinalTolerate);
+    NODE_SET_PROTOTYPE_METHOD(t, "finaltol", DecipherFinalTolerate); // ! undocumented !
 
     target->Set(String::NewSymbol("Decipher"), t->GetFunction());
   }
@@ -2318,18 +2339,24 @@ class Decipher : public ObjectWrap {
     return 1;
   }
 
+  int SetAutoPadding(bool auto_padding) {
+    if (!initialised_) return 0;
+    return EVP_CIPHER_CTX_set_padding(&ctx, auto_padding ? 1 : 0);
+  }
+
   // coverity[alloc_arg]
   int DecipherFinal(unsigned char** out, int *out_len, bool tolerate_padding) {
+    int r;
     if (!initialised_) return 0;
     *out = new unsigned char[EVP_CIPHER_CTX_block_size(&ctx)];
     if (tolerate_padding) {
-      local_EVP_DecryptFinal_ex(&ctx,*out,out_len);
+      r = local_EVP_DecryptFinal_ex(&ctx,*out,out_len);
     } else {
-      EVP_CipherFinal_ex(&ctx,*out,out_len);
+      r = EVP_CipherFinal_ex(&ctx,*out,out_len);
     }
     EVP_CIPHER_CTX_cleanup(&ctx);
     initialised_ = false;
-    return 1;
+    return r;
   }
 
 
@@ -2568,6 +2595,15 @@ class Decipher : public ObjectWrap {
 
   }
 
+  static Handle<Value> SetAutoPadding(const Arguments& args) {
+    HandleScope scope;
+    Decipher *cipher = ObjectWrap::Unwrap<Decipher>(args.This());
+
+    cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue());
+
+    return Undefined();
+  }
+
   static Handle<Value> DecipherFinal(const Arguments& args) {
     HandleScope scope;
 
@@ -2583,7 +2619,13 @@ class Decipher : public ObjectWrap {
     assert(out_len != -1);
 
     if (out_len == 0 || r == 0) {
-      return scope.Close(String::New(""));
+      delete [] out_value; // allocated even if out_len == 0
+      if (r == 0) {
+        Local<Value> exception = Exception::TypeError(String::New("DecipherFinal fail"));
+        return ThrowException(exception);
+      } else {
+        return scope.Close(String::New(""));
+      }
     }
 
 
@@ -2619,18 +2661,21 @@ class Decipher : public ObjectWrap {
 
     HandleScope scope;
 
-    unsigned char* out_value;
+    unsigned char* out_value = NULL;
     int out_len;
-    Local<Value> outString ;
+    Local<Value> outString;
 
-    out_value = NULL;
     int r = cipher->DecipherFinal(&out_value, &out_len, true);
 
     if (out_len == 0 || r == 0) {
-      delete [] out_value;
-      return scope.Close(String::New(""));
+      delete [] out_value; // allocated even if out_len == 0
+      if (r == 0) {
+        Local<Value> exception = Exception::TypeError(String::New("DecipherFinal fail"));
+        return ThrowException(exception);
+      } else {
+        return scope.Close(String::New(""));
+      }
     }
-
 
     if (args.Length() == 0 || !args[0]->IsString()) {
       outString = Encode(out_value, out_len, BINARY);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2177,7 +2177,8 @@ class Cipher : public ObjectWrap {
     if (out_len == 0 || r == 0) {
       delete[] out_value; // allocated even if out_len = 0
       if (r == 0) {
-        Local<Value> exception = Exception::TypeError(String::New("CipherFinal fail"));
+        Local<Value> exception = Exception::TypeError(
+	  String::New("CipherFinal fail"));
         return ThrowException(exception);
       } else {
         return scope.Close(String::New(""));
@@ -2261,7 +2262,8 @@ class Decipher : public ObjectWrap {
     NODE_SET_PROTOTYPE_METHOD(t, "update", DecipherUpdate);
     NODE_SET_PROTOTYPE_METHOD(t, "setAutoPadding", SetAutoPadding);
     NODE_SET_PROTOTYPE_METHOD(t, "final", DecipherFinal);
-    NODE_SET_PROTOTYPE_METHOD(t, "finaltol", DecipherFinalTolerate); // ! undocumented !
+    // this is completely undocumented:
+    NODE_SET_PROTOTYPE_METHOD(t, "finaltol", DecipherFinalTolerate);
 
     target->Set(String::NewSymbol("Decipher"), t->GetFunction());
   }
@@ -2621,7 +2623,8 @@ class Decipher : public ObjectWrap {
     if (out_len == 0 || r == 0) {
       delete [] out_value; // allocated even if out_len == 0
       if (r == 0) {
-        Local<Value> exception = Exception::TypeError(String::New("DecipherFinal fail"));
+        Local<Value> exception = Exception::TypeError(
+	  String::New("DecipherFinal fail"));
         return ThrowException(exception);
       } else {
         return scope.Close(String::New(""));
@@ -2670,7 +2673,8 @@ class Decipher : public ObjectWrap {
     if (out_len == 0 || r == 0) {
       delete [] out_value; // allocated even if out_len == 0
       if (r == 0) {
-        Local<Value> exception = Exception::TypeError(String::New("DecipherFinal fail"));
+        Local<Value> exception = Exception::TypeError(
+	  String::New("DecipherFinal fail"));
         return ThrowException(exception);
       } else {
         return scope.Close(String::New(""));

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2175,10 +2175,10 @@ class Cipher : public ObjectWrap {
     assert(out_len != -1);
 
     if (out_len == 0 || r == 0) {
-      delete[] out_value; // allocated even if out_len = 0
+      delete [] out_value; // allocated even if out_len == 0
       if (r == 0) {
         Local<Value> exception = Exception::TypeError(
-	  String::New("CipherFinal fail"));
+          String::New("CipherFinal fail"));
         return ThrowException(exception);
       } else {
         return scope.Close(String::New(""));
@@ -2624,7 +2624,7 @@ class Decipher : public ObjectWrap {
       delete [] out_value; // allocated even if out_len == 0
       if (r == 0) {
         Local<Value> exception = Exception::TypeError(
-	  String::New("DecipherFinal fail"));
+          String::New("DecipherFinal fail"));
         return ThrowException(exception);
       } else {
         return scope.Close(String::New(""));
@@ -2674,7 +2674,7 @@ class Decipher : public ObjectWrap {
       delete [] out_value; // allocated even if out_len == 0
       if (r == 0) {
         Local<Value> exception = Exception::TypeError(
-	  String::New("DecipherFinal fail"));
+          String::New("DecipherFinal fail"));
         return ThrowException(exception);
       } else {
         return scope.Close(String::New(""));

--- a/test/simple/test-crypto-padding.js
+++ b/test/simple/test-crypto-padding.js
@@ -1,0 +1,125 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+try {
+  var crypto = require('crypto');
+} catch (e) {
+  console.log('Not compiled with OPENSSL support.');
+  process.exit();
+}
+
+
+/** input data **/
+
+const ODD_LENGTH_PLAIN =
+  'Hello node world!';
+
+const EVEN_LENGTH_PLAIN =
+  'Hello node world!AbC09876dDeFgHi';
+
+const KEY_PLAIN = 'S3c.r.e.t.K.e.Y!';
+const KEY_HEX = '5333632e722e652e742e4b2e652e5921';
+const IV_PLAIN = 'blahFizz2011Buzz';
+const IV_HEX = '626c616846697a7a3230313142757a7a';
+
+const CIPHER_NAME = 'aes-128-cbc';
+
+/** expected result data **/
+
+const // echo -n 'Hello node world!' | openssl enc -aes-128-cbc -e -K 5333632e722e652e742e4b2e652e5921 -iv 626c616846697a7a3230313142757a7a | xxd -p -c256
+  ODD_LENGTH_ENCRYPTED = '7f57859550d4d2fdb9806da2a750461a9fe77253cd1cbd4b07beee4e070d561f';
+
+const // echo -n 'Hello node world!AbC09876dDeFgHi' | openssl enc -aes-128-cbc -e -K 5333632e722e652e742e4b2e652e5921 -iv 626c616846697a7a3230313142757a7a | xxd -p -c256
+  EVEN_LENGTH_ENCRYPTED = '7f57859550d4d2fdb9806da2a750461ab46e71b3d78ebe2d9684dfc87f7575b9886119866912cb8c7bcaf76c5ebc2378';
+
+const // echo -n 'Hello node world!AbC09876dDeFgHi' | openssl enc -aes-128-cbc -e -K 5333632e722e652e742e4b2e652e5921 -iv 626c616846697a7a3230313142757a7a -nopad | xxd -p -c256
+  EVEN_LENGTH_ENCRYPTED_NOPAD = '7f57859550d4d2fdb9806da2a750461ab46e71b3d78ebe2d9684dfc87f7575b9';
+
+
+/** helper wrappers **/
+
+function enc(plain, pad)
+{
+  var encrypt = crypto.createCipheriv(CIPHER_NAME, KEY_PLAIN, IV_PLAIN);
+  encrypt.setAutoPadding(pad);
+  var hex = encrypt.update(plain, 'ascii', 'hex');
+  hex += encrypt.final('hex');
+
+  return hex;
+}
+
+function dec(encd, pad)
+{
+  var decrypt = crypto.createDecipheriv(CIPHER_NAME, KEY_PLAIN, IV_PLAIN);
+  decrypt.setAutoPadding(pad);
+  var plain = decrypt.update(encd, 'hex');
+  plain += decrypt.final('binary');
+
+  return plain;
+}
+
+
+/** test encryption **/
+
+assert.equal( enc(ODD_LENGTH_PLAIN,  true), ODD_LENGTH_ENCRYPTED  );
+assert.equal( enc(EVEN_LENGTH_PLAIN, true), EVEN_LENGTH_ENCRYPTED );
+
+assert.throws(function()
+  {
+    // input must have block length %
+    enc(ODD_LENGTH_PLAIN, false);
+  });
+
+assert.doesNotThrow(function()
+  {
+    assert.equal( enc(EVEN_LENGTH_PLAIN, false), EVEN_LENGTH_ENCRYPTED_NOPAD );
+  });
+
+/** test decryption **/
+
+assert.equal( dec(ODD_LENGTH_ENCRYPTED,  true), ODD_LENGTH_PLAIN  );
+assert.equal( dec(EVEN_LENGTH_ENCRYPTED, true), EVEN_LENGTH_PLAIN );
+
+assert.doesNotThrow(function()
+  {
+    // returns including original padding
+    assert.equal( dec(ODD_LENGTH_ENCRYPTED,  false).length, 32 );
+    assert.equal( dec(EVEN_LENGTH_ENCRYPTED, false).length, 48 );
+  });
+
+assert.throws(function()
+  {
+    // must have at least 1 byte of padding (PKCS):
+    assert.equal( dec(EVEN_LENGTH_ENCRYPTED_NOPAD, true), EVEN_LENGTH_PLAIN );
+  });
+
+assert.doesNotThrow(function()
+  {
+    // no-pad encrypted string should return the same:
+    assert.equal( dec(EVEN_LENGTH_ENCRYPTED_NOPAD, false), EVEN_LENGTH_PLAIN );
+  });
+


### PR DESCRIPTION
This is basically an implementation of what has been requested in joyent#361. It includes docs and a test suite.

Regarding the public API:
I originally was going to use an argument `bool auto_padding` to `cipher.final` and `decipher.final`, however that is not possible in `decipher.final`, for `EVP_CipherUpdate` must already know about the padding situation when decrypting (setting it before calling `EVP_CipherFinalEx` would be enough when encrypting).
That's why I added new methods `setAutoPadding([bool enable = true])` to `Cipher` and `Decipher`.

Looking forward to reading your comments.
