### PR TITLE
Use more specific existence check in fs.exists

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -73,7 +73,7 @@ fs.Stats.prototype.isSocket = function() {
 
 fs.exists = function(path, callback) {
   binding.stat(path, function(err, stats) {
-    if (callback) callback(err ? false : true);
+    if (callback) callback((err && err.code === 'ENOENT') ? false : true);
   });
 };
 
@@ -82,7 +82,7 @@ fs.existsSync = function(path) {
     binding.stat(path);
     return true;
   } catch (e) {
-    return false;
+    return e.code !== 'ENOENT';
   }
 };
 

--- a/test/simple/test-fs-exists.js
+++ b/test/simple/test-fs-exists.js
@@ -21,9 +21,14 @@
 
 var assert = require('assert');
 var fs = require('fs');
+var common = require('../common');
 var f = __filename;
+var errTest = common.tmpDir + '/fs-exists-test';
 var exists;
 var doesNotExist;
+var existsButThrows;
+
+fs.symlinkSync(errTest, errTest);
 
 fs.exists(f, function(y) {
   exists = y;
@@ -33,10 +38,18 @@ fs.exists(f + '-NO', function (y) {
   doesNotExist = y;
 });
 
+fs.exists(errTest, function (y) {
+  existsButThrows = y;
+});
+
 assert(fs.existsSync(f));
 assert(!fs.existsSync(f + '-NO'));
+assert(fs.existsSync(errTest));
+
+fs.unlinkSync(errTest);
 
 process.on('exit', function () {
   assert.strictEqual(exists, true);
   assert.strictEqual(doesNotExist, false);
+  assert.strictEqual(existsButThrows, true);
 });


### PR DESCRIPTION
This is the same change from #2601.

Currently, `fs.exists` only checks whether or not an error occurs when trying to stat a given path - this leads to erroneous results in cases where attempting to stat the given path would produce `EACCES` or `ELOOP`, among other common errors.  

These functions should instead check specifically for `ENOENT`.  This provides a fix, as well as more test coverage. 
