### PR TITLE
Fix hello world addon on Windows

### DIFF
--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -3,10 +3,6 @@
 
 using namespace v8;
 
-extern "C" {
-  void init(Handle<Object> target);
-}
-
 Handle<Value> Method(const Arguments& args) {
   HandleScope scope;
   return scope.Close(String::New("world"));
@@ -15,3 +11,5 @@ Handle<Value> Method(const Arguments& args) {
 void init(Handle<Object> target) {
   NODE_SET_METHOD(target, "hello", Method);
 }
+
+NODE_MODULE(binding, init);

--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -1,9 +1,4 @@
 var assert = require('assert');
-var binding;
-if (process.platform == 'win32') {
-  binding = require('./Release/binding');
-} else {
-  binding = require('./out/Release/binding');
-}
+var binding = require('./out/Release/binding');
 assert.equal('world', binding.hello());
 console.log('binding.hello() =', binding.hello());

--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var binding;
-if (process.platform == 'win32')
+if (process.platform == 'win32') {
   binding = require('./Release/binding');
 } else {
   binding = require('./out/Release/binding');

--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -1,4 +1,9 @@
 var assert = require('assert');
-var binding = require('./out/Release/binding');
+var binding;
+if (process.platform == 'win32')
+  binding = require('./Release/binding');
+} else {
+  binding = require('./out/Release/binding');
+}
 assert.equal('world', binding.hello());
 console.log('binding.hello() =', binding.hello());


### PR DESCRIPTION
The "hello world" addon example was strangely throwing an "unknown error" on Windows when the `.node` file was require'd.

Additionally, the default build directory of the addon is different on Windows, so I added a conditional to test.js for that.
