### PR TITLE
Test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+
+before_script:
+  - "./configure"
+  - "make"
+
+script:
+  - "make test"
+
+notifications:
+  email: false
+  irc:
+    - "irc.freenode.net#libuv"
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Evented I/O for V8 javascript.
+Evented I/O for V8 javascript. [![Build Status](https://secure.travis-ci.org/joyent/node.png)](http://travis-ci.org/joyent/node)
 ===
 
 ### To build:


### PR DESCRIPTION
As discussed with @isaacs, build reports will be sent to #libuv IRC
channel. E-mail notifications are turned off so that Travis doesn't
bother committers about failures in forks.

Also, add Travis CI [build status image](http://about.travis-ci.org/docs/user/status-images/).

**To actually add this to Travis, please follow these steps.** They have to be performed with someone who has admin access to `joyent/node`.
- Please make sure that your modem lights are blinking and reset your computer
- Login to [Travis](http://travis-ci.org) with your GitHub account
- Go to Profile (click on your name at the top right)
- Copy the token
- Go to `joyent/node` repo admin panel, choose Service Hooks
- Click on Travis, paste the token, check Active and click Update settings (you can trigger the build by clicking on Test hook)

Bonus: [build log of my fork](http://travis-ci.org/#!/mmalecki/node/builds/370957) 
