### PR TITLE
process: added getrlimit() and setrlimit()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -355,3 +355,56 @@ given, otherwise returns the current mask.
 ### process.uptime()
 
 Number of seconds Node has been running.
+
+### process.getrlimit(resource)
+
+Get resource limits. (See getrlimit(2).)
+
+The `soft` limit is the value that the kernel enforces for the
+corresponding resource. The `hard` limit acts as a ceiling for the soft
+limit: an unprivileged process may only set its soft limit to a value in the
+range from 0 up to the hard limit, and (irreversibly) lower its hard limit.
+
+Supported resources:
+
+'`core'` (RLIMIT_CORE) Maximum size of core file.  When 0 no core dump files are
+created.
+
+`'cpu'` (RLIMIT_CPU) CPU time limit in seconds.  When the process reaches the
+soft limit, it is sent a SIGXCPU signal. The default action for this signal is
+to terminate the process.
+
+`'data'` (RLIMIT_DATA) The maximum size of the process's data segment
+(initialized data, uninitialized data, and heap).
+
+`'fsize'` (RLIMIT_FSIZE) The maximum size of files that the process may create.
+Attempts to extend a file beyond this limit result in delivery of a SIGXFSZ
+signal.
+
+`'nofile'` (RLIMIT_NOFILE) Specifies a value one greater than the maximum file
+descriptor number that can be opened by this process.
+
+`'stack'` (RLIMIT_STACK) The maximum size of the process stack, in bytes. Upon
+reaching this limit, a SIGSEGV signal is generated.
+
+`'as'` (RLIMIT_AS) The maximum size of the process's virtual memory (address
+space) in bytes.
+
+    var limits = process.getrlimit("nofile");
+    console.log('Current limits: soft=' + limits.soft + ", max=" + limits.hard);
+
+### process.setrlimit(resource, limits)
+
+Set resource limits. (See setrlimit(2).) Supported resource types are listed
+under `process.getrlimit`.
+
+The `limits` argument is an object in the form
+`{ soft: SOFT_LIMIT, hard: HARD_LIMIT }`. Current limit values are used if
+either `soft` or `hard` key is not specifing in the `limits` object. A limit
+value of `null` indicates "unlimited" (RLIM_INFINITY).
+
+    // raise maximum number of open file descriptors to 10k, hard limit is left unchanged
+    process.setrlimit("nofile", { soft: 10000 });
+
+    // enable core dumps of unlimited size
+    process.setrlimit("core", { soft: null, hard: null });

--- a/test/simple/test-process-rlimit.js
+++ b/test/simple/test-process-rlimit.js
@@ -1,0 +1,85 @@
+var assert = require('assert');
+var common = require('../common');
+
+var limits = [
+    "core",
+    "cpu",
+    "data",
+    "fsize",
+    "nofile",
+    "stack",
+    "as"
+];
+
+// getrlimit: invalid input args
+try {
+    process.getrlimit("foobar");
+    assert.ok(false);
+}
+catch(e) { }
+
+try {
+    process.getrlimit();
+    assert.ok(false);
+}
+catch(e) { }
+
+try {
+    process.getrlimit(0);
+    assert.ok(false);
+}
+catch(e) { }
+
+// getrlimit: check all supported resources
+for(var i in limits) {
+    console.log("getrlimit: " + limits[i]);
+    var limit = process.getrlimit(limits[i]);
+    console.log(common.inspect(limit));
+    assert.equal(true, typeof limit.soft == 'number');
+    assert.equal(true, typeof limit.hard == 'number');
+}
+
+// setrlimit: invalid input args
+try {
+    process.setrlimit();
+    assert.ok(false);
+}
+catch(e) { }
+
+try {
+    process.setrlimit("nofile");
+    assert.ok(false);
+}
+catch(e) { }
+
+try {
+    process.setrlimit("foobar", {soft: 100});
+    assert.ok(false);
+}
+catch(e) { }
+
+// make some "nofile" adjustments
+var begin = process.getrlimit("nofile")
+console.log("begin: " + common.inspect(begin));
+process.setrlimit("nofile", {soft: 500})
+var now = process.getrlimit("nofile")
+assert.equal(begin.hard, now.hard);
+console.log("adjusted: " + common.inspect(now));
+assert.equal(now.soft, 500);
+
+// setrlimit: lower each limit by one
+for(var i in limits) {
+    var limit = process.getrlimit(limits[i]);
+    if(limit.soft > 1) {
+        console.log("setrlimit: " + limits[i] + " " + common.inspect(limit));
+        process.setrlimit(limits[i], {
+            soft: limit.soft - 1,
+            hard: limit.hard
+        });
+        var limit2 = process.getrlimit(limits[i]);
+        assert.equal(limit.soft - 1, limit2.soft);
+        console.log(limits[i] + " was: " + common.inspect(limit));
+        console.log(limits[i] + " now: " + common.inspect(limit2));
+    }
+}
+


### PR DESCRIPTION
Get and set resource limits (getrlimit(2), setrlimit(2)).

Typical use for this is to raise the max limit of open file descriptors from the default low numbers such 256 (OSX) or 1024 (typical Linux default) to a more reasonable value.
