### PR TITLE
turn NODE_SET_METHOD and NODE_SET_PROTOTYPE_METHOD into functions

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -108,19 +108,22 @@ void EmitExit(v8::Handle<v8::Object> process);
                 static_cast<v8::PropertyAttribute>(                       \
                     v8::ReadOnly|v8::DontDelete))
 
-#define NODE_SET_METHOD(obj, name, callback)                              \
-  obj->Set(v8::String::NewSymbol(name),                                   \
-           v8::FunctionTemplate::New(callback)->GetFunction())
+template <typename target_t>
+void NODE_SET_METHOD(target_t obj, const char* name,
+        v8::InvocationCallback callback)
+{
+    obj->Set(v8::String::NewSymbol(name),
+        v8::FunctionTemplate::New(callback)->GetFunction());
+}
 
-#define NODE_SET_PROTOTYPE_METHOD(templ, name, callback)                  \
-do {                                                                      \
-  v8::Local<v8::Signature> __callback##_SIG = v8::Signature::New(templ);  \
-  v8::Local<v8::FunctionTemplate> __callback##_TEM =                      \
-    v8::FunctionTemplate::New(callback, v8::Handle<v8::Value>(),          \
-                          __callback##_SIG);                              \
-  templ->PrototypeTemplate()->Set(v8::String::NewSymbol(name),            \
-                                  __callback##_TEM);                      \
-} while (0)
+template <typename target_t>
+void NODE_SET_PROTOTYPE_METHOD(target_t target,
+        const char* name, v8::InvocationCallback callback)
+{
+    v8::Local<v8::FunctionTemplate> templ = v8::FunctionTemplate::New(callback);
+    target->PrototypeTemplate()->Set(v8::String::NewSymbol(name), templ);
+}
+
 
 enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX};
 enum encoding ParseEncoding(v8::Handle<v8::Value> encoding_v,


### PR DESCRIPTION
The defines cannot be used if the callback is a templated and
has multiple template arguments. The comma separating the arguments
breaks the preprocessor argument handling. Using a templated function
is clearer and more in line with c++.

Something like the following does not with when using defines.
NODE_SET_PROTOTYPE_METHOD(target, "comma_break", some_method<type1, type2>);
