### PR TITLE
Fix environment clearing in child_process.fork

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -193,7 +193,7 @@ exports.fork = function(modulePath /*, args, options*/) {
 
   // Just need to set this - child process won't actually use the fd.
   // For backwards compat - this can be changed to 'NODE_CHANNEL' before v0.6.
-  if (!options.env) options.env = { };
+  options.env = util._extend({}, options.env || process.env);
   options.env.NODE_CHANNEL_FD = 42;
 
   // stdin is the IPC channel.


### PR DESCRIPTION
Currently, if no env object is passed as part of options to child_process.fork, the environment is cleared. This is in contrast to both the typical Unix behavior of fork and child_process.spawn (from the docs for fork: This is a special case of the spawn() functionality for spawning Node processes.). I believe fork would better follow the principle of least surprise if it were implemented as I have changed it in this PR.
