### PR TITLE
Solaris build fixes

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -139,6 +139,10 @@
             'cflags': [ '-ansi' ],
             'ldflags': [ '-rdynamic' ],
           }],
+          [ 'OS=="solaris"', {
+            'cflags!': [ '-pthread' ],
+            'ldflags!': [ '-pthread' ],
+          }],
         ],
       }],
       ['OS=="mac"', {

--- a/common.gypi
+++ b/common.gypi
@@ -140,6 +140,8 @@
             'ldflags': [ '-rdynamic' ],
           }],
           [ 'OS=="solaris"', {
+            'cflags': [ '-pthreads' ],
+            'ldflags': [ '-pthreads' ],
             'cflags!': [ '-pthread' ],
             'ldflags!': [ '-pthread' ],
           }],

--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -16,9 +16,6 @@
       [ 'OS=="win"', {
         'libraries': [ '-l<(node_root_dir)/$(Configuration)/node.lib' ],
       }],
-      [ 'OS=="solaris"', {
-        'ldflags': [ '-shared', '-mimpure-text' ],
-      }],
       [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux" and target_arch!="ia32")', {
         'cflags': [ '-fPIC' ],
       }]

--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -16,6 +16,9 @@
       [ 'OS=="win"', {
         'libraries': [ '-l<(node_root_dir)/$(Configuration)/node.lib' ],
       }],
+      [ 'OS=="solaris"', {
+        'ldflags': [ '-shared', '-mimpure-text' ],
+      }],
       [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux" and target_arch!="ia32")', {
         'cflags': [ '-fPIC' ],
       }]


### PR DESCRIPTION
First commit is to not use `-pthread` on Solaris since it gives an error:

```
cc: unrecognized option `-pthread'
```

Second commit fixes building addons with `gyp_addon`. I was initially getting like this one:

```
ld: fatal: relocations remain against allocatable but non-writable sections
```

So I applied the [suggested fix from this `curl` mailing list entry](http://curl.haxx.se/mail/lib-2002-01/0092.html) and it worked well.

P.S. Testing using the 32-bit Solaris from the Joyent no.de SmartMachine hosting.
