### PR TITLE
Assume that HTTP/1.1 servers will provide a persistent connection by default.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1202,7 +1202,15 @@ ClientRequest.prototype.onSocket = function(socket) {
         return true;
       }
 
-      if (req.shouldKeepAlive && res.headers.connection !== 'keep-alive' && !req.upgraded) {
+      if (req.shouldKeepAlive && !req.upgraded &&
+              (res.httpVersion === '1.1' ?
+                  // in HTTP/1.1, default is keep-alive
+                  (res.headers.connection && res.headers.connection !== 'keep-alive')
+              :
+                  // in HTTP/1.0, default is no keep-alive
+                  (res.headers.connection !== 'keep-alive')
+              )
+          ) {
         // Server MUST respond with Connection:keep-alive for us to enable it.
         // If we've been upgraded (via WebSockets) we also shouldn't try to
         // keep the connection open.


### PR DESCRIPTION
As RFC 2616 says we should, assume that servers will provide a persistent connection by default.

> A significant difference between HTTP/1.1 and earlier versions of
> HTTP is that persistent connections are the default behavior of any
> HTTP connection. That is, unless otherwise indicated, the client
> SHOULD assume that the server will maintain a persistent connection,
> even after error responses from the server.
> 
> HTTP/1.1 applications that do not support persistent connections MUST
> include the "close" connection option in every message.
