### PR TITLE
Readline bugfix, and proposal.

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -126,6 +126,7 @@ Interface.prototype.setPrompt = function(prompt, length) {
 
 
 Interface.prototype.prompt = function(preserveCursor) {
+  if (this._closed) this.resume();
   if (this.enabled) {
     if (!preserveCursor) this.cursor = 0;
     this._refreshLine();
@@ -136,7 +137,7 @@ Interface.prototype.prompt = function(preserveCursor) {
 
 
 Interface.prototype.question = function(query, cb) {
-  if (cb) {
+  if (typeof cb === 'function') {
     this.resume();
     if (this._questionCallback) {
       this.output.write('\n');
@@ -153,6 +154,7 @@ Interface.prototype.question = function(query, cb) {
 
 
 Interface.prototype._onLine = function(line) {
+  if (this._closed) return;
   if (this._questionCallback) {
     var cb = this._questionCallback;
     this._questionCallback = null;
@@ -165,6 +167,7 @@ Interface.prototype._onLine = function(line) {
 
 
 Interface.prototype._addHistory = function() {
+  if (this._closed) return;
   if (this.line.length === 0) return '';
 
   this.history.unshift(this.line);
@@ -204,8 +207,8 @@ Interface.prototype.close = function(d) {
   if (this.enabled) {
     tty.setRawMode(false);
   }
-  this.emit('close');
   this._closed = true;
+  this.emit('close');
 };
 
 
@@ -220,6 +223,8 @@ Interface.prototype.resume = function() {
   if (this.enabled) {
     tty.setRawMode(true);
   }
+  this._closing = false;
+  this._closed = false;
 };
 
 
@@ -466,6 +471,8 @@ Interface.prototype._attemptClose = function() {
 
 // handle a write from the tty
 Interface.prototype._ttyWrite = function(s, key) {
+  if (this._closed) return;
+
   var next_word, next_non_word, previous_word, previous_non_word;
   key = key || {};
 


### PR DESCRIPTION
Before editing readline.js, I was having problems with closing a readline interface. The interface would "close", but would still trigger the `rl.on('line', ...)` event, and also echoing the command that was being input.

I notice that `rl.close()` only emulates closing. It doesn't actually destroy the input with `input.destroy()`. I left it emulating closing for the proposal.

The proposal: since `rl.close()` is only emulating closing, and doesn't actually destroy the input, the input still keeps the program open. I added code into `rl.resume()` to resume the readline without having to run `rl.createInterface()` again.

However, the problem with doing this is (as I pointed out) the readline makes the program hang from not destroying the input. So, I would also propose that the input be destroyed, but `rl.resume()` run `rl.createInterface()` with the input, output, and completer that was already provided.

Already spoke about this with @isaacs and @bnoordhuis, but wanted to see what everyone else has to say/add.
