### PR TITLE
`assert.deepEqual` support for `RegExp` objects - #620 fixed

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -171,9 +171,14 @@ function _deepEqual(actual, expected) {
     return actual.getTime() === expected.getTime();
 
   // 7.3 If the expected value is a RegExp object, the actual value is
-  // equivalent if it is also a RegExp object with the same source.
+  // equivalent if it is also a RegExp object with the same source and
+  // properties (`global`, `multiline`, `lastIndex`, `ignoreCase`).
   } else if (actual instanceof RegExp && expected instanceof RegExp) {
-    return actual.source === expected.source;
+    return actual.source === expected.source &&
+           actual.global === expected.global &&
+           actual.multiline === expected.multiline &&
+           actual.lastIndex === expected.lastIndex &&
+           actual.ignoreCase === expected.ignoreCase;
   
   // 7.4. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -170,12 +170,17 @@ function _deepEqual(actual, expected) {
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 
-  // 7.3. Other pairs that do not both pass typeof value == 'object',
+  // 7.3 If the expected value is a RegExp object, the actual value is
+  // equivalent if it is also a RegExp object with the same source.
+  } else if (actual instanceof RegExp && expected instanceof RegExp) {
+    return actual.source === expected.source;
+  
+  // 7.4. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {
     return actual == expected;
 
-  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // 7.5 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified
   // with Object.prototype.hasOwnProperty.call), the same set of keys
   // (although not necessarily the same order), equivalent values for every

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -83,7 +83,19 @@ assert.throws(makeBlock(a.deepEqual, new Date(), new Date(2000, 3, 14)),
 
 // 7.3
 assert.doesNotThrow(makeBlock(a.deepEqual, /a/, /a/));
+assert.doesNotThrow(makeBlock(a.deepEqual, /a/g, /a/g));
+assert.doesNotThrow(makeBlock(a.deepEqual, /a/i, /a/i));
+assert.doesNotThrow(makeBlock(a.deepEqual, /a/m, /a/m));
+assert.doesNotThrow(makeBlock(a.deepEqual, /a/igm, /a/igm));
 assert.throws(makeBlock(a.deepEqual, /ab/, /a/));
+assert.throws(makeBlock(a.deepEqual, /a/g, /a/));
+assert.throws(makeBlock(a.deepEqual, /a/i, /a/));
+assert.throws(makeBlock(a.deepEqual, /a/m, /a/));
+assert.throws(makeBlock(a.deepEqual, /a/igm, /a/im));
+
+var re1 = /a/;
+re1.lastIndex = 3;
+assert.throws(makeBlock(a.deepEqual, re1, /a/));
 
 
 // 7.4

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -82,13 +82,18 @@ assert.throws(makeBlock(a.deepEqual, new Date(), new Date(2000, 3, 14)),
               'deepEqual date');
 
 // 7.3
+assert.doesNotThrow(makeBlock(a.deepEqual, /a/, /a/));
+assert.throws(makeBlock(a.deepEqual, /ab/, /a/));
+
+
+// 7.4
 assert.doesNotThrow(makeBlock(a.deepEqual, 4, '4'), 'deepEqual == check');
 assert.doesNotThrow(makeBlock(a.deepEqual, true, 1), 'deepEqual == check');
 assert.throws(makeBlock(a.deepEqual, 4, '5'),
               a.AssertionError,
               'deepEqual == check');
 
-// 7.4
+// 7.5
 // having the same number of owned properties && the same set of keys
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4}, {a: 4}));
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '2'}, {a: 4, b: '2'}));


### PR DESCRIPTION
This is #620 with testing `RegExp`'s properties included.

Test case adjusted.
