### PR TITLE
fix javascript error on document page

### DIFF
--- a/doc/template.html
+++ b/doc/template.html
@@ -31,6 +31,5 @@
       var pageTracker = _gat._getTracker("UA-10874194-2");
       pageTracker._trackPageview();
       } catch(err) {}</script>
-  <script type="text/javascript">highlight(undefined, undefined, 'pre');</script>
 </body>
 </html>


### PR DESCRIPTION
`highlight()` is called twice. It causes following javascript error.

> Uncaught Found <pre> element with class="sh_sourcecode",
> but no such language exists
