### PR TITLE
build: support shared v8 properly

### DIFF
--- a/configure
+++ b/configure
@@ -208,8 +208,11 @@ def configure_v8(o):
     o['libraries'] += ['-L%s' % options.shared_v8_libpath]
   if options.shared_v8_libname:
     o['libraries'] += ['-l%s' % options.shared_v8_libname]
+  else:
+    o['libraries'] += ['-lv8']
   if options.shared_v8_includes:
     o['include_dirs'] += [options.shared_v8_includes]
+    o['variables']['node_shared_v8_includes'] = options.shared_v8_includes
 
 
 def configure_cares(o):

--- a/configure
+++ b/configure
@@ -208,7 +208,7 @@ def configure_v8(o):
     o['libraries'] += ['-L%s' % options.shared_v8_libpath]
   if options.shared_v8_libname:
     o['libraries'] += ['-l%s' % options.shared_v8_libname]
-  else:
+  elif options.shared_v8:
     o['libraries'] += ['-lv8']
   if options.shared_v8_includes:
     o['include_dirs'] += [options.shared_v8_includes]

--- a/node.gyp
+++ b/node.gyp
@@ -54,7 +54,6 @@
 
       'dependencies': [
         'deps/http_parser/http_parser.gyp:http_parser',
-        'deps/v8/tools/gyp/v8.gyp:v8',
         'deps/uv/uv.gyp:uv',
         'deps/zlib/zlib.gyp:zlib',
         'node_js2c#host',
@@ -110,8 +109,6 @@
         'src/stream_wrap.h',
         'src/v8_typed_array.h',
         'deps/http_parser/http_parser.h',
-        'deps/v8/include/v8.h',
-        'deps/v8/include/v8-debug.h',
         '<(SHARED_INTERMEDIATE_DIR)/node_natives.h',
         # javascript files to make for an even more pleasant IDE experience
         '<@(library_files)',
@@ -145,6 +142,21 @@
             # SHARED_INTERMEDIATE_DIR?
             'src/node_provider.h',
           ],
+        }],
+
+        [ 'node_shared_v8=="true"', {
+          'sources': [
+            '<(node_shared_v8_includes)/v8.h',
+            '<(node_shared_v8_includes)/v8-debug.h',
+          ],
+        }],
+
+        [ 'node_shared_v8=="false"', {
+          'sources': [
+            'deps/v8/include/v8.h',
+            'deps/v8/include/v8-debug.h',
+          ],
+          'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:v8' ],
         }],
 
         [ 'OS=="win"', {


### PR DESCRIPTION
-don't pull in bundled v8 as a dependency when node_shared_v8==true
-use node_shared_v8_includes for v8.h and v8-debug.h
