### PR TITLE
More broadcast-multicast test fixes

### DIFF
--- a/test/simple/test-dgram-broadcast-multi-process.js
+++ b/test/simple/test-dgram-broadcast-multi-process.js
@@ -46,8 +46,11 @@ if (process.argv[2] !== 'child') {
 
   //exit the test if it doesn't succeed within TIMEOUT
   timer = setTimeout(function () {
-    console.error('Responses were not received within %d ms.', TIMEOUT);
-    console.error('Fail');
+    console.error('[PARENT] Responses were not received within %d ms.', TIMEOUT);
+    console.error('[PARENT] Fail');
+
+    killChildren(workers);
+
     process.exit(1);
   }, TIMEOUT);
 
@@ -62,16 +65,20 @@ if (process.argv[2] !== 'child') {
       //handle the death of workers
       worker.on('exit', function (code, signal) {
          //don't consider this the true death if the worker has finished successfully
-        if (worker.isDone) {
+         //or if the exit code is 0
+        if (worker.isDone || code == 0) {
           return;
         }
         
         dead += 1;
-        console.error('Worker %d died. %d dead of %d', worker.pid, dead, listeners);
+        console.error('[PARENT] Worker %d died. %d dead of %d', worker.pid, dead, listeners);
 
         if (dead === listeners) {
-          console.error('All workers have died.');
-          console.error('Fail');
+          console.error('[PARENT] All workers have died.');
+          console.error('[PARENT] Fail');
+
+          killChildren(workers);
+
           process.exit(1);
         }
       });
@@ -91,12 +98,12 @@ if (process.argv[2] !== 'child') {
           if (worker.messagesReceived.length === messages.length) {
             done += 1;
             worker.isDone = true;
-            console.error('%d received %d messages total.', worker.pid,
+            console.error('[PARENT] %d received %d messages total.', worker.pid,
                     worker.messagesReceived.length);
           }
 
           if (done === listeners) {
-            console.error('All workers have received the required number of '
+            console.error('[PARENT] All workers have received the required number of '
                     + 'messages. Will now compare.');
 
             Object.keys(workers).forEach(function (pid) {
@@ -113,7 +120,7 @@ if (process.argv[2] !== 'child') {
                 }
               });
 
-              console.error('%d received %d matching messges.', worker.pid
+              console.error('[PARENT] %d received %d matching messges.', worker.pid
                     , count);
 
               assert.equal(count, messages.length
@@ -121,7 +128,8 @@ if (process.argv[2] !== 'child') {
             });
 
             clearTimeout(timer);
-            console.error('Success');
+            console.error('[PARENT] Success');
+            killChildren(workers);
           }
         }
       });
@@ -134,7 +142,7 @@ if (process.argv[2] !== 'child') {
   sendSocket.setBroadcast(true);
 
   sendSocket.on('close', function() {
-    console.error('sendSocket closed');
+    console.error('[PARENT] sendSocket closed');
   });
 
   sendSocket.sendNext = function() {
@@ -150,12 +158,19 @@ if (process.argv[2] !== 'child') {
 
       if (err) throw err;
 
-      console.error('sent %s to %s:%s', util.inspect(buf.toString())
+      console.error('[PARENT] sent %s to %s:%s', util.inspect(buf.toString())
                 , LOCAL_BROADCAST_HOST, common.PORT);
 
       process.nextTick(sendSocket.sendNext);
     });
   };
+  
+  function killChildren(children) {
+    Object.keys(children).forEach(function(key) {
+      var child = children[key];
+      child.kill();
+    });
+  }
 }
 
 if (process.argv[2] === 'child') {
@@ -163,7 +178,7 @@ if (process.argv[2] === 'child') {
   var listenSocket = dgram.createSocket('udp4');
 
   listenSocket.on('message', function(buf, rinfo) {
-    console.error('%s received %s from %j', process.pid
+    console.error('[CHILD] %s received %s from %j', process.pid
                 , util.inspect(buf.toString()), rinfo);
 
     receivedMessages.push(buf);
@@ -171,14 +186,19 @@ if (process.argv[2] === 'child') {
     process.send({ message : buf.toString() });
 
     if (receivedMessages.length == messages.length) {
-      process.nextTick(function() {
+      process.nextTick(function () {
         listenSocket.close();
       });
     }
   });
 
   listenSocket.on('close', function() {
-    process.exit();
+    //HACK: Wait to exit the process to ensure that the parent
+    //process has had time to receive all messages via process.send()
+    //This may be indicitave of some other issue.
+    setTimeout(function() {
+      process.exit();
+    }, 1000);
   });
 
   listenSocket.on('listening', function() {

--- a/test/simple/test-dgram-multicast-multi-process.js
+++ b/test/simple/test-dgram-multicast-multi-process.js
@@ -46,8 +46,11 @@ if (process.argv[2] !== 'child') {
 
   //exit the test if it doesn't succeed within TIMEOUT
   timer = setTimeout(function () {
-    console.error('Responses were not received within %d ms.', TIMEOUT);
-    console.error('Fail');
+    console.error('[PARENT] Responses were not received within %d ms.', TIMEOUT);
+    console.error('[PARENT] Fail');
+
+    killChildren(workers);
+
     process.exit(1);
   }, TIMEOUT);
 
@@ -62,16 +65,21 @@ if (process.argv[2] !== 'child') {
       //handle the death of workers
       worker.on('exit', function (code, signal) {
          //don't consider this the true death if the worker has finished successfully
-        if (worker.isDone) {
+
+         //or if the exit code is 0
+        if (worker.isDone || code === 0) {
           return;
         }
         
         dead += 1;
-        console.error('Worker %d died. %d dead of %d', worker.pid, dead, listeners);
+        console.error('[PARENT] Worker %d died. %d dead of %d', worker.pid, dead, listeners);
 
         if (dead === listeners) {
-          console.error('All workers have died.');
-          console.error('Fail');
+          console.error('[PARENT] All workers have died.');
+          console.error('[PARENT] Fail');
+
+          killChildren(workers);
+
           process.exit(1);
         }
       });
@@ -91,12 +99,12 @@ if (process.argv[2] !== 'child') {
           if (worker.messagesReceived.length === messages.length) {
             done += 1;
             worker.isDone = true;
-            console.error('%d received %d messages total.', worker.pid,
+            console.error('[PARENT] %d received %d messages total.', worker.pid,
                     worker.messagesReceived.length);
           }
 
           if (done === listeners) {
-            console.error('All workers have received the required number of '
+            console.error('[PARENT] All workers have received the required number of '
                     + 'messages. Will now compare.');
 
             Object.keys(workers).forEach(function (pid) {
@@ -113,7 +121,7 @@ if (process.argv[2] !== 'child') {
                 }
               });
 
-              console.error('%d received %d matching messages.', worker.pid
+              console.error('[PARENT] %d received %d matching messages.', worker.pid
                     , count);
 
               assert.equal(count, messages.length
@@ -121,7 +129,8 @@ if (process.argv[2] !== 'child') {
             });
 
             clearTimeout(timer);
-            console.error('Success');
+            console.error('[PARENT] Success');
+            killChildren(workers);
           }
         }
       });
@@ -139,7 +148,7 @@ if (process.argv[2] !== 'child') {
   sendSocket.setMulticastLoopback(true);
 
   sendSocket.on('close', function() {
-    console.error('sendSocket closed');
+    console.error('[PARENT] sendSocket closed');
   });
 
   sendSocket.sendNext = function() {
@@ -153,11 +162,18 @@ if (process.argv[2] !== 'child') {
     sendSocket.send(buf, 0, buf.length,
                 common.PORT, LOCAL_BROADCAST_HOST, function(err) {
       if (err) throw err;
-      console.error('sent %s to %s', util.inspect(buf.toString()),
+      console.error('[PARENT] sent %s to %s', util.inspect(buf.toString()),
                 LOCAL_BROADCAST_HOST + common.PORT);
       process.nextTick(sendSocket.sendNext);
     });
   };
+  
+  function killChildren(children) {
+    Object.keys(children).forEach(function(key) {
+      var child = children[key];
+      child.kill();
+    });
+  }
 }
 
 if (process.argv[2] === 'child') {
@@ -165,7 +181,7 @@ if (process.argv[2] === 'child') {
   var listenSocket = dgram.createSocket('udp4');
 
   listenSocket.on('message', function(buf, rinfo) {
-    console.error('%s received %s from %j', process.pid
+    console.error('[CHILD] %s received %s from %j', process.pid
                 ,util.inspect(buf.toString()), rinfo);
 
     receivedMessages.push(buf);
@@ -174,6 +190,7 @@ if (process.argv[2] === 'child') {
 
     if (receivedMessages.length == messages.length) {
       listenSocket.dropMembership(LOCAL_BROADCAST_HOST);
+
       process.nextTick(function() { // TODO should be changed to below.
         // listenSocket.dropMembership(LOCAL_BROADCAST_HOST, function() {
         listenSocket.close();
@@ -182,7 +199,12 @@ if (process.argv[2] === 'child') {
   });
 
   listenSocket.on('close', function() {
-    process.exit();
+    //HACK: Wait to exit the process to ensure that the parent
+    //process has had time to receive all messages via process.send()
+    //This may be indicitave of some other issue.
+    setTimeout(function () {
+      process.exit();
+	}, 1000);
   });
 
   listenSocket.on('listening', function() {


### PR DESCRIPTION
This patch addresses a couple issues. The most important one was brought up in issue #1993. @jbergstroem's [Gentoo build box](http://buildbot.nodejs.org:8010/buildslaves/jbergstroem) had lingering child processes after the parent exited. This will now kill all child processes before exiting.

Also, I saw on a single core box, some strange behavior where the last message received by a child was not received by the parent via `process.send()`. By setting a timeout of 1000ms before exiting the child process, the parent process can successfully receive the messages. This may be a workaround for some other issue.
