### PR TITLE
Cluster 2.0 – step 2 : silent option in fork

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -229,8 +229,9 @@ And then the child script, `'sub.js'` might look like this:
 In the child the `process` object will have a `send()` method, and `process`
 will emit objects each time it receives a message on its channel.
 
-By default the spawned Node process will have the stdin, stdout, stderr
-associated with the parent's.
+By default the spawned Node process will have the stdout, stderr associated
+with the parent's. To change this behavior set the `silent` property in the
+`options` object to `true`.
 
 These child Nodes are still whole new instances of V8. Assume at least 30ms
 startup and 10mb memory for each new Node. That is, you cannot create many

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -158,8 +158,8 @@ exports.fork = function(modulePath, args, options) {
   }
 
   // Leave stdin open for the IPC channel. stdout and stderr should be the
-  // same as the parent's.
-  options.customFds = [-1, 1, 2];
+  // same as the parent's if silent isn't set.
+  options.customFds = (options.silent ? [-1, -1, -1] : [-1, 1, 2]);
 
   // Just need to set this - child process won't actually use the fd.
   // For backwards compat - this can be changed to 'NODE_CHANNEL' before v0.6.

--- a/test/simple/test-child-process-silent.js
+++ b/test/simple/test-child-process-silent.js
@@ -1,0 +1,80 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var common = require('../common');
+var assert = require('assert');
+var fork = require('child_process').fork;
+
+var isChild = process.argv[2] === 'child';
+
+if (isChild) {
+  console.log('LOG: a stdout message');
+  console.error('LOG: a stderr message');
+
+  process.send('message from child');
+  process.once('message', function () {
+    process.send('got message from master');
+  });
+}
+
+else {
+
+  var checks = {
+    stdoutNotPiped: false,
+    stderrNotPiped: false,
+    childSending: false,
+    childReciveing: false
+  };
+
+
+
+  var child = fork(process.argv[1], ['child'], {silent: true});
+  child.on('message', function (message) {
+
+    if (checks.childSending === false) {
+      checks.childSending = (message === 'message from child');
+    }
+    if (checks.childReciveing === false) {
+      checks.childReciveing = (message === 'got message from master');
+    }
+    if (checks.childReciveing === true) {
+      child.kill();
+    }
+  });
+  checks.stdoutNotPiped = (child.stdout && child.stdout.readable === true);
+  checks.stderrNotPiped = (child.stderr && child.stderr.readable === true);
+
+  child.send('message to child');
+
+  //Check all values
+  process.once('exit', function() {
+
+    //Check message system
+    assert.ok(checks.childSending, 'The child was able to send a message');
+    assert.ok(checks.childReciveing, 'The child was able to receive a message');
+
+    //Check std(out|err) pipes
+    assert.ok(checks.stdoutNotPiped, 'The stdout socket was piped to parent');
+    assert.ok(checks.stdoutNotPiped, 'The stderr socket was piped to parent');
+  });
+
+}

--- a/test/simple/test-child-process-silent.js
+++ b/test/simple/test-child-process-silent.js
@@ -31,12 +31,11 @@ if (isChild) {
   console.error('LOG: a stderr message');
 
   process.send('message from child');
-  process.once('message', function () {
+  process.once('message', function() {
     process.send('got message from master');
   });
-}
 
-else {
+} else {
 
   var checks = {
     stdoutNotPiped: false,
@@ -45,10 +44,8 @@ else {
     childReciveing: false
   };
 
-
-
   var child = fork(process.argv[1], ['child'], {silent: true});
-  child.on('message', function (message) {
+  child.on('message', function(message) {
 
     if (checks.childSending === false) {
       checks.childSending = (message === 'message from child');


### PR DESCRIPTION
@ry

As discussed in the IRC i will pull the `silent` option in step 2. I also updated documentation and made a testcase.

I know this can't be pushed to v0.6, but the master branch is to unstable to work in.

About step 3 `fork(env)` you can just pull #2042 I have no code addition to that.
But @visionmedia need to update documetation, and perhaps make a testcase.
If you want I can make a step 3 too, but please inform me else i won't do it.

_This is about the merging in the `cluster 2.0` ( see #2038 ) pull request_
