### PR TITLE
Fix gypi for dlopen() error in loading the addon module on Linux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -127,9 +127,7 @@
           }],
           [ 'OS=="linux"', {
             'cflags': [ '-ansi' ],
-          }],
-          [ 'visibility=="hidden"', {
-            'cflags': [ '-fvisibility=hidden' ],
+            'ldflags': [ '-rdynamic' ],
           }],
         ],
       }],

--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -2,6 +2,7 @@
   'target_defaults': {
     'type': 'loadable_module',
     'product_extension': 'node',
+    'product_prefix': '',
     'include_dirs': [
       '../src',
       '../deps/uv/include',


### PR DESCRIPTION
In gyp built node on Linux, loading an addon module was failed because its cflags had -fvisibility=hidden and ldflags missed -rdynamic .

Also add 'product_prefix': '' in tools/addon.gypi so as not to add "lib" prefix to its target name  by default on Linux.

Testing result on test/addons/hello-world shows as below.

Build the test addon after change the value of product_prefix into empty as,

```
unix:~/tmp/github/node/test/addons/hello-world> ../../../tools/gyp_addon
unix:~/tmp/github/node/test/addons/hello-world> make BUILDTYPE=Release
  CXX(target) out/Release/obj.target/binding/binding.o
  SOLINK_MODULE(target) out/Release/obj.target/binding.node
  SOLINK_MODULE(target) out/Release/obj.target/binding.node: Finished
  COPY out/Release/binding.node
```

Before patch, the following error occurred.

```
unix:~/tmp/github/node/test/addons/hello-world> ../../../node test.js

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: Unable to load shared library /home/ohtsu/tmp/github/node/test/addons/hello-world/out/Release/binding.node
    at Object..node (module.js:465:11)
    at Module.load (module.js:353:31)
    at Function._load (module.js:310:12)
    at Module.require (module.js:359:17)
    at require (module.js:370:17)
    at Object.<anonymous> (/home/ohtsu/tmp/github/node/test/addons/hello-world/test.js:2:15)
    at Module._compile (module.js:434:26)
    at Object..js (module.js:452:10)
    at Module.load (module.js:353:31)
    at Function._load (module.js:310:12)
```

After this patch, it's working fine on my Linux.

```
unix:~/tmp/github/node/test/addons/hello-world> ../../../node test.js
binding.hello() = world
```
