### PR TITLE
Fix `process.argv[0]`

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -429,14 +429,18 @@
 
   startup.resolveArgv0 = function() {
     var cwd = process.cwd();
+    var isWindows = process.platform === 'win32';
 
     // Make process.argv[0] into a full path, but only touch argv[0] if it's
     // not a system $PATH lookup.
     // TODO: Make this work on Windows as well.  Note that "node" might
     // execute cwd\node.exe, or some %PATH%\node.exe on Windows,
     // and that every directory has its own cwd, so d:node.exe is valid.
-    var path = NativeModule.require('path');
-    process.argv[0] = path.resolve(process.argv[0]);
+    var argv0 = process.argv[0];
+    if (!isWindows && argv0.indexOf('/') !== -1 && argv0.charAt(0) !== '/') {
+      var path = NativeModule.require('path');
+      process.argv[0] = path.join(cwd, process.argv[0]);
+    }
   };
 
   // Below you find a minimal module system, which is used to load the node

--- a/test/simple/test-process-argv-0.js
+++ b/test/simple/test-process-argv-0.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+var util = require('util');
+var path = require('path');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var common = require('../common');
+
+if (process.argv[2] !== "child") {
+  var child = spawn('node', [__filename, "child"], {
+    cwd: common.tmpDir,
+    env: util._extend({ PATH: path.dirname(process.execPath) }, process.env)
+  });
+
+  var childArgv0 = '';
+  child.stdout.on('data', function (chunk) {
+    childArgv0 += chunk;
+  });
+  child.on('exit', function () {
+    assert.equal(childArgv0, process.execPath);
+  });
+}
+else {
+  process.stdout.write(process.argv[0]);
+}


### PR DESCRIPTION
joyent/node@b0c1541 introduced a
regression causing `process.argv[0]` to be invalid in node processes
spawned from `PATH` (without explicit path to executable file - for
example when using global node installation).

Instead of finding a correct path to the executable, `process.cwd()`
would be prepended to `process.argv[0]`.
