### PR TITLE
Couple of bug fixes

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -142,6 +142,8 @@ Example of listening for `SIGINT`:
 
 `function () {}`
 
+**This does not work on Windows.**
+
 Emitted whenever the `in` stream receives a `^Z`, respectively known as
 `SIGTSTP`. If there is no `SIGTSTP` event listener present when the `in` stream
 receives a `SIGTSTP`, the program will be sent to the background.
@@ -163,6 +165,8 @@ Example of listening for `SIGTSTP`:
 ### Event: 'SIGCONT'
 
 `function () {}`
+
+**This does not work on Windows.**
 
 Emitted whenever the `in` stream is sent to the background with `^Z`,
 respectively known as `SIGTSTP`, and then continued with `fg`. This event only

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -754,12 +754,7 @@ function Interface(stdin, stdout, args) {
   this.repl = new repl.REPLServer('debug> ', streams,
                                   this.controlEval.bind(this), false, true);
 
-  // Kill child process when repl closed or main process is dead
-  this.repl.rli.addListener('close', function() {
-    self.killed = true;
-    self.killChild();
-  });
-
+  // Kill child process when main process dies
   process.on('exit', function() {
     self.killChild();
   });

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -531,6 +531,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'z':
+        if (process.platform == 'win32') break;
         if (this.listeners('SIGTSTP').length) {
           this.emit('SIGTSTP');
         } else {
@@ -547,7 +548,7 @@ Interface.prototype._ttyWrite = function(s, key) {
           })(this));
           process.kill(process.pid, 'SIGTSTP');
         }
-        return;
+        break;
 
       case 'w': // delete backwards to a word boundary
       case 'backspace':
@@ -568,6 +569,7 @@ Interface.prototype._ttyWrite = function(s, key) {
 
       case 'right':
         this._wordRight();
+        break;
     }
 
   } else if (key.meta) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -148,7 +148,7 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
     self.displayPrompt();
   });
 
-  rli.addListener('line', function(cmd) {
+  rli.on('line', function(cmd) {
     sawSIGINT = false;
     var skipCatchall = false;
     cmd = trimWhitespace(cmd);
@@ -236,8 +236,8 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
     };
   });
 
-  rli.addListener('close', function() {
-    self.inputStream.destroy();
+  rli.on('SIGCONT', function() {
+    self.displayPrompt();
   });
 
   self.displayPrompt();


### PR DESCRIPTION
- Fixed REPL bug where REPL fails to restart after ^Z (SIGTSTP)
  
  Before:
  
  ```
  07:31 AM   sly@atlantis:~/dev/C++/node$ node
  > 
  [1]+  Stopped                 node
  07:44 AM   sly@atlantis:~/dev/C++/node$ fg
  node
  07:44 AM   sly@atlantis:~/dev/C++/node$ 
  ```
  
  After:
  
  ```
  07:55 AM   sly@atlantis:~/dev/C++/node$ node
  > 
  [1]+  Stopped                 node
  07:55 AM   sly@atlantis:~/dev/C++/node$ fg
  node
  > .exit
  07:55 AM   sly@atlantis:~/dev/C++/node$ 
  ```
- Removed old readline callbacks for the `close` event.
- Updated API docs
- Added bypass for SIGTSTP and SIGCONT on Windows.
