### PR TITLE
Rename errno, DRY errnoException()

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -133,7 +133,7 @@ function setupChannel(target, channel) {
     var writeReq = channel.write(buffer, 0, buffer.length, sendHandle);
 
     if (!writeReq) {
-      throw new Error(errno + 'cannot write to IPC channel.');
+      throw new Error(__errno + 'cannot write to IPC channel.');
     }
 
     writeReq.oncomplete = nop;
@@ -443,7 +443,7 @@ ChildProcess.prototype.spawn = function(options) {
 
     this._internal.close();
     this._internal = null;
-    throw errnoException(errno, 'spawn');
+    throw errnoException(__errno, 'spawn');
   }
 
   this.pid = this._internal.pid;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var errnoException = require('util')._errnoException;
 var EventEmitter = require('events').EventEmitter;
 var net = require('net');
 var Process = process.binding('process_wrap').Process;
@@ -469,17 +470,6 @@ ChildProcess.prototype.spawn = function(options) {
 
   return r;
 };
-
-
-function errnoException(errorno, syscall) {
-  // TODO make this more compatible with ErrnoException from src/node.cc
-  // Once all of Node is using this function the ErrnoException from
-  // src/node.cc should be removed.
-  var e = new Error(syscall + ' ' + errorno);
-  e.errno = e.code = errorno;
-  e.syscall = syscall;
-  return e;
-}
 
 
 ChildProcess.prototype.kill = function(sig) {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -23,6 +23,7 @@ var util = require('util');
 var events = require('events');
 
 var UDP = process.binding('udp_wrap').UDP;
+var errnoException = util._errnoException;
 
 // lazily loaded
 var dns = null;
@@ -306,13 +307,4 @@ function onMessage(handle, nread, buf, rinfo) {
     rinfo.size = buf.length; // compatibility
     self.emit('message', buf, rinfo);
   }
-}
-
-
-// TODO share with net_uv and others
-function errnoException(errorno, syscall) {
-  var e = new Error(syscall + ' ' + errorno);
-  e.errno = e.code = errorno;
-  e.syscall = syscall;
-  return e;
 }

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -121,7 +121,7 @@ Socket.prototype.bind = function(port, address) {
   self._handle.lookup(address, function(err, ip) {
     if (!err) {
       if (self._handle.bind(ip, port || 0, /*flags=*/0)) {
-        err = errnoException(errno, 'bind');
+        err = errnoException(__errno, 'bind');
       }
       else {
         self._bound = true;
@@ -184,7 +184,7 @@ Socket.prototype.send = function(buffer,
       }
       else {
         // don't emit as error, dgram_legacy.js compatibility
-        callback(errnoException(errno, 'send'));
+        callback(errnoException(__errno, 'send'));
       }
     }
   });
@@ -217,7 +217,7 @@ Socket.prototype.address = function() {
 
   var address = this._handle.getsockname();
   if (!address)
-    throw errnoException(errno, 'getsockname');
+    throw errnoException(__errno, 'getsockname');
 
   return address;
 };
@@ -301,7 +301,7 @@ function onMessage(handle, nread, buf, rinfo) {
   var self = handle.socket;
 
   if (nread == -1) {
-    self.emit('error', errnoException(errno, 'recvmsg'));
+    self.emit('error', errnoException(__errno, 'recvmsg'));
   }
   else {
     rinfo.size = buf.length; // compatibility

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -128,14 +128,14 @@ exports.lookup = function(domain, family, callback) {
         callback(null, addresses[0], addresses[0].indexOf(':') >= 0 ? 6 : 4);
       }
     } else {
-      callback(errnoException(errno, 'getaddrinfo'));
+      callback(errnoException(__errno, 'getaddrinfo'));
     }
   }
 
   var wrap = cares.getaddrinfo(domain, family);
 
   if (!wrap) {
-    throw errnoException(errno, 'getaddrinfo');
+    throw errnoException(__errno, 'getaddrinfo');
   }
 
   wrap.oncomplete = onanswer;
@@ -153,14 +153,14 @@ function resolver(bindingName) {
       if (!status) {
         callback(null, result);
       } else {
-        callback(errnoException(errno, bindingName));
+        callback(errnoException(__errno, bindingName));
       }
     }
 
     callback = makeAsync(callback);
     var wrap = binding(name, onanswer);
     if (!wrap) {
-      throw errnoException(errno, bindingName);
+      throw errnoException(__errno, bindingName);
     }
 
     callback.immediately = true;

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -20,24 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var cares = process.binding('cares_wrap'),
+    util = require('util'),
     net = require('net'),
     isIp = net.isIP;
 
 
 function errnoException(errorno, syscall) {
-  // TODO make this more compatible with ErrnoException from src/node.cc
-  // Once all of Node is using this function the ErrnoException from
-  // src/node.cc should be removed.
-  var e = new Error(syscall + ' ' + errorno);
-
   // For backwards compatibility. libuv returns ENOENT on NXDOMAIN.
-  if (errorno == 'ENOENT') {
-    errorno = 'ENOTFOUND'
-  }
-
-  e.errno = e.code = errorno;
-  e.syscall = syscall;
-  return e;
+  if (errorno === 'ENOENT') errorno = 'ENOTFOUND';
+  return util._errnoException(errorno, syscall);
 }
 
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -637,7 +637,7 @@ function FSWatcher() {
 
   this._handle.onchange = function(status, event, filename) {
     if (status) {
-      self.emit('error', errnoException(errno, 'watch'));
+      self.emit('error', errnoException(__errno, 'watch'));
     } else {
       self.emit('change', event, filename);
     }
@@ -650,7 +650,7 @@ FSWatcher.prototype.start = function(filename, persistent) {
 
   if (r) {
     this._handle.close();
-    throw errnoException(errno, 'watch');
+    throw errnoException(__errno, 'watch');
   }
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -33,6 +33,7 @@ var constants = process.binding('constants');
 var fs = exports;
 var Stream = require('stream').Stream;
 var EventEmitter = require('events').EventEmitter;
+var errnoException = util._errnoException;
 
 var kMinPoolSpace = 128;
 var kPoolSize = 40 * 1024;
@@ -627,17 +628,6 @@ fs.writeFileSync = function(path, data, encoding) {
   }
   fs.closeSync(fd);
 };
-
-
-function errnoException(errorno, syscall) {
-  // TODO make this more compatible with ErrnoException from src/node.cc
-  // Once all of Node is using this function the ErrnoException from
-  // src/node.cc should be removed.
-  var e = new Error(syscall + ' ' + errorno);
-  e.errno = e.code = errorno;
-  e.syscall = syscall;
-  return e;
-}
 
 
 function FSWatcher() {

--- a/lib/net.js
+++ b/lib/net.js
@@ -24,6 +24,7 @@ var stream = require('stream');
 var timers = require('timers');
 var util = require('util');
 var assert = require('assert');
+var errnoException = util._errnoException;
 
 function noop() {};
 
@@ -631,19 +632,6 @@ function afterConnect(status, handle, req) {
     self.destroy(errnoException(errno, 'connect'));
   }
 }
-
-
-function errnoException(errorno, syscall) {
-  // TODO make this more compatible with ErrnoException from src/node.cc
-  // Once all of Node is using this function the ErrnoException from
-  // src/node.cc should be removed.
-  var e = new Error(syscall + ' ' + errorno);
-  e.errno = e.code = errorno;
-  e.syscall = syscall;
-  return e;
-}
-
-
 
 
 function Server(/* [ options, ] listener */) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -245,7 +245,7 @@ Socket.prototype.end = function(data, encoding) {
     var shutdownReq = this._handle.shutdown();
 
     if (!shutdownReq) {
-      this.destroy(errnoException(errno, 'shutdown'));
+      this.destroy(errnoException(__errno, 'shutdown'));
       return false;
     }
 
@@ -354,7 +354,7 @@ function onread(buffer, offset, length) {
     // Optimization: emit the original buffer with end points
     if (self.ondata) self.ondata(buffer, offset, end);
 
-  } else if (errno == 'EOF') {
+  } else if (__errno == 'EOF') {
     // EOF
     self.readable = false;
 
@@ -370,10 +370,10 @@ function onread(buffer, offset, length) {
     if (self.onend) self.onend();
   } else {
     // Error
-    if (errno == 'ECONNRESET') {
+    if (__errno == 'ECONNRESET') {
       self.destroy();
     } else {
-      self.destroy(errnoException(errno, 'read'));
+      self.destroy(errnoException(__errno, 'read'));
     }
   }
 }
@@ -455,7 +455,7 @@ Socket.prototype._write = function(data, encoding, cb) {
   var writeReq = this._handle.write(data);
 
   if (!writeReq) {
-    this.destroy(errnoException(errno, 'write'));
+    this.destroy(errnoException(__errno, 'write'));
     return false;
   }
 
@@ -476,7 +476,7 @@ function afterWrite(status, handle, req, buffer) {
   }
 
   if (status) {
-    self.destroy(errnoException(errno, 'write'));
+    self.destroy(errnoException(__errno, 'write'));
     return;
   }
 
@@ -521,7 +521,7 @@ function connect(self, address, port, addressType) {
   if (connectReq !== null) {
     connectReq.oncomplete = afterConnect;
   } else {
-    self.destroy(errnoException(errno, 'connect'));
+    self.destroy(errnoException(__errno, 'connect'));
   }
 }
 
@@ -629,7 +629,7 @@ function afterConnect(status, handle, req) {
     }
   } else {
     self._connectQueueCleanUp();
-    self.destroy(errnoException(errno, 'connect'));
+    self.destroy(errnoException(__errno, 'connect'));
   }
 }
 
@@ -711,7 +711,7 @@ Server.prototype._listen2 = function(address, port, addressType) {
     self._handle = createServerHandle(address, port, addressType);
     if (!self._handle) {
       process.nextTick(function() {
-        self.emit('error', errnoException(errno, 'listen'));
+        self.emit('error', errnoException(__errno, 'listen'));
       });
       return;
     }
@@ -726,7 +726,7 @@ Server.prototype._listen2 = function(address, port, addressType) {
     self._handle.close();
     self._handle = null;
     process.nextTick(function() {
-      self.emit('error', errnoException(errno, 'listen'));
+      self.emit('error', errnoException(__errno, 'listen'));
     });
     return;
   }
@@ -810,7 +810,7 @@ function onconnection(clientHandle) {
   debug('onconnection');
 
   if (!clientHandle) {
-    self.emit('error', errnoException(errno, 'accept'));
+    self.emit('error', errnoException(__errno, 'accept'));
     return;
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -534,3 +534,11 @@ exports._deprecationWarning = function(moduleId, message) {
   else
     console.error(message);
 };
+
+
+exports._errnoException = function(errorno, syscall) {
+  var e = new Error(syscall + ' ' + errorno);
+  e.errno = e.code = errorno;
+  e.syscall = syscall;
+  return e;
+};

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -141,7 +141,7 @@ static const char* AresErrnoString(int errorno) {
 
 static void SetAresErrno(int errorno) {
   HandleScope scope;
-  Handle<Value> key = String::NewSymbol("errno");
+  Handle<Value> key = String::NewSymbol("__errno");
   Handle<Value> value = String::NewSymbol(AresErrnoString(errorno));
   Context::GetCurrent()->Global()->Set(key, value);
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -962,9 +962,7 @@ void MakeCallback(Handle<Object> object,
 void SetErrno(uv_err_t err) {
   HandleScope scope;
 
-  if (errno_symbol.IsEmpty()) {
-    errno_symbol = NODE_PSYMBOL("errno");
-  }
+  Local<String> errno_symbol = String::NewSymbol("__errno");
 
   if (err.code == UV_UNKNOWN) {
     char errno_buf[100];

--- a/src/node.js
+++ b/src/node.js
@@ -208,14 +208,13 @@
     };
   };
 
+  var _errnoException = null;
+
   function errnoException(errorno, syscall) {
-    // TODO make this more compatible with ErrnoException from src/node.cc
-    // Once all of Node is using this function the ErrnoException from
-    // src/node.cc should be removed.
-    var e = new Error(syscall + ' ' + errorno);
-    e.errno = e.code = errorno;
-    e.syscall = syscall;
-    return e;
+    if (!_errnoException) {
+      _errnoException = NativeModule.require('util')._errnoException;
+    }
+    return _errnoException(errorno, syscall);
   }
 
   function createWritableStdioStream(fd) {

--- a/src/node.js
+++ b/src/node.js
@@ -361,7 +361,7 @@
       }
 
       if (r) {
-        throw errnoException(errno, 'kill');
+        throw errnoException(__errno, 'kill');
       }
     };
   };

--- a/test/common.js
+++ b/test/common.js
@@ -87,8 +87,8 @@ process.on('exit', function() {
                       process,
                       global];
 
-  if (global.errno) {
-    knownGlobals.push(errno);
+  if (global.__errno) {
+    knownGlobals.push(__errno);
   }
 
   if (global.gc) {

--- a/test/simple/test-tcp-wrap.js
+++ b/test/simple/test-tcp-wrap.js
@@ -33,7 +33,7 @@ assert.equal(0, r);
 // Should not be able to bind to the same port again
 var r = handle.bind('0.0.0.0', common.PORT);
 assert.equal(-1, r);
-console.log(errno);
-assert.equal(errno, 'EINVAL');
+console.log(__errno);
+assert.equal(__errno, 'EINVAL');
 
 handle.close();


### PR DESCRIPTION
1. Rename `errno` to `__errno` to avoid clashing with user code. Maybe we should move it into the process object.
2. Move `errnoException()` into util.

Passes all tests. Patches are against v0.6.

Review / thoughts, please.
