### PR TITLE
child_process: do not disconnect on exit emit

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -158,7 +158,9 @@ function setupChannel(target, channel) {
 
   target.connected = true;
   target.disconnect = function() {
-      if (!this.connected) return;
+      if (!this.connected) {
+        this.emit('error', new Error('IPC channel is already disconnected'));
+      }
 
       // do not allow messages to be written
       this.connected = false;
@@ -230,9 +232,6 @@ exports.fork = function(modulePath /*, args, options*/) {
   var child = spawn(process.execPath, args, options);
 
   if (!options.thread) setupChannel(child, options.stdinStream);
-
-  // Disconnect when the child process exits.
-  child.once('exit', child.disconnect.bind(child));
 
   return child;
 };

--- a/test/simple/test-child-process-disconnect.js
+++ b/test/simple/test-child-process-disconnect.js
@@ -85,6 +85,7 @@ if (process.argv[2] === 'child') {
         // ready to be disconnected
         if (data === 'ready') {
           child.disconnect();
+          assert.throws(child.disconnect.bind(child), Error);
           return;
         }
 


### PR DESCRIPTION
When using isolate the .fork would break because it had
no .disconnect method. This remove the exit handler there
would call .disconnect since it was not required.
It also change .disconnect to throw if the channel is closed,
this was not possible before because .disconnect would be called
twice.

This fix #2647

**Edit:**
I'm not sure if I missed a edge case, but I really do not see what it should be.
