### PR TITLE
Make querystring parsing faster

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -172,7 +172,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq) {
   qs.split(sep).forEach(function(kvp) {
     var x = kvp.split(eq), k, v, useQS=false;
     try {
-      if (kvp.match(/\+/)) {
+      if (kvp.match(/\+/)) {	// decodeURIComponent does not decode + to space
         throw "has +";
       }
       k = decodeURIComponent(x[0]);

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -170,8 +170,11 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq) {
   }
 
   qs.split(sep).forEach(function(kvp) {
-    var x = kvp.replace(/\+/g, ' ').split(eq), k, v;
+    var x = kvp.split(eq), k, v, useQS=false;
     try {
+      if (kvp.match(/\+/)) {
+        throw "has +";
+      }
       k = decodeURIComponent(x[0]);
       v = decodeURIComponent(x.slice(1).join(eq) || "");
     } catch(e) {

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -170,9 +170,14 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq) {
   }
 
   qs.split(sep).forEach(function(kvp) {
-    var x = kvp.split(eq);
-    var k = QueryString.unescape(x[0], true);
-    var v = QueryString.unescape(x.slice(1).join(eq), true);
+    var x = kvp.replace(/\+/g, ' ').split(eq), k, v;
+    try {
+      k = decodeURIComponent(x[0]);
+      v = decodeURIComponent(x.slice(1).join(eq) || "");
+    } catch(e) {
+      k = QueryString.unescape(x[0], true);
+      v = QueryString.unescape(x.slice(1).join(eq), true);
+    }
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;


### PR DESCRIPTION
decodeURIComponent is faster than QueryString.unescape, but fails in some cases.  This patch will use decodeURIComponent where appropriate and falls back to unescape on failure.
