### PR TITLE
Adding .destroy() method to Zlib class

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -427,6 +427,12 @@ Zlib.prototype.resume = function() {
   this._process();
 };
 
+Zlib.prototype.destroy = function() {
+  this.readable = false;
+  this.writable = false;
+  this._ended = true;
+};
+
 util.inherits(Deflate, Zlib);
 util.inherits(Inflate, Zlib);
 util.inherits(Gzip, Zlib);


### PR DESCRIPTION
The Zlib class in zlib.js implements a readable/writeable stream interface, but doesn't have a .destroy() method.

If the zlib classes are used in a pipe and the source emits the close event, destroy() is called on the Zlib object, causing an exception that can only be handled through the global exception handler.

Example:

<pre>
zlib = require("zlib")
fs = require("fs")

gunzip = zlib.createGunzip()
rs = fs.createReadStream("/dev/zero")
rs.pipe(gunzip);

setTimeout(function() { rs.destroy(); }, 2000);
</pre>

Exception:

<pre>
stream.js:98
    dest.destroy();
         ^
TypeError: Object #<Gunzip> has no method 'destroy'
    at [object Object].onclose (stream.js:98:10)
    at [object Object].emit (events.js:88:20)
    at Object.oncomplete (fs.js:1167:12)
</pre>


This pull request implements a destroy() method. I hope that's in line with the ongoing discussion about which Stream classes should implement which methods.
