### PR TITLE
util.inherits returns the constructor

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -519,4 +519,7 @@ exports.inherits = function(ctor, superCtor) {
       configurable: true
     }
   });
+
+  return ctor;
+
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -501,7 +501,7 @@ exports.pump = function(readStream, writeStream, callback) {
  *
  * The Function.prototype.inherits from lang.js rewritten as a standalone
  * function (not on Function.prototype). NOTE: If this file is to be loaded
- * during bootstrapping this function needs to be revritten using some native
+ * during bootstrapping this function needs to be rewritten using some native
  * functions as prototype setup using normal JavaScript does not work as
  * expected during bootstrapping (see mirror.js in r114903).
  *


### PR DESCRIPTION
Hey hey,

If util.inherits returns the constructor (instead of returning nothing), you can write stuff like:

```
var util = require("util"),
    EventEmitter = require("events").EventEmitter;

var Foo = util.inherits(function (bar) {
  this.on("foo", function () {
    console.log(bar);
  });
}, EventEmitter);

var foo = new Foo("bar");
```

Then you could call `foo.emit("foo")` and it should console.log "bar".

This is also backwards-compatible, since nobody using it the normal way cares about the return value.
