### PR TITLE
Handle closure of a dgram socket before the DNS lookup completes

### DIFF
--- a/deps/uv/test/test-udp-multicast-ttl.c
+++ b/deps/uv/test/test-udp-multicast-ttl.c
@@ -1,0 +1,89 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK_HANDLE(handle) \
+  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+
+static uv_udp_t server;
+static uv_udp_t client;
+
+static int cl_recv_cb_called;
+
+static int sv_send_cb_called;
+
+static int close_cb_called;
+
+
+static void close_cb(uv_handle_t* handle) {
+  CHECK_HANDLE(handle);
+  close_cb_called++;
+}
+
+
+static void sv_send_cb(uv_udp_send_t* req, int status) {
+  ASSERT(req != NULL);
+  ASSERT(status == 0);
+  CHECK_HANDLE(req->handle);
+
+  sv_send_cb_called++;
+
+  uv_close((uv_handle_t*) req->handle, close_cb);
+}
+
+
+TEST_IMPL(udp_multicast_ttl) {
+  int r;
+  uv_udp_send_t req;
+  uv_buf_t buf;
+  struct sockaddr_in addr = uv_ip4_addr("239.255.0.1", TEST_PORT);
+
+  r = uv_udp_init(uv_default_loop(), &server);
+  ASSERT(r == 0);
+
+  r = uv_udp_bind(&server, uv_ip4_addr("0.0.0.0", 0), 0);
+  ASSERT(r == 0);
+
+  r = uv_udp_set_multicast_ttl(&server, 32);
+  ASSERT(r == 0);
+
+  /* server sends "PING" */
+  buf = uv_buf_init("PING", 4);
+  r = uv_udp_send(&req, &server, &buf, 1, addr, sv_send_cb);
+  ASSERT(r == 0);
+
+  ASSERT(close_cb_called == 0);
+  ASSERT(sv_send_cb_called == 0);
+
+  /* run the loop till all events are processed */
+  uv_run(uv_default_loop());
+
+  ASSERT(sv_send_cb_called == 1);
+  ASSERT(close_cb_called == 1);
+
+  return 0;
+}

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -176,14 +176,16 @@ Socket.prototype.send = function(buffer,
       self.emit('error', err);
     }
     else {
-      var req = self._handle.send(buffer, offset, length, port, ip);
-      if (req) {
-        req.oncomplete = afterSend;
-        req.cb = callback;
-      }
-      else {
-        // don't emit as error, dgram_legacy.js compatibility
-        callback(errnoException(errno, 'send'));
+      if (self._handle) {
+        var req = self._handle.send(buffer, offset, length, port, ip);
+        if (req) {
+          req.oncomplete = afterSend;
+          req.cb = callback;
+        }
+        else {
+          // don't emit as error, dgram_legacy.js compatibility
+          callback(errnoException(errno, 'send'));
+        }
       }
     }
   });

--- a/src/node.cc
+++ b/src/node.cc
@@ -2045,12 +2045,40 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   process->Set(String::NewSymbol("platform"), String::New(PLATFORM));
 
   // process.argv
+#ifdef _WIN32
+  // Windows - use unicode
+  WCHAR* command_line = GetCommandLineW();
+  if (command_line == NULL) {
+    winapi_perror("GetCommandLineW");
+    exit(1);
+  }
+
+  int wargc = 0;
+  WCHAR** wargv = CommandLineToArgvW(command_line, &wargc);
+  if (wargv == NULL || wargc <= 0) {
+    winapi_perror("CommandLineToArgvW");
+    exit(1);
+  }
+
+  assert(wargc == argc);
+
+  Local<Array> arguments = Array::New(wargc - option_end_index + 1);
+  arguments->Set(Integer::New(0), String::New(reinterpret_cast<uint16_t*>(wargv[0])));
+  for (j = 1, i = option_end_index; i < wargc; j++, i++) {
+    Local<String> arg = String::New(reinterpret_cast<uint16_t*>(wargv[i]));
+    arguments->Set(Integer::New(j), arg);
+  }
+
+  LocalFree(wargv);
+#else
+  // Unix
   Local<Array> arguments = Array::New(argc - option_end_index + 1);
   arguments->Set(Integer::New(0), String::New(argv[0]));
   for (j = 1, i = option_end_index; i < argc; j++, i++) {
     Local<String> arg = String::New(argv[i]);
     arguments->Set(Integer::New(j), arg);
   }
+#endif
   // assign it
   process->Set(String::NewSymbol("argv"), arguments);
 

--- a/test/simple/test-dgram-close.js
+++ b/test/simple/test-dgram-close.js
@@ -1,0 +1,35 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Ensure that if a dgram socket is closed before the DNS lookup completes, it
+// won't crash.
+
+var assert = require('assert'),
+    common = require('../common'),
+    dgram = require('dgram');
+
+var buf = new Buffer(1024);
+buf.fill(42);
+
+var socket = dgram.createSocket('udp4');
+
+socket.send(buf, 0, buf.length, common.port, 'localhost');
+socket.close();

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -26,26 +26,27 @@ set upload=
 
 :next-arg
 if "%1"=="" goto args-done
-if /i "%1"=="debug"        set config=Debug&goto arg-ok
-if /i "%1"=="release"      set config=Release&goto arg-ok
-if /i "%1"=="clean"        set target=Clean&goto arg-ok
-if /i "%1"=="ia32"         set target_arch=ia32&goto arg-ok
-if /i "%1"=="x86"          set target_arch=ia32&goto arg-ok
-if /i "%1"=="x64"          set target_arch=x64&goto arg-ok
-if /i "%1"=="noprojgen"    set noprojgen=1&goto arg-ok
-if /i "%1"=="nobuild"      set nobuild=1&goto arg-ok
-if /i "%1"=="nosign"       set nosign=1&goto arg-ok
-if /i "%1"=="nosnapshot"   set nosnapshot=1&goto arg-ok
-if /i "%1"=="test-uv"      set test=test-uv&goto arg-ok
-if /i "%1"=="test-internet"set test=test-internet&goto arg-ok
-if /i "%1"=="test-pummel"  set test=test-pummel&goto arg-ok
-if /i "%1"=="test-simple"  set test=test-simple&goto arg-ok
-if /i "%1"=="test-message" set test=test-message&goto arg-ok
-if /i "%1"=="test-all"     set test=test-all&goto arg-ok
-if /i "%1"=="test"         set test=test&goto arg-ok
-if /i "%1"=="msi"          set msi=1&goto arg-ok
-if /i "%1"=="upload"       set upload=1&goto arg-ok
+if /i "%1"=="debug"         set config=Debug&goto arg-ok
+if /i "%1"=="release"       set config=Release&goto arg-ok
+if /i "%1"=="clean"         set target=Clean&goto arg-ok
+if /i "%1"=="ia32"          set target_arch=ia32&goto arg-ok
+if /i "%1"=="x86"           set target_arch=ia32&goto arg-ok
+if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
+if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
+if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
+if /i "%1"=="nosign"        set nosign=1&goto arg-ok
+if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
+if /i "%1"=="test-uv"       set test=test-uv&goto arg-ok
+if /i "%1"=="test-internet" set test=test-internet&goto arg-ok
+if /i "%1"=="test-pummel"   set test=test-pummel&goto arg-ok
+if /i "%1"=="test-simple"   set test=test-simple&goto arg-ok
+if /i "%1"=="test-message"  set test=test-message&goto arg-ok
+if /i "%1"=="test-all"      set test=test-all&goto arg-ok
+if /i "%1"=="test"          set test=test&goto arg-ok
+if /i "%1"=="msi"           set msi=1&goto arg-ok
+if /i "%1"=="upload"        set upload=1&goto arg-ok
 
+echo Warning: ignoring invalid command line option `%1`.
 
 :arg-ok
 shift


### PR DESCRIPTION
As of 0.6.10, if the socket is closed before the DNS lookup completes, `self._handle` becomes null and the associated process crashes.

I'm unclear on whether it should trigger the callback or not.  Using `callback(errnoException(errno, 'send'));` doesn't work, as `errno` is undefined.
