### PR TITLE
docs fixes: Fix syntax error on cluster api page & swap expresso with mocha

### DIFF
--- a/doc/api/appendix_1.markdown
+++ b/doc/api/appendix_1.markdown
@@ -38,7 +38,7 @@ elsewhere.
 - [ncurses](https://github.com/mscdex/node-ncurses)
 
 - Testing/TDD/BDD: [vows](http://vowsjs.org/),
-  [expresso](https://github.com/visionmedia/expresso),
+  [mocha](https://github.com/visionmedia/mocha),
   [mjsunit.runner](https://github.com/tmpvar/mjsunit.runner)
 
 Patches to this list are welcome.

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -170,7 +170,7 @@ To know the difference between suicide and accidentally death a suicide boolean 
 
     cluster.on('death', function (worker) {
       if (worker.suicide === true) {
-        console.log('Oh, it was just suicide' – no need to worry').
+        console.log('Oh, it was just suicide\' – no need to worry').
       }
     });
 


### PR DESCRIPTION
Escape quotes on cluster api docs page.

Replace expresso with mocha on Appendix 1 as expresso has been superseded by mocha.
