### PR TITLE
debugger: rename `process.debug_port` to `process.debugPort`

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2115,7 +2115,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   }
   delete [] execPath;
 
-  process->SetAccessor(String::New("debug_port"),
+  process->SetAccessor(String::New("debugPort"),
                        DebugPortGetter,
                        DebugPortSetter);
 


### PR DESCRIPTION
We should comply to to camelCase naming convention.
