### PR TITLE
Feature Request: Overload http.request to accept a string that is parsed by url.parse

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -425,8 +425,9 @@ followed by `response.end()`.
 ## http.request(options, callback)
 
 Node maintains several connections per server to make HTTP requests.
-This function allows one to transparently issue requests.  `options` align
-with [url.parse()](url.html#url.parse).
+This function allows one to transparently issue requests.  
+
+`options` can be an object or a string. If `options` is a string, it is automatically parsed with [url.parse()](url.html#url.parse).
 
 Options:
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -512,13 +512,7 @@ that it sets the method to GET and calls `req.end()` automatically.
 
 Example:
 
-    var options = {
-      host: 'www.google.com',
-      port: 80,
-      path: '/index.html'
-    };
-
-    http.get(options, function(res) {
+    http.get("http://www.google.com/index.html", function(res) {
       console.log("Got response: " + res.statusCode);
     }).on('error', function(e) {
       console.log("Got error: " + e.message);

--- a/lib/http.js
+++ b/lib/http.js
@@ -1424,6 +1424,10 @@ ClientRequest.prototype.pause = function() {
 
 
 exports.request = function(options, cb) {
+  if (typeof options == 'string') {
+    var url = require('url');
+    options = url.parse(options);
+  } 
   if (options.protocol && options.protocol !== 'http:') {
     throw new Error('Protocol:' + options.protocol + ' not supported.');
   }

--- a/lib/http.js
+++ b/lib/http.js
@@ -22,6 +22,7 @@
 var util = require('util');
 var net = require('net');
 var stream = require('stream');
+var url = require('url');
 var EventEmitter = require('events').EventEmitter;
 var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;
@@ -1425,7 +1426,6 @@ ClientRequest.prototype.pause = function() {
 
 exports.request = function(options, cb) {
   if (typeof options == 'string') {
-    var url = require('url');
     options = url.parse(options);
   } 
   if (options.protocol && options.protocol !== 'http:') {

--- a/test/simple/test-http-client-get-url.js
+++ b/test/simple/test-http-client-get-url.js
@@ -1,0 +1,57 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var sent_body = '';
+var server_req_complete = false;
+var client_res_complete = false;
+
+var server = http.createServer(function(req, res) {
+  assert.equal('GET', req.method);
+  assert.equal('/foo?bar', req.url);
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.write('hello\n');
+  res.end();
+});
+server.listen(common.PORT);
+
+server.on('listening', function() {
+  var req = http.get("http://127.0.0.1/foo?bar", function(res) {
+    res.setEncoding('utf8');
+    res.on('data', function(chunk) {
+      console.log(chunk);
+    });
+    res.on('end', function() {
+      server.close();
+    });
+  });
+
+  common.error('client finished sending request');
+});
+
+process.on('exit', function() {
+  assert.equal('1\n2\n3\n', sent_body);
+  assert.equal(true, server_req_complete);
+  assert.equal(true, client_res_complete);
+});


### PR DESCRIPTION
Mostly just for convenience. Example invocation would be:

```
http.get("http://www.example.com/", function(stream){ ... });
```
