### PR TITLE
Set `process.platform` to "darwin" on OS X.

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -178,6 +178,9 @@
         }],
         [ 'OS=="mac"', {
           'libraries': [ '-framework Carbon' ],
+          'defines!': [
+            'PLATFORM="mac"',
+          ],
           'defines': [
             # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
             'PLATFORM="darwin"',

--- a/node.gyp
+++ b/node.gyp
@@ -178,6 +178,10 @@
         }],
         [ 'OS=="mac"', {
           'libraries': [ '-framework Carbon' ],
+          'defines': [
+            # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
+            'PLATFORM="darwin"',
+          ],
         }],
         [ 'OS=="linux"', {
           'libraries': [


### PR DESCRIPTION
This is consistent with the old waf build system, and doesn't break old scripts that are expecting the value to be "darwin".

Fixes #2518.
