### PR TITLE
Expose http parse error codes

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -455,9 +455,12 @@ public:
     // If there was a parse error in one of the callbacks
     // TODO What if there is an error on EOF?
     if (!parser->parser_.upgrade && nparsed != len) {
+      enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
+
       Local<Value> e = Exception::Error(String::NewSymbol("Parse Error"));
       Local<Object> obj = e->ToObject();
       obj->Set(String::NewSymbol("bytesParsed"), nparsed_obj);
+      obj->Set(String::NewSymbol("code"), String::New(http_errno_name(err)));
       return scope.Close(e);
     } else {
       return scope.Close(nparsed_obj);
@@ -478,9 +481,12 @@ public:
     if (parser->got_exception_) return Local<Value>();
 
     if (rv != 0) {
+      enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
+
       Local<Value> e = Exception::Error(String::NewSymbol("Parse Error"));
       Local<Object> obj = e->ToObject();
       obj->Set(String::NewSymbol("bytesParsed"), Integer::New(0));
+      obj->Set(String::NewSymbol("code"), String::New(http_errno_name(err)));
       return scope.Close(e);
     }
 

--- a/test/simple/test-http-client-parse-error.js
+++ b/test/simple/test-http-client-parse-error.js
@@ -48,6 +48,7 @@ srv.listen(common.PORT, '127.0.0.1', function() {
     console.log('got error from client');
     srv.close();
     assert.ok(e.message.indexOf('Parse Error') >= 0);
+    assert.equal(e.code, 'HPE_INVALID_CONSTANT');
     parseError = true;
   });
 });


### PR DESCRIPTION
Currently http parse errors do not expose the error details available
from http_parser. This patch exposes the error code as `err.code`.
