### PR TITLE
Export FromConstructorTemplate so it can be used from Windows add-ons.

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -158,7 +158,7 @@ v8::Local<v8::Object> BuildStatsObject(NODE_STAT_STRUCT *s);
  * @param args The arguments object passed to your constructor.
  * @see v8::Arguments::IsConstructCall
  */
-v8::Handle<v8::Value> FromConstructorTemplate(
+NODE_EXTERN v8::Handle<v8::Value> FromConstructorTemplate(
     v8::Persistent<v8::FunctionTemplate>& constructorTemplate,
     const v8::Arguments& args);
 


### PR DESCRIPTION
Not sure if there is a reason for this not to be exported, but it's useful outside of node too.
