### PR TITLE
Avoid minor array leak in Agent

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -896,6 +896,8 @@ function Agent(options) {
     var name = host + ':' + port;
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket);
+      if (!self.requests[name].length)
+        delete self.requests[name]; // don't leak []
     } else {
       // If there are no pending requests just destroy the
       // socket and it will get removed from the pool. This
@@ -914,27 +916,24 @@ Agent.defaultMaxSockets = 5;
 Agent.prototype.defaultPort = 80;
 Agent.prototype.addRequest = function(req, host, port) {
   var name = host + ':' + port;
-  if (!this.sockets[name]) {
-    this.sockets[name] = [];
-  }
-  if (this.sockets[name].length < this.maxSockets) {
+  if ((this.sockets[name] ? (this.sockets[name].length) : 0) < this.maxSockets) {
     // If we are under maxSockets create a new one.
     req.onSocket(this.createSocket(name, host, port));
   } else {
     // We are over limit so we'll add it to the queue.
-    if (!this.requests[name]) {
-      this.requests[name] = [];
-    }
-    this.requests[name].push(req);
+    if (!this.requests[name])
+      this.requests[name] = [req];
+    else
+      this.requests[name].push(req);
   }
 };
 Agent.prototype.createSocket = function(name, host, port) {
   var self = this;
   var s = self.createConnection(port, host, self.options);
-  if (!self.sockets[name]) {
-    self.sockets[name] = [];
-  }
-  this.sockets[name].push(s);
+  if (!self.sockets[name])
+    self.sockets[name] = [s];
+  else
+    this.sockets[name].push(s);
   var onFree = function() {
     self.emit('free', s, host, port);
   }
@@ -960,19 +959,21 @@ Agent.prototype.createSocket = function(name, host, port) {
 };
 Agent.prototype.removeSocket = function(s, name, host, port) {
   if (this.sockets[name]) {
-    var index = this.sockets[name].indexOf(s);
-    if (index !== -1) {
-      this.sockets[name].splice(index, 1);
+    if (this.sockets[name].length <= 1) {
+      delete this.sockets[name]; // don't leak []
+    } else {
+      var index = this.sockets[name].indexOf(s);
+      if (index !== -1) this.sockets[name].splice(index, 1);
     }
-  } else if (this.sockets[name] && this.sockets[name].length === 0) {
-    // don't leak
-    delete this.sockets[name];
-    delete this.requests[name];
   }
-  if (this.requests[name] && this.requests[name].length) {
-    // If we have pending requests and a socket gets closed a new one
-    // needs to be created to take over in the pool for the one that closed.
-    this.createSocket(name, host, port).emit('free');
+  if (this.requests[name]) {
+    if (this.requests[name].length) {
+      // If we have pending requests and a socket gets closed a new one
+      // needs to be created to take over in the pool for the one that closed.
+      this.createSocket(name, host, port).emit('free');
+    } else {
+      delete this.requests[name]; // don't leak []
+    }
   }
 };
 

--- a/test/simple/test-http-agent.js
+++ b/test/simple/test-http-agent.js
@@ -54,4 +54,7 @@ server.listen(common.PORT, function() {
 
 process.on('exit', function() {
   assert.equal(N * M, responses);
+  // no leaking arrays:
+  assert.equal(Object.keys(http.globalAgent.sockets).length, 0);
+  assert.equal(Object.keys(http.globalAgent.requests).length, 0);
 });

--- a/test/simple/test-http-client-agent.js
+++ b/test/simple/test-http-client-agent.js
@@ -52,8 +52,9 @@ function request(i) {
     var socket = req.socket;
     socket.on('close', function() {
       ++count;
-      assert.equal(http.globalAgent.sockets[name].length, max - count);
-      assert.equal(http.globalAgent.sockets[name].indexOf(socket), -1);
+      var sockets = http.globalAgent.sockets[name] || [];
+      assert.equal(sockets.length, max - count);
+      assert.equal(sockets.indexOf(socket), -1);
       if (count === max) {
         server.close();
       }
@@ -62,5 +63,9 @@ function request(i) {
 }
 
 process.on('exit', function() {
+  // no leaking arrays:
+  assert.equal(Object.keys(http.globalAgent.sockets).length, 0);
+  assert.equal(Object.keys(http.globalAgent.requests).length, 0);
+
   assert.equal(count, max);
 });

--- a/test/simple/test-http-upgrade-agent.js
+++ b/test/simple/test-http-upgrade-agent.js
@@ -77,7 +77,7 @@ srv.listen(common.PORT, '127.0.0.1', function() {
 
     process.nextTick(function() {
       // Make sure this request got removed from the pool.
-      assert.equal(http.globalAgent.sockets[options.host + ':' + options.port].length, 0);
+      assert.equal(Object.keys(http.globalAgent.sockets).length, 0);
       socket.end();
       srv.close();
 


### PR DESCRIPTION
A comment "// don't leak" was present, but in dead code, so this may be fixing a regression.

My app connects to many different hosts (thousands) over the process lifetime.  This bug would clearly leak keys and arrays in `.sockets` and `.requests` over the lifetime of the process.

Please consider cherry-picking to v0.6.
