### PR TITLE
Fix (two little) bugs found with Cppcheck

### DIFF
--- a/benchmark/io.c
+++ b/benchmark/io.c
@@ -51,7 +51,6 @@ static void writetest(int size, size_t bsize)
       exit(254);
     }
   }
-  close(fd);
 
 #ifndef NSYNC
 # ifdef __linux__
@@ -60,6 +59,8 @@ static void writetest(int size, size_t bsize)
   fsync(fd);
 # endif
 #endif /* SYNC */
+
+  close(fd);
 
   end = now();
   elapsed = (end - start) / 1e6;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4122,8 +4122,10 @@ PBKDF2(const Arguments& args) {
     return ThrowException(Exception::TypeError(String::New("Bad key length")));
   char* key = new char[keylen];
 
-  if (!args[4]->IsFunction())
+  if (!args[4]->IsFunction()) {
+    delete [] key;
     return ThrowException(Exception::TypeError(String::New("Callback not a function")));
+  }
   Local<Function> callback = Local<Function>::Cast(args[4]);
 
   pbkdf2_req* request = new pbkdf2_req;


### PR DESCRIPTION
This branch fixes the following cppcheck[1] warnings:
[benchmark/io.c:60]: (error) Dereferencing 'fd' after it is deallocated / released
[benchmark/io.c:58]: (error) Dereferencing 'fd' after it is deallocated / released
[src/node_crypto.cc:4126]: (error) Memory leak: key

I wasn't all sure about these and cppcheck also reported a lot of warnings for the third-party libraries:
[src/node.cc:2505]: (error) Using sizeof for array given as function argument returns the size of pointer.
[src/node_crypto.cc:3193]: (error) Memory leak: md_value
[src/platform_win32.cc:130]: (error) Mismatching allocation and deallocation: title_w
[src/platform_win32.cc:146]: (error) Mismatching allocation and deallocation: title_w

[1] http://sourceforge.net/projects/cppcheck/

Greetings,
       Jonathan Neuschäfer
