### PR TITLE
No need to have NativeModule.require('fs') in Module._findPath()

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -156,7 +156,6 @@ function tryExtensions(p, exts) {
 
 
 Module._findPath = function(request, paths) {
-  var fs = NativeModule.require('fs');
   var exts = Object.keys(Module._extensions);
 
   if (request.charAt(0) === '/') {


### PR DESCRIPTION
House keeping. I've found this when I had reviewed lib/module.js. 
The results of make test are fine except some of errors that are not caused by this patch. 
