### PR TITLE
docs: remove duplicate socket.write content from net

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -302,11 +302,6 @@ buffer. Returns `false` if all or part of the data was queued in user memory.
 The optional `callback` parameter will be executed when the data is finally
 written out - this may not be immediately.
 
-#### socket.write(data, [encoding], [callback])
-
-Write data with the optional encoding. The callback will be made when the
-data is flushed to the kernel.
-
 #### socket.end([data], [encoding])
 
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the


### PR DESCRIPTION
This is a very small change to the `net` documentation.

Forgive me if this was intentional (I'm assuming, if it was intentional, that it was meant to show both sync/async) but it didn't make sense to me as I read through it. It only had information available in the entry above it, and didn't add anything.

Additionally, this is my first pull request to node so if this isn't the appropriate branch please let me know. It appears that `json-api-docs` was the last place this file was changed.
