### PR TITLE
Output Dates with Date.toString not Date.toUTCString

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -181,7 +181,7 @@ function formatValue(ctx, value, recurseTimes) {
       return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
     }
     if (isDate(value)) {
-      return ctx.stylize(Date.prototype.toUTCString.call(value), 'date');
+      return ctx.stylize(Date.prototype.toString.call(value), 'date');
     }
     if (isError(value)) {
       return formatError(value);


### PR DESCRIPTION
I’m writing a program which works with Dates, doing a lot of comparisons. I spent some time tracking down a phantom bug — it seemed as if my Date instances were sometimes UTC and sometimes local, which made no sense to me given my understanding of how JS dates work.

It turned out I was just being confused by how util.inspect outputs Date values — they end up being formatted differently than if the Date values are just part of an Array or an Object, or concatenated with a string. This is misleading and I think we need to remove it, so Date values are output more consistently.

To illustrate, before this change:

``` js
> new Date()
Sun, 18 Dec 2011 15:03:36 GMT
> '' + new Date()
'Sun Dec 18 2011 10:03:38 GMT-0500 (EST)'
```

after change:

``` js
> new Date()
Sun Dec 18 2011 10:03:38 GMT-0500 (EST)
> '' + new Date()
'Sun Dec 18 2011 10:03:38 GMT-0500 (EST)'
```
