### PR TITLE
Add includes and libs to windows install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,8 @@ ipch/
 /gyp-mac-tool
 /dist-osx
 /npm.wxs
+/includes.wxs
+/libs.wxs
 /tools/msvs/npm.wixobj
+/tools/msvs/includes.wixobj
+/tools/msvs/libs.wixobj

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -16,16 +16,18 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>..\..\..\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NPMSourceDir=..\..\..\deps\npm\</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NPMSourceDir=..\..\..\deps\npm\;IncludeDir=..\..\..\Debug\include\;LibDir=..\..\..\Debug\lib\</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>..\..\..\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NPMSourceDir=..\..\..\deps\npm\</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NPMSourceDir=..\..\..\deps\npm\;IncludeDir=..\..\..\Release\include\;LibDir=..\..\..\Release\lib\</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="product.wxs" />
     <Compile Include="..\..\..\npm.wxs" />
+    <Compile Include="..\..\..\includes.wxs" />
+    <Compile Include="..\..\..\libs.wxs" />
   </ItemGroup>
   <ItemGroup>
     <WixExtension Include="WixUIExtension">

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -72,6 +72,8 @@
       <ComponentRef Id="npmrc" />
       <ComponentRef Id="npmappdata_folder" />
       <ComponentGroupRef Id="NPMFiles" />
+      <ComponentGroupRef Id="IncludeFiles" />
+      <ComponentGroupRef Id="LibFiles" />
       <?if $(var.Configuration) = Debug ?>
       <ComponentRef Id="nodepdb"/>
       <?endif?>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -42,6 +42,12 @@
                          Part="last" 
                          System="yes" 
                          Value="[NodeRoot]" />
+            <Environment Id="node_home_env"
+                         Action="set"             
+                         Name="NODE_HOME" 
+                         Part="all" 
+                         System="yes" 
+                         Value="[NodeRoot]" />
           </Component>
           <Component Id="npmcmd" Guid="31e9986d-74cd-44e1-878c-194d3e997d32">
             <File Id="filenpmcmd" KeyPath="yes" Source="$(var.NPMSourceDir)\bin\npm.cmd" />

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -99,6 +99,18 @@ python "%~dp0tools\getnodeversion.py" > "%temp%\node_version.txt"
 if not errorlevel 0 echo Cannot determine current version of node.js & goto exit
 for /F "tokens=*" %%i in (%temp%\node_version.txt) do set NODE_VERSION=%%i
 heat dir deps\npm -var var.NPMSourceDir -dr NodeModulesFolder -cg NPMFiles -gg -template fragment -nologo -out npm.wxs
+if "%config%"=="Debug" set includeDir=Debug\include\
+if "%config%"=="Release" set includeDir=Release\include\
+mkdir %includeDir%
+del /F /S /Q %includeDir%\*.*
+xcopy /Y deps\v8\include\*.h %includeDir%
+xcopy /S /Y deps\uv\include\*.h %includeDir%
+xcopy /Y src\*.h %includeDir%
+heat dir %includeDir% -var var.IncludeDir -dr NodeRoot -cg IncludeFiles -gg -template fragment -nologo -out includes.wxs
+if "%config%"=="Debug" set libDir=Debug\lib\
+if "%config%"=="Release" set libDir=Release\lib\
+xcopy /Y %libDir%..\*.lib %libDir%
+heat dir %libDir% -var var.LibDir -dr NodeRoot -cg LibFiles -gg -template fragment -nologo -out libs.wxs
 msbuild "%~dp0tools\msvs\msi\nodemsi.sln" /t:Clean,Build /p:Configuration=%config% /p:NodeVersion=%NODE_VERSION% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 


### PR DESCRIPTION
Currently to build native modules on windows a user needs to download the node source. Setup python and compile the source. Even then module's build scripts have problems finding node and the include files.

To better facilitate building native modules on windows this pull request adds the includes and libs into the install. Also to help building on windows I have also included an environment variable for NODE_HOME.
