### PR TITLE
Propogate a drain event when no resume method is defined

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -52,7 +52,9 @@ Stream.prototype.pipe = function(dest, options) {
   dest.on('drain', ondrain);
 
   if (!source.resume) {
-    source.resume = function () {source.emit('drain')};
+    source.resume = function() {
+      source.emit('drain')
+    };
   }
 
   // If the 'end' option is not supplied, dest.end() will be called when

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -51,6 +51,10 @@ Stream.prototype.pipe = function(dest, options) {
 
   dest.on('drain', ondrain);
 
+  if (!source.resume) {
+    source.resume = function () {source.emit('drain')};
+  }
+
   // If the 'end' option is not supplied, dest.end() will be called when
   // source gets the 'end' or 'close' events.  Only dest.end() once, and
   // only when all sources have ended.

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -53,7 +53,7 @@ Stream.prototype.pipe = function(dest, options) {
 
   if (!source.resume) {
     source.resume = function() {
-      source.emit('drain')
+      source.emit('drain');
     };
   }
 


### PR DESCRIPTION
Paused pipe() chains will never resume in 0.6 if a stream is in the chain that uses stream.Stream and doesn't define it's own resume() method.
