### PR TITLE
disable -fomit-frame-pointer on solaris systems

### DIFF
--- a/deps/v8/SConstruct
+++ b/deps/v8/SConstruct
@@ -127,7 +127,7 @@ LIBRARY_FLAGS = {
       'CPPDEFINES': ['__C99FEATURES__'],
       'CPPPATH' : ['/usr/local/include'],
       'LIBPATH' : ['/usr/local/lib'],
-      'CCFLAGS':      ['-ansi'],
+      'CCFLAGS':      ['-ansi', '-fno-omit-frame-pointer'],
     },
     'os:win32': {
       'CCFLAGS':      ['-DWIN32'],


### PR DESCRIPTION
This "optimization" cripples debuggability and has dubious performance value, so we want to disable it at least on SmartOS.
