### PR TITLE
net.js: emit errors when pipe is unavailable, instead of throw

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -480,7 +480,7 @@ Socket.prototype.write = function(data, arg1, arg2) {
 Socket.prototype._write = function(data, encoding, cb) {
   timers.active(this);
 
-  if (!this._handle) throw new Error('This socket is closed.');
+  if (!this._handle) return this.emit('error', new Error('This socket is closed.'));
 
   // `encoding` is unused right now, `data` is always a buffer.
   var writeReq = this._handle.write(data);
@@ -886,10 +886,7 @@ function onconnection(clientHandle) {
 
 
 Server.prototype.close = function(cb) {
-  if (!this._handle) {
-    // Throw error. Follows net_legacy behaviour.
-    throw new Error('Not running');
-  }
+  if (!this._handle) return this.emit('error', new Error('This server is not running.'));
 
   if (cb) {
     this.once('close', cb);


### PR DESCRIPTION
There are two locations in net.js that throw an error when a pipe is unavailable for interaction.  This is a legitimate error condition, but throwing instead of emitting an error seems inconsistent in this situation.

Throughout the remainder of the file, errors are only thrown due to obvious programmer errors (e.g., TypeErrors, deprecated APIs, etc.).  In the case of an unavailable `_handle`, however, the situation may have been caused by network/connectivity issues, rather than programmer error.  Developers can mitigate this situation by extremely defensively and frequently checking the `writable` flag (assuming `writable == !!_handle` in all cases), but given the high traffic nature of this code it is a difficult situation to guard against.  Other error conditions caused by network conditions (e.g., failed dns lookups) emit an error as well, and I believe this is generally the expected behavior.

This pull request simply addresses these two locations where the errors are being thrown, by replacing the throws with emitted errors.
