### PR TITLE
Addon docs

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -22,8 +22,8 @@ Node statically compiles all its dependencies into the executable. When
 compiling your module, you don't need to worry about linking to any of these
 libraries.
 
-To get started let's make a small Addon which does the following except in
-C++:
+To get started let's make a small Addon which is the C++ equivalent of
+the following Javascript code:
 
     exports.hello = function() { return 'world'; };
 
@@ -40,11 +40,16 @@ To get started we create a file `hello.cc`:
     }
 
     void init(Handle<Object> target) {
-      NODE_SET_METHOD(target, "method", Method);
+      NODE_SET_METHOD(target, "hello", Method);
     }
-    NODE_MODULE(hello, init)
+    NODE_MODULE(hello, init);
 
-This source code needs to be built into `hello.node`, the binary Addon. To
+Note that all Node addons must export an initialization function:
+
+    void Initialize (Handle<Object> target);
+    NODE_MODULE(module_name, Initialize);
+
+The source code needs to be built into `hello.node`, the binary Addon. To
 do this we create a file called `wscript` which is python code and looks
 like this:
 
@@ -70,10 +75,12 @@ Running `node-waf configure build` will create a file
 `node-waf` is just [WAF](http://code.google.com/p/waf), the python-based build system. `node-waf` is
 provided for the ease of users.
 
-All Node addons must export an initialization function:
+You can now use the binary addon in a Node project by pointing `require` to
+the recently build module:
 
-    void Initialize (Handle<Object> target);
-    NODE_MODULE(hello, Initialize)
+    var addon = require('./build/Release/hello');
+
+    console.log(addon.hello()); // 'world'
 
 For the moment, that is all the documentation on addons. Please see
 <https://github.com/ry/node_postgres> for a real example.

--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -76,7 +76,7 @@ Running `node-waf configure build` will create a file
 provided for the ease of users.
 
 You can now use the binary addon in a Node project by pointing `require` to
-the recently build module:
+the recently built module:
 
     var addon = require('./build/Release/hello');
 

--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -42,12 +42,14 @@ To get started we create a file `hello.cc`:
     void init(Handle<Object> target) {
       NODE_SET_METHOD(target, "hello", Method);
     }
-    NODE_MODULE(hello, init);
+    NODE_MODULE(hello, init)
 
 Note that all Node addons must export an initialization function:
 
     void Initialize (Handle<Object> target);
-    NODE_MODULE(module_name, Initialize);
+    NODE_MODULE(module_name, Initialize)
+
+There is no semi-colon after `NODE_MODULE` as it's not a function (see `node.h`).
 
 The source code needs to be built into `hello.node`, the binary Addon. To
 do this we create a file called `wscript` which is python code and looks

--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -75,7 +75,7 @@ Running `node-waf configure build` will create a file
 `node-waf` is just [WAF](http://code.google.com/p/waf), the python-based build system. `node-waf` is
 provided for the ease of users.
 
-You can now use the binary addon in a Node project by pointing `require` to
+You can now use the binary addon in a Node project `hello.js` by pointing `require` to
 the recently built module:
 
     var addon = require('./build/Release/hello');


### PR DESCRIPTION
The example given wasn't working, because of the 2nd argument of `NODE_SET_METHOD` (changed from `"method"` to `"hello"` to match the rest of the example).

Also added a simple `hello.js` snippet to complete the demonstration.
