### PR TITLE
build: fix make install and out/doc/api%.html in BUILDTYPE=Debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,15 @@ PYTHON ?= python
 
 ifeq ($(BUILDTYPE),Release)
 all: out/Makefile node
+
+install: all
+	out/Release/node tools/installer.js ./config.gypi install
 else
 all: out/Makefile node_g
+
+install: all
+	$(MAKE) -C out BUILDTYPE=Release
+	out/Release/node tools/installer.js ./config.gypi install
 endif
 
 # The .PHONY is needed to ensure that we recursively use the out/Makefile
@@ -29,9 +36,6 @@ out/Debug/node:
 
 out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp deps/v8/build/common.gypi deps/v8/tools/gyp/v8.gyp node.gyp config.gypi
 	tools/gyp_node -f make
-
-install: all
-	out/Release/node tools/installer.js ./config.gypi install
 
 uninstall:
 	out/Release/node tools/installer.js ./config.gypi uninstall
@@ -131,7 +135,7 @@ out/doc/%: doc/%
 	cp $< $@
 
 out/doc/api/%.html: doc/api/%.markdown node $(apidoc_dirs) $(apiassets) tools/doctool/doctool.js
-	out/Release/node tools/doctool/doctool.js doc/template.html $< > $@
+	out/$(BUILDTYPE)/node tools/doctool/doctool.js doc/template.html $< > $@
 
 out/doc/%:
 


### PR DESCRIPTION
It is reported in Japanese NodeJS ML that installing of 0.7.1 with nave is failed. 
This is because nave builds and installs node with "./configure --debug ; make; make install" and GYP in 0.7.x only build out/Debug while WAF in 0.6.x build both out/Debug and out/Release.

It might be an issue of nave but I think it is worth to fix this in the node side to be compatible with the build  behaviors between 0.6.x and 0.7.x 

Before applying this patch, it fails to make install after configure --debug as below

```
# ./configure --debug ; make ; make install
(snip)
make[1]: Entering directory `/home/ohtsu/tmp/github/node/out'
make[1]: Nothing to be done for `all'.
make[1]: Leaving directory `/home/ohtsu/tmp/github/node/out'
ln -fs out/Debug/node node_g
out/Release/node tools/installer.js ./config.gypi install
make: out/Release/node: Command not found
make: *** [install] Error 127
```

Bfter applying this patch, the Release build is checked before make install and install was completed fine.

```
# ./configure --debug ; make ; make install
(snip)
mkdir -p /usr/local/lib/node/
cp -rf tools/wafadmin /usr/local/lib/node/
cp -rf tools/node-waf /usr/local/bin/node-waf
mkdir -p /usr/local/lib/node_modules/
cp -rf deps/npm /usr/local/lib/node_modules/npm
ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
#
```
