### PR TITLE
Fix a docs link that was using HTML instead of Markdown

### DIFF
--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -45,8 +45,8 @@ header on responses.
 
 **Note: these examples are drastically simplified to show
 the basic concept.**  Zlib encoding can be expensive, and the results
-ought to be cached.  See <a href="#memory_Usage_Tuning">Memory Usage
-Tuning</a> below for more information on the speed/memory/compression
+ought to be cached.  See [Memory Usage Tuning](#memory_Usage_Tuning) 
+below for more information on the speed/memory/compression
 tradeoffs involved in zlib usage.
 
     // client request example


### PR DESCRIPTION
This link shows up as raw HTML at http://nodejs.org/docs/v0.6.0/api/zlib.html.  Using Markdown for it should fix that.
