### PR TITLE
don't double-eval

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -179,8 +179,14 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
       // First we attempt to eval as expression with parens.
       // This catches '{a : 1}' properly.
-      self.eval('(' + evalCmd + ')',
-                self.context,
+
+      // create a nested REPL to test ( cmd )
+      var magic = new REPLServer('', new ArrayStream());
+      magic.context = magic.createContext();
+      magic.inputStream.run(self.lines);
+
+      magic.eval('(' + evalCmd + ')',
+                magic.context,
                 'repl',
                 function(e, ret) {
             if (e && !isSyntaxError(e)) return finish(e);

--- a/test/simple/test-repl-double-eval.js
+++ b/test/simple/test-repl-double-eval.js
@@ -1,0 +1,69 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var util = require('util');
+
+var repl = require('repl');
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function (data) {
+    var self = this;
+    data.forEach(function (line) {
+      self.emit('data', line);
+    });
+  }
+}
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function () {};
+ArrayStream.prototype.write = function () {};
+
+var putIn = new ArrayStream();
+var testMe = repl.start('', putIn);
+var setup = [
+  'var funky = 0;',
+  'function get_funky() {',
+// update a global each time we execute
+  'funky += 1;',
+  'return function() {};',
+  '};'
+];
+
+putIn.run(['.clear']);
+putIn.run(setup);
+// make sure our initial condition are set
+assert.strictEqual(testMe.context.funky, 0);
+// execute with trailing;
+putIn.run(['get_funky();']);
+// global should be one
+assert.strictEqual(testMe.context.funky, 1);
+
+putIn.run(['.clear']);
+putIn.run(setup);
+// make sure our initial condition are set
+assert.strictEqual(testMe.context.funky, 0);
+// execute without trailing;
+putIn.run(['get_funky()']);
+// global should be one
+assert.strictEqual(testMe.context.funky, 1);


### PR DESCRIPTION
to determine if a command is complete the REPL should eval in a separate context.

This should fix #807 and #870.  Funny that these two cases would be the same.  I don't know if you want to accept this because it is a bit inefficient.  But it does solve the problem.

This is the same technique as the local tab complete.  I do not know how many REPL's people are using per node process and I don't know the expected concurrency.  Since all the REPL's generally use the same context I could make both this and the tab complete use a singleton.  But that would be a problem is you have 2 users typing into the same RPEL.

Of course, test included.
