### PR TITLE
Set the 'errno' and 'code' of a module when not found.

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -115,7 +115,7 @@ That is, `circle.js` must be in the same directory as `foo.js` for
 Without a leading '/' or './' to indicate a file, the module is either a
 "core module" or is loaded from a `node_modules` folder.
 
-If the given path does not exist, `require()` will throw an Error with it's
+If the given path does not exist, `require()` will throw an Error with its
 `code` property set to `'MODULE_NOT_FOUND'`.
 
 ### Loading from `node_modules` Folders

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -115,6 +115,9 @@ That is, `circle.js` must be in the same directory as `foo.js` for
 Without a leading '/' or './' to indicate a file, the module is either a
 "core module" or is loaded from a `node_modules` folder.
 
+If the given path does not exist, `require()` will throw an Error with it's
+`code` property set to `'MODULE_NOT_FOUND'`.
+
 ### Loading from `node_modules` Folders
 
 If the module identifier passed to `require()` is not a native module,

--- a/lib/module.js
+++ b/lib/module.js
@@ -331,7 +331,7 @@ Module._resolveFilename = function(request, parent) {
 
   var filename = Module._findPath(request, paths);
   if (!filename) {
-    var err = "Cannot find module '" + request + "'";
+    var err = new Error("Cannot find module '" + request + "'");
     err.code = 'MODULE_NOT_FOUND';
     throw err;
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -331,7 +331,9 @@ Module._resolveFilename = function(request, parent) {
 
   var filename = Module._findPath(request, paths);
   if (!filename) {
-    throw new Error("Cannot find module '" + request + "'");
+    var err = "Cannot find module '" + request + "'";
+    err.code = 'MODULE_NOT_FOUND';
+    throw err;
   }
   id = filename;
   return [id, filename];

--- a/test/simple/test-require-exceptions.js
+++ b/test/simple/test-require-exceptions.js
@@ -34,9 +34,9 @@ assert.throws(function() {
 
 // Requiring a module that does not exist should throw an
 // error with it's `code` set to MODULE_NOT_FOUND
-try {
+assert.throws(function () {
   require(common.fixturesDir + '/DOES_NOT_EXIST');
-  assert(false, 'require() should have thrown an Error');
-} catch (e) {
+}, function (e) {
   assert.equal('MODULE_NOT_FOUND', e.code);
-}
+  return true;
+});

--- a/test/simple/test-require-exceptions.js
+++ b/test/simple/test-require-exceptions.js
@@ -33,7 +33,7 @@ assert.throws(function() {
 });
 
 // Requiring a module that does not exist should throw an
-// error with it's `code` set to MODULE_NOT_FOUND
+// error with its `code` set to MODULE_NOT_FOUND
 assert.throws(function () {
   require(common.fixturesDir + '/DOES_NOT_EXIST');
 }, function (e) {

--- a/test/simple/test-require-exceptions.js
+++ b/test/simple/test-require-exceptions.js
@@ -31,3 +31,12 @@ assert.throws(function() {
 assert.throws(function() {
   require(common.fixturesDir + '/throws_error');
 });
+
+// Requiring a module that does not exist should throw an
+// error with it's `code` set to MODULE_NOT_FOUND
+try {
+  require(common.fixturesDir + '/DOES_NOT_EXIST');
+  assert(false, 'require() should have thrown an Error');
+} catch (e) {
+  assert.equal('MODULE_NOT_FOUND', e.code);
+}


### PR DESCRIPTION
I'm not sure if you guys will take this one, but basically I'm currently sniffing `"not find"` from the error object's `message`, which is rather hacky. So checking this property is a little cleaner approach.

Example of what I'm talking about:
https://github.com/TooTallNate/node-weak/blob/1781429d8590eaf70c7fe64d87dbc642af6d1e1d/lib/bindings.js#L13
