### PR TITLE
build: support shared zlib

### DIFF
--- a/configure
+++ b/configure
@@ -98,6 +98,26 @@ parser.add_option("--shared-cares-libpath",
     dest="shared_cares_libpath",
     help="A directory to search for the shared C-Ares DLL")
 
+parser.add_option("--shared-zlib",
+    action="store_true",
+    dest="shared_zlib",
+    help="Link to a shared zlib DLL instead of static linking")
+
+parser.add_option("--shared-zlib-includes",
+    action="store",
+    dest="shared_zlib_includes",
+    help="Directory containing zlib header files")
+
+parser.add_option("--shared-zlib-libpath",
+    action="store",
+    dest="shared_zlib_libpath",
+    help="A directory to search for the shared zlib DLL")
+
+parser.add_option("--shared-zlib-libname",
+    action="store",
+    dest="shared_zlib_libname",
+    help="Alternative lib name to link to (default: 'z')")
+
 parser.add_option("--with-dtrace",
     action="store_true",
     dest="with_dtrace",
@@ -197,7 +217,17 @@ def configure_node(o):
 
 
 def configure_libz(o):
-  o['libraries'] += ['-lz']
+  o['variables']['node_shared_zlib'] = b(options.shared_zlib)
+
+  # assume shared_zlib if one of these is set?
+  if options.shared_zlib_libpath:
+    o['libraries'] += ['-L%s' % options.shared_zlib_libpath]
+  if options.shared_zlib_libname:
+    o['libraries'] += ['-l%s' % options.shared_zlib_libname]
+  elif options.shared_zlib:
+    o['libraries'] += ['-lz']
+  if options.shared_zlib_includes:
+    o['include_dirs'] += [options.shared_zlib_includes]
 
 
 def configure_v8(o):

--- a/node.gyp
+++ b/node.gyp
@@ -6,6 +6,7 @@
     'werror': '',
     'node_use_dtrace': 'false',
     'node_shared_v8%': 'false',
+    'node_shared_zlib%': 'false',
     'node_use_openssl%': 'true',
     'node_use_system_openssl%': 'false',
     'library_files': [
@@ -56,7 +57,6 @@
       'dependencies': [
         'deps/http_parser/http_parser.gyp:http_parser',
         'deps/uv/uv.gyp:uv',
-        'deps/zlib/zlib.gyp:zlib',
         'node_js2c#host',
       ],
 
@@ -156,6 +156,10 @@
             'deps/v8/include/v8-debug.h',
           ],
           'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:v8' ],
+        }],
+
+        [ 'node_shared_zlib=="false"', {
+          'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
         }],
 
         [ 'OS=="win"', {


### PR DESCRIPTION
Fixes #2115

I went ahead and made sure this supports all the switches the other shared libraries do, though I can't imagine a platform where one can't rely on the sanctity of `-lz`.  Let me know if that's unnecessary.
