### PR TITLE
Changed: `console.dir()` to bypass inspect() methods

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -38,7 +38,7 @@ exports.error = exports.warn;
 
 
 exports.dir = function(object) {
-  process.stdout.write(util.inspect(object) + '\n');
+  process.stdout.write(util.inspect(object, null, null, null, true) + '\n');
 };
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -91,9 +91,10 @@ var error = exports.error = function(x) {
  * @param {Boolean} colors Flag to turn on ANSI escape codes to color the
  *    output. Default is false (no coloring).
  */
-function inspect(obj, showHidden, depth, colors) {
+function inspect(obj, showHidden, depth, colors, bypassInspect) {
   var ctx = {
     showHidden: showHidden,
+    bypassInspect: bypassInspect,
     seen: [],
     stylize: colors ? stylizeWithColor : stylizeNoColor
   };
@@ -157,7 +158,8 @@ function formatValue(ctx, value, recurseTimes) {
       // Filter out the util module, it's inspect function is special
       value.inspect !== exports.inspect &&
       // Also filter out any prototype objects using the circular check.
-      !(value.constructor && value.constructor.prototype === value)) {
+      !(value.constructor && value.constructor.prototype === value) &&
+      !ctx.bypassInspect) {
     return value.inspect(recurseTimes);
   }
 


### PR DESCRIPTION
Given the following script:

``` js
function User(first, last) {
  this.first = first;
  this.last = last;
  this._id = 12345;
  this._role = 'admin';
  this.inspect = function(){
    return '#<User ' + this.first + '>'
  };
}

function UserCollection() {
  var users = [];
  this.push = function(user){ users.push(user); };
  this.inspect = function(){
    return '#<UserCollection\n  ' + users.map(function(user){
      return user.inspect();
    }).join('\n  ') + '>'
  };
}

var users = new UserCollection;
users.push(new User('tobi', 'ferret'));
users.push(new User('loki', 'ferret'));
users.push(new User('jane', 'ferret'));

console.log(users);
console.log();
console.dir(users);
```

before this change you get the same output of:

```
#<UserCollection
  #<User tobi>
  #<User loki>
  #<User jane>>

#<UserCollection
  #<User tobi>
  #<User loki>
  #<User jane>>
```

not so useful, to make `console.dir()` more like the browser in that it's more representative of what the object really contains I think this would be a really useful switch, otherwise there's no way (AFAIK) to bypass potentially confusing `.inspect()` implementations. With this change you'll then get:

```

#<UserCollection
  #<User tobi>
  #<User loki>
  #<User jane>>

{ push: [Function], inspect: [Function] }
```
