### PR TITLE
Use -fPIC for native addons in Linux.

### DIFF
--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -16,7 +16,7 @@
       [ 'OS=="win"', {
         'libraries': [ '-l<(node_root_dir)/$(Configuration)/node.lib' ],
       }],
-      [ 'OS=="linux"', {
+      [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux" and target_arch!="ia32")', {
         'cflags': [ '-fPIC' ],
       }]
     ]

--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -15,6 +15,9 @@
       }],
       [ 'OS=="win"', {
         'libraries': [ '-l<(node_root_dir)/$(Configuration)/node.lib' ],
+      }],
+      [ 'OS=="linux"', {
+        'cflags': [ '-fPIC' ],
       }]
     ]
   }


### PR DESCRIPTION
I discussed this with @isaacs in IRC earlier today.

For why, see: https://github.com/brianmcd/contextify/pull/17#issuecomment-3875756

A few things I wasn't sure about (probably questions for @bnoordhuis):
1. Should other platforms get this flag? OS X? Solaris? I think no since `node-gyp` is working fine on OS X, but I've yet to test on Solaris.
2. Should this go in `common.gypi` instead so that node itself gets compiled with this? Again, it doesn't seem necessary to me, but was just double checking.

Thanks!
