### PR TITLE
Reusing the event handler call optimization for array of handlers

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -50,9 +50,9 @@ function callHandler(self, handler, args) {
       break;
     // slower
     default:
-      var l = args.length;
-      var argsAfterFirst = new Array(l - 1);
-      for (var i = 1; i < l; i++) argsAfterFirst[i - 1] = args[i];
+      var i = args.length - 1, argsAfterFirst = [];
+      while(i--) {argsAfterFirst[i] = args[i]};
+      argsAfterFirst.shift();
       handler.apply(self, argsAfterFirst);
   }
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -50,7 +50,7 @@ function callHandler(self, handler, args) {
       break;
     // slower
     default:
-      var i = args.length - 1, argsAfterFirst = [];
+      var i = args.length, argsAfterFirst = [];
       while(i--) {argsAfterFirst[i] = args[i]};
       argsAfterFirst.shift();
       handler.apply(self, argsAfterFirst);

--- a/lib/events.js
+++ b/lib/events.js
@@ -39,6 +39,26 @@ EventEmitter.prototype.setMaxListeners = function(n) {
 
 EventEmitter.prototype.emit = function() {
   var type = arguments[0];
+  function callHandler(self, handler, arguments) {
+    switch (arguments.length) {
+      // fast cases
+      case 1:
+        handler.call(self);
+        break;
+      case 2:
+        handler.call(self, arguments[1]);
+        break;
+      case 3:
+        handler.call(self, arguments[1], arguments[2]);
+        break;
+      // slower
+      default:
+        var l = arguments.length;
+        var args = new Array(l - 1);
+        for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+        handler.apply(self, args);
+    }
+  };
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events || !this._events.error ||
@@ -58,34 +78,13 @@ EventEmitter.prototype.emit = function() {
   if (!handler) return false;
 
   if (typeof handler == 'function') {
-    switch (arguments.length) {
-      // fast cases
-      case 1:
-        handler.call(this);
-        break;
-      case 2:
-        handler.call(this, arguments[1]);
-        break;
-      case 3:
-        handler.call(this, arguments[1], arguments[2]);
-        break;
-      // slower
-      default:
-        var l = arguments.length;
-        var args = new Array(l - 1);
-        for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-        handler.apply(this, args);
-    }
+    callHandler(this, handler, arguments);
     return true;
 
   } else if (isArray(handler)) {
-    var l = arguments.length;
-    var args = new Array(l - 1);
-    for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-
     var listeners = handler.slice();
     for (var i = 0, l = listeners.length; i < l; i++) {
-      listeners[i].apply(this, args);
+      callHandler(this, listeners[i], arguments);
     }
     return true;
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -36,29 +36,29 @@ EventEmitter.prototype.setMaxListeners = function(n) {
   this._maxListeners = n;
 };
 
+function callHandler(self, handler, args) {
+  switch (args.length) {
+    // fast cases
+    case 1:
+      handler.call(self);
+      break;
+    case 2:
+      handler.call(self, args[1]);
+      break;
+    case 3:
+      handler.call(self, args[1], args[2]);
+      break;
+    // slower
+    default:
+      var l = args.length;
+      var argsAfterFirst = new Array(l - 1);
+      for (var i = 1; i < l; i++) argsAfterFirst[i - 1] = args[i];
+      handler.apply(self, argsAfterFirst);
+  }
+};
 
 EventEmitter.prototype.emit = function() {
   var type = arguments[0];
-  function callHandler(self, handler, arguments) {
-    switch (arguments.length) {
-      // fast cases
-      case 1:
-        handler.call(self);
-        break;
-      case 2:
-        handler.call(self, arguments[1]);
-        break;
-      case 3:
-        handler.call(self, arguments[1], arguments[2]);
-        break;
-      // slower
-      default:
-        var l = arguments.length;
-        var args = new Array(l - 1);
-        for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-        handler.apply(self, args);
-    }
-  };
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events || !this._events.error ||


### PR DESCRIPTION
I noticed that you have an optimization for calling handlers if there are 0 to 2 arguments. But this optimization is not used if there is an array of handlers. Therefore, I moved the optimization code to a separate function. I am assuming that a function call is more efficient than the argument computation (not verified this). If not, an alternative is to flatten this code and remove the callHandler function.
