### PR TITLE
Make QueryString.parse() even faster

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -169,17 +169,18 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq) {
     return obj;
   }
 
-  qs.split(sep).forEach(function(kvp) {
-    var x = kvp.split(eq), k, v, useQS=false;
+  var qssplit = qs.split(sep), regexp = /\+/g;
+  for (var i=0,len=qssplit.length; i<len; ++i) {
+    var x = qssplit[i].replace(regexp, '%20'),
+        idx = x.indexOf(eq), kstr = x.substring(0, idx),
+        vstr = x.substring(idx + 1), k, v;
+
     try {
-      if (kvp.match(/\+/)) {	// decodeURIComponent does not decode + to space
-        throw "has +";
-      }
-      k = decodeURIComponent(x[0]);
-      v = decodeURIComponent(x.slice(1).join(eq) || "");
+      k = decodeURIComponent(kstr);
+      v = decodeURIComponent(vstr);
     } catch(e) {
-      k = QueryString.unescape(x[0], true);
-      v = QueryString.unescape(x.slice(1).join(eq), true);
+      k = QueryString.unescape(kstr, true);
+      v = QueryString.unescape(vstr, true);
     }
 
     if (!hasOwnProperty(obj, k)) {
@@ -189,7 +190,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq) {
     } else {
       obj[k].push(v);
     }
-  });
+  }
 
   return obj;
 };

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -170,7 +170,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq) {
   }
 
   var qssplit = qs.split(sep), regexp = /\+/g;
-  for (var i=0,len=qssplit.length; i<len; ++i) {
+  for (var i = 0, len = qssplit.length; i < len; ++i) {
     var x = qssplit[i].replace(regexp, '%20'),
         idx = x.indexOf(eq), kstr = x.substring(0, idx),
         vstr = x.substring(idx + 1), k, v;


### PR DESCRIPTION
Results using @bluesmoon's test query string from #2248:

original qs parse: 9338ms (pre 5166758)
new qs parse: 6436ms (5166758)
newer qs parse: 2898ms (this commit)
