### PR TITLE
build: Change default BUILDTYPE of vcbuild.bat in Windows into Release

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -12,7 +12,7 @@ if /i "%1"=="--?" goto help
 if /i "%1"=="/?" goto help
 
 @rem Process arguments.
-set config=Debug
+set config=Release
 set target=Build
 set target_arch=ia32
 set noprojgen=


### PR DESCRIPTION
Per discussion on #2571 , I think  that the default BUILDTYPE of Node should be better to be **Release** . 
I'm not so much familiar with  the common convention of BUILDTYPE which is specific to Windows, so  if Debug is better, it also should be written in the comment or documented.
