### PR TITLE
Add HTTP Status Codes from draft-nottingham-http-new-status-02

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -187,6 +187,9 @@ var STATUS_CODES = exports.STATUS_CODES = {
   424 : 'Failed Dependency',          // RFC 4918
   425 : 'Unordered Collection',       // RFC 4918
   426 : 'Upgrade Required',           // RFC 2817
+  428 : 'Precondition Required',      // draft-nottingham-http-new-status-02
+  429 : 'Too Many Requests',          // draft-nottingham-http-new-status-02
+  431 : 'Request Header Fields Too Large',// draft-nottingham-http-new-status-02
   500 : 'Internal Server Error',
   501 : 'Not Implemented',
   502 : 'Bad Gateway',
@@ -196,7 +199,8 @@ var STATUS_CODES = exports.STATUS_CODES = {
   506 : 'Variant Also Negotiates',    // RFC 2295
   507 : 'Insufficient Storage',       // RFC 4918
   509 : 'Bandwidth Limit Exceeded',
-  510 : 'Not Extended'                // RFC 2774
+  510 : 'Not Extended',               // RFC 2774
+  511 : 'Network Authentication Required' // draft-nottingham-http-new-status-02
 };
 
 


### PR DESCRIPTION
Not really much to say - I wanted to use 429, and figured I might as well just add the set of them from the draft.
