### PR TITLE
child_process: abstract isolate message parsing

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -585,15 +585,53 @@ Isolate.prototype.kill = function(sig) {
   // ignore silently for now, need a way to signal the other thread
 };
 
+Isolate.prototype.send = messageSend;
 
-Isolate.prototype.send = function(msg, sendHandle) {
-  if (typeof msg === 'undefined') throw new TypeError('Bad argument.');
-  if (!this._handle) throw new Error('Isolate not running.');
-  msg = JSON.stringify(msg);
-  msg = new Buffer(msg);
+//handle messages
+function messageSend(message, sendHandle) {
+  if (typeof message === 'undefined') {
+    throw new TypeError('message cannot be undefined');
+  }
+
+  message = new Buffer(JSON.stringify(message));
 
   // Update simultaneous accepts on Windows
   net._setSimultaneousAccepts(sendHandle);
 
-  return this._handle.send(msg, sendHandle);
+  if (this === process) {
+    this._send(message, sendHandle);
+  } else {
+    this._handle.send(message, sendHandle);
+  }
+}
+function messageHandler(message, recvHandle) {
+  message = JSON.parse('' + message);
+
+  // Update simultaneous accepts on Windows
+  net._setSimultaneousAccepts(recvHandle);
+
+  // Filter out internal messages
+  // if cmd property begin with "_NODE"
+  if (message !== null &&
+      typeof message === 'object' &&
+      typeof message.cmd === 'string' &&
+      message.cmd.indexOf('NODE_') === 0) {
+    this.emit('internalMessage', message, recvHandle);
+  }
+
+  // Non-internal message
+  else {
+    this.emit('message', message, recvHandle);
+  }
+}
+
+// will be called from node.js in treads
+exports._isolateInit = function() {
+
+  // handle message
+  process._onmessage = messageHandler.bind(process);
+  process.send = messageSend.bind(process);
+
+  // handle exit call
+  process.exit = process._exit;
 };

--- a/src/node.js
+++ b/src/node.js
@@ -123,30 +123,8 @@
 
     if (process.tid === 1) return;
 
-    var net = NativeModule.require('net');
-
     // isolate initialization
-    process.send = function(msg, sendHandle) {
-      if (typeof msg === 'undefined') throw new TypeError('Bad argument.');
-      msg = JSON.stringify(msg);
-      msg = new Buffer(msg);
-
-      // Update simultaneous accepts on Windows
-      net._setSimultaneousAccepts(sendHandle);
-
-      return process._send(msg, sendHandle);
-    };
-
-    process._onmessage = function(msg, recvHandle) {
-      msg = JSON.parse('' + msg);
-
-      // Update simultaneous accepts on Windows
-      net._setSimultaneousAccepts(recvHandle);
-
-      process.emit('message', msg, recvHandle);
-    };
-
-    process.exit = process._exit;
+    NativeModule.require('child_process')._isolateInit();
   }
 
   startup.globalVariables = function() {


### PR DESCRIPTION
This is a part of my [Reducing complexity in child_process](https://github.com/joyent/node/pull/2544) patch. It reduce the complexity by abstracting the message handling between `src/node.js` and `lib/child_process.js`.

This also add `internalMessage` support to isolates.
