### PR TITLE
remove the line requiring events module

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var events = require('events');
-
-
 var formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (typeof f !== 'string') {


### PR DESCRIPTION
I haven't seen the history of it but, util.js seems not using events module.

Thanks
