### PR TITLE
Fix: Makefile not to ignore --debug option in configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BUILDTYPE := $(shell python -c "print 'Debug' if eval (open('config.gypi').read(), {'__builtins__': None},None)['variables']['node_debug'] == 'true' else 'Release'")
 BUILDTYPE ?= Release
 PYTHON ?= python
 


### PR DESCRIPTION
The debug build option of "configure --debug" is ignored because the current Makefile defines BUILDTYPE as Release by default when BUILDTYPE is not specified explicitly.

I've changed Makefile so as to lookup config.gypi and define a proper variable of BUILDTYPE by invoking python command inline.
If you would like to put it out of Makefile, I can make a new python script in tools such as toosl/check_buildtype.py 

The result after applying patch shows as below.

```
unix:~/tmp/github/node> ./configure --debug; make
{ 'target_defaults': { 'cflags': [],
                       'defines': [],
                       'include_dirs': [],
                       'libraries': ['-lz']},
  'variables': { 'host_arch': 'ia32',
                 'node_debug': 'true',
                 'node_install_npm': 'true',
                 'node_install_waf': 'true',
                 'node_prefix': '',
                 'node_shared_cares': 'false',
                 'node_shared_v8': 'false',
                 'node_use_dtrace': 'false',
                 'node_use_isolates': 'true',
                 'node_use_openssl': 'true',
                 'node_use_system_openssl': 'false',
                 'target_arch': 'ia32',
                 'v8_use_snapshot': 'true'}}
creating  ./config.gypi
make -C out BUILDTYPE=Debug
make[1]: Entering directory `/home/ohtsu/tmp/github/node/out'
```
