### PR TITLE
dgram: broadcast and multicast test fixes

### DIFF
--- a/test/simple/test-dgram-broadcast-multi-process.js
+++ b/test/simple/test-dgram-broadcast-multi-process.js
@@ -27,6 +27,7 @@ var common = require('../common'),
     assert = require('assert'),
     Buffer = require('buffer').Buffer,
     LOCAL_BROADCAST_HOST = '255.255.255.255',
+    TIMEOUT = 5000,
     messages = [
       new Buffer('First message to send'),
       new Buffer('Second message to send'),
@@ -38,8 +39,34 @@ if (cluster.isMaster) {
   var workers = {},
     listeners = 3,
     listening = 0,
+    dead = 0,
     i = 0,
-    done = 0;
+    done = 0,
+    timer = null;
+
+  //handle the death of workers
+  cluster.on('death', function (worker) {
+    //don't consider this the true death if the worker has finished successfully
+    if (worker.isDone) {
+      return;
+    }
+
+    dead += 1;
+    console.error('Worker %d died. %d dead of %d', worker.pid, dead, listeners);
+
+    if (dead === listeners) {
+      console.error('All workers have died.');
+      console.error('Fail');
+      process.exit(1);
+    }
+  });
+
+  //exit the test if it doesn't succeed within TIMEOUT
+  timer = setTimeout(function () {
+    console.error('Responses were not received within %d ms.', TIMEOUT);
+    console.error('Fail');
+    process.exit(1);
+  }, TIMEOUT);
 
   //launch child processes
   for (var x = 0; x < listeners; x++) {
@@ -63,6 +90,7 @@ if (cluster.isMaster) {
 
           if (worker.messagesReceived.length === messages.length) {
             done += 1;
+            worker.isDone = true;
             console.error('%d received %d messages total.', worker.pid,
                     worker.messagesReceived.length);
           }
@@ -91,6 +119,9 @@ if (cluster.isMaster) {
               assert.equal(count, messages.length
                 ,'A worker received an invalid multicast message');
             });
+
+            clearTimeout(timer);
+            console.error('Success');
           }
         }
       });

--- a/test/simple/test-dgram-broadcast-multi-process.js
+++ b/test/simple/test-dgram-broadcast-multi-process.js
@@ -21,11 +21,11 @@
 
 var common = require('../common'),
     assert = require('assert'),
-    cluster = require('cluster'),
     dgram = require('dgram'),
     util = require('util'),
     assert = require('assert'),
     Buffer = require('buffer').Buffer,
+    fork = require('child_process').fork,
     LOCAL_BROADCAST_HOST = '255.255.255.255',
     TIMEOUT = 5000,
     messages = [
@@ -35,7 +35,7 @@ var common = require('../common'),
       new Buffer('Fourth message to send')
     ];
 
-if (cluster.isMaster) {
+if (process.argv[2] !== 'child') {
   var workers = {},
     listeners = 3,
     listening = 0,
@@ -43,23 +43,6 @@ if (cluster.isMaster) {
     i = 0,
     done = 0,
     timer = null;
-
-  //handle the death of workers
-  cluster.on('death', function (worker) {
-    //don't consider this the true death if the worker has finished successfully
-    if (worker.isDone) {
-      return;
-    }
-
-    dead += 1;
-    console.error('Worker %d died. %d dead of %d', worker.pid, dead, listeners);
-
-    if (dead === listeners) {
-      console.error('All workers have died.');
-      console.error('Fail');
-      process.exit(1);
-    }
-  });
 
   //exit the test if it doesn't succeed within TIMEOUT
   timer = setTimeout(function () {
@@ -71,10 +54,27 @@ if (cluster.isMaster) {
   //launch child processes
   for (var x = 0; x < listeners; x++) {
     (function () {
-      var worker = cluster.fork();
+      var worker = fork(process.argv[1], ['child']);
       workers[worker.pid] = worker;
 
       worker.messagesReceived = [];
+
+      //handle the death of workers
+      worker.on('exit', function (code, signal) {
+         //don't consider this the true death if the worker has finished successfully
+        if (worker.isDone) {
+          return;
+        }
+        
+        dead += 1;
+        console.error('Worker %d died. %d dead of %d', worker.pid, dead, listeners);
+
+        if (dead === listeners) {
+          console.error('All workers have died.');
+          console.error('Fail');
+          process.exit(1);
+        }
+      });
 
       worker.on('message', function (msg) {
         if (msg.listening) {
@@ -158,7 +158,7 @@ if (cluster.isMaster) {
   };
 }
 
-if (!cluster.isMaster) {
+if (process.argv[2] === 'child') {
   var receivedMessages = [];
   var listenSocket = dgram.createSocket('udp4');
 


### PR DESCRIPTION
The broadcast and multicast multiple process tests don't fail properly when they are unable to receive messages or if the child processes die. This pull request fixes these shortcomings. 
- watch for the death of child processes and fail the test if they all die
- use setTimeout to fail the test if responses are not received and processed in 5000ms
  
  Discussed briefly in issue #1993
