### PR TITLE
Add WebSocket RFC6455 multiheader fields to the http parser

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -359,6 +359,8 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
     case 'pragma':
     case 'link':
     case 'www-authenticate':
+    case 'sec-websocket-extensions':
+    case 'sec-websocket-protocol':
       if (field in dest) {
         dest[field] += ', ' + value;
       } else {

--- a/test/simple/test-http-server-multiheaders.js
+++ b/test/simple/test-http-server-multiheaders.js
@@ -33,6 +33,8 @@ var srv = http.createServer(function(req, res) {
   assert.equal(req.headers['www-authenticate'], 'foo, bar, baz');
   assert.equal(req.headers['x-foo'], 'bingo');
   assert.equal(req.headers['x-bar'], 'banjo, bango');
+  assert.equal(req.headers['sec-websocket-protocol'], 'chat, share');
+  assert.equal(req.headers['sec-websocket-extensions'], 'foo; 1, bar; 2, baz');
 
   res.writeHead(200, {'Content-Type' : 'text/plain'});
   res.end('EOF');
@@ -57,7 +59,12 @@ srv.listen(common.PORT, function() {
       ['WWW-AUTHENTICATE', 'baz'],
       ['x-foo', 'bingo'],
       ['x-bar', 'banjo'],
-      ['x-bar', 'bango']
+      ['x-bar', 'bango'],
+      ['sec-websocket-protocol', 'chat'],
+      ['sec-websocket-protocol', 'share'],
+      ['sec-websocket-extensions', 'foo; 1'],
+      ['sec-websocket-extensions', 'bar; 2'],
+      ['sec-websocket-extensions', 'baz']
     ]
   });
 });


### PR DESCRIPTION
The WebSocket RFC defines two new http header fields which may be repeated over multiple lines.

See:
 http://tools.ietf.org/html/rfc6455#section-11.3.2
 http://tools.ietf.org/html/rfc6455#section-11.3.4
