### PR TITLE
remove internet test from simpel

### DIFF
--- a/test/simple/test-c-ares.js
+++ b/test/simple/test-c-ares.js
@@ -42,13 +42,6 @@ dns.lookup('::1', function(error, result, addressType) {
   assert.equal(6, addressType);
 });
 
-dns.lookup('ipv6.google.com', function(error, result, addressType) {
-  if (error) throw error;
-  console.dir(arguments);
-  //assert.equal('string', typeof result);
-  assert.equal(6, addressType);
-});
-
 // Windows doesn't usually have an entry for localhost 127.0.0.1 in
 // C:\Windows\System32\drivers\etc\hosts
 // so we disable this test on Windows.


### PR DESCRIPTION
This remove a testcase there require internet access from `test/simpel`. The test is found here:
https://github.com/joyent/node/blob/master/test/simple/test-c-ares.js#L45-50

The test do not need to be moved it is already being tested here:
https://github.com/joyent/node/blob/master/test/internet/test-dns.js#L292-302
