### PR TITLE
disable -fomit-frame-pointer on solaris systems (master branch)

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -35,8 +35,13 @@
         },
       },
       'Release': {
+        'conditions': [
+          [ 'OS!="solaris"', {
+            'cflags': [ '-fomit-frame-pointer' ]
+          }],
+        ],
         # 'defines': [ 'NDEBUG' ],
-        'cflags': [ '-O3', '-fomit-frame-pointer', '-fdata-sections', '-ffunction-sections' ],
+        'cflags': [ '-O3', '-fdata-sections', '-ffunction-sections' ],
         'msvs_settings': {
           'VCCLCompilerTool': {
             'target_conditions': [


### PR DESCRIPTION
Using "make V=1", I verified that this does the right thing on Solaris systems (includes "-O3 -fdata-sections" ...). I also ran it on MacOS, and didn't see "-fdata-sections" at all. So while it wasn't affected by my change, I'm not sure how it works on Mac.
