### PR TITLE
Lowercase npm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -79,8 +79,8 @@ The externally maintained libraries used by Node are:
     licensed under a permissive free software license. See
     deps/zlib/LICENSE.
 
-  - deps/npm NPM is a package manager program copyright 2009, 2010, 2011
-    Isaac Z. Schlueter and licensed under MIT. NPM includes several
+  - deps/npm npm is a package manager program copyright 2009, 2010, 2011
+    Isaac Z. Schlueter and licensed under MIT. npm includes several
     subpackages MIT or Apache licenses, see deps/npm/LICENSE for more
-    information. NPM is included in the Node .msi and .pkg distributions
+    information. npm is included in the Node .msi and .pkg distributions
     but not in the Node binary itself.

--- a/doc/v0.4_announcement.html
+++ b/doc/v0.4_announcement.html
@@ -43,7 +43,7 @@
 
       <li> With a good amount of experience now, some modifications to the
       module loading system were made to better support package managers.
-      In particular, NPM was forced to resort to deep symlinks and "shim"
+      In particular, npm was forced to resort to deep symlinks and "shim"
       modules to work around missing features in <code>require()</code>. The main
       changes are:
       <ol>

--- a/lib/net.js
+++ b/lib/net.js
@@ -101,7 +101,7 @@ function Socket(options) {
 
   if (typeof options == 'number') {
     // Legacy interface.
-    // Must support legacy interface. NPM depends on it.
+    // Must support legacy interface. Old versions of npm depend on it.
     // https://github.com/isaacs/npm/blob/c7824f412f0cb59d6f55cf0bc220253c39e6029f/lib/utils/output.js#L110
     var fd = options;
 

--- a/tools/osx-pkg.pmdoc/index.xml
+++ b/tools/osx-pkg.pmdoc/index.xml
@@ -12,7 +12,7 @@
 \
    /usr/local/bin/node\
 \
-NPM was installed at\
+npm was installed at\
 \
    /usr/local/bin/npm\
 \

--- a/wscript
+++ b/wscript
@@ -980,7 +980,7 @@ def install_npm(bld):
   start_dir = bld.path.find_dir('deps/npm')
   # The chmod=-1 is a Node hack. We changed WAF so that when chmod was set to
   # -1 that the same permission in this tree are used. Necessary to get
-  # npm-cli.js to be executable without having to list every file in NPM.
+  # npm-cli.js to be executable without having to list every file in npm.
   bld.install_files('${LIBDIR}/node_modules/npm',
                     start_dir.ant_glob('**/*'),
                     cwd=start_dir,


### PR DESCRIPTION
The word "npm" should be lowercase in prose contexts.
