### PR TITLE
Make deepEquals make use of any .equals function

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -185,7 +185,13 @@ function _deepEqual(actual, expected) {
   } else if (typeof actual != 'object' && typeof expected != 'object') {
     return actual == expected;
 
-  // 7.5 For all other Object pairs, including Array objects, equivalence is
+  // 7.5. In case the expected object has an equals function,
+  // use that to determine equality.
+  } else if ( expected && 
+              typeof(expected.equals) == 'function') {
+    return expected.equals(actual);
+
+  // 7.6 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified
   // with Object.prototype.hasOwnProperty.call), the same set of keys
   // (although not necessarily the same order), equivalent values for every

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -105,7 +105,27 @@ assert.throws(makeBlock(a.deepEqual, 4, '5'),
               a.AssertionError,
               'deepEqual == check');
 
+
 // 7.5
+// If the actual object has an equals function,
+// use it for matching.
+var expected = {  equals: function(x) { return true } }
+var actual = "irrelevant"
+assert.doesNotThrow(makeBlock(a.deepEqual, actual, expected), 'deepEqual equals()');
+
+expected = {  equals: function(x) { return false } }
+actual = "irrelevant"
+assert.throws(makeBlock(a.deepEqual, actual, expected), 
+              a.AssertionError, 'deepEqual equals()');
+
+// Just in the (crazy) case someone has named a non-function
+// property "equals", it should fall back on normal comparisons.
+expected =    { equals: 'a string' };
+actual =  { equals: 'a string' };
+assert.doesNotThrow(makeBlock(a.deepEqual, actual, expected), 'deepEqual equals()');
+
+
+// 7.6
 // having the same number of owned properties && the same set of keys
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4}, {a: 4}));
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '2'}, {a: 4, b: '2'}));


### PR DESCRIPTION
This is my first pull request to node, so please be gentle. :)

Extended deepEquals to also try and make use of any .equals() function found on the expected object.

The reason for this is that deepEquals fails in a horribly hard-to-debug manner on ObjectIDs from node-mongodb-native (or any other object that uses memoization). This is the issue that made me start thinking about it: https://github.com/christkv/node-mongodb-native/pull/452 

A (probably) really great way to solve this would be if deepEquals used any .equals() function available, so I made it do that, and made a pull request. What do you think?
