### PR TITLE
[uv] remove eio_set_max_poll_reqs limit

### DIFF
--- a/deps/uv/src/unix/uv-eio.c
+++ b/deps/uv/src/unix/uv-eio.c
@@ -98,11 +98,6 @@ static void uv_eio_done_poll(eio_channel *channel) {
 
 static void uv__eio_init(void) {
   eio_init(uv_eio_want_poll, uv_eio_done_poll);
-  /*
-   * Don't handle more than 10 reqs on each eio_poll(). This is to avoid
-   * race conditions. See Node's test/simple/test-eio-race.js
-   */
-  eio_set_max_poll_reqs(10);
 }
 
 static uv_once_t uv__eio_init_once_guard = UV_ONCE_INIT;

--- a/test/simple/test-eio-limit.js
+++ b/test/simple/test-eio-limit.js
@@ -1,0 +1,28 @@
+var assert = require('assert'),
+    zlib = require('zlib'),
+    started = 0,
+    done = 0;
+
+function repeat(fn) {
+  if (started != 0) {
+    assert.ok(started - done < 100)
+  }
+
+  process.nextTick(function() {
+    fn();
+    repeat(fn);
+  });
+}
+
+repeat(function() {
+  if (started > 1000) return process.exit(0);
+
+  for (var i = 0; i < 30; i++) {
+    started++;
+    var deflate = zlib.createDeflate();
+    deflate.write('123');
+    deflate.flush(function() {
+      done++;
+    });
+  }
+});


### PR DESCRIPTION
if each ev tick creates more than 10 eio requests, eio queue will grow and process will eventually terminate due to malloc failure.

see joyent/node#2508 for details
