### PR TITLE
add node::SetMethod and node::SetPrototypeMethod

### DIFF
--- a/benchmark/function_call/binding.cc
+++ b/benchmark/function_call/binding.cc
@@ -15,5 +15,5 @@ static Handle<Value> Hello(const Arguments& args) {
 extern "C" void init (Handle<Object> target) {
   HandleScope scope;
   //target->Set(String::New("hello"), String::New("World"));
-  NODE_SET_METHOD(target, "hello", Hello);
+  node::SetMethod(target, "hello", Hello);
 }

--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -40,7 +40,7 @@ To get started we create a file `hello.cc`:
     }
 
     void init(Handle<Object> target) {
-      NODE_SET_METHOD(target, "hello", Method);
+      node::SetMethod(target, "hello", Method);
     }
     NODE_MODULE(hello, init)
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -739,17 +739,17 @@ static void Initialize(Handle<Object> target) {
   uv_ares_init_options(uv_default_loop(), &ares_channel, &options, 0);
   assert(r == 0);
 
-  NODE_SET_METHOD(target, "queryA", Query<QueryAWrap>);
-  NODE_SET_METHOD(target, "queryAaaa", Query<QueryAaaaWrap>);
-  NODE_SET_METHOD(target, "queryCname", Query<QueryCnameWrap>);
-  NODE_SET_METHOD(target, "queryMx", Query<QueryMxWrap>);
-  NODE_SET_METHOD(target, "queryNs", Query<QueryNsWrap>);
-  NODE_SET_METHOD(target, "queryTxt", Query<QueryTxtWrap>);
-  NODE_SET_METHOD(target, "querySrv", Query<QuerySrvWrap>);
-  NODE_SET_METHOD(target, "getHostByAddr", Query<GetHostByAddrWrap>);
-  NODE_SET_METHOD(target, "getHostByName", QueryWithFamily<GetHostByNameWrap>);
+  node::SetMethod(target, "queryA", Query<QueryAWrap>);
+  node::SetMethod(target, "queryAaaa", Query<QueryAaaaWrap>);
+  node::SetMethod(target, "queryCname", Query<QueryCnameWrap>);
+  node::SetMethod(target, "queryMx", Query<QueryMxWrap>);
+  node::SetMethod(target, "queryNs", Query<QueryNsWrap>);
+  node::SetMethod(target, "queryTxt", Query<QueryTxtWrap>);
+  node::SetMethod(target, "querySrv", Query<QuerySrvWrap>);
+  node::SetMethod(target, "getHostByAddr", Query<GetHostByAddrWrap>);
+  node::SetMethod(target, "getHostByName", QueryWithFamily<GetHostByNameWrap>);
 
-  NODE_SET_METHOD(target, "getaddrinfo", GetAddrInfo);
+  node::SetMethod(target, "getaddrinfo", GetAddrInfo);
 
   target->Set(String::NewSymbol("AF_INET"), Integer::New(AF_INET));
   target->Set(String::NewSymbol("AF_INET6"), Integer::New(AF_INET6));

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -80,8 +80,8 @@ void FSEventWrap::Initialize(Handle<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("FSEvent"));
 
-  NODE_SET_PROTOTYPE_METHOD(t, "start", Start);
-  NODE_SET_PROTOTYPE_METHOD(t, "close", Close);
+  node::SetPrototypeMethod(t, "start", Start);
+  node::SetPrototypeMethod(t, "close", Close);
 
   target->Set(String::NewSymbol("FSEvent"),
               Persistent<FunctionTemplate>::New(t)->GetFunction());

--- a/src/node.cc
+++ b/src/node.cc
@@ -2082,36 +2082,36 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
 
   // define various internal methods
-  NODE_SET_METHOD(process, "_needTickCallback", NeedTickCallback);
-  NODE_SET_METHOD(process, "reallyExit", Exit);
-  NODE_SET_METHOD(process, "chdir", Chdir);
-  NODE_SET_METHOD(process, "cwd", Cwd);
+  node::SetMethod(process, "_needTickCallback", NeedTickCallback);
+  node::SetMethod(process, "reallyExit", Exit);
+  node::SetMethod(process, "chdir", Chdir);
+  node::SetMethod(process, "cwd", Cwd);
 
 #ifdef _WIN32
-  NODE_SET_METHOD(process, "_cwdForDrive", CwdForDrive);
+  node::SetMethod(process, "_cwdForDrive", CwdForDrive);
 #endif
 
-  NODE_SET_METHOD(process, "umask", Umask);
+  node::SetMethod(process, "umask", Umask);
 
 #ifdef __POSIX__
-  NODE_SET_METHOD(process, "getuid", GetUid);
-  NODE_SET_METHOD(process, "setuid", SetUid);
+  node::SetMethod(process, "getuid", GetUid);
+  node::SetMethod(process, "setuid", SetUid);
 
-  NODE_SET_METHOD(process, "setgid", SetGid);
-  NODE_SET_METHOD(process, "getgid", GetGid);
+  node::SetMethod(process, "setgid", SetGid);
+  node::SetMethod(process, "getgid", GetGid);
 #endif // __POSIX__
 
-  NODE_SET_METHOD(process, "_kill", Kill);
+  node::SetMethod(process, "_kill", Kill);
 
-  NODE_SET_METHOD(process, "_debugProcess", DebugProcess);
+  node::SetMethod(process, "_debugProcess", DebugProcess);
 
-  NODE_SET_METHOD(process, "dlopen", DLOpen);
+  node::SetMethod(process, "dlopen", DLOpen);
 
-  NODE_SET_METHOD(process, "uptime", Uptime);
-  NODE_SET_METHOD(process, "memoryUsage", MemoryUsage);
-  NODE_SET_METHOD(process, "uvCounters", UVCounters);
+  node::SetMethod(process, "uptime", Uptime);
+  node::SetMethod(process, "memoryUsage", MemoryUsage);
+  node::SetMethod(process, "uvCounters", UVCounters);
 
-  NODE_SET_METHOD(process, "binding", Binding);
+  node::SetMethod(process, "binding", Binding);
 
   return process;
 }

--- a/src/node.h
+++ b/src/node.h
@@ -109,19 +109,22 @@ void EmitExit(v8::Handle<v8::Object> process);
                 static_cast<v8::PropertyAttribute>(                       \
                     v8::ReadOnly|v8::DontDelete))
 
-#define NODE_SET_METHOD(obj, name, callback)                              \
-  obj->Set(v8::String::NewSymbol(name),                                   \
-           v8::FunctionTemplate::New(callback)->GetFunction())
+template <typename target_t>
+void NODE_SET_METHOD(target_t obj, const char* name,
+        v8::InvocationCallback callback)
+{
+    obj->Set(v8::String::NewSymbol(name),
+        v8::FunctionTemplate::New(callback)->GetFunction());
+}
 
-#define NODE_SET_PROTOTYPE_METHOD(templ, name, callback)                  \
-do {                                                                      \
-  v8::Local<v8::Signature> __callback##_SIG = v8::Signature::New(templ);  \
-  v8::Local<v8::FunctionTemplate> __callback##_TEM =                      \
-    v8::FunctionTemplate::New(callback, v8::Handle<v8::Value>(),          \
-                          __callback##_SIG);                              \
-  templ->PrototypeTemplate()->Set(v8::String::NewSymbol(name),            \
-                                  __callback##_TEM);                      \
-} while (0)
+template <typename target_t>
+void NODE_SET_PROTOTYPE_METHOD(target_t target,
+        const char* name, v8::InvocationCallback callback)
+{
+    v8::Local<v8::FunctionTemplate> templ = v8::FunctionTemplate::New(callback);
+    target->PrototypeTemplate()->Set(v8::String::NewSymbol(name), templ);
+}
+
 
 enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX};
 enum encoding ParseEncoding(v8::Handle<v8::Value> encoding_v,

--- a/src/node.h
+++ b/src/node.h
@@ -110,7 +110,7 @@ void EmitExit(v8::Handle<v8::Object> process);
                     v8::ReadOnly|v8::DontDelete))
 
 template <typename target_t>
-void NODE_SET_METHOD(target_t obj, const char* name,
+void SetMethod(target_t obj, const char* name,
         v8::InvocationCallback callback)
 {
     obj->Set(v8::String::NewSymbol(name),
@@ -118,13 +118,16 @@ void NODE_SET_METHOD(target_t obj, const char* name,
 }
 
 template <typename target_t>
-void NODE_SET_PROTOTYPE_METHOD(target_t target,
+void SetPrototypeMethod(target_t target,
         const char* name, v8::InvocationCallback callback)
 {
     v8::Local<v8::FunctionTemplate> templ = v8::FunctionTemplate::New(callback);
     target->PrototypeTemplate()->Set(v8::String::NewSymbol(name), templ);
 }
 
+// for backwards compatibility
+#define NODE_SET_METHOD node::SetMethod
+#define NODE_SET_PROTOTYPE_METHOD node::SetPrototypeMethod
 
 enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX};
 enum encoding ParseEncoding(v8::Handle<v8::Value> encoding_v,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -768,26 +768,26 @@ void Buffer::Initialize(Handle<Object> target) {
   constructor_template->SetClassName(String::NewSymbol("SlowBuffer"));
 
   // copy free
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "binarySlice", Buffer::BinarySlice);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "asciiSlice", Buffer::AsciiSlice);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "base64Slice", Buffer::Base64Slice);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "ucs2Slice", Buffer::Ucs2Slice);
-  // TODO NODE_SET_PROTOTYPE_METHOD(t, "utf16Slice", Utf16Slice);
+  node::SetPrototypeMethod(constructor_template, "binarySlice", Buffer::BinarySlice);
+  node::SetPrototypeMethod(constructor_template, "asciiSlice", Buffer::AsciiSlice);
+  node::SetPrototypeMethod(constructor_template, "base64Slice", Buffer::Base64Slice);
+  node::SetPrototypeMethod(constructor_template, "ucs2Slice", Buffer::Ucs2Slice);
+  // TODO node::SetPrototypeMethod(t, "utf16Slice", Utf16Slice);
   // copy
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "utf8Slice", Buffer::Utf8Slice);
+  node::SetPrototypeMethod(constructor_template, "utf8Slice", Buffer::Utf8Slice);
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "utf8Write", Buffer::Utf8Write);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "asciiWrite", Buffer::AsciiWrite);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "binaryWrite", Buffer::BinaryWrite);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "base64Write", Buffer::Base64Write);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "ucs2Write", Buffer::Ucs2Write);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "fill", Buffer::Fill);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "copy", Buffer::Copy);
+  node::SetPrototypeMethod(constructor_template, "utf8Write", Buffer::Utf8Write);
+  node::SetPrototypeMethod(constructor_template, "asciiWrite", Buffer::AsciiWrite);
+  node::SetPrototypeMethod(constructor_template, "binaryWrite", Buffer::BinaryWrite);
+  node::SetPrototypeMethod(constructor_template, "base64Write", Buffer::Base64Write);
+  node::SetPrototypeMethod(constructor_template, "ucs2Write", Buffer::Ucs2Write);
+  node::SetPrototypeMethod(constructor_template, "fill", Buffer::Fill);
+  node::SetPrototypeMethod(constructor_template, "copy", Buffer::Copy);
 
-  NODE_SET_METHOD(constructor_template->GetFunction(),
+  node::SetMethod(constructor_template->GetFunction(),
                   "byteLength",
                   Buffer::ByteLength);
-  NODE_SET_METHOD(constructor_template->GetFunction(),
+  node::SetMethod(constructor_template->GetFunction(),
                   "makeFastBuffer",
                   Buffer::MakeFastBuffer);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -158,17 +158,17 @@ void SecureContext::Initialize(Handle<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("SecureContext"));
 
-  NODE_SET_PROTOTYPE_METHOD(t, "init", SecureContext::Init);
-  NODE_SET_PROTOTYPE_METHOD(t, "setKey", SecureContext::SetKey);
-  NODE_SET_PROTOTYPE_METHOD(t, "setCert", SecureContext::SetCert);
-  NODE_SET_PROTOTYPE_METHOD(t, "addCACert", SecureContext::AddCACert);
-  NODE_SET_PROTOTYPE_METHOD(t, "addCRL", SecureContext::AddCRL);
-  NODE_SET_PROTOTYPE_METHOD(t, "addRootCerts", SecureContext::AddRootCerts);
-  NODE_SET_PROTOTYPE_METHOD(t, "setCiphers", SecureContext::SetCiphers);
-  NODE_SET_PROTOTYPE_METHOD(t, "setOptions", SecureContext::SetOptions);
-  NODE_SET_PROTOTYPE_METHOD(t, "setSessionIdContext",
+  node::SetPrototypeMethod(t, "init", SecureContext::Init);
+  node::SetPrototypeMethod(t, "setKey", SecureContext::SetKey);
+  node::SetPrototypeMethod(t, "setCert", SecureContext::SetCert);
+  node::SetPrototypeMethod(t, "addCACert", SecureContext::AddCACert);
+  node::SetPrototypeMethod(t, "addCRL", SecureContext::AddCRL);
+  node::SetPrototypeMethod(t, "addRootCerts", SecureContext::AddRootCerts);
+  node::SetPrototypeMethod(t, "setCiphers", SecureContext::SetCiphers);
+  node::SetPrototypeMethod(t, "setOptions", SecureContext::SetOptions);
+  node::SetPrototypeMethod(t, "setSessionIdContext",
                                SecureContext::SetSessionIdContext);
-  NODE_SET_PROTOTYPE_METHOD(t, "close", SecureContext::Close);
+  node::SetPrototypeMethod(t, "close", SecureContext::Close);
 
   target->Set(String::NewSymbol("SecureContext"), t->GetFunction());
 }
@@ -708,33 +708,33 @@ void Connection::Initialize(Handle<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("Connection"));
 
-  NODE_SET_PROTOTYPE_METHOD(t, "encIn", Connection::EncIn);
-  NODE_SET_PROTOTYPE_METHOD(t, "clearOut", Connection::ClearOut);
-  NODE_SET_PROTOTYPE_METHOD(t, "clearIn", Connection::ClearIn);
-  NODE_SET_PROTOTYPE_METHOD(t, "encOut", Connection::EncOut);
-  NODE_SET_PROTOTYPE_METHOD(t, "clearPending", Connection::ClearPending);
-  NODE_SET_PROTOTYPE_METHOD(t, "encPending", Connection::EncPending);
-  NODE_SET_PROTOTYPE_METHOD(t, "getPeerCertificate", Connection::GetPeerCertificate);
-  NODE_SET_PROTOTYPE_METHOD(t, "getSession", Connection::GetSession);
-  NODE_SET_PROTOTYPE_METHOD(t, "setSession", Connection::SetSession);
-  NODE_SET_PROTOTYPE_METHOD(t, "isSessionReused", Connection::IsSessionReused);
-  NODE_SET_PROTOTYPE_METHOD(t, "isInitFinished", Connection::IsInitFinished);
-  NODE_SET_PROTOTYPE_METHOD(t, "verifyError", Connection::VerifyError);
-  NODE_SET_PROTOTYPE_METHOD(t, "getCurrentCipher", Connection::GetCurrentCipher);
-  NODE_SET_PROTOTYPE_METHOD(t, "start", Connection::Start);
-  NODE_SET_PROTOTYPE_METHOD(t, "shutdown", Connection::Shutdown);
-  NODE_SET_PROTOTYPE_METHOD(t, "receivedShutdown", Connection::ReceivedShutdown);
-  NODE_SET_PROTOTYPE_METHOD(t, "close", Connection::Close);
+  node::SetPrototypeMethod(t, "encIn", Connection::EncIn);
+  node::SetPrototypeMethod(t, "clearOut", Connection::ClearOut);
+  node::SetPrototypeMethod(t, "clearIn", Connection::ClearIn);
+  node::SetPrototypeMethod(t, "encOut", Connection::EncOut);
+  node::SetPrototypeMethod(t, "clearPending", Connection::ClearPending);
+  node::SetPrototypeMethod(t, "encPending", Connection::EncPending);
+  node::SetPrototypeMethod(t, "getPeerCertificate", Connection::GetPeerCertificate);
+  node::SetPrototypeMethod(t, "getSession", Connection::GetSession);
+  node::SetPrototypeMethod(t, "setSession", Connection::SetSession);
+  node::SetPrototypeMethod(t, "isSessionReused", Connection::IsSessionReused);
+  node::SetPrototypeMethod(t, "isInitFinished", Connection::IsInitFinished);
+  node::SetPrototypeMethod(t, "verifyError", Connection::VerifyError);
+  node::SetPrototypeMethod(t, "getCurrentCipher", Connection::GetCurrentCipher);
+  node::SetPrototypeMethod(t, "start", Connection::Start);
+  node::SetPrototypeMethod(t, "shutdown", Connection::Shutdown);
+  node::SetPrototypeMethod(t, "receivedShutdown", Connection::ReceivedShutdown);
+  node::SetPrototypeMethod(t, "close", Connection::Close);
 
 #ifdef OPENSSL_NPN_NEGOTIATED
-  NODE_SET_PROTOTYPE_METHOD(t, "getNegotiatedProtocol", Connection::GetNegotiatedProto);
-  NODE_SET_PROTOTYPE_METHOD(t, "setNPNProtocols", Connection::SetNPNProtocols);
+  node::SetPrototypeMethod(t, "getNegotiatedProtocol", Connection::GetNegotiatedProto);
+  node::SetPrototypeMethod(t, "setNPNProtocols", Connection::SetNPNProtocols);
 #endif
 
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-  NODE_SET_PROTOTYPE_METHOD(t, "getServername", Connection::GetServername);
-  NODE_SET_PROTOTYPE_METHOD(t, "setSNICallback",  Connection::SetSNICallback);
+  node::SetPrototypeMethod(t, "getServername", Connection::GetServername);
+  node::SetPrototypeMethod(t, "setSNICallback",  Connection::SetSNICallback);
 #endif
 
   target->Set(String::NewSymbol("Connection"), t->GetFunction());
@@ -1894,10 +1894,10 @@ class Cipher : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "init", CipherInit);
-    NODE_SET_PROTOTYPE_METHOD(t, "initiv", CipherInitIv);
-    NODE_SET_PROTOTYPE_METHOD(t, "update", CipherUpdate);
-    NODE_SET_PROTOTYPE_METHOD(t, "final", CipherFinal);
+    node::SetPrototypeMethod(t, "init", CipherInit);
+    node::SetPrototypeMethod(t, "initiv", CipherInitIv);
+    node::SetPrototypeMethod(t, "update", CipherUpdate);
+    node::SetPrototypeMethod(t, "final", CipherFinal);
 
     target->Set(String::NewSymbol("Cipher"), t->GetFunction());
   }
@@ -2255,11 +2255,11 @@ class Decipher : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "init", DecipherInit);
-    NODE_SET_PROTOTYPE_METHOD(t, "initiv", DecipherInitIv);
-    NODE_SET_PROTOTYPE_METHOD(t, "update", DecipherUpdate);
-    NODE_SET_PROTOTYPE_METHOD(t, "final", DecipherFinal<false>);
-    NODE_SET_PROTOTYPE_METHOD(t, "finaltol", DecipherFinal<true>);
+    node::SetPrototypeMethod(t, "init", DecipherInit);
+    node::SetPrototypeMethod(t, "initiv", DecipherInitIv);
+    node::SetPrototypeMethod(t, "update", DecipherUpdate);
+    node::SetPrototypeMethod(t, "final", DecipherFinal<false>);
+    node::SetPrototypeMethod(t, "finaltol", DecipherFinal<true>);
 
     target->Set(String::NewSymbol("Decipher"), t->GetFunction());
   }
@@ -2669,9 +2669,9 @@ class Hmac : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "init", HmacInit);
-    NODE_SET_PROTOTYPE_METHOD(t, "update", HmacUpdate);
-    NODE_SET_PROTOTYPE_METHOD(t, "digest", HmacDigest);
+    node::SetPrototypeMethod(t, "init", HmacInit);
+    node::SetPrototypeMethod(t, "update", HmacUpdate);
+    node::SetPrototypeMethod(t, "digest", HmacDigest);
 
     target->Set(String::NewSymbol("Hmac"), t->GetFunction());
   }
@@ -2862,8 +2862,8 @@ class Hash : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "update", HashUpdate);
-    NODE_SET_PROTOTYPE_METHOD(t, "digest", HashDigest);
+    node::SetPrototypeMethod(t, "update", HashUpdate);
+    node::SetPrototypeMethod(t, "digest", HashDigest);
 
     target->Set(String::NewSymbol("Hash"), t->GetFunction());
   }
@@ -3017,9 +3017,9 @@ class Sign : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "init", SignInit);
-    NODE_SET_PROTOTYPE_METHOD(t, "update", SignUpdate);
-    NODE_SET_PROTOTYPE_METHOD(t, "sign", SignFinal);
+    node::SetPrototypeMethod(t, "init", SignInit);
+    node::SetPrototypeMethod(t, "update", SignUpdate);
+    node::SetPrototypeMethod(t, "sign", SignFinal);
 
     target->Set(String::NewSymbol("Sign"), t->GetFunction());
   }
@@ -3220,9 +3220,9 @@ class Verify : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "init", VerifyInit);
-    NODE_SET_PROTOTYPE_METHOD(t, "update", VerifyUpdate);
-    NODE_SET_PROTOTYPE_METHOD(t, "verify", VerifyFinal);
+    node::SetPrototypeMethod(t, "init", VerifyInit);
+    node::SetPrototypeMethod(t, "update", VerifyUpdate);
+    node::SetPrototypeMethod(t, "verify", VerifyFinal);
 
     target->Set(String::NewSymbol("Verify"), t->GetFunction());
   }
@@ -3474,14 +3474,14 @@ class DiffieHellman : public ObjectWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "generateKeys", GenerateKeys);
-    NODE_SET_PROTOTYPE_METHOD(t, "computeSecret", ComputeSecret);
-    NODE_SET_PROTOTYPE_METHOD(t, "getPrime", GetPrime);
-    NODE_SET_PROTOTYPE_METHOD(t, "getGenerator", GetGenerator);
-    NODE_SET_PROTOTYPE_METHOD(t, "getPublicKey", GetPublicKey);
-    NODE_SET_PROTOTYPE_METHOD(t, "getPrivateKey", GetPrivateKey);
-    NODE_SET_PROTOTYPE_METHOD(t, "setPublicKey", SetPublicKey);
-    NODE_SET_PROTOTYPE_METHOD(t, "setPrivateKey", SetPrivateKey);
+    node::SetPrototypeMethod(t, "generateKeys", GenerateKeys);
+    node::SetPrototypeMethod(t, "computeSecret", ComputeSecret);
+    node::SetPrototypeMethod(t, "getPrime", GetPrime);
+    node::SetPrototypeMethod(t, "getGenerator", GetGenerator);
+    node::SetPrototypeMethod(t, "getPublicKey", GetPublicKey);
+    node::SetPrototypeMethod(t, "getPrivateKey", GetPrivateKey);
+    node::SetPrototypeMethod(t, "setPublicKey", SetPublicKey);
+    node::SetPrototypeMethod(t, "setPrivateKey", SetPrivateKey);
 
     target->Set(String::NewSymbol("DiffieHellman"), t->GetFunction());
   }
@@ -4303,9 +4303,9 @@ void InitCrypto(Handle<Object> target) {
   Sign::Initialize(target);
   Verify::Initialize(target);
 
-  NODE_SET_METHOD(target, "PBKDF2", PBKDF2);
-  NODE_SET_METHOD(target, "randomBytes", RandomBytes<RAND_bytes>);
-  NODE_SET_METHOD(target, "pseudoRandomBytes", RandomBytes<RAND_pseudo_bytes>);
+  node::SetMethod(target, "PBKDF2", PBKDF2);
+  node::SetMethod(target, "randomBytes", RandomBytes<RAND_bytes>);
+  node::SetMethod(target, "pseudoRandomBytes", RandomBytes<RAND_pseudo_bytes>);
 
   subject_symbol    = NODE_PSYMBOL("subject");
   issuer_symbol     = NODE_PSYMBOL("issuer");

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -936,36 +936,36 @@ static Handle<Value> FUTimes(const Arguments& args) {
 void File::Initialize(Handle<Object> target) {
   HandleScope scope;
 
-  NODE_SET_METHOD(target, "close", Close);
-  NODE_SET_METHOD(target, "open", Open);
-  NODE_SET_METHOD(target, "read", Read);
-  NODE_SET_METHOD(target, "fdatasync", Fdatasync);
-  NODE_SET_METHOD(target, "fsync", Fsync);
-  NODE_SET_METHOD(target, "rename", Rename);
-  NODE_SET_METHOD(target, "truncate", Truncate);
-  NODE_SET_METHOD(target, "rmdir", RMDir);
-  NODE_SET_METHOD(target, "mkdir", MKDir);
-  NODE_SET_METHOD(target, "sendfile", SendFile);
-  NODE_SET_METHOD(target, "readdir", ReadDir);
-  NODE_SET_METHOD(target, "stat", Stat);
-  NODE_SET_METHOD(target, "lstat", LStat);
-  NODE_SET_METHOD(target, "fstat", FStat);
-  NODE_SET_METHOD(target, "link", Link);
-  NODE_SET_METHOD(target, "symlink", Symlink);
-  NODE_SET_METHOD(target, "readlink", ReadLink);
-  NODE_SET_METHOD(target, "unlink", Unlink);
-  NODE_SET_METHOD(target, "write", Write);
+  node::SetMethod(target, "close", Close);
+  node::SetMethod(target, "open", Open);
+  node::SetMethod(target, "read", Read);
+  node::SetMethod(target, "fdatasync", Fdatasync);
+  node::SetMethod(target, "fsync", Fsync);
+  node::SetMethod(target, "rename", Rename);
+  node::SetMethod(target, "truncate", Truncate);
+  node::SetMethod(target, "rmdir", RMDir);
+  node::SetMethod(target, "mkdir", MKDir);
+  node::SetMethod(target, "sendfile", SendFile);
+  node::SetMethod(target, "readdir", ReadDir);
+  node::SetMethod(target, "stat", Stat);
+  node::SetMethod(target, "lstat", LStat);
+  node::SetMethod(target, "fstat", FStat);
+  node::SetMethod(target, "link", Link);
+  node::SetMethod(target, "symlink", Symlink);
+  node::SetMethod(target, "readlink", ReadLink);
+  node::SetMethod(target, "unlink", Unlink);
+  node::SetMethod(target, "write", Write);
 
-  NODE_SET_METHOD(target, "chmod", Chmod);
-  NODE_SET_METHOD(target, "fchmod", FChmod);
-  //NODE_SET_METHOD(target, "lchmod", LChmod);
+  node::SetMethod(target, "chmod", Chmod);
+  node::SetMethod(target, "fchmod", FChmod);
+  //node::SetMethod(target, "lchmod", LChmod);
 
-  NODE_SET_METHOD(target, "chown", Chown);
-  NODE_SET_METHOD(target, "fchown", FChown);
-  //NODE_SET_METHOD(target, "lchown", LChown);
+  node::SetMethod(target, "chown", Chown);
+  node::SetMethod(target, "fchown", FChown);
+  //node::SetMethod(target, "lchown", LChown);
 
-  NODE_SET_METHOD(target, "utimes", UTimes);
-  NODE_SET_METHOD(target, "futimes", FUTimes);
+  node::SetMethod(target, "utimes", UTimes);
+  node::SetMethod(target, "futimes", FUTimes);
 
   errno_symbol = NODE_PSYMBOL("errno");
   encoding_symbol = NODE_PSYMBOL("node:encoding");

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -582,9 +582,9 @@ void InitHttpParser(Handle<Object> target) {
   t->Set(String::NewSymbol("REQUEST"), Integer::New(HTTP_REQUEST), attrib);
   t->Set(String::NewSymbol("RESPONSE"), Integer::New(HTTP_RESPONSE), attrib);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "execute", Parser::Execute);
-  NODE_SET_PROTOTYPE_METHOD(t, "finish", Parser::Finish);
-  NODE_SET_PROTOTYPE_METHOD(t, "reinitialize", Parser::Reinitialize);
+  node::SetPrototypeMethod(t, "execute", Parser::Execute);
+  node::SetPrototypeMethod(t, "finish", Parser::Finish);
+  node::SetPrototypeMethod(t, "reinitialize", Parser::Reinitialize);
 
   target->Set(String::NewSymbol("HTTPParser"), t->GetFunction());
 

--- a/src/node_io_watcher.cc
+++ b/src/node_io_watcher.cc
@@ -42,9 +42,9 @@ void IOWatcher::Initialize(Handle<Object> target) {
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("IOWatcher"));
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "start", IOWatcher::Start);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "stop", IOWatcher::Stop);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "set", IOWatcher::Set);
+  node::SetPrototypeMethod(constructor_template, "start", IOWatcher::Start);
+  node::SetPrototypeMethod(constructor_template, "stop", IOWatcher::Stop);
+  node::SetPrototypeMethod(constructor_template, "set", IOWatcher::Set);
 
   target->Set(String::NewSymbol("IOWatcher"), constructor_template->GetFunction());
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -170,15 +170,15 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
 void OS::Initialize(v8::Handle<v8::Object> target) {
   HandleScope scope;
 
-  NODE_SET_METHOD(target, "getHostname", GetHostname);
-  NODE_SET_METHOD(target, "getLoadAvg", GetLoadAvg);
-  NODE_SET_METHOD(target, "getUptime", GetUptime);
-  NODE_SET_METHOD(target, "getTotalMem", GetTotalMemory);
-  NODE_SET_METHOD(target, "getFreeMem", GetFreeMemory);
-  NODE_SET_METHOD(target, "getCPUs", GetCPUInfo);
-  NODE_SET_METHOD(target, "getOSType", GetOSType);
-  NODE_SET_METHOD(target, "getOSRelease", GetOSRelease);
-  NODE_SET_METHOD(target, "getInterfaceAddresses", GetInterfaceAddresses);
+  node::SetMethod(target, "getHostname", GetHostname);
+  node::SetMethod(target, "getLoadAvg", GetLoadAvg);
+  node::SetMethod(target, "getUptime", GetUptime);
+  node::SetMethod(target, "getTotalMem", GetTotalMemory);
+  node::SetMethod(target, "getFreeMem", GetFreeMemory);
+  node::SetMethod(target, "getCPUs", GetCPUInfo);
+  node::SetMethod(target, "getOSType", GetOSType);
+  node::SetMethod(target, "getOSRelease", GetOSRelease);
+  node::SetMethod(target, "getInterfaceAddresses", GetInterfaceAddresses);
 }
 
 

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -194,35 +194,35 @@ void WrappedScript::Initialize(Handle<Object> target) {
   // See GH-203 https://github.com/joyent/node/issues/203
   constructor_template->SetClassName(String::NewSymbol("NodeScript"));
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template,
+  node::SetPrototypeMethod(constructor_template,
                             "createContext",
                             WrappedScript::CreateContext);
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template,
+  node::SetPrototypeMethod(constructor_template,
                             "runInContext",
                             WrappedScript::RunInContext);
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template,
+  node::SetPrototypeMethod(constructor_template,
                             "runInThisContext",
                             WrappedScript::RunInThisContext);
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template,
+  node::SetPrototypeMethod(constructor_template,
                             "runInNewContext",
                             WrappedScript::RunInNewContext);
 
-  NODE_SET_METHOD(constructor_template,
+  node::SetMethod(constructor_template,
                   "createContext",
                   WrappedScript::CreateContext);
 
-  NODE_SET_METHOD(constructor_template,
+  node::SetMethod(constructor_template,
                   "runInContext",
                   WrappedScript::CompileRunInContext);
 
-  NODE_SET_METHOD(constructor_template,
+  node::SetMethod(constructor_template,
                   "runInThisContext",
                   WrappedScript::CompileRunInThisContext);
 
-  NODE_SET_METHOD(constructor_template,
+  node::SetMethod(constructor_template,
                   "runInNewContext",
                   WrappedScript::CompileRunInNewContext);
 

--- a/src/node_signal_watcher.cc
+++ b/src/node_signal_watcher.cc
@@ -37,8 +37,8 @@ void SignalWatcher::Initialize(Handle<Object> target) {
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("SignalWatcher"));
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "start", SignalWatcher::Start);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "stop", SignalWatcher::Stop);
+  node::SetPrototypeMethod(constructor_template, "start", SignalWatcher::Start);
+  node::SetPrototypeMethod(constructor_template, "stop", SignalWatcher::Stop);
 
   target->Set(String::NewSymbol("SignalWatcher"),
       constructor_template->GetFunction());

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -39,8 +39,8 @@ void StatWatcher::Initialize(Handle<Object> target) {
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("StatWatcher"));
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "start", StatWatcher::Start);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "stop", StatWatcher::Stop);
+  node::SetPrototypeMethod(constructor_template, "start", StatWatcher::Start);
+  node::SetPrototypeMethod(constructor_template, "stop", StatWatcher::Stop);
 
   target->Set(String::NewSymbol("StatWatcher"), constructor_template->GetFunction());
 }

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -306,8 +306,8 @@ template <node_zlib_mode mode> class ZCtx : public ObjectWrap {
   { \
     Local<FunctionTemplate> z = FunctionTemplate::New(ZCtx<mode>::New); \
     z->InstanceTemplate()->SetInternalFieldCount(1); \
-    NODE_SET_PROTOTYPE_METHOD(z, "write", ZCtx<mode>::Write); \
-    NODE_SET_PROTOTYPE_METHOD(z, "init", ZCtx<mode>::Init); \
+    node::SetPrototypeMethod(z, "write", ZCtx<mode>::Write); \
+    node::SetPrototypeMethod(z, "init", ZCtx<mode>::Init); \
     z->SetClassName(String::NewSymbol(name)); \
     target->Set(String::NewSymbol(name), z->GetFunction()); \
   }

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -83,22 +83,22 @@ void PipeWrap::Initialize(Handle<Object> target) {
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "close", HandleWrap::Close);
-  NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
-  NODE_SET_PROTOTYPE_METHOD(t, "ref", HandleWrap::Ref);
+  node::SetPrototypeMethod(t, "close", HandleWrap::Close);
+  node::SetPrototypeMethod(t, "unref", HandleWrap::Unref);
+  node::SetPrototypeMethod(t, "ref", HandleWrap::Ref);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "readStart", StreamWrap::ReadStart);
-  NODE_SET_PROTOTYPE_METHOD(t, "readStop", StreamWrap::ReadStop);
-  NODE_SET_PROTOTYPE_METHOD(t, "write", StreamWrap::Write);
-  NODE_SET_PROTOTYPE_METHOD(t, "shutdown", StreamWrap::Shutdown);
+  node::SetPrototypeMethod(t, "readStart", StreamWrap::ReadStart);
+  node::SetPrototypeMethod(t, "readStop", StreamWrap::ReadStop);
+  node::SetPrototypeMethod(t, "write", StreamWrap::Write);
+  node::SetPrototypeMethod(t, "shutdown", StreamWrap::Shutdown);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "bind", Bind);
-  NODE_SET_PROTOTYPE_METHOD(t, "listen", Listen);
-  NODE_SET_PROTOTYPE_METHOD(t, "connect", Connect);
-  NODE_SET_PROTOTYPE_METHOD(t, "open", Open);
+  node::SetPrototypeMethod(t, "bind", Bind);
+  node::SetPrototypeMethod(t, "listen", Listen);
+  node::SetPrototypeMethod(t, "connect", Connect);
+  node::SetPrototypeMethod(t, "open", Open);
 
 #ifdef _WIN32
-  NODE_SET_PROTOTYPE_METHOD(t, "setPendingInstances", SetPendingInstances);
+  node::SetPrototypeMethod(t, "setPendingInstances", SetPendingInstances);
 #endif
 
   pipeConstructor = Persistent<Function>::New(t->GetFunction());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -66,10 +66,10 @@ class ProcessWrap : public HandleWrap {
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
     constructor->SetClassName(String::NewSymbol("Process"));
 
-    NODE_SET_PROTOTYPE_METHOD(constructor, "close", HandleWrap::Close);
+    node::SetPrototypeMethod(constructor, "close", HandleWrap::Close);
 
-    NODE_SET_PROTOTYPE_METHOD(constructor, "spawn", Spawn);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "kill", Kill);
+    node::SetPrototypeMethod(constructor, "spawn", Spawn);
+    node::SetPrototypeMethod(constructor, "kill", Kill);
 
     target->Set(String::NewSymbol("Process"), constructor->GetFunction());
   }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -104,25 +104,25 @@ void TCPWrap::Initialize(Handle<Object> target) {
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "close", HandleWrap::Close);
+  node::SetPrototypeMethod(t, "close", HandleWrap::Close);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "readStart", StreamWrap::ReadStart);
-  NODE_SET_PROTOTYPE_METHOD(t, "readStop", StreamWrap::ReadStop);
-  NODE_SET_PROTOTYPE_METHOD(t, "write", StreamWrap::Write);
-  NODE_SET_PROTOTYPE_METHOD(t, "shutdown", StreamWrap::Shutdown);
+  node::SetPrototypeMethod(t, "readStart", StreamWrap::ReadStart);
+  node::SetPrototypeMethod(t, "readStop", StreamWrap::ReadStop);
+  node::SetPrototypeMethod(t, "write", StreamWrap::Write);
+  node::SetPrototypeMethod(t, "shutdown", StreamWrap::Shutdown);
 
-  NODE_SET_PROTOTYPE_METHOD(t, "bind", Bind);
-  NODE_SET_PROTOTYPE_METHOD(t, "listen", Listen);
-  NODE_SET_PROTOTYPE_METHOD(t, "connect", Connect);
-  NODE_SET_PROTOTYPE_METHOD(t, "bind6", Bind6);
-  NODE_SET_PROTOTYPE_METHOD(t, "connect6", Connect6);
-  NODE_SET_PROTOTYPE_METHOD(t, "getsockname", GetSockName);
-  NODE_SET_PROTOTYPE_METHOD(t, "getpeername", GetPeerName);
-  NODE_SET_PROTOTYPE_METHOD(t, "setNoDelay", SetNoDelay);
-  NODE_SET_PROTOTYPE_METHOD(t, "setKeepAlive", SetKeepAlive);
+  node::SetPrototypeMethod(t, "bind", Bind);
+  node::SetPrototypeMethod(t, "listen", Listen);
+  node::SetPrototypeMethod(t, "connect", Connect);
+  node::SetPrototypeMethod(t, "bind6", Bind6);
+  node::SetPrototypeMethod(t, "connect6", Connect6);
+  node::SetPrototypeMethod(t, "getsockname", GetSockName);
+  node::SetPrototypeMethod(t, "getpeername", GetPeerName);
+  node::SetPrototypeMethod(t, "setNoDelay", SetNoDelay);
+  node::SetPrototypeMethod(t, "setKeepAlive", SetKeepAlive);
 
 #ifdef _WIN32
-  NODE_SET_PROTOTYPE_METHOD(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
+  node::SetPrototypeMethod(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
 #endif
 
   tcpConstructor = Persistent<Function>::New(t->GetFunction());

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -62,13 +62,13 @@ class TimerWrap : public HandleWrap {
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
     constructor->SetClassName(String::NewSymbol("Timer"));
 
-    NODE_SET_PROTOTYPE_METHOD(constructor, "close", HandleWrap::Close);
+    node::SetPrototypeMethod(constructor, "close", HandleWrap::Close);
 
-    NODE_SET_PROTOTYPE_METHOD(constructor, "start", Start);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "stop", Stop);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "setRepeat", SetRepeat);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "getRepeat", GetRepeat);
-    NODE_SET_PROTOTYPE_METHOD(constructor, "again", Again);
+    node::SetPrototypeMethod(constructor, "start", Start);
+    node::SetPrototypeMethod(constructor, "stop", Stop);
+    node::SetPrototypeMethod(constructor, "setRepeat", SetRepeat);
+    node::SetPrototypeMethod(constructor, "getRepeat", GetRepeat);
+    node::SetPrototypeMethod(constructor, "again", Again);
 
     target->Set(String::NewSymbol("Timer"), constructor->GetFunction());
   }

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -67,19 +67,19 @@ class TTYWrap : StreamWrap {
 
     t->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "close", HandleWrap::Close);
-    NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
-    NODE_SET_PROTOTYPE_METHOD(t, "ref", HandleWrap::Ref);
+    node::SetPrototypeMethod(t, "close", HandleWrap::Close);
+    node::SetPrototypeMethod(t, "unref", HandleWrap::Unref);
+    node::SetPrototypeMethod(t, "ref", HandleWrap::Ref);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "readStart", StreamWrap::ReadStart);
-    NODE_SET_PROTOTYPE_METHOD(t, "readStop", StreamWrap::ReadStop);
-    NODE_SET_PROTOTYPE_METHOD(t, "write", StreamWrap::Write);
+    node::SetPrototypeMethod(t, "readStart", StreamWrap::ReadStart);
+    node::SetPrototypeMethod(t, "readStop", StreamWrap::ReadStop);
+    node::SetPrototypeMethod(t, "write", StreamWrap::Write);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "getWindowSize", TTYWrap::GetWindowSize);
-    NODE_SET_PROTOTYPE_METHOD(t, "setRawMode", SetRawMode);
+    node::SetPrototypeMethod(t, "getWindowSize", TTYWrap::GetWindowSize);
+    node::SetPrototypeMethod(t, "setRawMode", SetRawMode);
 
-    NODE_SET_METHOD(target, "isTTY", IsTTY);
-    NODE_SET_METHOD(target, "guessHandleType", GuessHandleType);
+    node::SetMethod(target, "isTTY", IsTTY);
+    node::SetMethod(target, "guessHandleType", GuessHandleType);
 
     target->Set(String::NewSymbol("TTY"), t->GetFunction());
   }

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -126,14 +126,14 @@ void UDPWrap::Initialize(Handle<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("UDP"));
 
-  NODE_SET_PROTOTYPE_METHOD(t, "bind", Bind);
-  NODE_SET_PROTOTYPE_METHOD(t, "send", Send);
-  NODE_SET_PROTOTYPE_METHOD(t, "bind6", Bind6);
-  NODE_SET_PROTOTYPE_METHOD(t, "send6", Send6);
-  NODE_SET_PROTOTYPE_METHOD(t, "close", Close);
-  NODE_SET_PROTOTYPE_METHOD(t, "recvStart", RecvStart);
-  NODE_SET_PROTOTYPE_METHOD(t, "recvStop", RecvStop);
-  NODE_SET_PROTOTYPE_METHOD(t, "getsockname", GetSockName);
+  node::SetPrototypeMethod(t, "bind", Bind);
+  node::SetPrototypeMethod(t, "send", Send);
+  node::SetPrototypeMethod(t, "bind6", Bind6);
+  node::SetPrototypeMethod(t, "send6", Send6);
+  node::SetPrototypeMethod(t, "close", Close);
+  node::SetPrototypeMethod(t, "recvStart", RecvStart);
+  node::SetPrototypeMethod(t, "recvStop", RecvStop);
+  node::SetPrototypeMethod(t, "getsockname", GetSockName);
 
   target->Set(String::NewSymbol("UDP"),
               Persistent<FunctionTemplate>::New(t)->GetFunction());


### PR DESCRIPTION
See https://github.com/joyent/node/pull/2122 for more details about why this is better than using defines.

I also left NODE_SET_PROTOTYPE_METHOD and NODE_SET_METHOD as defines:

```
#define NODE_SET_METHOD node::SetMethod
#define NODE_SET_PROTOTYPE_METHOD node::SetPrototypeMethod
```

Per the discussion before for people that might have code with #ifdef NODE_SET_METHOD

This pull request also updates the codebase and docs to use the new functions.
