### PR TITLE
a cleaner default output for deepEqual

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -85,6 +85,93 @@ assert.AssertionError.prototype.toString = function() {
   }
 };
 
+// function to format a deepEqual failure
+function formatDeepEqual(actual, expected, depth) {
+  var out = [''];
+  depth = depth || 1;
+
+  if (depth > 5) {
+    // I don't want to recurse forever, 5 is plenty.
+    // maybe a config? proccess.env.inspect_depth?
+    return format('', actual, expected, 0);
+  }
+
+  if (Array.isArray(actual) && Array.isArray(expected)) {
+    // make sure we have an opening [
+    out[0] += '[';
+
+    // who's longer?
+    var l = actual.length > expected.length ? actual.length : expected.length;
+    // for each row output someging like:
+    //    5: "actual value" = "expected value"
+    for (var i = 0; i < l; i++) {
+      out.push(format(i, actual[i], expected[i], depth));
+    }
+    // push closeing ]
+    out.push(new Array((depth - 1) * 2).join(' ') + ']');
+
+  } else if (typeof actual === 'object' && typeof expected === 'object'
+            && !(Array.isArray(actual) || Array.isArray(expected))) {
+    // make sure we have an opening {
+    out[0] += '{';
+
+    // for each row output someging like:
+    //   key: "actual value" = "expected value"
+    for (var i in actual) {
+      if (actual.hasOwnProperty(i)) {
+        out.push(format(i, actual[i], expected[i], depth));
+      }
+    }
+
+    // now go back over expected and get anything that does not exist
+    // in actual
+    for (var i in expected) {
+      if (expected.hasOwnProperty(i) && !actual.hasOwnProperty(i)) {
+        out.push(format(i, undefined, expected[i], depth));
+      }
+    }
+
+    // push closeing }
+    out.push(new Array((depth - 1) * 2).join(' ') + '}');
+
+  } else if (depth > 1) {
+    // I only want acutal == expected, in this case I was called recursively
+    // and I don't need tab depth.
+    return format('', actual, expected, 0);
+  } else {
+    // I don't think there is a way to format this that will be more
+    // helpfull then the default msg
+    return '';
+  }
+
+  if (depth === 1) {
+    return 'deepEqual: ' + out.join('\n');
+  } else {
+    return out.join('\n');
+  }
+
+  // helper
+  function format(key, a, e, depth) {
+    var tab = new Array(depth * 2).join(' ');
+
+    // if a and e are both [] or {}
+    if ((Array.isArray(a) && Array.isArray(e))
+        || (typeof a === 'object' && typeof e === 'object'
+           && !(Array.isArray(a) || Array.isArray(e)))
+       && a !== null && e !== null) {
+      return tab + key + ': ' + formatDeepEqual(a, e, depth + 1);
+    } else {
+      a = a !== undefined ?
+              truncate(JSON.stringify(a, replacer), 128) :
+              'key-undefined';
+      e = e !== undefined ?
+              truncate(JSON.stringify(e, replacer), 128) :
+              'key-undefined';
+      return tab + key + ': ' + a + ' == ' + e;
+    }
+  }
+}
+
 // assert.AssertionError instanceof Error
 
 assert.AssertionError.__proto__ = Error.prototype;
@@ -147,6 +234,10 @@ assert.notEqual = function notEqual(actual, expected, message) {
 
 assert.deepEqual = function deepEqual(actual, expected, message) {
   if (!_deepEqual(actual, expected)) {
+    // if you don't pass a message, try and make something nice.
+    if (!message) {
+      message = formatDeepEqual(actual, expected);
+    }
     fail(actual, expected, message, 'deepEqual', assert.deepEqual);
   }
 };
@@ -242,6 +333,11 @@ function objEquiv(a, b) {
 
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
   if (_deepEqual(actual, expected)) {
+    // if you don't pass a message, try and make something nice.
+    if (!message) {
+      message = formatDeepEqual(actual, expected);
+    }
+
     fail(actual, expected, message, 'notDeepEqual', assert.notDeepEqual);
   }
 };

--- a/test/simple/test-assert-deepEqual-format.js
+++ b/test/simple/test-assert-deepEqual-format.js
@@ -1,0 +1,238 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+// if you pass a message, don't change it
+try {
+  assert.deepEqual({
+    'same' : 'thing',
+    'diff' : 'thing'
+  },{
+    'same' : 'thing',
+    'diff' : 'gniht'
+  },'my message');
+} catch (e) {
+  assert.equal(e.message,
+    'my message');
+}
+
+// basic test of object differance
+try {
+  assert.deepEqual({
+    'same' : 'thing',
+    'diff' : 'thing'
+  },{
+    'same' : 'thing',
+    'diff' : 'gniht'
+  });
+} catch (e) {
+  assert.equal(e.message,
+    'deepEqual: {\n' +
+    ' same: "thing" == "thing"\n' +
+    ' diff: "thing" == "gniht"\n' +
+    '}');
+}
+
+// basic test of array differance
+try {
+  assert.deepEqual(['same', 'diff'], ['same','rent']);
+} catch (e) {
+  assert.equal(e.message,
+    'deepEqual: [\n' +
+    ' 0: "same" == "same"\n' +
+    ' 1: "diff" == "rent"\n' +
+    ']');
+}
+
+// actual has an extra key
+try {
+  assert.deepEqual({
+    'same' : 'thing',
+    'diff' : 'thing'
+  },{
+    'same' : 'thing'
+  });
+} catch (e) {
+  assert.equal(e.message,
+    'deepEqual: {\n' +
+    ' same: "thing" == "thing"\n' +
+    ' diff: "thing" == key-undefined\n' +
+    '}');
+}
+
+// actual missing a key
+try {
+  assert.deepEqual({
+    'same' : 'thing'
+  },{
+    'same' : 'thing',
+    'diff' : 'thing'
+  });
+} catch (e) {
+  assert.equal(e.message,
+    'deepEqual: {\n' +
+    ' same: "thing" == "thing"\n' +
+    ' diff: key-undefined == "thing"\n' +
+    '}');
+}
+
+// actual has an extra value
+try {
+  assert.deepEqual(['same', 'diff'], ['same']);
+} catch (e) {
+  assert.equal(e.message,
+    'deepEqual: [\n' +
+    ' 0: "same" == "same"\n' +
+    ' 1: "diff" == key-undefined\n' +
+    ']');
+}
+
+// actual missing a value
+try {
+  assert.deepEqual(['same'], ['same','rent']);
+} catch (e) {
+  assert.equal(e.message,
+    'deepEqual: [\n' +
+    ' 0: "same" == "same"\n' +
+    ' 1: key-undefined == "rent"\n' +
+    ']');
+}
+
+// potentially annoying values to format
+try {
+  assert.deepEqual({
+    'a' : null,
+    'b' : false,
+    'c' : null,
+    'd' : '',
+    'e' : 0
+  },{
+    'a' : '',
+    'b' : 0
+  });
+} catch (e) {
+  assert.equal(e.message,
+'deepEqual: {\n'+
+' a: null == ""\n'+
+' b: false == 0\n'+
+' c: null == key-undefined\n'+
+' d: "" == key-undefined\n'+
+' e: 0 == key-undefined\n'+
+'}');
+}
+
+// a wide variaty of anoying things are different
+try {
+  assert.deepEqual(
+    [
+      {
+        'some' : 'key',
+        'other' : 'value',
+        'miss' : 'ing'
+      },
+      {
+        'more' : 'complex',
+        'anoying' : null,
+        5 : 10
+      },
+      ['object', 'where', false],
+      {
+        'things' : {
+          'are' : 'other'
+        }
+      }
+  ],
+  [
+      {
+        'some' : 'key',
+        'other' : 'value2'
+      },
+      {
+        'more' : 'complex',
+        'anoying' : '',
+        5 : 10
+      },
+      ['object', 'where', 0],
+      {
+        'things' : {
+          'are' : 'other',
+          'miss' : 'ing'
+        }
+      }
+  ]);
+} catch (e) {
+  assert.equal(e.message,
+'deepEqual: [\n'+
+' 0: {\n'+
+'   some: "key" == "key"\n'+
+'   other: "value" == "value2"\n'+
+'   miss: "ing" == key-undefined\n'+
+' }\n'+
+' 1: {\n'+
+'   5: 10 == 10\n'+
+'   more: "complex" == "complex"\n'+
+'   anoying: null == ""\n'+
+' }\n'+
+' 2: [\n'+
+'   0: "object" == "object"\n'+
+'   1: "where" == "where"\n'+
+'   2: false == 0\n'+
+' ]\n'+
+' 3: {\n'+
+'   things: {\n'+
+'     are: "other" == "other"\n'+
+'     miss: key-undefined == "ing"\n'+
+'   }\n'+
+' }\n'+
+']');
+}
+
+// diffrent objects should not update the message
+// i.e. if there is not a lot of benifit to a new format, don't do it.
+try {
+  assert.deepEqual({'same': 'asdf', 'diff': 'value'}, ['same']);
+} catch (e) {
+  assert.equal(e.message, '');
+}
+
+// nessted different objects should fall back to
+// truncate(JSON.stringify(a, replacer), 128)
+try {
+  assert.deepEqual(
+    [
+      {
+        'some' : 'key',
+        'other' : 'value',
+        'miss' : 'ing'
+      }
+  ],
+  [
+      ['object', 'where', 0]
+  ]);
+} catch (e) {
+  assert.equal(e.message,
+'deepEqual: [\n'+
+' 0: {"some":"key","other":"value","miss":"ing"} == ["object","where",0]\n'+
+']');
+}
+


### PR DESCRIPTION
I find myself pasting in this code every time I have to fix a bunch of unit tests that use deepEqual.

Maybe the world will find it useful?  It is clearly inefficient to walk to object twice, once to find that it is not equal and once to format output.  But I like to thing that we can spend a few cycles to scratch our own back...

deepEqual/notDeepEqual by default return
truncate(JSON.stringify(a, replacer), 128) for both the actual and expected values.

This makes it hard to debug what is actually different.

Now, if a user makes a deepEqual call without passing a message I will attempt to format the message into something readable.

e.g.

```
deepEqual : {
 'key': "actual" == "expected"
}
```
