### PR TITLE
Make coding style in http.js and https.js more consistent

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -354,7 +354,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
 
 
     default:
-      if (field.slice(0, 2) == 'x-') {
+      if (field.slice(0, 2) === 'x-') {
         // except for x-
         if (field in dest) {
           dest[field] += ', ' + value;
@@ -363,7 +363,9 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
         }
       } else {
         // drop duplicates
-        if (!(field in dest)) dest[field] = value;
+        if (!(field in dest)) {
+          dest[field] = value;
+        }
       }
       break;
   }
@@ -442,11 +444,13 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
 
 
 OutgoingMessage.prototype._buffer = function(data, encoding) {
-  if (data.length === 0) return;
+  if (data.length === 0) {
+    return;
+  }
 
   var length = this.output.length;
 
-  if (length === 0 || typeof data != 'string') {
+  if (length === 0 || typeof data !== 'string') {
     this.output.push(data);
     this.outputEncodings.push(encoding);
     return false;
@@ -493,7 +497,9 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
 
     } else if (transferEncodingExpression.test(field)) {
       sentTransferEncodingHeader = true;
-      if (chunkExpression.test(value)) self.chunkedEncoding = true;
+      if (chunkExpression.test(value)) {
+        self.chunkedEncoding = true;
+      }
 
     } else if (contentLengthExpression.test(field)) {
       sentContentLengthHeader = true;
@@ -539,7 +545,7 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
     }
   }
 
-  if (sentContentLengthHeader == false && sentTransferEncodingHeader == false) {
+  if (sentContentLengthHeader === false && sentTransferEncodingHeader === false) {
     if (this._hasBody) {
       if (this.useChunkedEncodingByDefault) {
         messageHeader += 'Transfer-Encoding: chunked\r\n';
@@ -558,7 +564,9 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
 
   // wait until the first body chunk, or close(), is sent to flush,
   // UNLESS we're sending Expect: 100-continue.
-  if (sentExpect) this._send('');
+  if (sentExpect) {
+    this._send('');
+  }
 };
 
 
@@ -584,7 +592,9 @@ OutgoingMessage.prototype.getHeader = function(name) {
     throw new Error("`name` is required for getHeader().");
   }
 
-  if (!this._headers) return;
+  if (!this._headers) {
+    return;
+  }
 
   var key = name.toLowerCase();
   return this._headers[key];
@@ -600,7 +610,9 @@ OutgoingMessage.prototype.removeHeader = function(name) {
     throw new Error("Can't remove headers after they are sent.");
   }
 
-  if (!this._headers) return;
+  if (!this._headers) {
+    return;
+  }
 
   var key = name.toLowerCase();
   delete this._headers[key];
@@ -613,7 +625,9 @@ OutgoingMessage.prototype._renderHeaders = function() {
     throw new Error("Can't render headers after they are sent to the client.");
   }
 
-  if (!this._headers) return {};
+  if (!this._headers) {
+    return {};
+  }
 
   var headers = {};
   var keys = Object.keys(this._headers);
@@ -641,7 +655,9 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
     throw new TypeError('first argument must be a string or Buffer');
   }
 
-  if (chunk.length === 0) return false;
+  if (chunk.length === 0) {
+    return false;
+  }
 
   var len, ret;
   if (this.chunkedEncoding) {
@@ -785,12 +801,16 @@ OutgoingMessage.prototype._flush = function() {
   // This function, outgoingFlush(), is called by both the Server and Client
   // to attempt to flush any pending messages out to the socket.
 
-  if (!this.socket) return;
+  if (!this.socket) {
+    return;
+  }
 
   var ret;
   while (this.output.length) {
 
-    if (!this.socket.writable) return; // XXX Necessary?
+    if (!this.socket.writable) {
+      return; // XXX Necessary?
+    }
 
     var data = this.output.shift();
     var encoding = this.outputEncodings.shift();
@@ -813,7 +833,9 @@ OutgoingMessage.prototype._flush = function() {
 function ServerResponse(req) {
   OutgoingMessage.call(this);
 
-  if (req.method === 'HEAD') this._hasBody = false;
+  if (req.method === 'HEAD') {
+    this._hasBody = false;
+  }
 
   if (req.httpVersionMajor < 1 || req.httpVersionMinor < 1) {
     this.useChunkedEncodingByDefault = false;
@@ -841,7 +863,7 @@ ServerResponse.prototype.assignSocket = function(socket) {
 };
 
 ServerResponse.prototype.detachSocket = function(socket) {
-  assert(socket._httpMessage == this);
+  assert(socket._httpMessage === this);
   socket.removeListener('close', onServerResponseClose);
   socket._httpMessage = null;
   this.socket = this.connection = null;
@@ -859,7 +881,7 @@ ServerResponse.prototype._implicitHeader = function() {
 ServerResponse.prototype.writeHead = function(statusCode) {
   var reasonPhrase, headers, headerIndex;
 
-  if (typeof arguments[1] == 'string') {
+  if (typeof arguments[1] === 'string') {
     reasonPhrase = arguments[1];
     headerIndex = 2;
   } else {
@@ -891,7 +913,9 @@ ServerResponse.prototype.writeHead = function(statusCode) {
       var keys = Object.keys(obj);
       for (var i = 0; i < keys.length; i++) {
         var k = keys[i];
-        if (k) headers[k] = obj[k];
+        if (k) {
+          headers[k] = obj[k];
+        }
       }
     }
   } else if (this._headers) {
@@ -1001,14 +1025,14 @@ Agent.prototype.createSocket = function(name, host, port) {
   this.sockets[name].push(s);
   var onFree = function() {
     self.emit('free', s, host, port);
-  }
+  };
   s.on('free', onFree);
   var onClose = function(err) {
     // This is the only place where sockets get removed from the Agent.
     // If you want to remove a socket from the pool, just close it.
     // All socket errors end in a close event anyway.
     self.removeSocket(s, name, host, port);
-  }
+  };
   s.on('close', onClose);
   var onRemove = function() {
     // We need this function for cases like HTTP "upgrade"
@@ -1018,7 +1042,7 @@ Agent.prototype.createSocket = function(name, host, port) {
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
     s.removeListener('agentRemove', onRemove);
-  }
+  };
   s.on('agentRemove', onRemove);
   return s;
 };
@@ -1199,7 +1223,7 @@ ClientRequest.prototype.onSocket = function(socket) {
         freeParser();
       }
       socket.destroy();
-    }
+    };
     socket.on('error', errorListener);
 
     socket.ondata = function(d, start, end) {
@@ -1271,7 +1295,7 @@ ClientRequest.prototype.onSocket = function(socket) {
         // fire on the request.
         req.emit('error', createHangUpError());
       }
-    }
+    };
     socket.on('close', closeListener);
 
     parser.onIncoming = function(res, shouldKeepAlive) {
@@ -1296,10 +1320,10 @@ ClientRequest.prototype.onSocket = function(socket) {
       // but *can* have a content-length which actually corresponds
       // to the content-length of the entity-body had the request
       // been a GET.
-      var isHeadResponse = req.method == 'HEAD';
+      var isHeadResponse = req.method === 'HEAD';
       debug('AGENT isHeadResponse ' + isHeadResponse);
 
-      if (res.statusCode == 100) {
+      if (res.statusCode === 100) {
         // restart the parser, as this is a continue message.
         delete req.res; // Clear res so that we don't hit double-responses.
         req.emit('continue');
@@ -1363,7 +1387,7 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
         if (cb) { cb(); }
       });
     }
-  }
+  };
   if (!self.socket) {
     self.once('socket', onSocket);
   } else {
@@ -1408,7 +1432,9 @@ exports.get = function(options, cb) {
 
 
 function ondrain() {
-  if (this._httpMessage) this._httpMessage.emit('drain');
+  if (this._httpMessage) {
+    this._httpMessage.emit('drain');
+  }
 }
 
 
@@ -1419,7 +1445,9 @@ function httpSocketSetup(socket) {
 
 
 function Server(requestListener) {
-  if (!(this instanceof Server)) return new Server(requestListener);
+  if (!(this instanceof Server)) {
+    return new Server(requestListener);
+  }
   net.Server.call(this, { allowHalfOpen: true });
 
   if (requestListener) {
@@ -1532,13 +1560,17 @@ function connectionListener(socket) {
 
     if (!self.httpAllowHalfOpen) {
       abortIncoming();
-      if (socket.writable) socket.end();
+      if (socket.writable) {
+        socket.end();
+      }
     } else if (outgoing.length) {
       outgoing[outgoing.length - 1]._last = true;
     } else if (socket._httpMessage) {
       socket._httpMessage._last = true;
     } else {
-      if (socket.writable) socket.end();
+      if (socket.writable) {
+        socket.end();
+      }
     }
   };
 
@@ -1568,7 +1600,7 @@ function connectionListener(socket) {
       // Usually the first incoming element should be our request.  it may
       // be that in the case abortIncoming() was called that the incoming
       // array will be empty.
-      assert(incoming.length == 0 || incoming[0] === req);
+      assert(incoming.length === 0 || incoming[0] === req);
 
       incoming.shift();
 
@@ -1586,7 +1618,7 @@ function connectionListener(socket) {
     });
 
     if ('expect' in req.headers &&
-        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1) &&
+        (req.httpVersionMajor === 1 && req.httpVersionMinor === 1) &&
         continueExpression.test(req.headers['expect'])) {
       res._expect_continue = true;
       if (self.listeners('checkContinue').length) {

--- a/lib/https.js
+++ b/lib/https.js
@@ -24,7 +24,9 @@ var http = require('http');
 var inherits = require('util').inherits;
 
 function Server(opts, requestListener) {
-  if (!(this instanceof Server)) return new Server(opts, requestListener);
+  if (!(this instanceof Server)) {
+    return new Server(opts, requestListener);
+  }
 
   if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
@@ -55,12 +57,12 @@ function createConnection(port, host, options) {
   options.port = port;
   options.host = host;
   return tls.connect(options);
-};
+}
 
 function Agent(options) {
   http.Agent.call(this, options);
   this.createConnection = createConnection;
-};
+}
 inherits(Agent, http.Agent);
 Agent.prototype.defaultPort = 443;
 


### PR DESCRIPTION
This patch makes the coding style in http.js and https.js a bit more consistent and compliant with the style guide, with respect to:
- usage of === and == operators (use ===)
- usage of ; after assignment statements and function definition statements (use ; after assignments, and not after definitions)
- usage of single-statement if blocks (should be in new line and curly braces should be used, rather than having a single-line if block)

Currently, these constructs are used inconsistently, i.e. examples of both alternatives for each point may be found (even for the exact same expression, e.g. both `=== 0` and `== 0` are used).
