### PR TITLE
child_process: Expose 'detached' option to allow spawning detached child processes

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -364,6 +364,7 @@ var spawn = exports.spawn = function(file, args, options) {
     file: file,
     args: args,
     cwd: options ? options.cwd : null,
+    detached: options ? options.detached : false,
     windowsVerbatimArguments: !!(options && options.windowsVerbatimArguments),
     envPairs: envPairs,
     customFds: options ? options.customFds : null,
@@ -379,6 +380,8 @@ function maybeExit(subprocess) {
 
   if (subprocess._closesGot == subprocess._closesNeeded) {
     subprocess.emit('exit', subprocess.exitCode, subprocess.signalCode);
+  } else if (subprocess.detached) {
+    subprocess.emit('detached', subprocess.pid);
   }
 }
 
@@ -440,6 +443,8 @@ function setStreamOption(name, index, options) {
 
 ChildProcess.prototype.spawn = function(options) {
   var self = this;
+
+  if (options.detached) this.detached = true;
 
   setStreamOption('stdinStream', 0, options);
   setStreamOption('stdoutStream', 1, options);

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -169,6 +169,8 @@ class ProcessWrap : public HandleWrap {
       options.stderr_stream = stderr_wrap->UVHandle();
     }
 
+    options.detached = js_options->Get(String::NewSymbol("detached"))->IsTrue();
+
     // options.windows_verbatim_arguments
 #if defined(_WIN32)
     options.windows_verbatim_arguments = js_options->

--- a/test/fixtures/detached.js
+++ b/test/fixtures/detached.js
@@ -1,0 +1,24 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var interval = setInterval(function () {
+  console.log('ping.');
+}, 500);

--- a/test/simple/test-child-process-detached.js
+++ b/test/simple/test-child-process-detached.js
@@ -1,0 +1,40 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var spawn = require('child_process').spawn;
+
+var detachedPid = 'I am definitely not a number.';
+
+var child = spawn(process.argv[0], ['test/fixtures/detached.js'], {
+  detached: true
+});
+
+child.on('detached', function (pid) {
+  detachedPid = pid;
+});
+
+process.on('exit', function () {
+  assert.ok(!isNaN(parseInt(detachedPid, 10)));
+  process.kill(detachedPid, 'SIGTERM');
+});


### PR DESCRIPTION
This functionality now [exists in libuv master](https://github.com/joyent/libuv/compare/f6c8e78d...ea9baef) - `uv_spawn()` is now able to spawn detached (i.e. daemonized) child processes on both unix and Windows.

This patch exposes that option to Node.JS userland as a `detached` option to `child_process.spawn`.  

``` js

var spawn = require('child_process').spawn;

var child = spawn('server.js', ['-p', '80'], {
  detached: true
});

child.on('detached', function (pid) {
  console.log('Child is now detached.  pid: %d.', pid);
});
```

Despite the fact that the `stdio` streams created in js are closed in `libuv`, the child closing its streams and exiting isn't enough to tell `child_process.js` that the child has exited.  

`this._internal.onexit` is called successfully, but the `maybeExit` function is explicitly waiting for `close` events from the number of streams that were opened in js.  Despite the fact that the underlying streams have been closed, the `close` events on the `stdio` streams in node don't fire of their own accord.

This keeps the parent process alive indefinitely, as the criteria specified for emitting the `exit` event will never occur.

Since a detached process is semantically somewhat different than a normal child process that exits, a separate `detached` event seemed like a good way to solve this.  If the process being spawned is detached, the parent now emits a `detached` event without waiting for the other `close` events.

It might be better to somehow close or destroy the `stdout` and `stderr` streams, but the event loop doesn't seem to care, and node exits just fine.
