### PR TITLE
util.isDate() does not check for invalid Dates

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -392,7 +392,10 @@ exports.isRegExp = isRegExp;
 
 
 function isDate(d) {
-  return typeof d === 'object' && objectToString(d) === '[object Date]';
+  if (typeof d === 'object' && objectToString(d) === '[object Date]') {
+    return (!isNaN(d.getTime()));
+  }
+  return false;
 }
 exports.isDate = isDate;
 

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -57,6 +57,7 @@ assert.equal(false, util.isDate({}))
 assert.equal(false, util.isDate([]))
 assert.equal(false, util.isDate(new Error))
 assert.equal(false, util.isDate(Object.create(Date.prototype)))
+assert.equal(false, util.isDate(new Date('not a date')))
 
 // isError
 assert.equal(true, util.isError(new Error))


### PR DESCRIPTION
Currently, in Node 0.6.7, this returns true:

``` javascript
var util = require('util');
util.isDate(new Date('not a date'));
```

This pull request adds an additional check to isDate() to check if the UNIX timestamp of the Date object is a number.
