### PR TITLE
Allow for cross-OS cross compiles, implement dest-cpu, dest-os options

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -3,6 +3,7 @@
     'visibility%': 'hidden',         # V8's visibility setting
     'target_arch%': 'ia32',          # set v8's target architecture
     'host_arch%': 'ia32',            # set v8's host architecture
+    'host_os%': '<(OS)',             # set v8's host os 
     'library%': 'static_library',    # allow override to 'shared_library' for DLL/.so builds
     'component%': 'static_library',  # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',  # we do enable multicore compiles, but not using the V8 way
@@ -96,18 +97,24 @@
       },
     },
     'conditions': [
-      ['OS == "win"', {
-        'msvs_cygwin_shell': 0, # prevent actions from trying to use cygwin
+      [ 'host_os == "win"', {
         'defines': [
           'WIN32',
-          # we don't really want VC++ warning us about
-          # how dangerous C functions are...
-          '_CRT_SECURE_NO_DEPRECATE',
-          # ... or that C implementations shouldn't use
-          # POSIX names
-          '_CRT_NONSTDC_NO_DEPRECATE',
           'BUILDING_V8_SHARED=1',
           'BUILDING_UV_SHARED=1',
+        ],
+        'conditions': [
+          [ 'OS=="win"', {
+            'msvs_cygwin_shell': 0, # prevent actions from trying to use cygwin
+            'defines': [
+              # we don't really want VC++ warning us about
+              # how dangerous C functions are...
+              '_CRT_SECURE_NO_DEPRECATE',
+              # ... or that C implementations shouldn't use
+              # POSIX names
+              '_CRT_NONSTDC_NO_DEPRECATE',
+            ],
+          }],
         ],
       }],
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
@@ -127,7 +134,7 @@
           }],
         ],
       }],
-      ['OS=="mac"', {
+      ['host_os=="mac"', {
         'xcode_settings': {
           'ALWAYS_SEARCH_USER_PATHS': 'NO',
           'GCC_CW_ASM_SYNTAX': 'NO',                # No -fasm-blocks

--- a/configure
+++ b/configure
@@ -131,14 +131,20 @@ def uname(switch):
 
 
 def parse_arch(arch, default):
-  return {
-    'arm': 'arm',
-    'x86': 'ia32',
-    'i386': 'ia32',
-    'ia32': 'ia32',
-    'x86_64': 'x64',
-    'x64': 'x64'
-  }.get(arch, default)
+  mapping = {
+    'arm': {'arm'},
+    'ia32': {'x86','ia32','i386'},
+    'x64': {'x64','amd64','x86_64'},
+    # TODO support MIPS when acceptable
+  }
+  
+  if arch is not None:
+    for (arch_normalised, arch_mapping) in mapping.items():
+      for arch_optional in arch_mapping:
+        if arch.startswith(arch_optional):
+          return arch_normalised
+  
+  return default
 
 def host_arch():
   """Host architecture. One of arm, ia32 or x64."""
@@ -154,20 +160,22 @@ def target_arch():
   return parse_arch(options.dest_cpu, host_arch())
 
 def parse_os(os, default):
-  # TODO what to do about cygwin/mingw
-  return {
-    'linux': 'linux',
-    'linux2': 'linux',
-    'win': 'win',
-    'win32': 'win',
-    'w64': 'win',
-    'cygwin': 'linux',
-    'darwin': 'mac',
-    'sunos5': 'solaris',
-    'freebsd7': 'freebsd',
-    'freebsd7': 'freebsd',
-    'openbsd': 'openbsd',
-  }.get(os, default)
+  mapping = {
+    'linux': {'linux','cygwin'},
+    'win': {'w'},
+    'mac': {'mac','darwin','osx'},
+    'solaris': {'solaris','sunos'},
+    'freebsd': {'freebsd'},
+    'openbsd': {'openbsd'},
+  }
+  
+  if os is not None:
+    for (os_normalised, os_mapping) in mapping.items():
+      for os_optional in os_mapping:
+        if os.startswith(os_optional):
+          return os_normalised
+  
+  return default
 
 def host_os():
   """Host operating system. One of win, linux, freebsd, openbsd, solaris, mac."""

--- a/configure
+++ b/configure
@@ -141,7 +141,7 @@ def parse_arch(arch, default):
   if arch is not None:
     for (arch_normalised, arch_mapping) in mapping.items():
       for arch_optional in arch_mapping:
-        if arch.startswith(arch_optional):
+        if arch == arch_optional:
           return arch_normalised
   
   return default

--- a/configure
+++ b/configure
@@ -100,6 +100,12 @@ parser.add_option("--dest-cpu",
     dest="dest_cpu",
     help="CPU architecture to build for. Valid values are: arm, ia32, x64")
 
+parser.add_option("--dest-os",
+    action="store",
+    dest="dest_os",
+    help="Operating system to build for. Valid values are: win, linux, freebsd, openbsd, solaris, mac")
+
+
 (options, args) = parser.parse_args()
 
 
@@ -124,6 +130,16 @@ def uname(switch):
   return s
 
 
+def parse_arch(arch, default):
+  return {
+    'arm': 'arm',
+    'x86': 'ia32',
+    'i386': 'ia32',
+    'ia32': 'ia32',
+    'x86_64': 'x64',
+    'x64': 'x64'
+  }.get(arch, default)
+
 def host_arch():
   """Host architecture. One of arm, ia32 or x64."""
   arch = uname('-p')
@@ -131,26 +147,46 @@ def host_arch():
   if arch == 'unknown':
     arch = uname('-m')
 
-  return {
-    'arm': 'arm',
-    'x86': 'ia32',
-    'i386': 'ia32',
-    'x86_64': 'x64',
-  }.get(arch, 'ia32')
+  return parse_arch(arch, 'ia32')
 
 
 def target_arch():
-  # TODO act on options.dest_cpu
-  return host_arch()
+  return parse_arch(options.dest_cpu, host_arch())
+
+def parse_os(os, default):
+  # TODO what to do about cygwin/mingw
+  return {
+    'linux': 'linux',
+    'linux2': 'linux',
+    'win': 'win',
+    'win32': 'win',
+    'w64': 'win',
+    'cygwin': 'linux',
+    'darwin': 'mac',
+    'sunos5': 'solaris',
+    'freebsd7': 'freebsd',
+    'freebsd7': 'freebsd',
+    'openbsd': 'openbsd',
+  }.get(os, default)
+
+def host_os():
+  """Host operating system. One of win, linux, freebsd, openbsd, solaris, mac."""
+  return parse_os(sys.platform, 'linux')
+
+def target_os():
+  """Target operating system to build node for. One of win, linux, freebsd, openbsd, solaris, mac."""
+  return parse_os(options.dest_os, host_os())
 
 
 def configure_node(o):
-  # TODO add gdb and dest_cpu
+  # TODO add gdb
   o['variables']['node_debug'] = 'true' if options.debug else 'false'
   o['variables']['node_prefix'] = options.prefix if options.prefix else ''
   o['variables']['node_use_dtrace'] = 'true' if options.with_dtrace else 'false'
   o['variables']['host_arch'] = host_arch()
   o['variables']['target_arch'] = target_arch()
+  o['variables']['host_os'] = host_os()
+  o['variables']['OS'] = target_os()
 
   # TODO move to node.gyp
   if sys.platform == 'sunos5':
@@ -158,7 +194,9 @@ def configure_node(o):
 
 
 def configure_libz(o):
-  o['libraries'] += ['-lz']
+  # TODO add -lz to libraries if linking libz as shared
+  pass
+  
 
 
 def configure_v8(o):
@@ -172,6 +210,12 @@ def configure_v8(o):
     o['libraries'] += ['-l%s' % options.shared_v8_libname]
   if options.shared_v8_includes:
     o['include_dirs'] += [options.shared_v8_includes]
+
+  # prevent v8 being built twice when its not needed
+  if (target_arch()=="arm" and host_arch()!="arm") or (target_arch()=="x64" and host_arch()!="x64"):
+    o['variables']['want_separate_host_toolset'] = 1
+  else:
+    o['variables']['want_separate_host_toolset'] = 0
 
 
 def configure_cares(o):

--- a/node.gyp
+++ b/node.gyp
@@ -154,16 +154,25 @@
           'sources': [
             'src/platform_win32.cc',
             # headers to make for a more pleasant IDE experience
-            'src/platform_win32.h',
-            'tools/msvs/res/node.rc',
-          ],
+            'src/platform_win32.h',     
+          ],   
           'defines': [
             'FD_SETSIZE=1024',
             # we need to use node's preferred "win32" rather than gyp's preferred "win"
             'PLATFORM="win32"',
           ],
-          'libraries': [ '-lpsapi.lib' ]
-        },{ # POSIX
+          'conditions': [
+            [ 'host_os=="win"', {
+              'sources': [
+                'tools/msvs/res/node.rc',
+              ],
+              'libraries': [ '-lpsapi.lib' ],
+            },{ # host_os != win
+              # TODO use node.rc
+              'libraries': [ '-lpsapi' ],
+            }],
+          ],
+        },{ # OS != win
           'defines': [ '__POSIX__' ],
           'sources': [
             'src/node_signal_watcher.cc',


### PR DESCRIPTION
This is step 1 to cross-compile for Windows on Linux (other patches to uv.gyp and v8.gyp needed for this).
Also, I made it pay respect to dest-cpu and dest-os options.
Hopefully, fixes joyent/node#1736 (not sure, looks to be only once) by setting `want_separate_host_toolset` variable.

Not sure what to do with libz and some other tidbits, see TODOs in the code.
