### PR TITLE
Use more specific existence check in path.exists

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -403,7 +403,7 @@ exports.extname = function(path) {
 
 exports.exists = function(path, callback) {
   process.binding('fs').stat(path, function(err, stats) {
-    if (callback) callback(err ? false : true);
+    if (callback) callback((err && err.code === 'ENOENT') ? false : true);
   });
 };
 
@@ -413,7 +413,7 @@ exports.existsSync = function(path) {
     process.binding('fs').stat(path);
     return true;
   } catch (e) {
-    return false;
+    return e.code !== 'ENOENT';
   }
 };
 

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -23,6 +23,7 @@ var common = require('../common');
 var assert = require('assert');
 
 var path = require('path');
+var fs = require('fs');
 
 var isWindows = process.platform === 'win32';
 
@@ -78,9 +79,33 @@ if (isWindows) {
                '\\\\unc\\share\\foo\\bar');
 }
 
-path.exists(f, function(y) { assert.equal(y, true) });
+var errTest = common.fixturesDir + '/path-exists-test';
+var existent, nonExistent, existsButThrows;
+
+fs.writeFileSync(errTest, '');
+fs.chmodSync(errTest, 0);
+
+path.exists(f, function(y) { 
+  existent = y;
+});
+path.exists(f + '-NO', function(y) { 
+  nonExistent = y;
+});
+path.exists(errTest, function(y) { 
+  existsButThrows = y;
+});
+
+process.on('exit', function () {
+  assert.strictEqual(existent, true);
+  assert.strictEqual(nonExistent, false);
+  assert.strictEqual(existsButThrows, true);
+});
 
 assert.equal(path.existsSync(f), true);
+assert.equal(path.existsSync(f + '-NO'), false);
+assert.equal(path.existsSync(errTest), true);
+
+fs.unlinkSync(errTest);
 
 assert.equal(path.extname(''), '');
 assert.equal(path.extname('/path/to/file'), '');


### PR DESCRIPTION
Currently, `path.exists` in `v0.6` and `fs.exists` on `master` only check whether or not an error occurs when trying to stat a given path - this leads to erroneous results in cases where attempting to stat the given path would produce `EACCES` or `ELOOP`, among other common errors.  

These functions should instead check specifically for `ENOENT`.  This provides a fix, as well as more test coverage. 

I'll make the same change to `master` in a separate pull, pending discussion of this.
