### PR TITLE
Make addon-related files generate in the "out" dir

### DIFF
--- a/tools/gyp_addon
+++ b/tools/gyp_addon
@@ -22,6 +22,12 @@ if __name__ == '__main__':
   args.extend(['-Dnode_root_dir=%s' % node_root])
   args.extend(['--depth=.']);
 
+  # Tell gyp to write the Makefiles into output_dir
+  args.extend(['--generator-output', 'out'])
+
+  # Tell make to write its output into the same dir
+  args.extend(['-Goutput_dir=.'])
+
   gyp_args = list(args)
   rc = gyp.main(gyp_args)
   if rc != 0:

--- a/tools/gyp_addon
+++ b/tools/gyp_addon
@@ -3,7 +3,11 @@ import os
 import sys
 
 script_dir = os.path.dirname(__file__)
-node_root  = os.path.normpath(os.path.join(script_dir, os.pardir))
+node_root  = os.path.abspath(os.path.join(script_dir, os.pardir))
+if sys.platform == 'win32':
+  output_dir = os.path.join(os.getcwd(), 'out')
+else:
+  output_dir = 'out'
 
 sys.path.insert(0, os.path.join(node_root, 'tools', 'gyp', 'pylib'))
 import gyp
@@ -22,8 +26,8 @@ if __name__ == '__main__':
   args.extend(['-Dnode_root_dir=%s' % node_root])
   args.extend(['--depth=.']);
 
-  # Tell gyp to write the Makefiles into output_dir
-  args.extend(['--generator-output', 'out'])
+  # Tell gyp to write the Makefile/Solution files into output_dir
+  args.extend(['--generator-output', output_dir])
 
   # Tell make to write its output into the same dir
   args.extend(['-Goutput_dir=.'])


### PR DESCRIPTION
This fixes two "problems" with the addon build system:
1. Files generated from `gyp_addon` were polluting the cwd (usually the root) of the native module, leading to [`.gitignore` files with a lot of unnecessary entries](https://github.com/TooTallNate/node-time/commit/62bbfe6d08ce6dbcb113a89649a5e8610444e919). Now all these files get generated in the `out` dir, just like how node does it in the `configure` script, and only `out` needs to be ignored.
2. On Windows, builds into `./out/Release` instead of `./Release` and `./out/Debug` instead of `./Debug`. This  makes the resulting build location of the addon .node file consistent across platforms, and renders [this commit](https://github.com/TooTallNate/node/commit/63e9ad29b9dbf822f60b10eedc03fcce8880f637) from #2828 as unnecessary. Node itself suffers from the same problem, and it can probably be fixed in a similar way, but I wanted to take care of the addons first.

Cheers!
