### PR TITLE
Fix fs.realpath to return on error (Windows)

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -774,7 +774,7 @@ if (isWindows) {
       return cb(null, cache[p]);
     }
     fs.stat(p, function(err) {
-      if (err) cb(err);
+      if (err) return cb(err);
       if (cache) cache[p] = p;
       cb(null, p);
     });


### PR DESCRIPTION
There is a missing return statement on error for fs.realpath on Windows.
