### PR TITLE
Fix type: order of args to errnoException() - child_process.js

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -440,7 +440,7 @@ ChildProcess.prototype.spawn = function(options) {
 
     this._internal.close();
     this._internal = null;
-    throw errnoException('spawn', errno);
+    throw errnoException(errno, 'spawn');
   }
 
   this.pid = this._internal.pid;


### PR DESCRIPTION
References:  original pull req 2.5 months ago
    https://github.com/joyent/node/pull/1689

The other typo fix, as discovered by @piscisaureus  commit Nov 24, 2011
    https://github.com/joyent/node/commit/83152d174cbba36f967cab775260262d98706475#lib/dgram.js
