### PR TITLE
Emit an 'unknown' key event for any unknown key sequence.

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -305,6 +305,7 @@ ReadStream.prototype._emitKey = function(s) {
 
       /* misc. */
       case '[Z': key.name = 'tab'; key.shift = true; break;
+      default: key.name = 'unknown'; key.sequence = s; break;
 
     }
   } else if (s.length > 1 && s[0] !== '\x1b') {


### PR DESCRIPTION
Originally from this thread on `nodejs-dev`: http://groups.google.com/group/nodejs-dev/browse_thread/thread/a0c23008029e5fa7

This allows extensibility of the 'keypress' events in user-space, for example parsing the output from "mouse reporting", which could then be re-emitted on the Stream as 'mousedown' and 'mouseup' events.

There didn't seem to be any `tty` tests, probably because this is a hard thing to test for, so I didn't add any in this case.
