### PR TITLE
Add the networkinterfaces for Windows (Resync with head)

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -160,7 +160,7 @@
             # we need to use node's preferred "win32" rather than gyp's preferred "win"
             'PLATFORM="win32"',
           ],
-          'libraries': [ '-lpsapi.lib' ]
+          'libraries': [ '-lpsapi.lib', 'Iphlpapi.lib' ]
         },{ # POSIX
           'defines': [ '__POSIX__' ],
           'sources': [

--- a/src/platform_win32.h
+++ b/src/platform_win32.h
@@ -58,6 +58,7 @@
 
 #include <windows.h>
 #include <winsock2.h>
+#include <Iphlpapi.h>
 
 #if defined(_MSC_VER)
 #define STDIN_FILENO 0


### PR DESCRIPTION
Add the networkInterfaces for os module and apply the cpplint google style on it.

{ 'Wireless Network Connection 2': [ { address: '169.254.209.253', family: 'IPv4', internal: false } ],
  'Local Area Connection': [ { address: '192.168.1.12', family: 'IPv4', internal: false } ],
  'Wireless Network Connection': [ { address: '192.168.1.11', family: 'IPv4', internal: false } ],
  'VirtualBox Host-Only Network': [ { address: '169.254.214.110', family: 'IPv4', internal: false } ],
  'Loopback Pseudo-Interface 1': [ { address: '127.0.0.1', family: 'IPv4', internal: true } ],
  'Local Area Connection\* 11': [ { address: 'fe80::e0:0:0:0%13', family: 'IPv6', internal: false } ],
  'Local Area Connection\* 9': [ { address: 'fe80::e0:0:0:0%13', family: 'IPv6', internal: false } ],
  'isatap.{A8C2C90D-0CD4-4B85-9657-AB841C73CFE6}': [ { address: 'fe80::e0:0:0:0%13', family: 'IPv6', internal: false } ],
  'isatap.lan':
   [ { address: 'fe80::5efe:192.168.1.12%37',
       family: 'IPv6',
       internal: false } ],
  'isatap.{D197A7D7-FB8F-4FD5-9D33-202343CA9EEE}':
   [ { address: 'fe80::5efe:192.168.1.12%37',
       family: 'IPv6',
       internal: false } ] }

Signed-off-by: Yann Stephan Yann.Stephan@gmail.com
