### PR TITLE
require common in setproctitle

### DIFF
--- a/test/simple/test-setproctitle.js
+++ b/test/simple/test-setproctitle.js
@@ -27,6 +27,7 @@ if ('linux freebsd'.indexOf(process.platform) === -1) {
   process.exit();
 }
 
+var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 


### PR DESCRIPTION
I found that the test `common` module wasn't required in `test-setproctitle`. `common` is not just useful properties it also test if there are some `global` property there shouldn't be there.
