### PR TITLE
OutgoingMessage.prototype.write does not take Array

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -597,9 +597,8 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
     return true;
   }
 
-  if (typeof chunk !== 'string' && !Buffer.isBuffer(chunk) &&
-      !Array.isArray(chunk)) {
-    throw new TypeError('first argument must be a string, Array, or Buffer');
+  if (typeof chunk !== 'string' && !Buffer.isBuffer(chunk)) {
+    throw new TypeError('first argument must be a string or Buffer');
   }
 
   if (chunk.length === 0) return false;

--- a/test/simple/test-http-res-write-end-dont-take-array.js
+++ b/test/simple/test-http-res-write-end-dont-take-array.js
@@ -1,0 +1,67 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var url = require('url');
+var assert = require('assert');
+var http = require('http');
+
+var test = 1;
+
+var server = http.createServer(function (req, res) {
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  if (test === 1) {
+    // write should accept string
+    res.write('string');
+    // write should accept buffer
+    res.write(new Buffer('asdf'));
+
+    // write should not accept an Array
+    assert.throws(function() {
+      res.write(['array']);
+    }, TypeError, 'first argument must be a string or Buffer');
+
+    // end should not accept an Array
+    assert.throws(function() {
+      res.end(['moo']);
+    }, TypeError, 'first argument must be a string or Buffer');
+
+    // end should accept string
+    res.end('string');
+  } else if (test === 2) {
+    // end should accept Buffer
+    res.end(new Buffer('asdf'));
+  }
+});
+
+server.listen(common.PORT, function() {
+  // just make a request, other tests handle responses
+  http.get({port:common.PORT}, function() {
+    // lazy serial test, becuase we can only call end once per request
+    test += 1;
+    // do it again to test .end(Buffer);
+    http.get({port:common.PORT}, function() {
+      server.close();
+    });
+  });
+});


### PR DESCRIPTION
Changed the type checking for OutgoingMessage.prototype.write so it only accepts string and Buffer.

And test.
Fixes #2162

I tested this agains v0.6 but I can not build master right now.  I can rebase and test again if you like once that works, but it seems small.
