### PR TITLE
Mapped ignoreUndefined arg on the `repl.start` function to the `REPLServer` constructor

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -247,8 +247,8 @@ exports.REPLServer = REPLServer;
 
 // prompt is a string to print on each line for the prompt,
 // source is a stream to use for I/O, defaulting to stdin/stdout.
-exports.start = function(prompt, source, eval, useGlobal) {
-  var repl = new REPLServer(prompt, source, eval, useGlobal);
+exports.start = function(prompt, source, eval, useGlobal, ignoreUndefined) {
+  var repl = new REPLServer(prompt, source, eval, useGlobal, ignoreUndefined);
   if (!exports.repl) exports.repl = repl;
   return repl;
 };


### PR DESCRIPTION
Simple change, ignoreUndefined argument defined in the constructor of the REPLServer but not exposed in the repl.start function (was inconsistent with the docs).  Fixed.  Have signed CLA :)
