### PR TITLE
Updated lib/http.js - removed this.socket from IncomingMessage

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -213,8 +213,6 @@ var continueExpression = /100-continue/i;
 function IncomingMessage(socket) {
   stream.Stream.call(this);
 
-  // TODO Remove one of these eventually.
-  this.socket = socket;
   this.connection = socket;
 
   this.httpVersion = null;
@@ -231,7 +229,7 @@ function IncomingMessage(socket) {
 
   // response (client) only
   this.statusCode = null;
-  this.client = this.socket;
+  this.client = this.connection;
 }
 util.inherits(IncomingMessage, stream.Stream);
 
@@ -240,7 +238,7 @@ exports.IncomingMessage = IncomingMessage;
 
 
 IncomingMessage.prototype.destroy = function(error) {
-  this.socket.destroy(error);
+  this.connection.destroy(error);
 };
 
 
@@ -251,12 +249,12 @@ IncomingMessage.prototype.setEncoding = function(encoding) {
 
 
 IncomingMessage.prototype.pause = function() {
-  this.socket.pause();
+  this.connection.pause();
 };
 
 
 IncomingMessage.prototype.resume = function() {
-  this.socket.resume();
+  this.connection.resume();
 };
 
 


### PR DESCRIPTION
There was a small todo which said to remove one variable of two which meant the same thing. That's what this patch does.
