### PR TITLE
Avoid necessary call to ReadStream._read().

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1130,9 +1130,7 @@ var ReadStream = fs.ReadStream = function(path, options) {
   }
 
   if (this.fd !== null) {
-    return process.nextTick(function() {
-      self._read();
-    });
+    return self._read();
   }
 
   fs.open(this.path, this.flags, this.mode, function(err, fd) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1130,7 +1130,8 @@ var ReadStream = fs.ReadStream = function(path, options) {
   }
 
   if (this.fd !== null) {
-    return self._read();
+    this._read();
+    return;
   }
 
   fs.open(this.path, this.flags, this.mode, function(err, fd) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1130,7 +1130,9 @@ var ReadStream = fs.ReadStream = function(path, options) {
   }
 
   if (this.fd !== null) {
-    return;
+    return process.nextTick(function() {
+      self._read();
+    });
   }
 
   fs.open(this.path, this.flags, this.mode, function(err, fd) {

--- a/test/simple/test-fs-read-stream-fd.js
+++ b/test/simple/test-fs-read-stream-fd.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var fs = require('fs');
+var assert = require('assert');
+var path = require('path');
+
+var common = require('../common');
+
+var file = path.join(common.tmpDir, '/read_stream_fd_test.txt');
+var input = 'hello world';
+var output = '';
+var fd, stream;
+
+fs.writeFileSync(file, input);
+fd = fs.openSync(file, 'r');
+
+stream = fs.createReadStream(null, { fd: fd, encoding: 'utf8' });
+stream.on('data', function(data) {
+  output += data;
+});
+
+process.on('exit', function() {
+  fs.unlinkSync(file);
+  assert.equal(output, input);
+});


### PR DESCRIPTION
This avoids a necessary userspace call to `ReadStream.prototype._read()` after passing a raw file descriptor to the ReadStream constructor and binding events.

Currently, this is what is necessary if you want to pass an fd to the read stream constructor:

``` js
var stream = fs.createReadStream(null, { fd: fd });
stream.on('data', function(data) {
  console.log(data);
});
stream._read();
```

The reads are never started if the constructor sees an `fd` is present.
