### PR TITLE
process.memoryUsage().rss Reports incorrectly when memory usage is over 4GB

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1484,7 +1484,7 @@ v8::Handle<v8::Value> MemoryUsage(const v8::Arguments& args) {
     heap_used_symbol = NODE_PSYMBOL("heapUsed");
   }
 
-  info->Set(rss_symbol, Integer::NewFromUnsigned(rss));
+  info->Set(rss_symbol, Number::New(rss));
 
   // V8 memory usage
   HeapStatistics v8_heap_stats;


### PR DESCRIPTION
The max value of an Unsigned integer is 4294967295.  To avoid unwanted silent truncation when reporting on applications using more than 4GB, use a Number.
