### PR TITLE
update silent testcase

### DIFF
--- a/test/simple/test-child-process-silent.js
+++ b/test/simple/test-child-process-silent.js
@@ -21,57 +21,89 @@
 
 var common = require('../common');
 var assert = require('assert');
-var fork = require('child_process').fork;
+var childProcess = require('child_process');
 
-var isChild = process.argv[2] === 'child';
+//Child pipe test
+if (process.argv[2] === 'pipetest') {
+  process.stdout.write('stdout message');
+  process.stderr.write('stderr message');
+}
 
-if (isChild) {
-  console.log('LOG: a stdout message');
-  console.error('LOG: a stderr message');
-
+//Child IPC test
+else if (process.argv[2] === 'ipctest') {
   process.send('message from child');
-  process.once('message', function () {
+  process.on('message', function () {
     process.send('got message from master');
   });
+}
 
-} else {
+//Parent | start child pipe test
+else if (process.argv[2] === 'parent') {
 
-  var checks = {
-    stdoutNotPiped: false,
-    stderrNotPiped: false,
-    childSending: false,
-    childReciveing: false
-  };
+  var child = childProcess.fork(process.argv[1], ['pipetest'], {silent: true});
 
-  var child = fork(process.argv[1], ['child'], { silent: true });
+  //Allow child process to self terminate
+  child._channel.close();
+  child._channel = null;
+
+  child.on('exit', function () {
+    process.exit(0);
+  });
+}
+
+//testcase | start parent && child IPC test
+else {
+
+  //testing: is stderr and stdout piped to parent
+  var parent = childProcess.spawn(process.execPath, [process.argv[1], 'parent']);
+
+  //got any stderr or std data
+  var stdoutData = false;
+  parent.stdout.on('data', function () {
+    stdoutData = true;
+  });
+  var stderrData = false;
+  parent.stdout.on('data', function () {
+    stderrData = true;
+  });
+
+  //testing: do message system work when using silent
+  var child = childProcess.fork(process.argv[1], ['ipctest'], {silent: true});
+
+  //Manual pipe so we will get errors
+  child.stderr.pipe(process.stderr, {end: false});
+  child.stdout.pipe(process.stdout, {end: false});
+
+  var childSending = false;
+  var childReciveing = false;
   child.on('message', function (message) {
-    if (checks.childSending === false) {
-      checks.childSending = (message === 'message from child');
+    if (childSending === false) {
+      childSending = (message === 'message from child');
     }
 
-    if (checks.childReciveing === false) {
-      checks.childReciveing = (message === 'got message from master');
+    if (childReciveing === false) {
+      childReciveing = (message === 'got message from master');
     }
 
-    if (checks.childReciveing === true) {
+    if (childReciveing === true) {
       child.kill();
     }
   });
-
-  checks.stdoutNotPiped = (child.stdout && child.stdout.readable === true);
-  checks.stderrNotPiped = (child.stderr && child.stderr.readable === true);
-
   child.send('message to child');
 
   //Check all values
-  process.once('exit', function() {
-
-    //Check message system
-    assert.ok(checks.childSending, 'The child was able to send a message');
-    assert.ok(checks.childReciveing, 'The child was able to receive a message');
+  process.on('exit', function() {
+    //clean up
+    child.kill();
+    parent.kill();
 
     //Check std(out|err) pipes
-    assert.ok(checks.stdoutNotPiped, 'The stdout socket was piped to parent');
-    assert.ok(checks.stdoutNotPiped, 'The stderr socket was piped to parent');
+    assert.ok(!stdoutData, 'The stdout socket was piped to parent');
+    assert.ok(!stderrData, 'The stderr socket was piped to parent');
+
+    //Check message system
+    assert.ok(childSending, 'The child was able to send a message');
+    assert.ok(childReciveing, 'The child was able to receive a message');
+
   });
 }

--- a/test/simple/test-child-process-silent.js
+++ b/test/simple/test-child-process-silent.js
@@ -23,60 +23,60 @@ var common = require('../common');
 var assert = require('assert');
 var childProcess = require('child_process');
 
-//Child pipe test
+// Child pipe test
 if (process.argv[2] === 'pipetest') {
   process.stdout.write('stdout message');
   process.stderr.write('stderr message');
 }
 
-//Child IPC test
+// Child IPC test
 else if (process.argv[2] === 'ipctest') {
   process.send('message from child');
-  process.on('message', function () {
+  process.on('message', function() {
     process.send('got message from master');
   });
 }
 
-//Parent | start child pipe test
+// Parent | start child pipe test
 else if (process.argv[2] === 'parent') {
 
   var child = childProcess.fork(process.argv[1], ['pipetest'], {silent: true});
 
-  //Allow child process to self terminate
+  // Allow child process to self terminate
   child._channel.close();
   child._channel = null;
 
-  child.on('exit', function () {
+  child.on('exit', function() {
     process.exit(0);
   });
 }
 
-//testcase | start parent && child IPC test
+// testcase | start parent && child IPC test
 else {
 
-  //testing: is stderr and stdout piped to parent
+  // testing: is stderr and stdout piped to parent
   var parent = childProcess.spawn(process.execPath, [process.argv[1], 'parent']);
 
   //got any stderr or std data
   var stdoutData = false;
-  parent.stdout.on('data', function () {
+  parent.stdout.on('data', function() {
     stdoutData = true;
   });
   var stderrData = false;
-  parent.stdout.on('data', function () {
+  parent.stdout.on('data', function() {
     stderrData = true;
   });
 
-  //testing: do message system work when using silent
+  // testing: do message system work when using silent
   var child = childProcess.fork(process.argv[1], ['ipctest'], {silent: true});
 
-  //Manual pipe so we will get errors
+  // Manual pipe so we will get errors
   child.stderr.pipe(process.stderr, {end: false});
   child.stdout.pipe(process.stdout, {end: false});
 
   var childSending = false;
   var childReciveing = false;
-  child.on('message', function (message) {
+  child.on('message', function(message) {
     if (childSending === false) {
       childSending = (message === 'message from child');
     }
@@ -91,7 +91,7 @@ else {
   });
   child.send('message to child');
 
-  //Check all values
+  // Check all values
   process.on('exit', function() {
     //clean up
     child.kill();


### PR DESCRIPTION
When/if #2454 gets merged the `test-child-process-silent.js` testcase wont be useful in any way. This is a much better testcase there actually test if a `stderr` or `stdout` message was received.

It do not matter if this land before or after #2454.
