### PR TITLE
Documenting the lack of Windows support for fs.watchFile

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -218,7 +218,7 @@ Synchronous rmdir(2).
 ### fs.mkdir(path, [mode], [callback])
 
 Asynchronous mkdir(2). No arguments other than a possible exception are given
-to the completion callback. `mode` defaults to `0777`. 
+to the completion callback. `mode` defaults to `0777`.
 
 ### fs.mkdirSync(path, [mode])
 
@@ -386,6 +386,9 @@ Example:
 The synchronous version of `fs.writeFile`.
 
 ### fs.watchFile(filename, [options], listener)
+
+***Warning:*** This method is deprecated, and will throw an error under
+Windows. Use `fs.watch` instead.
 
 Watch for changes on `filename`. The callback `listener` will be called each
 time the file is accessed.

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -218,7 +218,7 @@ Synchronous rmdir(2).
 ### fs.mkdir(path, [mode], [callback])
 
 Asynchronous mkdir(2). No arguments other than a possible exception are given
-to the completion callback. `mode` defaults to `0777`. 
+to the completion callback. `mode` defaults to `0777`.
 
 ### fs.mkdirSync(path, [mode])
 
@@ -386,6 +386,8 @@ Example:
 The synchronous version of `fs.writeFile`.
 
 ### fs.watchFile(filename, [options], listener)
+
+***Warning:*** This method is deprecated, and will throw an error under Windows. Use `fs.watch` instead.
 
 Watch for changes on `filename`. The callback `listener` will be called each
 time the file is accessed.


### PR DESCRIPTION
`fs.watchFile` doesn't exist under Windows (#1358), yet the docs [don't mention this](http://nodejs.org/docs/v0.6.0/api/fs.html#fs.watchFile). If `fs.watch` is the future, the docs should push Node devs to use it.
