### PR TITLE
docs: client should be closed in the callback

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -53,8 +53,9 @@ Example of sending a UDP packet to a random port on `localhost`;
     var dgram = require('dgram');
     var message = new Buffer("Some bytes");
     var client = dgram.createSocket("udp4");
-    client.send(message, 0, message.length, 41234, "localhost");
-    client.close();
+    client.send(message, 0, message.length, 41234, "localhost", function(err, bytes) {
+      client.close();
+    });
 
 **A Note about UDP datagram size**
 


### PR DESCRIPTION
On my environment, the original example did not fire any udp packet on node v0.6.0.
(both worked on node v0.4.9)
