### PR TITLE
Default node_shared_v8 to false.

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -5,6 +5,7 @@
     # See http://codereview.chromium.org/8159015
     'werror': '',
     'node_use_dtrace': 'false',
+    'node_shared_v8%': 'false',
     'node_use_openssl%': 'true',
     'node_use_system_openssl%': 'false',
     'library_files': [


### PR DESCRIPTION
We needed to set a default value for the `node_shared_v8` variable.

Fixes #2818.
