### PR TITLE
Remove dummy `setsid` argument from child_processes

### DIFF
--- a/doc/api/child_processes.markdown
+++ b/doc/api/child_processes.markdown
@@ -66,13 +66,10 @@ The third argument is used to specify additional options, which defaults to:
 
     { cwd: undefined,
       env: process.env,
-      setsid: false
     }
 
 `cwd` allows you to specify the working directory from which the process is spawned.
 Use `env` to specify environment variables that will be visible to the new process.
-
-`setsid`, if set true, will cause the subprocess to be run in a new session.
 
 Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit code:
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -248,7 +248,6 @@ exports.execFile = function(file /* args, options, callback */) {
     timeout: 0,
     maxBuffer: 200 * 1024,
     killSignal: 'SIGTERM',
-    setsid: false,
     cwd: null,
     env: null
   };


### PR DESCRIPTION
When @AvianFlu was digging into the libuv code to add the detach stuff, we noticed that the `setsid` argument didn't actually _do_ anything anymore. My understanding is that it's vestigial from v0.4.x.

Anyway, these commits remove what little bit of `setsid` that was left in `child_processes.js` and the docs.
