### PR TITLE
Minor fixes for `make distclean`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ clean:
 
 distclean:
 	-rm -rf out
-	-rm config.gypi
-	-rm config.mk
+	-rm -f config.gypi
+	-rm -f config.mk
 
 test: all
 	$(PYTHON) tools/test.py --mode=release simple message

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ clean:
 distclean:
 	-rm -rf out
 	-rm config.gypi
+	-rm config.mk
 
 test: all
 	$(PYTHON) tools/test.py --mode=release simple message


### PR DESCRIPTION
First clean up the `config.mk` file, second don't error out when already clean.
