### PR TITLE
Added support for `.inspect()` to return other objects

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -158,7 +158,10 @@ function formatValue(ctx, value, recurseTimes) {
       value.inspect !== exports.inspect &&
       // Also filter out any prototype objects using the circular check.
       !(value.constructor && value.constructor.prototype === value)) {
-    return value.inspect(recurseTimes);
+    var ret = value.inspect(recurseTimes);
+    return 'string' == typeof ret
+      ? ret
+      : formatValue(ctx, ret, recurseTimes);
   }
 
   // Primitive types cannot have properties


### PR DESCRIPTION
not the greatest example but it's often useful to ignore some "private" properties or very large ones that are not really relevant.

``` js

function User(first, last) {
  this.first = first;
  this.last = last;
  this._id = 12345;
  this._role = 'admin';
  this.inspect = function(){
    return {
      first: first,
      last: last
    };
  };
}

function UserCollection() {
  var users = [];
  this.push = function(user){ users.push(user); };
  this.inspect = function(){ return users; };
}

var users = new UserCollection;
users.push(new User('tobi', 'ferret'));
users.push(new User('loki', 'ferret'));
users.push(new User('jane', 'ferret'));

console.log(users);
```

will output:

``` js
[ { first: 'tobi', last: 'ferret' },
  { first: 'loki', last: 'ferret' },
  { first: 'jane', last: 'ferret' } ]
```

I had added the constructor name like `[User { first: 'tobi' }]` etc but with `[` all over the place it gets really difficult to read although I think that would be useful in general.
