### PR TITLE
Gc on exit

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2554,6 +2554,8 @@ int Start(int argc, char *argv[]) {
   EmitExit(process);
 
 #ifndef NDEBUG
+  while (!V8::IdleNotification()) ;
+
   // Clean up.
   context.Dispose();
   V8::Dispose();


### PR DESCRIPTION
It is much easier to debug a c++ module with valgrind when everything exits cleanly
and the things you expect to be gc'd are.
