### PR TITLE
build: use else instead of node_shared_v8==false

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -150,9 +150,7 @@
             '<(node_shared_v8_includes)/v8.h',
             '<(node_shared_v8_includes)/v8-debug.h',
           ],
-        }],
-
-        [ 'node_shared_v8=="false"', {
+        }, {
           'sources': [
             'deps/v8/include/v8.h',
             'deps/v8/include/v8-debug.h',


### PR DESCRIPTION
If this looks good now I'll go ahead and fix the other shared options soon.  :-)

You can also go ahead and close issue #2187 too.  Forgot about it last time.
