### PR TITLE
events: Fix checking of max listeners

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -115,27 +115,29 @@ EventEmitter.prototype.addListener = function(type, listener) {
     // If we've already got an array, just append.
     this._events[type].push(listener);
 
-    // Check for listener leak
-    if (!this._events[type].warned) {
-      var m;
-      if (this._maxListeners !== undefined) {
-        m = this._maxListeners;
-      } else {
-        m = defaultMaxListeners;
-      }
-
-      if (m && m > 0 && this._events[type].length > m) {
-        this._events[type].warned = true;
-        console.error('(node) warning: possible EventEmitter memory ' +
-                      'leak detected. %d listeners added. ' +
-                      'Use emitter.setMaxListeners() to increase limit.',
-                      this._events[type].length);
-        console.trace();
-      }
-    }
   } else {
     // Adding the second element, need to change to array.
     this._events[type] = [this._events[type], listener];
+
+  }
+
+  // Check for listener leak
+  if (isArray(this._events[type]) && !this._events[type].warned) {
+    var m;
+    if (this._maxListeners !== undefined) {
+      m = this._maxListeners;
+    } else {
+      m = defaultMaxListeners;
+    }
+
+    if (m && m > 0 && this._events[type].length > m) {
+      this._events[type].warned = true;
+      console.error('(node) warning: possible EventEmitter memory ' +
+                    'leak detected. %d listeners added. ' +
+                    'Use emitter.setMaxListeners() to increase limit.',
+                    this._events[type].length);
+      console.trace();
+    }
   }
 
   return this;

--- a/test/simple/test-event-emitter-check-listener-leaks.js
+++ b/test/simple/test-event-emitter-check-listener-leaks.js
@@ -41,6 +41,13 @@ assert.ok(!e._events['specific'].hasOwnProperty('warned'));
 e.on('specific', function() {});
 assert.ok(e._events['specific'].warned);
 
+// only one
+e.setMaxListeners(1);
+e.on('only one', function() {});
+assert.ok(!e._events['only one'].hasOwnProperty('warned'));
+e.on('only one', function() {});
+assert.ok(e._events['only one'].hasOwnProperty('warned'));
+
 // unlimited
 e.setMaxListeners(0);
 for (var i = 0; i < 1000; i++) {


### PR DESCRIPTION
`EventEmitter.prototype.setMaxListeners(1)` does not work as expected.
It works correctly with the argument(ex. 5, 100, ...) other than 1.

``` js
var EventEmitter = require('events').EventEmitter;
var ee = new EventEmitter();
ee.setMaxListeners(1);
ee.on('message', function() {});
ee.on('message', function() {}); // doesn't show warning against my expectation.
ee.on('message', function() {}); // show warning.
```

I fixed this issue by the way to check for max listeners after it set.

Thank you!
