### PR TITLE
Remove support for multi-source pipe()

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -52,12 +52,8 @@ Stream.prototype.pipe = function(dest, options) {
   dest.on('drain', ondrain);
 
   // If the 'end' option is not supplied, dest.end() will be called when
-  // source gets the 'end' or 'close' events.  Only dest.end() once, and
-  // only when all sources have ended.
+  // source gets the 'end' or 'close' events.  Only dest.end() once.
   if (!dest._isStdio && (!options || options.end !== false)) {
-    dest._pipeCount = dest._pipeCount || 0;
-    dest._pipeCount++;
-
     source.on('end', onend);
     source.on('close', onclose);
   }
@@ -67,15 +63,8 @@ Stream.prototype.pipe = function(dest, options) {
     if (didOnEnd) return;
     didOnEnd = true;
 
-    dest._pipeCount--;
-
     // remove the listeners
     cleanup();
-
-    if (dest._pipeCount > 0) {
-      // waiting for other incoming streams to end.
-      return;
-    }
 
     dest.end();
   }
@@ -85,15 +74,8 @@ Stream.prototype.pipe = function(dest, options) {
     if (didOnEnd) return;
     didOnEnd = true;
 
-    dest._pipeCount--;
-
     // remove the listeners
     cleanup();
-
-    if (dest._pipeCount > 0) {
-      // waiting for other incoming streams to end.
-      return;
-    }
 
     dest.destroy();
   }

--- a/test/simple/test-stream-pipe-cleanup.js
+++ b/test/simple/test-stream-pipe-cleanup.js
@@ -77,16 +77,6 @@ assert.equal(limit, w.endCalls);
 
 w.endCalls = 0;
 
-var r2;
-r = new Readable();
-r2 = new Readable();
-
-r.pipe(w);
-r2.pipe(w);
-r.emit('close');
-r2.emit('close');
-assert.equal(1, w.endCalls);
-
 r = new Readable();
 
 for (i = 0; i < limit; i++) {


### PR DESCRIPTION
This reverts 6c5b31bd which had too few use cases, too much complexity,
and can be handled in user-land by using `{end: false}`.

Closes #1996
