### PR TITLE
Add optional features: One domain per incoming data event, catchall Socket listener

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -115,6 +115,11 @@ function Socket(options) {
 
   stream.Stream.call(this);
 
+  if (Socket.genericEmitter != null) {
+    this.on('connect', Socket.genericEmitter.emit.bind(Socket.genericEmitter, this, 'connect'));
+    this.on('close', Socket.genericEmitter.emit.bind(Socket.genericEmitter, this, 'close'));
+  }
+
   if (typeof options == 'number') {
     // Legacy interface.
     // Must support legacy interface. NPM depends on it.
@@ -141,6 +146,14 @@ util.inherits(Socket, stream.Stream);
 
 exports.Socket = Socket;
 exports.Stream = Socket; // Legacy naming.
+
+
+Socket.addGenericListener = function(event, listener) {
+  if (Socket.genericEmitter == null) {
+    Socket.genericEmitter = new events.EventEmitter;
+  }
+  Socket.genericEmitter.on(event, listener);
+};
 
 
 Socket.prototype.listen = function() {
@@ -333,16 +346,19 @@ function onread(buffer, offset, length) {
   if (buffer) {
     // Emit 'data' event.
 
+    var data = buffer.slice(offset, end);
+
+    if (Socket.genericEmitter != null) {
+      Socket.genericEmitter.emit(self, 'data', data);
+    }
+
     if (self._decoder) {
       // Emit a string.
-      var string = self._decoder.write(buffer.slice(offset, end));
+      var string = self._decoder.write(data);
       if (string.length) self.emit('data', string);
     } else {
-      // Emit a slice. Attempt to avoid slicing the buffer if no one is
-      // listening for 'data'.
-      if (self._events && self._events['data']) {
-        self.emit('data', buffer.slice(offset, end));
-      }
+      // Emit a slice.
+      self.emit('data', data);
     }
 
     self.bytesRead += length;
@@ -444,6 +460,10 @@ Socket.prototype.write = function(data, arg1, arg2) {
 
 Socket.prototype._write = function(data, encoding, cb) {
   timers.active(this);
+
+  if (Socket.genericEmitter != null) {
+    Socket.genericEmitter.emit('write', this, data);
+  }
 
   // `encoding` is unused right now, `data` is always a buffer.
   var writeReq = this._handle.write(data);

--- a/lib/net.js
+++ b/lib/net.js
@@ -347,24 +347,38 @@ function onread(buffer, offset, length) {
     // Emit 'data' event.
 
     var data = buffer.slice(offset, end);
-
-    if (Socket.genericEmitter != null) {
-      Socket.genericEmitter.emit('data', self, data);
-    }
-
-    if (self._decoder) {
-      // Emit a string.
-      var string = self._decoder.write(data);
-      if (string.length) self.emit('data', string);
+    var eventId;
+    
+    if (Socket.eventDomains) {
+      eventId = Math.random();
+      var domain = domains.create(null, emitEvent);
+      // FIXME ugly, ugly, ugly hack
+      process.nextTick(function(){});
+      domain.eventId = eventId;
+      domain.isNetDataEventDomain = true;
     } else {
-      // Emit a slice.
-      self.emit('data', data);
+      emitEvent()
     }
 
-    self.bytesRead += length;
+    function emitEvent() {
+      if (Socket.genericEmitter != null) {
+        Socket.genericEmitter.emit('data', self, data, eventId);
+      }
 
-    // Optimization: emit the original buffer with end points
-    if (self.ondata) self.ondata(buffer, offset, end);
+      if (self._decoder) {
+        // Emit a string.
+        var string = self._decoder.write(data);
+        if (string.length) self.emit('data', string);
+      } else {
+        // Emit a slice.
+        self.emit('data', data);
+      }
+
+      self.bytesRead += length;
+
+      // Optimization: emit the original buffer with end points
+      if (self.ondata) self.ondata(buffer, offset, end);
+    }
 
   } else if (errno == 'EOF') {
     // EOF

--- a/lib/net.js
+++ b/lib/net.js
@@ -349,7 +349,7 @@ function onread(buffer, offset, length) {
     var data = buffer.slice(offset, end);
 
     if (Socket.genericEmitter != null) {
-      Socket.genericEmitter.emit(self, 'data', data);
+      Socket.genericEmitter.emit('data', self, data);
     }
 
     if (self._decoder) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -116,8 +116,8 @@ function Socket(options) {
   stream.Stream.call(this);
 
   if (Socket.genericEmitter != null) {
-    this.on('connect', Socket.genericEmitter.emit.bind(Socket.genericEmitter, this, 'connect'));
-    this.on('close', Socket.genericEmitter.emit.bind(Socket.genericEmitter, this, 'close'));
+    this.on('connect', Socket.genericEmitter.emit.bind(Socket.genericEmitter, 'connect', this));
+    this.on('close', Socket.genericEmitter.emit.bind(Socket.genericEmitter, 'close', this));
   }
 
   if (typeof options == 'number') {


### PR DESCRIPTION
Hello,
this patch adds two features:
- `Socket.addGenericListener` allows you to listen to `data`, `write`, `connect` and `close` events of all sockets
- if `Socket.eventDomains` is set, you get one domain per incoming data event

Yes, if you use these features, you'll probably get some performance impact, but it also allows you to do cool stuff like a network traffic viewer that can show you which events belong together: http://www.youtube.com/watch?v=4iSDwAb8XEA
