### PR TITLE
allow options without args in fork

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -198,7 +198,7 @@ subshell but rather the specified file directly. This makes it slightly
 leaner than `child_process.exec`. It has the same options.
 
 
-### child_process.fork(modulePath, arguments, options)
+### child_process.fork(modulePath, [arguments], [options])
 
 This is a special case of the `spawn()` functionality for spawning Node
 processes. In addition to having all the methods in a normal ChildProcess

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -148,7 +148,7 @@ function nop() { }
 
 exports.fork = function(modulePath /*, args, options*/) {
 
-  // get optinal options and args arguments
+  // Get options and args arguments.
   var options, args;
   if (Array.isArray(arguments[1])) {
     args = arguments[1];

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -150,9 +150,13 @@ exports.fork = function(modulePath /*, args, options*/) {
 
   // get optinal options and args arguments
   var options, args;
-  var existArgs = Array.isArray(arguments[1]);
-  options = arguments[existArgs ? 2 : 1] || {};
-  args = existArgs ? arguments[1] : [];
+  if (Array.isArray(arguments[1])) {
+    args = arguments[1];
+    options = arguments[2] || {};
+  } else {
+    args = [];
+    options = arguments[1] || {};
+  }
 
   // Copy args and add modulePath
   args = args.slice(0);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -146,13 +146,19 @@ function setupChannel(target, channel) {
 
 function nop() { }
 
+exports.fork = function(modulePath /*, args, options*/) {
 
-exports.fork = function(modulePath, args, options) {
-  if (!options) options = {};
+  //get optinal options and args arguments
+  var options, args;
+  var existArgs = Array.isArray(arguments[1]);
+  options = arguments[existArgs ? 2 : 1] || {};
+  args = existArgs ? arguments[1] : [];
 
-  args = args ? args.slice(0) : [];
+  //Copy args and add modulePath
+  args = args.slice(0);
   args.unshift(modulePath);
 
+  //Don't allow stdinStream and customFds since a stdin channel will be used
   if (options.stdinStream) {
     throw new Error('stdinStream not allowed for fork()');
   }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -148,17 +148,17 @@ function nop() { }
 
 exports.fork = function(modulePath /*, args, options*/) {
 
-  //get optinal options and args arguments
+  // get optinal options and args arguments
   var options, args;
   var existArgs = Array.isArray(arguments[1]);
   options = arguments[existArgs ? 2 : 1] || {};
   args = existArgs ? arguments[1] : [];
 
-  //Copy args and add modulePath
+  // Copy args and add modulePath
   args = args.slice(0);
   args.unshift(modulePath);
 
-  //Don't allow stdinStream and customFds since a stdin channel will be used
+  // Don't allow stdinStream and customFds since a stdin channel will be used
   if (options.stdinStream) {
     throw new Error('stdinStream not allowed for fork()');
   }


### PR DESCRIPTION
This patch allow use of options without the args argument in `child_process.fork`. This arguments was already optional in the code, but `.slice(0)` would throw an error if someone would do `child_process.fork('child,js', {slient: true})`. 

This patch detect if the second argument is an array and then define the arguments variables.
