### PR TITLE
Cluster 2.0 – step 4+ : fix spelling and _queryEcho overkill

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -229,10 +229,10 @@ And then the child script, `'sub.js'` might look like this:
 In the child the `process` object will have a `send()` method, and `process`
 will emit objects each time it receives a message on its channel.
 
-There is a special case when seinding a `{cmd: 'NODE_foo'}` message. All messages
-containging a `NODE_` prefix in its `cmd` property will not be emitted in
-the `message` event, since this are internal messages used by node core.
-Messages contain the prefix are emitted in the `internalMessage` event, you
+There is a special case when sending a `{cmd: 'NODE_foo'}` message. All messages
+containing a `NODE_` prefix in its `cmd` property will not be emitted in
+the `message` event, since they are internal messages used by node core.
+Messages containing the prefix are emitted in the `internalMessage` event, you
 should by all means avoid using this feature, it may change without warranty.
 
 By default the spawned Node process will have the stdout, stderr associated

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -110,9 +110,9 @@ will be added to the process environment in the worker.
 ### cluster.workers
 
 In the cluster all living worker objects are stored in this object by there
-`uniqueID` as the key. This makes it easy to loop thouge all liveing workers.
+`uniqueID` as the key. This makes it easy to loop through all living workers.
 
-    // Go througe all workers
+    // Go through all workers
     function eachWorker(callback) {
       for (var uniqueID in cluster.workers) {
         callback(cluster.workers[uniqueID]);
@@ -122,8 +122,8 @@ In the cluster all living worker objects are stored in this object by there
       worker.send('big announcement to all workers');
     });
 
-Should you wich to reference a worker over a communication channel this unsing
-there `uniqueID` this is also the easies way to find the worker.
+Should you wish to reference a worker over a communication channel, using
+the worker's uniqueID is the easiest way to find the worker.
 
     socket.on('data', function (uniqueID) {
       var worker = cluster.workers[uniqueID];
@@ -132,12 +132,12 @@ there `uniqueID` this is also the easies way to find the worker.
 ## Worker
 
 This object contains all public information and method about a worker.
-In the master it can be obtainedusing `cluster.workers`. In a worker
-it can be obtained ained using `cluster.worker`.
+In the master it can be obtained using `cluster.workers`. In a worker
+it can be obtained using `cluster.worker`.
 
 ### Worker.uniqueID
 
-Each new worker is given its own unique id, this id i stored in the `uniqueID`.
+Each new worker is given its own unique id, this id is stored in the `uniqueID`.
 
 ### Worker.process
 
@@ -166,7 +166,7 @@ This example will echo back all messages from the master:
 ### Worker.destroy()
 
 This function will kill the worker, and inform the master to not spawn a new worker.
-To know the difference between suicide and accidently death a suicide boolean is set to true.
+To know the difference between suicide and accidentally death a suicide boolean is set to true.
 
     cluster.on('death', function (worker) {
       if (worker.suicide === true) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -120,7 +120,7 @@ function startMaster() {
 }
 
 // Check if a message is internal only
-var INTERNAL_PREFIX = 'NODE_CLUTER_';
+var INTERNAL_PREFIX = 'NODE_CLUSTER_';
 function isInternalMessage(message) {
   return (isObject(message) &&
           typeof message.cmd === 'string' &&

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -147,7 +147,7 @@ function handleResponse(outMessage, outHandle, inMessage, inHandle, worker) {
   message._queryEcho = inMessage._requestEcho;
 
   // Call callback if a query echo is received
-  if (inMessage.hasOwnProperty('_queryEcho')) {
+  if (inMessage._queryEcho) {
     queryCallbacks[inMessage._queryEcho](inMessage.content, inHandle);
     delete queryCallbacks[inMessage._queryEcho];
   }


### PR DESCRIPTION
Apparently there was some minor issues in the lastest cluster patch:
5f08c3cfa1ee3ece6032d1ffeda6f403e54dd5c0

@visionmedia @mscdex this should fix all issues.

@ry I'm hoping this won't take long time to land.

When I do the next cluster improvement I will aks you all for a review. 

_This is about the merging in the `cluster 2.0` ( see #2038 ) pull request_
