### PR TITLE
Ensure that the util.inspect function isn't the one being executed.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -155,7 +155,7 @@ function formatValue(ctx, value, recurseTimes) {
   // Check that value is an object with an inspect function on it
   if (value && typeof value.inspect === 'function' &&
       // Filter out the util module, it's inspect function is special
-      value !== exports &&
+      value.inspect !== exports.inspect &&
       // Also filter out any prototype objects using the circular check.
       !(value.constructor && value.constructor.prototype === value)) {
     return value.inspect(recurseTimes);

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -75,3 +75,7 @@ assert.doesNotThrow(function () {
   r.toString = null;
   util.inspect(r);
 });
+
+// GH-2225
+var x = { inspect: util.inspect };
+assert.ok(util.inspect(x).indexOf('inspect') != -1);


### PR DESCRIPTION
Fixes #2225.

Also fixes the case with the `sys` module:

``` js
require('util').inspect(require('sys'));
  // before:
  // '2'
  // now: 
  // The "sys" module is now called "util". It should have a similar interface.
  // '{ print: [Function],\n  puts: [Function],\n  debug: [Function],\n  error: [Function],\n  inspect: [Function: inspect],\n  p: [Function],\n  log: [Function],\n  exec: [Function],\n  pump: [Function],\n  inherits: [Function] }'
```
