### PR TITLE
[fix] `newListener` emits correct fn when using `once`

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -105,7 +105,8 @@ EventEmitter.prototype.addListener = function(type, listener) {
 
   // To avoid recursion in the case that type == "newListeners"! Before
   // adding it to the listeners, first emit "newListeners".
-  this.emit('newListener', type, listener);
+  this.emit('newListener', type, typeof listener.listener === 'function' ?
+              listener.listener : listener);
 
   if (!this._events[type]) {
     // Optimize the case of one listener. Don't need the extra array object.

--- a/lib/events.js
+++ b/lib/events.js
@@ -106,7 +106,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
   // To avoid recursion in the case that type == "newListeners"! Before
   // adding it to the listeners, first emit "newListeners".
   this.emit('newListener', type, typeof listener.listener === 'function' ?
-              listener.listener : listener);
+            listener.listener : listener);
 
   if (!this._events[type]) {
     // Optimize the case of one listener. Don't need the extra array object.

--- a/test/simple/test-event-emitter-add-listeners.js
+++ b/test/simple/test-event-emitter-add-listeners.js
@@ -26,6 +26,7 @@ var events = require('events');
 var e = new events.EventEmitter();
 
 var events_new_listener_emited = [];
+var listeners_new_listener_emited = [];
 var times_hello_emited = 0;
 
 // sanity check
@@ -34,14 +35,19 @@ assert.equal(e.addListener, e.on);
 e.on('newListener', function(event, listener) {
   console.log('newListener: ' + event);
   events_new_listener_emited.push(event);
+  listeners_new_listener_emited.push(listener);
 });
 
-e.on('hello', function(a, b) {
+function hello(a, b) {
   console.log('hello');
   times_hello_emited += 1;
   assert.equal('a', a);
   assert.equal('b', b);
-});
+}
+e.on('hello', hello);
+
+var foo = function() {};
+e.once('foo', foo);
 
 console.log('start');
 
@@ -54,7 +60,8 @@ f.setMaxListeners(0);
 
 
 process.on('exit', function() {
-  assert.deepEqual(['hello'], events_new_listener_emited);
+  assert.deepEqual(['hello', 'foo'], events_new_listener_emited);
+  assert.deepEqual([hello, foo], listeners_new_listener_emited);
   assert.equal(1, times_hello_emited);
 });
 


### PR DESCRIPTION
The event emitter `once` function wraps the listener around a self removing function. In that case the wrapping function gets emitted in `newListener` event instead of the original listener.

This pull request fixes that.
