### PR TITLE
child_process: give forks `stdout` and `stderr`

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -167,10 +167,6 @@ exports.fork = function(modulePath, args, options) {
     throw new Error('customFds not allowed for fork()');
   }
 
-  // Leave stdin open for the IPC channel. stdout and stderr should be the
-  // same as the parent's if silent isn't set.
-  options.customFds = (options.silent ? [-1, -1, -1] : [-1, 1, 2]);
-
   // Just need to set this - child process won't actually use the fd.
   // For backwards compat - this can be changed to 'NODE_CHANNEL' before v0.6.
   if (!options.env) options.env = { };
@@ -180,6 +176,11 @@ exports.fork = function(modulePath, args, options) {
   options.stdinStream = createPipe(true);
 
   var child = spawn(process.execPath, args, options);
+
+  if (!options.silent) {
+    child.stdout.pipe(process.stdout, { end: false });
+    child.stderr.pipe(process.stderr, { end: false });
+  }
 
   setupChannel(child, options.stdinStream);
 


### PR DESCRIPTION
Previously using these streams was not possible because of making them
use given file descriptors. This solution is more generic - it uses
`pipe` function to pipe fork's output into parent's `stdout` and
`stderr` unless `silent: true` is set as an option.

This doesn't break any existing API and it makes `fork` more compatible
with `spawn`.

Please note that fork's `stdout` and `stderr` aren't meant to be used as
communication channels - use `fork(...).send()` instead.

Fixes #2442.

It'd be awesome to backport it to 0.6, it can be merge easily (I can provide another pull request for that). I find current behavior inconsistent with other APIs (also, [documentation doesn't mention it](https://github.com/joyent/node/pull/2442#issuecomment-3333681)).

/cc @bmeck
