### PR TITLE
Fix #2114

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -148,6 +148,7 @@ Socket.prototype.setTimeout = function(msecs, callback) {
 
 
 Socket.prototype._onTimeout = function() {
+  debug("_onTimeout");
   this.emit('timeout');
 };
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -108,6 +108,8 @@ var unenroll = exports.unenroll = function(item) {
     list.close();
     delete lists[item._idleTimeout];
   }
+  //if active is called later, then we want to make sure not to insert again
+  delete item._idleTimeout;
 };
 
 

--- a/test/simple/test-net-settimeout.js
+++ b/test/simple/test-net-settimeout.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// This example sets a timeout then immediately attempts to disable the timeout
+// https://github.com/joyent/node/pull/2245
+
+var common = require('../common');
+var net = require('net');
+var assert = require('assert');
+
+var T = 100;
+
+var server = net.createServer(function(c) {
+  c.write('hello');
+});
+server.listen(9999);
+
+var socket = net.createConnection(9999, 'localhost');
+
+socket.setTimeout(T, function() {
+  socket.destroy();
+  server.close();
+  assert.ok(false);
+});
+
+socket.setTimeout(0);
+
+setTimeout(function() {
+  socket.destroy();
+  server.close();
+  assert.ok(true);
+}, T*2);


### PR DESCRIPTION
When we unenroll, we should remove the _idleTimeout in the event that active is called again. We don't want to re-enroll the item when active is called.
