### PR TITLE
export child process constructor

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -500,3 +500,5 @@ ChildProcess.prototype.kill = function(sig) {
     // TODO: raise error if r == -1?
   }
 };
+
+exports.ChildProcess = ChildProcess;


### PR DESCRIPTION
This might not be a good idea, but I'm looking to subclass ChildProcess. I think it should be exported from the module unless there's a real good reason not to do it.
