### PR TITLE
punycode: Update to v0.3.0

### DIFF
--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -40,8 +40,8 @@
 	/** Error messages */
 	errors = {
 		'overflow': 'Overflow: input needs wider integers to process.',
-		'utf16decode': 'UTF-16(decode): illegal UTF-16 sequence',
-		'utf16encode': 'UTF-16(encode): illegal UTF-16 value',
+		'ucs2decode': 'UCS-2(decode): illegal sequence',
+		'ucs2encode': 'UCS-2(encode): illegal value',
 		'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
 		'invalid-input': 'Invalid input'
 	},
@@ -99,14 +99,13 @@
 	/**
 	 * Creates an array containing the decimal code points of each character in
 	 * the string.
-	 * @see `punycode.utf16.encode`
-	 * @see <http://tools.ietf.org/html/rfc2781>
-	 * @memberOf punycode.utf16
+	 * @see `punycode.ucs2.encode`
+	 * @memberOf punycode.ucs2
 	 * @name decode
 	 * @param {String} string The Unicode input string.
 	 * @returns {Array} The new array.
 	 */
-	function utf16decode(string) {
+	function ucs2decode(string) {
 		var output = [],
 		    counter = 0,
 		    length = string.length,
@@ -117,7 +116,7 @@
 			if ((value & 0xF800) == 0xD800) {
 				extra = string.charCodeAt(counter++);
 				if ((value & 0xFC00) != 0xD800 || (extra & 0xFC00) != 0xDC00) {
-					error('utf16decode');
+					error('ucs2decode');
 				}
 				value = ((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000;
 			}
@@ -128,18 +127,17 @@
 
 	/**
 	 * Creates a string based on an array of decimal code points.
-	 * @see `punycode.utf16.decode`
-	 * @see <http://tools.ietf.org/html/rfc2781>
-	 * @memberOf punycode.utf16
+	 * @see `punycode.ucs2.decode`
+	 * @memberOf punycode.ucs2
 	 * @name encode
 	 * @param {Array} codePoints The array of decimal code points.
 	 * @returns {String} The new string.
 	 */
-	function utf16encode(array) {
+	function ucs2encode(array) {
 		return map(array, function(value) {
 			var output = '';
 			if ((value & 0xF800) == 0xD800) {
-				error('utf16encode');
+				error('ucs2encode');
 			}
 			if (value > 0xFFFF) {
 				value -= 0x10000;
@@ -224,7 +222,7 @@
 	 * @returns {String} The resulting string of Unicode code points.
 	 */
 	function decode(input) {
-		// Don't use UTF-16
+		// Don't use UCS-2
 		var output = [],
 		    inputLength = input.length,
 		    out,
@@ -315,7 +313,7 @@
 
 		}
 
-		return utf16encode(output);
+		return ucs2encode(output);
 	}
 
 	/**
@@ -345,8 +343,8 @@
 		    baseMinusT,
 		    qMinusT;
 
-		// Convert the input in UTF-16 to Unicode
-		input = utf16decode(input);
+		// Convert the input in UCS-2 to Unicode
+		input = ucs2decode(input);
 
 		// Cache the length
 		inputLength = input.length;
@@ -475,16 +473,16 @@
 		 * @memberOf punycode
 		 * @type String
 		 */
-		'version': '0.2.1',
+		'version': '0.3.0',
 		/**
 		 * An object of methods to convert from JavaScript's internal character
-		 * representation to Unicode and back.
+		 * representation (UCS-2) to Unicode and back.
 		 * @memberOf punycode
 		 * @type Object
 		 */
-		'utf16': {
-			'decode': utf16decode,
-			'encode': utf16encode
+		'ucs2': {
+			'decode': ucs2decode,
+			'encode': ucs2encode
 		},
 		'decode': decode,
 		'encode': encode,


### PR DESCRIPTION
The Punycode.js v0.3.0 package features more extensive unit and performance test coverage.

As for the code itself, the only change between v0.2.1 and v0.3.0 is a minor API change. The `utf16` object has been renamed to `ucs2` which is more accurate. The main exposed methods (`toASCII`, `toUnicode`, `encode`, `decode`) are unaffected.

Even though no functionality is added it seems like a good idea to keep Node’s punycode.js in sync with the main repo.
