### PR TITLE
fix memory leak in setTimeout

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -151,7 +151,10 @@ exports.setTimeout = function(callback, after) {
     timer = new Timer();
 
     if (arguments.length <= 2) {
-      timer._onTimeout = callback;
+      timer._onTimeout = function() {
+        callback();
+        timer.close();
+      }
     } else {
       var args = Array.prototype.slice.call(arguments, 2);
       timer._onTimeout = function() {

--- a/test/simple/test-timers-zero-timeout.js
+++ b/test/simple/test-timers-zero-timeout.js
@@ -27,6 +27,7 @@ var assert = require('assert');
   var ncalled = 0;
 
   setTimeout(f, 0, 'foo', 'bar', 'baz');
+  var timer = setTimeout(function(){}, 0);
 
   function f(a, b, c) {
     assert.equal(a, 'foo');
@@ -37,6 +38,8 @@ var assert = require('assert');
 
   process.on('exit', function() {
     assert.equal(ncalled, 1);
+    // timer should be already closed
+    assert.equal(timer.close(), -1);
   });
 })();
 


### PR DESCRIPTION
Closing handle is leaked when setTimeout called with arguments which are
1. a callback
2. zero delay
(i.e. setTimeout(function(){}, 0); )
