### PR TITLE
Add IPC disconnect method when using fork 

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -24,6 +24,13 @@ of the signal, otherwise `null`.
 
 See `waitpid(2)`.
 
+### Event: 'disconnect'
+
+This event will emit after using the `.disconnect()` method in the parent or
+in the child. After this event has emitted it is not possible to send messages
+to the child or parent. An alternative way to check if you can send messages
+is to check if the `child.connected` property is `true`.
+
 ### child.stdin
 
 A `Writable Stream` that represents the child process's `stdin`.
@@ -265,6 +272,11 @@ processes:
     });
 
 
+To close the IPC connection between parent and child use the `child.disconnect()`
+method. This allow the child to die graceful since there is no IPC channel
+keeping it alive. When calling this method the `disconnect` event will emit
+in both parent and child. The `connected` flag will also be set to `false`.
+Please note that you can call `process.disconnect()` from the child.
 
 ### child.kill([signal])
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -85,6 +85,7 @@ function setupChannel(target, channel) {
     }
   }
 
+  channel.buffering = false;
   channel.onread = function(pool, offset, length, recvHandle) {
     if (recvHandle && setSimultaneousAccepts) {
       // Update simultaneous accepts on Windows
@@ -92,12 +93,15 @@ function setupChannel(target, channel) {
     }
 
     if (pool) {
+      this.buffering = true;
       jsonBuffer += pool.toString('ascii', offset, offset + length);
 
       var i, start = 0;
 
       //Linebreak is used as a message end sign
       while ((i = jsonBuffer.indexOf('\n', start)) >= 0) {
+        this.buffering = false;
+
         var json = jsonBuffer.slice(start, i);
         var message = JSON.parse(json);
 
@@ -119,8 +123,8 @@ function setupChannel(target, channel) {
       jsonBuffer = jsonBuffer.slice(start);
 
     } else {
-      channel.close();
-      target._channel = null;
+      this.buffering = false;
+      target.disconnect();
     }
   };
 
@@ -129,7 +133,7 @@ function setupChannel(target, channel) {
       throw new TypeError('message cannot be undefined');
     }
 
-    if (!target._channel) throw new Error("channel closed");
+    if (!this.connected) throw new Error("channel closed");
 
     // For overflow protection don't write if channel queue is too deep.
     if (channel.writeQueueSize > 1024 * 1024) {
@@ -152,6 +156,34 @@ function setupChannel(target, channel) {
     writeReq.oncomplete = nop;
 
     return true;
+  };
+
+  target.connected = true;
+  target.disconnect = function() {
+      if (!this.connected) return;
+
+      // do not allow messages to be written
+      this.connected = false;
+      this._channel = null;
+
+      var fired = false;
+      function finish() {
+        if (fired) return;
+        fired = true;
+
+        channel.close();
+        target.emit('disconnect');
+      }
+
+      // if a message is being read, then wait until finished reading
+      if (channel.buffering) {
+        this.once('message', finish);
+        this.once('internalMessage', finish);
+
+        return;
+      }
+
+      finish();
   };
 
   channel.readStart();
@@ -201,11 +233,8 @@ exports.fork = function(modulePath /*, args, options*/) {
 
   if (!options.thread) setupChannel(child, options.stdinStream);
 
-  child.on('exit', function() {
-    if (child._channel) {
-      child._channel.close();
-    }
-  });
+  //Disconnect when process exit
+  child.once('exit', child.disconnect.bind(child));
 
   return child;
 };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -93,15 +93,12 @@ function setupChannel(target, channel) {
     }
 
     if (pool) {
-      this.buffering = true;
       jsonBuffer += pool.toString('ascii', offset, offset + length);
 
       var i, start = 0;
 
       //Linebreak is used as a message end sign
       while ((i = jsonBuffer.indexOf('\n', start)) >= 0) {
-        this.buffering = false;
-
         var json = jsonBuffer.slice(start, i);
         var message = JSON.parse(json);
 
@@ -121,6 +118,7 @@ function setupChannel(target, channel) {
         start = i + 1;
       }
       jsonBuffer = jsonBuffer.slice(start);
+      this.buffering = jsonBuffer.length !== 0;
 
     } else {
       this.buffering = false;

--- a/test/simple/test-child-process-disconnect.js
+++ b/test/simple/test-child-process-disconnect.js
@@ -1,0 +1,105 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common');
+var fork = require('child_process').fork;
+var net = require('net');
+
+// child
+if (process.argv[2] === 'child') {
+
+  var server = net.createServer();
+
+  server.on('connection', function (socket) {
+
+    process.on('disconnect', function () {
+      socket.end((process.connected).toString());
+    });
+
+    // when the socket is closed, we will close the server
+    // allowing the process to self terminate
+    socket.on('end', function () {
+      server.close();
+    });
+
+    socket.write('ready');
+  });
+
+  // when the server is ready tell parent
+  server.on('listening', function () {
+    process.send('ready');
+  });
+
+  server.listen(common.PORT);
+
+} else {
+  // testcase
+  var child = fork(process.argv[1], ['child']);
+
+  var childFlag = false;
+  var childSelfTerminate = false;
+  var parentEmit = false;
+  var parentFlag = false;
+
+  // when calling .disconnect the event should emit
+  // and the disconnected flag should be true.
+  child.on('disconnect', function () {
+    parentEmit = true;
+    parentFlag = child.connected;
+  });
+
+  // the process should also self terminate without using signals
+  child.on('exit', function () {
+    childSelfTerminate = true;
+  });
+
+  // when child is listning
+  child.on('message', function (msg) {
+    if (msg === 'ready') {
+
+      // connect to child using TCP to know if disconnect was emitted
+      var socket = net.connect(common.PORT);
+
+      socket.on('data', function (data) {
+        data = data.toString();
+
+        // ready to be disconnected
+        if (data === 'ready') {
+          child.disconnect();
+          return;
+        }
+
+        // disconnect is emitted
+        childFlag = (data === 'true');
+      });
+
+    }
+  });
+
+  process.on('exit', function () {
+    assert.equal(childFlag, false);
+    assert.equal(parentFlag, false);
+
+    assert.ok(childSelfTerminate);
+    assert.ok(parentEmit);
+  });
+}


### PR DESCRIPTION
@indutny

This add a `disconnect` method to the `child` object (in parent) and in the `process` object (in child), when using `.fork`. It allow the child to self terminate since there is no IPC keeping it alive:

It allow the following issues to be fixed:
- issue #1740
- issue #1363
- issue #2088

_Please note that is related to #2426, I will update that one when this has landed, but it just made sense to split #2426 up in two pull requests._  

_This also solves some future issues related to cluster 2.0 (see #2038)_
