### PR TITLE
process: remove old notices about removed methods

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -46,8 +46,6 @@
 
     startup.processChannel();
 
-    startup.removedMethods();
-
     startup.resolveArgv0();
 
     // There are various modes that Node can run in. The most common two
@@ -430,37 +428,6 @@
       assert(process.send);
     }
   }
-
-  startup._removedProcessMethods = {
-    'assert': 'process.assert() use require("assert").ok() instead',
-    'debug': 'process.debug() use console.error() instead',
-    'error': 'process.error() use console.error() instead',
-    'watchFile': 'process.watchFile() has moved to fs.watchFile()',
-    'unwatchFile': 'process.unwatchFile() has moved to fs.unwatchFile()',
-    'mixin': 'process.mixin() has been removed.',
-    'createChildProcess': 'childProcess API has changed. See doc/api.txt.',
-    'inherits': 'process.inherits() has moved to util.inherits()',
-    '_byteLength': 'process._byteLength() has moved to Buffer.byteLength'
-  };
-
-  startup.removedMethods = function() {
-    var desc = {
-      configurable: true,
-      writable: true,
-      enumerable: false
-    };
-    for (var method in startup._removedProcessMethods) {
-      var reason = startup._removedProcessMethods[method];
-      desc.value = startup._removedMethod(reason);
-      Object.defineProperty(process, method, desc);
-    }
-  };
-
-  startup._removedMethod = function(reason) {
-    return function() {
-      throw new Error(reason);
-    };
-  };
 
   startup.resolveArgv0 = function() {
     var cwd = process.cwd();


### PR DESCRIPTION
These methods were removed a long time ago. Keeping these notices here
makes no sense anymore.

Also, removing this part of code slightly speeds up the startup.
