### PR TITLE
Tidy lib/module.js::_resolveFilename, and symlink handling for shared libraries

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -455,11 +455,11 @@ Module._extensions['.json'] = function(module, filename) {
 };
 
 
-//Native extension for .node
+//Native extension for .node and OS-specific equivalents
 Module._extensions['.node'] = function(module, filename) {
   process.dlopen(filename, module.exports);
 };
-
+Module._extensions['.dylib'] = Module._extensions['.node'];
 
 // bootstrap main module.
 Module.runMain = function() {

--- a/lib/module.js
+++ b/lib/module.js
@@ -276,18 +276,16 @@ Module._load = function(request, parent, isMain) {
     debug('Module._load REQUEST  ' + (request) + ' parent: ' + parent.id);
   }
 
-  var resolved = Module._resolveFilename(request, parent);
-  var id = resolved[0];
-  var filename = resolved[1];
+  var filename = Module._resolveFilename(request, parent);
 
   var cachedModule = Module._cache[filename];
   if (cachedModule) {
     return cachedModule.exports;
   }
 
-  if (NativeModule.exists(id)) {
+  if (NativeModule.exists(filename)) {
     // REPL is a special case, because it needs the real require.
-    if (id == 'repl') {
+    if (filename == 'repl') {
       var replModule = new Module('repl');
       replModule._compile(NativeModule.getSource('repl'), 'repl.js');
       NativeModule._cache.repl = replModule;
@@ -295,10 +293,10 @@ Module._load = function(request, parent, isMain) {
     }
 
     debug('load native module ' + request);
-    return NativeModule.require(id);
+    return NativeModule.require(filename);
   }
 
-  var module = new Module(id, parent);
+  var module = new Module(filename, parent);
 
   if (isMain) {
     process.mainModule = module;
@@ -318,7 +316,7 @@ Module._load = function(request, parent, isMain) {
 
 Module._resolveFilename = function(request, parent) {
   if (NativeModule.exists(request)) {
-    return [request, request];
+    return request;
   }
 
   var resolvedModule = Module._resolveLookupPaths(request, parent);
@@ -333,8 +331,7 @@ Module._resolveFilename = function(request, parent) {
   if (!filename) {
     throw new Error("Cannot find module '" + request + "'");
   }
-  id = filename;
-  return [id, filename];
+  return filename;
 };
 
 
@@ -369,7 +366,7 @@ Module.prototype._compile = function(content, filename) {
   }
 
   require.resolve = function(request) {
-    return Module._resolveFilename(request, self)[1];
+    return Module._resolveFilename(request, self);
   };
 
   Object.defineProperty(require, 'paths', { get: function() {


### PR DESCRIPTION
@isaacs: as discussed on IRC.

The first commit removes redundant vestigial complexity in _resolveFilename where it returned a pair of identical strings (corresponding to both a symbolic module ID and the resolved path to its implementation).

The second commit allows a symlink to link to a shared library implementation of a native addon, where the filename of the library complies with the host naming conventions for shared libraries (ie ".dylib" on darwin) without adding to the search complexity. This is done for darwin only.
