### PR TITLE
Keep-alive probe interval and probe limit for keep-alives on sockets

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -339,14 +339,17 @@ Disables the Nagle algorithm. By default TCP connections use the Nagle
 algorithm, they buffer data before sending it off. Setting `noDelay` will
 immediately fire off data each time `socket.write()` is called.
 
-#### socket.setKeepAlive(enable=false, [initialDelay])
+#### socket.setKeepAlive(enable=false, [initialDelay], [probeInterval], [failureCount])
 
-Enable/disable keep-alive functionality, and optionally set the initial
-delay before the first keepalive probe is sent on an idle socket.
-Set `initialDelay` (in milliseconds) to set the delay between the last
-data packet received and the first keepalive probe. Setting 0 for
-initialDelay will leave the value unchanged from the default
-(or previous) setting.
+Enable/disable keep-alive functionality, and optionally override default
+keep-alive options. Set `initialDelay` (in milliseconds) to set the delay
+between the last data packet received and the first keepalive probe. Set
+`probeInterval` (in milliseconds) to set the interval between the keep-
+alive probes sent after the initial probe. Set `failureCount` to set the
+maximum number of probes that can fail before the OS closes the connection.
+probeInterval and failureCount do not work on Windows OS. Setting 0 for
+initialDelay, probeInterval, or failureCount will leave the value unchanged
+from the default (or previous) setting.
 
 #### socket.address()
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -158,9 +158,9 @@ Socket.prototype.setNoDelay = function() {
 };
 
 
-Socket.prototype.setKeepAlive = function(setting, msecs) {
+Socket.prototype.setKeepAlive = function(setting, msecs, interval, count) {
   if (this._handle && this._handle.setKeepAlive)
-    this._handle.setKeepAlive(setting, ~~(msecs / 1000));
+    this._handle.setKeepAlive(setting, ~~(msecs / 1000), ~~(interval / 1000), count);
 };
 
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -267,8 +267,10 @@ Handle<Value> TCPWrap::SetKeepAlive(const Arguments& args) {
 
   int enable = args[0]->Int32Value();
   unsigned int delay = args[1]->Uint32Value();
+  unsigned int interval = args[2]->Uint32Value();
+  unsigned int count = args[3]->Uint32Value();
 
-  int r = uv_tcp_keepalive(&wrap->handle_, enable, delay);
+  int r = uv_tcp_keepalive(&wrap->handle_, enable, delay, interval, count);
   if (r)
     SetErrno(uv_last_error(uv_default_loop()));
 


### PR DESCRIPTION
It would be nice to have the probing interval and the failure count available on sockets for keep-alive's.

Caveat: These will not work on Windows but work on Linux 2.4+.
