### PR TITLE
The net.js client does not release the socket on DNS errors

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -604,6 +604,7 @@ Socket.prototype.connect = function(options, cb) {
         // error event to the next tick.
         process.nextTick(function() {
           self.emit('error', err);
+          self.destroy();
         });
       } else {
         timers.active(self);

--- a/test/simple/test-net-dns-error.js
+++ b/test/simple/test-net-dns-error.js
@@ -19,14 +19,12 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var common = require('../common');
 var assert = require('assert');
 
-var http = require('http');
-var https = require('https');
+var net = require('net');
 
-var expected_bad_requests = 0;
-var actual_bad_requests = 0;
+var expected_bad_connections = 1;
+var actual_bad_connections = 0;
 
 var host = '********';
 host += host;
@@ -39,30 +37,12 @@ function do_not_call() {
   throw new Error('This function should not have been called.');
 }
 
-function test(mod) {
-  expected_bad_requests += 2;
-
-  // Bad host name should not throw an uncatchable exception.
-  // Ensure that there is time to attach an error listener.
-  var req = mod.get({host: host, port: 42}, do_not_call);
-  req.on('error', function(err) {
-    assert.equal(err.code, 'ENOTFOUND');
-    actual_bad_requests++;
-  });
-  // http.get() called req.end() for us
-
-  var req = mod.request({method: 'GET', host: host, port: 42}, do_not_call);
-  req.on('error', function(err) {
-    assert.equal(err.code, 'ENOTFOUND');
-    actual_bad_requests++;
-  });
-  req.end();
-}
-
-test(https);
-test(http);
-
-process.on('exit', function() {
-  assert.equal(actual_bad_requests, expected_bad_requests);
+var socket = net.connect(42, host, do_not_call);
+socket.on('error', function (err) {
+  assert.equal(err.code, 'ENOTFOUND');
+  actual_bad_connections++;
 });
 
+process.on('exit', function() {
+  assert.equal(actual_bad_connections, expected_bad_connections);
+});


### PR DESCRIPTION
Which means that the socket stays there forever and the event loop waits for a connection that is not going to happen. The http.js client is patched against this behavior, but the issue lies within net.js.

A simple script to reproduce it:

``` javascript
var net = require('net');
var socket = net.connect(80, '.foo.bar', function () {
  console.log('connected');
  socket.destroy();
});
socket.on('error', function (err) {
  console.error(err);
});
```

The result is simple: the process hangs.

This small patch makes sure of that it is destroyed when the deferred error event is sent. Also added a specific test for this issue. I also corrected the http-dns-error error test that didn't test the https.js specifically because this bug.
