### PR TITLE
build: Fix default_configuration of GYP to be consistent with BUILDTYPE

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -10,7 +10,7 @@
   },
 
   'target_defaults': {
-    'default_configuration': 'Debug',
+    'default_configuration': 'Release',
     'configurations': {
       'Debug': {
         'defines': [ 'DEBUG', '_DEBUG' ],

--- a/common.gypi
+++ b/common.gypi
@@ -10,7 +10,6 @@
   },
 
   'target_defaults': {
-    'default_configuration': 'Debug',
     'configurations': {
       'Debug': {
         'defines': [ 'DEBUG', '_DEBUG' ],

--- a/common.gypi
+++ b/common.gypi
@@ -10,6 +10,7 @@
   },
 
   'target_defaults': {
+    'default_configuration': 'Debug',
     'configurations': {
       'Debug': {
         'defines': [ 'DEBUG', '_DEBUG' ],

--- a/configure
+++ b/configure
@@ -189,6 +189,7 @@ def configure_node(o):
   o['variables']['node_install_waf'] = b(not options.without_waf)
   o['variables']['host_arch'] = host_arch()
   o['variables']['target_arch'] = options.dest_cpu or target_arch()
+  o['default_configuration'] = 'Debug' if options.debug else 'Release'
 
   # TODO move to node.gyp
   if sys.platform == 'sunos5':

--- a/tools/gyp_addon
+++ b/tools/gyp_addon
@@ -15,7 +15,8 @@ if __name__ == '__main__':
   config_gypi = os.path.join(node_root, 'config.gypi')
   args.extend(['-I', addon_gypi])
   args.extend(['-I', common_gypi])
-  args.extend(['-I', config_gypi])
+  if os.path.exists(config_gypi):
+    args.extend(['-I', config_gypi])
   args.extend(['-Dlibrary=shared_library'])
   args.extend(['-Dvisibility=default'])
   args.extend(['-Dnode_root_dir=%s' % node_root])

--- a/tools/gyp_addon
+++ b/tools/gyp_addon
@@ -12,8 +12,10 @@ if __name__ == '__main__':
   args = sys.argv[1:]
   addon_gypi = os.path.join(node_root, 'tools', 'addon.gypi')
   common_gypi = os.path.join(node_root, 'common.gypi')
+  config_gypi = os.path.join(node_root, 'config.gypi')
   args.extend(['-I', addon_gypi])
   args.extend(['-I', common_gypi])
+  args.extend(['-I', config_gypi])
   args.extend(['-Dlibrary=shared_library'])
   args.extend(['-Dvisibility=default'])
   args.extend(['-Dnode_root_dir=%s' % node_root])


### PR DESCRIPTION
Fix default_configuration of GYP to be consistent with BUILDTYPE by moving it into config.gypi. 
I also change tools/gyp_addon to include config.gypi to lookup default_configuration in building addon modules.

The test results of building addon module in both Debug and Release show below.

as BUILDTYPE is Release

```
unix:~/tmp/github/node> ./configure
{ 'target_defaults': { 'cflags': [],
                       'default_configuration': 'Release',
                       'defines': [],
                       'include_dirs': [],
                       'libraries': ['-lz']},
  'variables': { 'host_arch': 'ia32',
                 'node_install_npm': 'true',
                 'node_install_waf': 'true',
                 'node_prefix': '',
                 'node_shared_cares': 'false',
                 'node_shared_v8': 'false',
                 'node_use_dtrace': 'false',
                 'node_use_isolates': 'true',
                 'node_use_openssl': 'true',
                 'node_use_system_openssl': 'false',
                 'target_arch': 'ia32',
                 'v8_use_snapshot': 'true'}}
creating  ./config.gypi
creating  ./config.mk
unix:~/tmp/github/node/test/addons/hello-world> ../../../tools/gyp_addon; make
  CXX(target) out/Release/obj.target/binding/binding.o
  SOLINK_MODULE(target) out/Release/obj.target/binding.node
  SOLINK_MODULE(target) out/Release/obj.target/binding.node: Finished
  COPY out/Release/binding.node
```

as BUILDTYPE is Debug

```
unix:~/tmp/github/node> ./configure --debug
{ 'target_defaults': { 'cflags': [],
                       'default_configuration': 'Debug',
                       'defines': [],
                       'include_dirs': [],
                       'libraries': ['-lz']},
  'variables': { 'host_arch': 'ia32',
                 'node_install_npm': 'true',
                 'node_install_waf': 'true',
                 'node_prefix': '',
                 'node_shared_cares': 'false',
                 'node_shared_v8': 'false',
                 'node_use_dtrace': 'false',
                 'node_use_isolates': 'true',
                 'node_use_openssl': 'true',
                 'node_use_system_openssl': 'false',
                 'target_arch': 'ia32',
                 'v8_use_snapshot': 'true'}}
creating  ./config.gypi
creating  ./config.mk
unix:~/tmp/github/node/test/addons/hello-world> ../../../tools/gyp_addon ; make
  CXX(target) out/Debug/obj.target/binding/binding.o
  SOLINK_MODULE(target) out/Debug/obj.target/binding.node
  SOLINK_MODULE(target) out/Debug/obj.target/binding.node: Finished
  COPY out/Debug/binding.node
```
