### PR TITLE
Add `util._extend`, squash `options` object pollutions

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -22,7 +22,7 @@
 var EventEmitter = require('events').EventEmitter;
 var net = require('net');
 var Process = process.binding('process_wrap').Process;
-var inherits = require('util').inherits;
+var util = require('util');
 var constants; // if (!constants) constants = process.binding('constants');
 
 var Pipe;
@@ -51,19 +51,6 @@ function createSocket(pipe, readable) {
   }
 
   return s;
-}
-
-function mergeOptions(target, overrides) {
-  if (overrides) {
-    var keys = Object.keys(overrides);
-    for (var i = 0, len = keys.length; i < len; i++) {
-      var k = keys[i];
-      if (overrides[k] !== undefined) {
-        target[k] = overrides[k];
-      }
-    }
-  }
-  return target;
 }
 
 
@@ -244,7 +231,7 @@ exports.exec = function(command /*, options, callback */) {
     args = ['/s', '/c', '"' + command + '"'];
     // Make a shallow copy before patching so we don't clobber the user's
     // options object.
-    options = mergeOptions({}, options);
+    options = util._extend({}, options);
     options.windowsVerbatimArguments = true;
   } else {
     file = '/bin/sh';
@@ -281,7 +268,7 @@ exports.execFile = function(file /* args, options, callback */) {
   }
 
   // Merge optionArg into options
-  mergeOptions(options, optionArg);
+  util._extend(options, optionArg);
 
   var child = spawn(file, args, {
     cwd: options.cwd,
@@ -430,7 +417,7 @@ function ChildProcess() {
     maybeExit(self);
   };
 }
-inherits(ChildProcess, EventEmitter);
+util.inherits(ChildProcess, EventEmitter);
 
 
 function setStreamOption(name, index, options) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -29,18 +29,6 @@ function isObject(o) {
   return (typeof o === 'object' && o !== null);
 }
 
-function extendObject(origin, add) {
-  // Don't do anything if add isn't an object
-  if (!add) return origin;
-
-  var keys = Object.keys(add),
-      i = keys.length;
-  while (i--) {
-    origin[keys[i]] = add[keys[i]];
-  }
-  return origin;
-}
-
 var debug;
 if (process.env.NODE_DEBUG && /cluster/.test(process.env.NODE_DEBUG)) {
   debug = function(x) {
@@ -138,7 +126,7 @@ function isInternalMessage(message) {
 
 // Modyfi message object to be internal
 function internalMessage(inMessage) {
-  var outMessage = extendObject({}, inMessage);
+  var outMessage = util._extend({}, inMessage);
 
   // Add internal prefix to cmd
   outMessage.cmd = INTERNAL_PREFIX + (outMessage.cmd || '');
@@ -172,7 +160,7 @@ var messageHandingObject = {};
 function handleMessage(worker, inMessage, inHandle) {
 
   //Remove internal prefix
-  var message = extendObject({}, inMessage);
+  var message = util._extend({}, inMessage);
   message.cmd = inMessage.cmd.substr(INTERNAL_PREFIX.length);
 
   var respondUsed = false;
@@ -276,11 +264,11 @@ function Worker(customEnv) {
 
     // Create env object
     // first: copy and add uniqueID
-    var envCopy = extendObject({}, env);
+    var envCopy = util._extend({}, env);
     envCopy['NODE_UNIQUE_ID'] = this.uniqueID;
     // second: extend envCopy with the env argument
     if (isObject(customEnv)) {
-      envCopy = extendObject(envCopy, customEnv);
+      envCopy = util._extend(envCopy, customEnv);
     }
 
     // fork worker

--- a/lib/http.js
+++ b/lib/http.js
@@ -1076,14 +1076,16 @@ exports.globalAgent = globalAgent;
 function ClientRequest(options, cb) {
   var self = this;
   OutgoingMessage.call(self);
-  self.agent = options.agent;
-  options.defaultPort = options.defaultPort || 80;
 
-  options.port = options.port || options.defaultPort;
-  options.host = options.hostname || options.host || 'localhost';
+  self.agent = options.agent === undefined ? globalAgent : options.agent;
+
+  var defaultPort = options.defaultPort || 80;
+
+  var port = options.port || defaultPort;
+  var host = options.hostname || options.host || 'localhost';
 
   if (options.setHost === undefined) {
-    options.setHost = true;
+    var setHost = true;
   }
 
   self.socketPath = options.socketPath;
@@ -1102,10 +1104,10 @@ function ClientRequest(options, cb) {
         self.setHeader(key, options.headers[key]);
       }
     }
-    if (options.host && !this.getHeader('host') && options.setHost) {
-      var hostHeader = options.host;
-      if (options.port && +options.port !== options.defaultPort) {
-        hostHeader += ':' + options.port;
+    if (host && !this.getHeader('host') && setHost) {
+      var hostHeader = host;
+      if (port && +port !== defaultPort) {
+        hostHeader += ':' + port;
       }
       this.setHeader('Host', hostHeader);
     }
@@ -1142,15 +1144,15 @@ function ClientRequest(options, cb) {
     // If there is an agent we should default to Connection:keep-alive.
     self._last = false;
     self.shouldKeepAlive = true;
-    self.agent.addRequest(self, options.host, options.port);
+    self.agent.addRequest(self, host, port);
   } else {
     // No agent, default to Connection:close.
     self._last = true;
     self.shouldKeepAlive = false;
     if (options.createConnection) {
-      var conn = options.createConnection(options.port, options.host, options);
+      var conn = options.createConnection(port, host, options);
     } else {
-      var conn = net.createConnection(options.port, options.host);
+      var conn = net.createConnection(port, host);
     }
     self.onSocket(conn);
   }
@@ -1426,15 +1428,10 @@ exports.request = function(options, cb) {
     throw new Error('Protocol:' + options.protocol + ' not supported.');
   }
 
-  if (options.agent === undefined) {
-    options.agent = globalAgent;
-  }
-
   return new ClientRequest(options, cb);
 };
 
 exports.get = function(options, cb) {
-  options.method = 'GET';
   var req = exports.request(options, cb);
   req.end();
   return req;

--- a/lib/https.js
+++ b/lib/https.js
@@ -83,7 +83,6 @@ exports.request = function(options, cb) {
 };
 
 exports.get = function(options, cb) {
-  options.method = 'GET';
   var req = exports.request(options, cb);
   req.end();
   return req;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1061,27 +1061,29 @@ Server.prototype.SNICallback = function(servername) {
 //
 //
 exports.connect = function(/* [port, host], options, cb */) {
-  var options = {}, cb;
+  var options, port, host, cb;
 
   if (typeof arguments[0] === 'object') {
     options = arguments[0];
   } else if (typeof arguments[1] === 'object') {
     options = arguments[1];
-    options.port = arguments[0];
+    port = arguments[0];
   } else if (typeof arguments[2] === 'object') {
     options = arguments[2];
-    options.port = arguments[0];
-    options.host = arguments[1];
+    port = arguments[0];
+    host = arguments[1];
   } else {
     // This is what happens when user passes no `options` argument, we can't
     // throw `TypeError` here because it would be incompatible with old API
     if (typeof arguments[0] === 'number') {
-      options.port = arguments[0];
+      port = arguments[0];
     }
     if (typeof arguments[1] === 'string') {
-      options.host = arguments[1];
+      host = arguments[1];
     }
   }
+
+  options = util._extend({ port: port, host: host }, options || {});
 
   if (typeof arguments[arguments.length - 1] === 'function') {
     cb = arguments[arguments.length - 1];

--- a/lib/util.js
+++ b/lib/util.js
@@ -506,3 +506,15 @@ exports.inherits = function(ctor, superCtor) {
     }
   });
 };
+
+exports._extend = function(origin, add) {
+  // Don't do anything if add isn't an object
+  if (!add) return origin;
+
+  var keys = Object.keys(add);
+  var i = keys.length;
+  while (i--) {
+    origin[keys[i]] = add[keys[i]];
+  }
+  return origin;
+};


### PR DESCRIPTION
There were 2 functions with merging functionality in `cluster` and
`child_process` modules which were replaced by `util._extend`.

Also, some `options` object pollutions were fixed in `http`, `https` and `tls` modules.
