### PR TITLE
net: Tell the user why socket.write() was failed when the connection is already closed.

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -442,6 +442,8 @@ Socket.prototype.write = function(data, arg1, arg2) {
 Socket.prototype._write = function(data, encoding, cb) {
   timers.active(this);
 
+  if (!this._handle) throw new Error('This socket is closed.');
+
   // `encoding` is unused right now, `data` is always a buffer.
   var writeReq = this._handle.write(data);
 

--- a/test/simple/test-net-write-after-close.js
+++ b/test/simple/test-net-write-after-close.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+
+var server = net.createServer(function(socket) {
+  setTimeout(function() {
+    assert.throws(
+      function() {
+        socket.write('test');
+      },
+      /This socket is closed/
+    );
+    process.exit();
+  }, 250);
+});
+
+server.listen(common.PORT, function() {
+  var client = net.connect(common.PORT, function() {
+    client.end();
+  });
+});
+


### PR DESCRIPTION
When the connection is closed or reset by peer or not initialized, `socket._handle` is not existing. so If you try to write in that case, you would receive the following error message on current version:

```
TypeError: Cannot call method 'write' of undefined
    at Socket._write (net.js:434:31)
    at Socket.write (net.js:426:15)
    at repl:1:4
    at REPLServer.eval (repl.js:80:21)
    at Interface.<anonymous> (repl.js:182:12)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:162:10)
    at Interface._line (readline.js:426:8)
    at Interface._ttyWrite (readline.js:603:14)
    at ReadStream.<anonymous> (readline.js:82:12)
```

In my opinion, an proper exception should be raised in this situation.

Therefore, I modified `net.js` to raise the exception forcibly as follows.

```
Error: This socket is closed. 
    at Socket._write (net.js:460:24)
    at Socket.write (net.js:438:15)
    at repl:1:4
    at REPLServer.eval (repl.js:80:21)
    at Interface.<anonymous> (repl.js:182:12)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:162:10)
    at Interface._line (readline.js:426:8)
    at Interface._ttyWrite (readline.js:603:14)
```

The test case is included for your convenience at `test/simple/test-net-write-after-close.js`.
