### PR TITLE
Add os.networkInterfaces() support for WIN32

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -160,7 +160,7 @@
             # we need to use node's preferred "win32" rather than gyp's preferred "win"
             'PLATFORM="win32"',
           ],
-          'libraries': [ '-lpsapi.lib' ]
+          'libraries': [ '-lpsapi.lib', 'Iphlpapi.lib' ]
         },{ # POSIX
           'defines': [ '__POSIX__' ],
           'sources': [

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -540,10 +540,10 @@ static Handle<Value> Rename(const Arguments& args) {
 
 #ifndef _LARGEFILE_SOURCE
 #define ASSERT_TRUNCATE_LENGTH(a) \
-  if (!(a)->IsUndefined() && !(a)->IsNull() && !(a)->IsUInt32()) { \
+  if (!(a)->IsUndefined() && !(a)->IsNull() && !(a)->IsUint32()) { \
     return ThrowException(Exception::TypeError(String::New("Not an integer"))); \
   }
-#define GET_TRUNCATE_LENGTH(a) ((a)->UInt32Value())
+#define GET_TRUNCATE_LENGTH(a) ((a)->ToUint32())
 #else
 #define ASSERT_TRUNCATE_LENGTH(a) \
   if (!(a)->IsUndefined() && !(a)->IsNull() && !IsInt64((a)->NumberValue())) { \
@@ -562,7 +562,7 @@ static Handle<Value> Truncate(const Arguments& args) {
   int fd = args[0]->Int32Value();
 
   ASSERT_TRUNCATE_LENGTH(args[1]);
-  off_t len = GET_TRUNCATE_LENGTH(args[1]);
+  off_t len = GET_TRUNCATE_LENGTH(args[1])->Value();
 
   if (args[2]->IsFunction()) {
     ASYNC_CALL(ftruncate, args[2], fd, len)

--- a/src/platform_win32.h
+++ b/src/platform_win32.h
@@ -58,6 +58,7 @@
 
 #include <windows.h>
 #include <winsock2.h>
+#include <Iphlpapi.h>
 
 #if defined(_MSC_VER)
 #define STDIN_FILENO 0


### PR DESCRIPTION
Add networkInterfaces for the OS modules and apply google's cpplint on it. Build test done with node.gyp and result can be seen below.

{ 'VLAN - HOME': [ { address: '192.168.1.6', family: 'IPv4', internal: false } ],
  'Home - Internet': [ { address: '169.254.68.144', family: 'IPv4', internal: false } ],
  'VirtualBox Host-Only Network': [ { address: '192.168.56.1', family: 'IPv4', internal: false } ],
  'Loopback Pseudo-Interface 1': [ { address: '127.0.0.1', family: 'IPv4', internal: true } ],
  'isatap.lan':
   [ { address: 'fe80::5efe:192.168.1.6%13',
       family: 'IPv6',
       internal: false } ],
  'Local Area Connection\* 8':
   [ { address: 'fe80::100:7f:fffe%16',
       family: 'IPv6',
       internal: false } ],
  'isatap.{C3556CFE-3852-4E23-9400-DC4B348E5268}':
   [ { address: 'fe80::5efe:192.168.56.1%20',
       family: 'IPv6',
       internal: false } ] }
