### PR TITLE
docs: Added documentation for crypto/tls and added `honorCipherOrder` option

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -12,10 +12,12 @@ It also offers a set of wrappers for OpenSSL's hash, hmac, cipher, decipher, sig
 
 Creates a credentials object, with the optional details being a dictionary with keys:
 
-* `key` : a string holding the PEM encoded private key
-* `cert` : a string holding the PEM encoded certificate
-* `ca` : either a string or list of strings of PEM encoded CA certificates to trust.
-* `ciphers`: a string describing the ciphers to use or exclude. Consult
+* `key` : A string holding the PEM encoded private key
+* `passphrase` : A string of passphrase for the private key
+* `cert` : A string holding the PEM encoded certificate
+* `ca` : Either a string or list of strings of PEM encoded CA certificates to trust.
+* `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate Revocation List)
+* `ciphers`: A string describing the ciphers to use or exclude. Consult
   <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for details
   on the format.
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -46,9 +46,27 @@ The `options` object has these possibilities:
     omitted several well known "root" CAs will be used, like VeriSign.
     These are used to authorize connections.
 
+  - `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate
+    Revocation List)
+
   - `ciphers`: A string describing the ciphers to use or exclude. Consult
     <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for
     details on the format.
+    To mitigate [BEAST attacks]
+    (http://blog.ivanristic.com/2011/10/mitigating-the-beast-attack-on-tls.html),
+    it is recommended that you use this option in conjunction with the
+    `honorCipherOrder` option described below to prioritize the RC4 algorithm,
+    since it is a non-CBC cipher. A recommended cipher list follows:
+    `ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM`
+
+  - `honorCipherOrder` : 
+	When choosing a cipher, use the server's preferences instead of the client
+	preferences.
+	Note that if SSLv2 is used, the server will send its list of preferences
+	to the client, and the client chooses the cipher.
+	Although, this option is disabled by default, it is *recommended* that you
+	use this option in conjunction with the `ciphers` option to mitigate
+	BEAST attacks.
 
   - `requestCert`: If `true` the server will request a certificate from
     clients that connect and attempt to verify that certificate. Default:

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -953,14 +953,9 @@ Server.prototype.setOptions = function(options) {
   if (options.crl) this.crl = options.crl;
   if (options.ciphers) this.ciphers = options.ciphers;
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
-  if (options.honorCipherOrder) {
-    if (options.secureOptions) {
-      options.secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
-    } else {
-      options.secureOptions = constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
-    }
-  }
-  if (options.secureOptions) this.secureOptions = options.secureOptions;
+  var secureOptions = options.secureOptions || 0;
+  if (options.honorCipherOrder) secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+  if (secureOptions) this.secureOptions = secureOptions;
   if (options.NPNProtocols) convertNPNProtocols(options.NPNProtocols, this);
   if (options.SNICallback) {
     this.SNICallback = options.SNICallback;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -26,6 +26,7 @@ var events = require('events');
 var stream = require('stream');
 var END_OF_FILE = 42;
 var assert = require('assert').ok;
+var constants = require('constants');
 
 var debug;
 if (process.env.NODE_DEBUG && /tls/.test(process.env.NODE_DEBUG)) {
@@ -952,6 +953,13 @@ Server.prototype.setOptions = function(options) {
   if (options.crl) this.crl = options.crl;
   if (options.ciphers) this.ciphers = options.ciphers;
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
+  if (options.honorCipherOrder)
+  {
+    if(options.secureOptions)
+      options.secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+    else
+      options.secureOptions = constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+  }
   if (options.secureOptions) this.secureOptions = options.secureOptions;
   if (options.NPNProtocols) convertNPNProtocols(options.NPNProtocols, this);
   if (options.SNICallback) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -953,12 +953,12 @@ Server.prototype.setOptions = function(options) {
   if (options.crl) this.crl = options.crl;
   if (options.ciphers) this.ciphers = options.ciphers;
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
-  if (options.honorCipherOrder)
-  {
-    if(options.secureOptions)
+  if (options.honorCipherOrder) {
+    if (options.secureOptions) {
       options.secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
-    else
+    } else {
       options.secureOptions = constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+    }
   }
   if (options.secureOptions) this.secureOptions = options.secureOptions;
   if (options.NPNProtocols) convertNPNProtocols(options.NPNProtocols, this);


### PR DESCRIPTION
Added documentation for additional options (i.e. crl option) for
`tls.createServer`. Added `honorCipherOrder` option.
Documented how to mitigate BEAST attacks.

Please let me know what you think.  Fixes #2727
