### PR TITLE
Include the node.lib file at link time on Windows.

### DIFF
--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -14,7 +14,7 @@
         'libraries': [ '-undefined dynamic_lookup' ],
       }],
       [ 'OS=="win"', {
-        'libraries': [ '-l<(node_root_dir>/$(Configuration)/node.lib' ],
+        'libraries': [ '-l<(node_root_dir)/$(Configuration)/node.lib' ],
       }]
     ]
   }

--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -14,7 +14,7 @@
         'libraries': [ '-undefined dynamic_lookup' ],
       }],
       [ 'OS=="win"', {
-        'libraries': [ '-l<(node_root_dir>/Debug/node.lib' ],
+        'libraries': [ '-l<(node_root_dir>/$(Configuration)/node.lib' ],
       }]
     ]
   }

--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -12,6 +12,9 @@
     'conditions': [
       [ 'OS=="mac"', {
         'libraries': [ '-undefined dynamic_lookup' ],
+      }],
+      [ 'OS=="win"', {
+        'libraries': [ '-l<(node_root_dir>/Debug/node.lib' ],
       }]
     ]
   }

--- a/tools/gyp_addon
+++ b/tools/gyp_addon
@@ -16,6 +16,7 @@ if __name__ == '__main__':
   args.extend(['-I', common_gypi])
   args.extend(['-Dlibrary=shared_library'])
   args.extend(['-Dvisibility=default'])
+  args.extend(['-Dnode_root_dir=%s' % node_root])
   args.extend(['--depth=.']);
 
   gyp_args = list(args)


### PR DESCRIPTION
Makes the basic `gyp_addon` script work with Windows.

The "Debug" dir is currently hard-coded. A better way would be to use the currently selected "configuration" that gyp is executing, but I could not figure out how to get a variable of the configuration. If someone knows a way to get the Debug/Release value through gyp then that would be great.
