### PR TITLE
Make logo a link back to homepage on nodejs.org static pages

### DIFF
--- a/doc/about/index.html
+++ b/doc/about/index.html
@@ -20,7 +20,9 @@
   </head>
   <body>
     <div id="intro">
-        <img id="logo" src="../logo.png" alt="node.js">
+        <a href="/" title="Go back to the home page">
+            <img id="logo" src="../logo.png" alt="node.js">
+        </a>
     </div>
     <div id="content" class="clearfix">
             <div id="column1" class="interior">

--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -23,7 +23,9 @@
   </head>
   <body>
     <div id="intro">
-        <img id="logo" src="../logo.png" alt="node.js">
+        <a href="/" title="Go back to the home page">
+            <img id="logo" src="../logo.png" alt="node.js">
+        </a>
     </div>
     <div id="content" class="clearfix">
             <div id="column1" class="interior">

--- a/doc/logos/index.html
+++ b/doc/logos/index.html
@@ -23,7 +23,9 @@
   </head>
   <body>
     <div id="intro">
-        <img id="logo" src="../logo.png" alt="node.js">
+        <a href="/" title="Go back to the home page">
+            <img id="logo" src="../logo.png" alt="node.js">
+        </a>
     </div>
     <div id="content" class="clearfix">
             <div id="column1" class="interior">


### PR DESCRIPTION
This pull request makes the node.js logo a link back to the homepage on the new-style about, community and logos pages.
