### PR TITLE
child_process: allow to specify a command for `fork`

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -179,7 +179,7 @@ exports.fork = function(modulePath, args, options) {
   // stdin is the IPC channel.
   options.stdinStream = createPipe(true);
 
-  var child = spawn(process.execPath, args, options);
+  var child = spawn(options.command || process.execPath, args, options);
 
   setupChannel(child, options.stdinStream);
 


### PR DESCRIPTION
Such a feature is useful for spawning, for example other versions of
`node` or CoffeeScript applications.

However, this parameter is not essential in this case, so it belongs
to `options` object.
