### PR TITLE
add cluster.fork(env)

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -140,7 +140,7 @@ function eachWorker(cb) {
 };
 
 
-cluster.fork = function() {
+cluster.fork = function(env) {
   // This can only be called from the master.
   assert(cluster.isMaster);
 
@@ -148,7 +148,7 @@ cluster.fork = function() {
   startMaster();
 
   var id = ++ids;
-  var envCopy = {};
+  var envCopy = env || {};
 
   for (var x in process.env) {
     envCopy[x] = process.env[x];


### PR DESCRIPTION
I need to add my own ids since node always increments, the workaround is not brutal, but it would be nicer to have this.

lame workaround:

``` js
process.env.CLOUD_WORKER_ID = id;
var proc = cluster.fork();
delete process.env.CLOUD_WORKER_ID;
```
