### PR TITLE
Fixed minimum values for writeInt*() functions.

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -988,7 +988,7 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
     assert.ok(offset < buffer.length,
         'Trying to write beyond buffer length');
 
-    verifsint(value, 0x7f, -0xf0);
+    verifsint(value, 0x7f, -0x80);
   }
 
   if (value >= 0) {
@@ -1012,7 +1012,7 @@ function writeInt16(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(offset + 1 < buffer.length,
         'Trying to write beyond buffer length');
 
-    verifsint(value, 0x7fff, -0xf000);
+    verifsint(value, 0x7fff, -0x8000);
   }
 
   if (value >= 0) {
@@ -1044,7 +1044,7 @@ function writeInt32(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(offset + 3 < buffer.length,
         'Trying to write beyond buffer length');
 
-    verifsint(value, 0x7fffffff, -0xf0000000);
+    verifsint(value, 0x7fffffff, -0x80000000);
   }
 
   if (value >= 0) {

--- a/test/simple/test-writeint.js
+++ b/test/simple/test-writeint.js
@@ -19,6 +19,19 @@ function test8() {
   ASSERT.throws(function() {
     buffer.writeInt8(0xabc, 0);
   });
+  
+  /* Make sure we handle min/max correctly */
+  buffer.writeInt8(0x7f, 0);
+  buffer.writeInt8(-0x80, 1);
+  
+  ASSERT.equal(0x7f, buffer[0]);
+  ASSERT.equal(0x80, buffer[1]);
+  ASSERT.throws(function() {
+    buffer.writeInt8(0x7f + 1, 0);
+  });
+  ASSERT.throws(function() {
+    buffer.writeInt8(-0x80 - 1, 0);
+  });
 }
 
 
@@ -45,6 +58,33 @@ function test16() {
   ASSERT.equal(0x71, buffer[2]);
   ASSERT.equal(0x71, buffer[3]);
   ASSERT.equal(0xf9, buffer[4]);
+  
+  /* Make sure we handle min/max correctly */
+  buffer.writeInt16BE(0x7fff, 0);
+  buffer.writeInt16BE(-0x8000, 2);
+  ASSERT.equal(0x7f, buffer[0]);
+  ASSERT.equal(0xff, buffer[1]);
+  ASSERT.equal(0x80, buffer[2]);
+  ASSERT.equal(0x00, buffer[3]);
+  ASSERT.throws(function() {
+    buffer.writeInt16BE(0x7fff + 1, 0);
+  });
+  ASSERT.throws(function() {
+    buffer.writeInt16BE(-0x8000 - 1, 0);
+  });
+  
+  buffer.writeInt16LE(0x7fff, 0);
+  buffer.writeInt16LE(-0x8000, 2);
+  ASSERT.equal(0xff, buffer[0]);
+  ASSERT.equal(0x7f, buffer[1]);
+  ASSERT.equal(0x00, buffer[2]);
+  ASSERT.equal(0x80, buffer[3]);
+  ASSERT.throws(function() {
+    buffer.writeInt16LE(0x7fff + 1, 0);
+  });
+  ASSERT.throws(function() {
+    buffer.writeInt16LE(-0x8000 - 1, 0);
+  });
 }
 
 
@@ -83,6 +123,41 @@ function test32() {
   ASSERT.equal(0xfe, buffer[5]);
   ASSERT.equal(0xff, buffer[6]);
   ASSERT.equal(0xcf, buffer[7]);
+  
+  /* Make sure we handle min/max correctly */
+  buffer.writeInt32BE(0x7fffffff, 0);
+  buffer.writeInt32BE(-0x80000000, 4);
+  ASSERT.equal(0x7f, buffer[0]);
+  ASSERT.equal(0xff, buffer[1]);
+  ASSERT.equal(0xff, buffer[2]);
+  ASSERT.equal(0xff, buffer[3]);
+  ASSERT.equal(0x80, buffer[4]);
+  ASSERT.equal(0x00, buffer[5]);
+  ASSERT.equal(0x00, buffer[6]);
+  ASSERT.equal(0x00, buffer[7]);
+  ASSERT.throws(function() {
+    buffer.writeInt32BE(0x7fffffff + 1, 0);
+  });
+  ASSERT.throws(function() {
+    buffer.writeInt32BE(-0x80000000 - 1, 0);
+  });
+  
+  buffer.writeInt32LE(0x7fffffff, 0);
+  buffer.writeInt32LE(-0x80000000, 4);
+  ASSERT.equal(0xff, buffer[0]);
+  ASSERT.equal(0xff, buffer[1]);
+  ASSERT.equal(0xff, buffer[2]);
+  ASSERT.equal(0x7f, buffer[3]);
+  ASSERT.equal(0x00, buffer[4]);
+  ASSERT.equal(0x00, buffer[5]);
+  ASSERT.equal(0x00, buffer[6]);
+  ASSERT.equal(0x80, buffer[7]);
+  ASSERT.throws(function() {
+    buffer.writeInt32LE(0x7fffffff + 1, 0);
+  });
+  ASSERT.throws(function() {
+    buffer.writeInt32LE(-0x80000000 - 1, 0);
+  });
 }
 
 


### PR DESCRIPTION
Currently writeInt8/16/32 functions accept values out of their range (when they should throw an exception):
int8: from -240 to 127
int16: from -61440 to 32767
int32: from -4026531840 to 2147483647

I've changed the minimums to -128, -32768, -2147483648.
