### PR TITLE
Fix #2147.

### DIFF
--- a/tools/gyp_node
+++ b/tools/gyp_node
@@ -42,6 +42,7 @@ if __name__ == '__main__':
     args.extend(['-I', options_fn])
 
   args.append('--depth=' + node_root)
+  args.append('--toplevel-dir=' + os.path.abspath(node_root))
 
   # There's a bug with windows which doesn't allow this feature.
   if sys.platform != 'win32':


### PR DESCRIPTION
This fixes #2147 by specifying --toplevel-dir, so gyp knows from where to regenerate.
