### PR TITLE
Add IPC channel disconnect method and process isolate method.  

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -21,8 +21,18 @@ This event is emitted after the child process ends. If the process terminated
 normally, `code` is the final exit code of the process, otherwise `null`. If
 the process terminated due to receipt of a signal, `signal` is the string name
 of the signal, otherwise `null`.
+When using the `.isolate()` method the `exit` event won't emit when the process die.
 
 See `waitpid(2)`.
+
+### Event: 'isolate'
+
+This event will emit after all sockets are closed after using the `.isolate()` method.
+
+### Event: 'disconnect'
+
+This event will emit after using the `.disconnect()` method. The event is only emitted
+when using `.fork()`.
 
 ### child.stdin
 
@@ -258,7 +268,9 @@ processes:
       }
     });
 
-
+To close the IPC connection between parent and child use the `child.disconnect()` method.
+This allow the child to die gracefull since there is no IPC channel keeping it alive.
+After calling this the `disconnect` event will emit.
 
 ### child.kill(signal='SIGTERM')
 
@@ -279,3 +291,13 @@ Note that while the function is called `kill`, the signal delivered to the child
 process may not actually kill it.  `kill` really just sends a signal to a process.
 
 See `kill(2)`
+
+### child.isolate([callback])
+
+This function will isolate the process from its parent. This allow the parent to
+self terminate because the child no longer is a part of the event loop. However
+this has the sideefect that the `exit` event won't emit.
+
+When all std sockets between parent and child are closed the callback and the
+`isolate` event will emit.
+

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -105,8 +105,7 @@ function setupChannel(target, channel) {
       jsonBuffer = jsonBuffer.slice(start);
 
     } else {
-      channel.close();
-      target._channel = null;
+      target.disconnect();
     }
   };
 
@@ -138,6 +137,11 @@ function setupChannel(target, channel) {
     writeReq.oncomplete = nop;
 
     return true;
+  };
+
+  target.disconnect = function() {
+    channel.close();
+    target._channel = null;
   };
 
   channel.readStart();
@@ -177,10 +181,11 @@ exports.fork = function(modulePath, args, options) {
 
   setupChannel(child, options.stdinStream);
 
-  child.on('exit', function() {
-    if (child._channel) {
-      child._channel.close();
-    }
+  //Disconnect when process exit
+  var disconnect = child.disconnect.bind(child);
+  child.once('exit', disconnect);
+  child.once('disconnect', function() {
+    child.removeListener('exit', disconnect);
   });
 
   return child;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -142,6 +142,7 @@ function setupChannel(target, channel) {
   target.disconnect = function() {
     channel.close();
     target._channel = null;
+    target.emit('disconnect');
   };
 
   channel.readStart();

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -182,11 +182,7 @@ exports.fork = function(modulePath, args, options) {
   setupChannel(child, options.stdinStream);
 
   //Disconnect when process exit
-  var disconnect = child.disconnect.bind(child);
-  child.once('exit', disconnect);
-  child.once('disconnect', function() {
-    child.removeListener('exit', disconnect);
-  });
+  child.once('exit', child.disconnect.bind(child));
 
   return child;
 };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -505,23 +505,41 @@ ChildProcess.prototype.kill = function(sig) {
 
 //This will isolate the fork from the parent
 //so the parent will die independent of its child
-ChildProcess.prototype.isolate = function() {
+ChildProcess.prototype.isolate = function(callback) {
   if (this.isolated) return;
   this.isolated = true;
+
+  var self = this;
 
   //Disconnect IPC
   if (this._channel) {
     this.disconnect();
   }
 
+  var need = 0;
+  var got = 0;
+  var setGot = function() {
+    got++;
+    if (got >= need) {
+      if (callback) callback();
+      self.emit('isolate');
+    }
+  };
+
   //Destroy sockets
   if (this.stdin && !this.stdin.destroyed) {
+    need++;
+    this.stdin.once('close', setGot);
     this.stdin.destroy();
   }
   if (this.stdout && !this.stdout.destroyed) {
+    need++;
+    this.stdout.once('close', setGot);
     this.stdout.destroy();
   }
   if (this.stderr && !this.stderr.destroyed) {
+    need++;
+    this.stderr.once('close', setGot);
     this.stderr.destroy();
   }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -377,6 +377,7 @@ function ChildProcess() {
   this.signalCode = null;
   this.exitCode = null;
   this.killed = false;
+  this.isolated = false;
 
   this._internal = new Process();
   this._internal.onexit = function(exitCode, signalCode) {
@@ -504,4 +505,31 @@ ChildProcess.prototype.kill = function(sig) {
     var r = this._internal.kill(signal);
     // TODO: raise error if r == -1?
   }
+};
+
+//This will isolate the fork from the parent
+//so the parent will die independent of its child
+ChildProcess.prototype.isolate = function() {
+  if (this.isolated) return;
+  this.isolated = true;
+
+  //Disconnect IPC
+  if (this._channel) {
+    this.disconnect();
+  }
+
+  //Destroy sockets
+  if (this.stdin && !this.stdin.destroyed) {
+    this.stdin.destroy();
+  }
+  if (this.stdout && !this.stdout.destroyed) {
+    this.stdout.destroy();
+  }
+  if (this.stderr && !this.stderr.destroyed) {
+    this.stderr.destroy();
+  }
+
+  //Close internal
+  this._internal.close();
+  this._internal = null;
 };

--- a/test/simple/test-child-process-fork.js
+++ b/test/simple/test-child-process-fork.js
@@ -24,29 +24,37 @@ var common = require('../common');
 var fork = require('child_process').fork;
 var args = ['foo', 'bar'];
 
-var n = fork(common.fixturesDir + '/child-process-spawn-node.js', args);
+var child = fork(common.fixturesDir + '/child-process-spawn-node.js', args);
 assert.deepEqual(args, ['foo', 'bar']);
 
-var messageCount = 0;
+var disconnectEmit = false;
+child.on('disconnect', function () {
+  disconnectEmit = true;
+  assert.throws(function() { child.send('foo'); }, Error);
+});
 
-n.on('message', function(m) {
+var messageCount = 0;
+child.on('message', function(m) {
   console.log('PARENT got message:', m);
   assert.ok(m.foo);
   messageCount++;
+  child.disconnect();
 });
 
 // https://github.com/joyent/node/issues/2355 - JSON.stringify(undefined)
 // returns "undefined" but JSON.parse() cannot parse that...
-assert.throws(function() { n.send(undefined); }, TypeError);
-assert.throws(function() { n.send(); }, TypeError);
+assert.throws(function() { child.send(undefined); }, TypeError);
+assert.throws(function() { child.send(); }, TypeError);
 
-n.send({ hello: 'world' });
+child.send({ hello: 'world' });
 
 var childExitCode = -1;
-n.on('exit', function(c) {
+child.on('exit', function(c) {
   childExitCode = c;
 });
 
 process.on('exit', function() {
-  assert.ok(childExitCode == 0);
+  assert.equal(messageCount, 1);
+  assert.equal(childExitCode, 0);
+  assert.ok(disconnectEmit);
 });

--- a/test/simple/test-child-process-isolate.js
+++ b/test/simple/test-child-process-isolate.js
@@ -1,0 +1,124 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fork = require('child_process').fork;
+var net = require('net');
+
+var isParent = process.argv[2] === 'parent';
+var isChild = process.argv[2] === 'child';
+
+//This will keep the child process alive
+//and works as a kill+respond method
+if (isChild) {
+  var server = net.createServer(function() {
+    process.exit(0);
+  });
+  server.on('listening', function () {
+    process.send('online');
+  });
+  server.listen(common.PORT, 'localhost');
+}
+
+//This is the parant there will spawn a child and then die
+//The result is that the child is pulled in the background
+else if (isParent) {
+  var child = fork(process.argv[1], ['child']);
+
+  //Send pids
+  process.send({ cmd: 'pid', data: child.pid });
+
+  //Inform testcase that the child is online
+  child.once('message', function() {
+    process.send({ cmd: 'online' });
+  });
+
+  //Inform testcase that isolate has emitted
+  child.once('isolate', function() {
+    process.send({ cmd: 'isolate emit' });
+  });
+
+  //When asked to die isolate child
+  process.once('message', function() {
+    child.isolate();
+  });
+}
+
+//Testcase: will spawn parant and check if child still is alive
+else {
+
+  var alive = function(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+
+  //Create parrent
+  var parent = fork(process.argv[1], ['parent']);
+
+  //Get pids
+  var childPid;
+  var isolateEmit = false;
+  parent.on('message', function messageHandler(msg) {
+    if (msg.cmd === 'pid') {
+      childPid = msg.data;
+
+    } else if (msg.cmd === 'online') {
+      //Ask parrent to die
+      parent.send('do isolate');
+
+    } else if (msg.cmd === 'isolate emit') {
+      isolateEmit = true;
+
+      //Dissconnect IPC connection so the parent can die graceful
+      parent.disconnect();
+    }
+  });
+
+  //Check that the parent process die but not its child
+  var parentDie = false;
+  var childAlive = false;
+  parent.once('exit', function(code) {
+    assert.equal(code, 0);
+    parentDie = true;
+
+    //Check that the child is stil alive
+    childAlive = alive(childPid);
+    quitChild();
+  });
+
+  //When the parent is dead this function will kill its child (cleanup)
+  var quitChild = function() {
+    var socket = net.createConnection(common.PORT);
+    //Keep the testcase alive until the child die
+    socket.on('close', function () {});
+  };
+
+  process.on('exit', function() {
+    assert.ok(parentDie, 'the parent never died');
+    assert.ok(childAlive, 'the child died with the parent');
+    assert.ok(isolateEmit, 'the isolate event did not emit');
+  });
+}


### PR DESCRIPTION
This allow the following issues to be fixed:
- issue #2344
- issue #1740
- issue #2292
- issue #1363
- issue #2088

**disconnect:**
This allow one to disconnect the IPC between parent and child, allowing the child to die gracefull.  

**isolate:**
This allow the parent to die gracefull independent of its child. This makes it easy to pull a process in the background should you wich so.

@ry @bnoordhuis
I have a felling that the `process._channel.close()` is async but do not have a callback, could you confirm or disconfirm this.

_This also solves some future issues related to `cluster 2.0` (see #2038)_ 
