### PR TITLE
child_process: stop .disconnect() call if channel is diconnected

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -142,6 +142,7 @@ function setupChannel(target, channel) {
   target.disconnect = function() {
       if (!this.connected) {
         this.emit('error', new Error('IPC channel is already disconnected'));
+        return;
       }
 
       // do not allow messages to be written


### PR DESCRIPTION
call return after emitting `error` if `connected === false` 
