### PR TITLE
streams: pipe is destructed by 'end' event from destination

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -112,7 +112,6 @@ Stream.prototype.pipe = function(dest, options) {
   source.on('end', cleanup);
   source.on('close', cleanup);
 
-  dest.on('end', cleanup);
   dest.on('close', cleanup);
 
   dest.emit('pipe', source);

--- a/test/simple/test-stream-pipe-cleanup.js
+++ b/test/simple/test-stream-pipe-cleanup.js
@@ -46,6 +46,12 @@ function Readable() {
 }
 util.inherits(Readable, stream.Stream);
 
+function Duplex() {
+  this.readable = true;
+  Writable.call(this);
+}
+util.inherits(Duplex, Writable);
+
 var i = 0;
 var limit = 100;
 
@@ -82,14 +88,38 @@ r = new Readable();
 for (i = 0; i < limit; i++) {
   w = new Writable();
   r.pipe(w);
-  w.emit('end');
-}
-assert.equal(0, w.listeners('end').length);
-
-for (i = 0; i < limit; i++) {
-  w = new Writable();
-  r.pipe(w);
   w.emit('close');
 }
 assert.equal(0, w.listeners('close').length);
 
+r = new Readable();
+w = new Writable();
+d = new Duplex();
+r.pipe(d); // pipeline A
+d.pipe(w); // pipeline B
+assert.equal(r.listeners('end').length, 2);   // A.onend, A.cleanup
+assert.equal(r.listeners('close').length, 2); // A.onclose, A.cleanup
+assert.equal(d.listeners('end').length, 2);   // B.onend, B.cleanup
+assert.equal(d.listeners('close').length, 3); // A.cleanup, B.onclose, B.cleanup
+assert.equal(w.listeners('end').length, 0);
+assert.equal(w.listeners('close').length, 1); // B.cleanup
+
+r.emit('end');
+assert.equal(d.endCalls, 1);
+assert.equal(w.endCalls, 0);
+assert.equal(r.listeners('end').length, 0);
+assert.equal(r.listeners('close').length, 0);
+assert.equal(d.listeners('end').length, 2);   // B.onend, B.cleanup
+assert.equal(d.listeners('close').length, 2); // B.onclose, B.cleanup
+assert.equal(w.listeners('end').length, 0);
+assert.equal(w.listeners('close').length, 1); // B.cleanup
+
+d.emit('end');
+assert.equal(d.endCalls, 1);
+assert.equal(w.endCalls, 1);
+assert.equal(r.listeners('end').length, 0);
+assert.equal(r.listeners('close').length, 0);
+assert.equal(d.listeners('end').length, 0);
+assert.equal(d.listeners('close').length, 0);
+assert.equal(w.listeners('end').length, 0);
+assert.equal(w.listeners('close').length, 0);


### PR DESCRIPTION
`'end'` event is emitted from a readable stream, not a writable stream (see also [API docs](http://nodejs.org/docs/latest/api/streams.html)). However, `Stream.pipe()` destructs a pipeline by `'end'` event from destination that is a writable stream ([source](https://github.com/joyent/node/blob/b3f91f15b2482a8f3e5d37f0e09429a4b4775230/lib/stream.js#L115)). This behavior causes a problem when duplex stream (i.e. `net.Socket`) with `allowHalfOpen: true` is used.

For example, here is three streams:

``` javascript
var reader = ...; // readable stream
var writer = ...; // writable stream
var socket = net.connect({port: 80, allowHalfOpen: true}); // duplex stream
```

Constructs two pipelines:

``` javascript
reader.pipe(socket); // pipeline (A)
socket.pipe(writer); // pipeline (B)
```

```
+--------+  (A)  +--------+
| reader | ----> |        |
+--------+       |        |
                 | socket |
+--------+  (B)  |        |
| writer | <---- |        |
+--------+       +--------+
```

When the socket receives a FIN packet, `socket` emits `'end'` event. Then, `Stream.pipe()` destructs not only pipeline (B), but also pipeline (A). Please note that `socket` is still opened and writable.

After that, if `reader` emits `'data'` event, the data is not written to `socket`. And if `reader` emits `'end'` event, `socket.end()` is never called. It makes resource (fd) leaks.

I think that `Stream.pipe()` should not destruct pipeline by `'end'` event from destination.

Please review.
