### PR TITLE
[ISSUE #2554] Throw if start type is not number

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1038,8 +1038,13 @@ var ReadStream = fs.ReadStream = function(path, options) {
   if (this.encoding) this.setEncoding(this.encoding);
 
   if (this.start !== undefined) {
+    if ('number' !== typeof this.start) {
+      throw TypeError("'start' must be a Number (not a string containing a number)");
+    }
     if (this.end === undefined) {
       this.end = Infinity;
+    } else if ('number' !== typeof this.end) {
+      throw TypeError("'end' must be a Number (not a string containing a number)");
     }
 
     if (this.start > this.end) {


### PR DESCRIPTION
fs.createReadStream allows strings to be passed as `start` and `end`, but then concatenates them rather than throwing an error or converting them.

see Issue #2554
