### PR TITLE
simple fix for #2364 (zlib inflate/deflate/gunzip/gzip crashes when called on non-string input)

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -122,18 +122,18 @@ function zlibBuffer(engine, buffer, callback) {
   var buffers = [];
   var nread = 0;
 
-  var onError = function(err) {
+  function onError (err) {
     engine.removeListener('end', onEnd);
     engine.removeListener('error', onError);
     callback(err);
   };
 
-  var onData = function(chunk) {
+  function onData (chunk) {
     buffers.push(chunk);
     nread += chunk.length;
   };
 
-  var onEnd = function() {
+  function onEnd() {
     var buffer;
     switch(buffers.length) {
       case 0:

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -122,18 +122,18 @@ function zlibBuffer(engine, buffer, callback) {
   var buffers = [];
   var nread = 0;
 
-  engine.on('error', function(err) {
-    engine.removeListener('end');
-    engine.removeListener('error');
+  var onError = function(err) {
+    engine.removeListener('end', onEnd);
+    engine.removeListener('error', onError);
     callback(err);
-  });
+  };
 
-  engine.on('data', function(chunk) {
+  var onData = function(chunk) {
     buffers.push(chunk);
     nread += chunk.length;
-  });
+  };
 
-  engine.on('end', function() {
+  var onEnd = function() {
     var buffer;
     switch(buffers.length) {
       case 0:
@@ -153,7 +153,11 @@ function zlibBuffer(engine, buffer, callback) {
         break;
     }
     callback(null, buffer);
-  });
+  };
+
+  engine.on('error', onError);
+  engine.on('data', onData);
+  engine.on('end', onEnd);
 
   engine.write(buffer);
   engine.end();

--- a/test/simple/test-zlib-invalid-input.js
+++ b/test/simple/test-zlib-invalid-input.js
@@ -1,0 +1,38 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// test uncompressing invalid input
+
+var assert = require('assert');
+var zlib = require('zlib');
+
+var nonStringInputs = [1, true, {a: 1}, ['a']];
+
+nonStringInputs.forEach(function(input) {
+  // zlib.gunzip should not throw an error when called with bad input.
+  assert.doesNotThrow(function () {
+    console.log(input);
+    zlib.gunzip(input, function (err, buffer) {
+      // zlib.gunzip should pass the error to the callback.
+      assert.ok(err);
+    });
+  });
+});

--- a/test/simple/test-zlib-invalid-input.js
+++ b/test/simple/test-zlib-invalid-input.js
@@ -29,7 +29,6 @@ var nonStringInputs = [1, true, {a: 1}, ['a']];
 nonStringInputs.forEach(function(input) {
   // zlib.gunzip should not throw an error when called with bad input.
   assert.doesNotThrow(function () {
-    console.log(input);
     zlib.gunzip(input, function (err, buffer) {
       // zlib.gunzip should pass the error to the callback.
       assert.ok(err);


### PR DESCRIPTION
The bug symptom is that calling any of the zlib convenience methods with a non-string argument results in a crash.

The `zlibBuffer` function is calling `removeListener` without passing in the event listener itself.

This patch saves the event listeners in variables, and passes them to `removeListener`.
