### PR TITLE
Don't pollute global namespace in buffer.readInt*

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -698,7 +698,7 @@ Buffer.prototype.readInt8 = function(offset, noAssert) {
 };
 
 function readInt16(buffer, offset, isBigEndian, noAssert) {
-  var neg;
+  var neg, val;
 
   if (!noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
@@ -729,7 +729,7 @@ Buffer.prototype.readInt16BE = function(offset, noAssert) {
 };
 
 function readInt32(buffer, offset, isBigEndian, noAssert) {
-  var neg;
+  var neg, val;
 
   if (!noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',


### PR DESCRIPTION
The buffer.readInt\* methods set "val" in the global namespace. Adding a "var" declaration in the affected methods fixes this.

```
$ node
> b = new Buffer(4); b.writeInt32LE(255, 0);
undefined
> val
ReferenceError: val is not defined
    at repl:1:2
    [...]
> v = b.readInt32LE(0);
255
> val
255
```
