### PR TITLE
startMaster() no longer supports options.workerFilename, options.args and options.workers

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -67,18 +67,6 @@ var queryCallbacks = {};
 cluster.isWorker = 'NODE_WORKER_ID' in process.env;
 cluster.isMaster = ! cluster.isWorker;
 
-// Call this from the master process. It will start child workers.
-//
-// options.workerFilename
-// Specifies the script to execute for the child processes. Default is
-// process.argv[1]
-//
-// options.args
-// Specifies program arguments for the workers. The Default is
-// process.argv.slice(2)
-//
-// options.workers
-// The number of workers to start. Defaults to os.cpus().length.
 function startMaster() {
   // This can only be called from the master.
   assert(cluster.isMaster);


### PR DESCRIPTION
I was looking through the code to find a way to specify the workerFilename; seems like from 86528489ecb1213c95437d646d90eb3919c4f81a onwards the option to specify `options.workerFilename`, `options.args` and `options.workers` were removed. 

Would be nice to remove the related comments from the code as well.
