### PR TITLE
Allow for HTTP/1.0 requests

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -394,6 +394,7 @@ Options:
 - `headers`: An object containing request headers.
 - `auth`: Basic authentication i.e. `'user:password'` to compute an
   Authorization header.
+- `version`: A string specifying the HTTP version. Defaults to `'1.1'`.
 - `agent`: Controls [Agent](#http.Agent) behavior. When an Agent is used
   request will default to `Connection: keep-alive`. Possible values:
  - `undefined` (default): use [global Agent](#http.globalAgent) for this host
@@ -514,17 +515,17 @@ Global instance of Agent which is used as the default for all http client reques
 
 ### agent.maxSockets
 
-By default set to 5. Determines how many concurrent sockets the agent can have 
+By default set to 5. Determines how many concurrent sockets the agent can have
 open per host.
 
 ### agent.sockets
 
-An object which contains arrays of sockets currently in use by the Agent. Do not 
+An object which contains arrays of sockets currently in use by the Agent. Do not
 modify.
 
 ### agent.requests
 
-An object which contains queues of requests that have not yet been assigned to 
+An object which contains queues of requests that have not yet been assigned to
 sockets. Do not modify.
 
 
@@ -680,19 +681,19 @@ Aborts a request.  (New since v0.3.8.)
 
 ### request.setTimeout(timeout, [callback])
 
-Once a socket is assigned to this request and is connected 
+Once a socket is assigned to this request and is connected
 [socket.setTimeout(timeout, [callback])](net.html#socket.setTimeout)
 will be called.
 
 ### request.setNoDelay(noDelay=true)
 
-Once a socket is assigned to this request and is connected 
+Once a socket is assigned to this request and is connected
 [socket.setNoDelay(noDelay)](net.html#socket.setNoDelay)
 will be called.
 
 ### request.setSocketKeepAlive(enable=false, [initialDelay])
 
-Once a socket is assigned to this request and is connected 
+Once a socket is assigned to this request and is connected
 [socket.setKeepAlive(enable, [initialDelay])](net.html#socket.setKeepAlive)
 will be called.
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -988,6 +988,7 @@ function ClientRequest(options, cb) {
 
   options.port = options.port || options.defaultPort;
   options.host = options.hostname || options.host || 'localhost';
+  self.httpVersion = options.version || '1.1';
 
   if (options.setHost === undefined) {
     options.setHost = true;
@@ -1024,17 +1025,17 @@ function ClientRequest(options, cb) {
                    new Buffer(options.auth).toString('base64'));
   }
 
-  if (method === 'GET' || method === 'HEAD') {
+  if (method === 'GET' || method === 'HEAD' || self.httpVersion === '1.0') {
     self.useChunkedEncodingByDefault = false;
   } else {
     self.useChunkedEncodingByDefault = true;
   }
 
   if (Array.isArray(options.headers)) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
+    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + self.httpVersion + '\r\n',
                       options.headers);
   } else if (self.getHeader('expect')) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
+    self._storeHeader(self.method + ' ' + self.path + ' HTTP/' + self.httpVersion + '\r\n',
                       self._renderHeaders());
   }
   if (self.socketPath) {
@@ -1071,7 +1072,7 @@ util.inherits(ClientRequest, OutgoingMessage);
 exports.ClientRequest = ClientRequest;
 
 ClientRequest.prototype._implicitHeader = function() {
-  this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n', this._renderHeaders());
+  this._storeHeader(this.method + ' ' + this.path + ' HTTP/' + this.httpVersion + '\r\n', this._renderHeaders());
 };
 
 ClientRequest.prototype.abort = function() {

--- a/test/simple/test-http-1-0-request.js
+++ b/test/simple/test-http-1-0-request.js
@@ -1,0 +1,63 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var req_count = 0;
+
+var server = http.createServer(function(req, res) {
+  if (req.url === '/1.0') {
+    assert.equal('1.0', req.httpVersion);
+  }
+  else {
+    assert.equal('1.1', req.httpVersion);
+  }
+
+  req.on('end', function() {
+    res.end();
+    req_count++;
+    if (req_count === 2) {
+      server.close();
+    }
+  });
+});
+server.listen(common.PORT);
+
+server.on('listening', function() {
+  var req10 = http.request({
+    port: common.PORT,
+    method: 'GET',
+    path: '/1.0',
+    version: '1.0'
+  });
+  req10.write('\n');
+  req10.end();
+
+  var req11 = http.request({
+    port: common.PORT,
+    method: 'GET',
+    path: '/1.1'
+  });
+  req11.write('\n');
+  req11.end();
+});


### PR DESCRIPTION
Our work proxy requires a HTTP/1.0 CONNECT to tunnel HTTPS over HTTP.  This patch adds the ability to specify which HTTP version should be used with `http.request()`.  Defaults to `'1.1'` for backwards compatibility.
