### PR TITLE
Fix to throw an ENOSYS error properly at fs.futimesSync() when futimes(3) is not supported.

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -201,7 +201,7 @@ static void After(uv_fs_t *req) {
 // This struct is only used on sync fs calls.
 // For async calls FSReqWrap is used.
 struct fs_req_wrap {
-  fs_req_wrap() {}
+  fs_req_wrap() { req->path = NULL; }
   ~fs_req_wrap() { uv_fs_req_cleanup(&req); }
   // Ensure that copy ctor and assignment operator are not used.
   fs_req_wrap(const fs_req_wrap& req);

--- a/test/simple/test-fs-utimes.js
+++ b/test/simple/test-fs-utimes.js
@@ -57,6 +57,12 @@ function runTests(atime, mtime, callback) {
     fs.utimesSync(__filename, atime, mtime);
     expect_ok('utimesSync', __filename, undefined, atime, mtime);
     tests_run++;
+    
+    if (is_windows) {
+      fd = fs.openSync(__filename, 'r+');
+    } else {
+      fd = fs.openSync(__filename, 'r');
+    }
 
     // some systems don't have futimes
     // if there's an error, it should be ENOSYS
@@ -87,6 +93,10 @@ function runTests(atime, mtime, callback) {
     expect_errno('futimesSync', -1, err, 'EBADF');
     tests_run++;
   }
+  //
+  // test sync code paths at first
+  //
+  syncTests();
 
   //
   // test async code paths
@@ -109,7 +119,6 @@ function runTests(atime, mtime, callback) {
 
         fs.futimes(-1, atime, mtime, function(err) {
           expect_errno('futimes', -1, err, 'EBADF');
-          syncTests();
           callback();
         });
         tests_run++;


### PR DESCRIPTION
When futimes(3) is not supported, Node was crashed by invoking fs.futimesSync()  because the fs_req_wrap destructor calls  free(req->path) without initializing.  Here below is the reproduction code of crash.

var fs = require('fs');
var fd = fs.openSync(__filename, 'r');
fs.futimesSync(fd, new Date(), new Date());

Fix to throw an ENOSYS error properly when fs.futimesSync() is invoked and HAVE_FUTIMES is false by adding  NULL initialization of req->path at the  fs_req_wrap constructor.

 It can also be fixed by another patch if we move uv_fs_req_init() out of  #if HAVE_FUTIMES  at deps/uv/src/unix/fs.c:524 but this pull request has only the former. 

I also found that the async call of fs.uv_fs_futime() causes the assertion error at the same case. Since it seems to have several options to fix, I will submit an another issue ticket.
