### PR TITLE
Readline.js: multiline support

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -228,13 +228,11 @@ Interface.prototype._refreshLine = function() {
   }
 
   // Move cursor to original position.
-  var cursor = this._promptLength + this.cursor;
-
-  var cursorLine = Math.floor(cursor / columns);
-  if (cursorLine+1 === this.usedLines) {
-    this.output.cursorTo(cursor % columns);
+  var cursorPos = this._getCursorPos();
+  if (this.usedLines === 1) {
+    this.output.cursorTo(cursorPos[0]);
   } else {
-    this.output.cursorTo(cursor % columns, this.rows - this.usedLines + cursorLine);
+    this.output.cursorTo(cursorPos[0], this.rows - this.usedLines + cursorPos[1]);
   }
 };
 
@@ -493,16 +491,25 @@ Interface.prototype._historyPrev = function() {
 };
 
 
-Interface.prototype._moveCursor = function(dx) {
+// Returns current cursor's position and line
+Interface.prototype._getCursorPos = function() {
   var columns = this.columns;
-  if (!columns) columns = Infinity;
+  var pos = this.cursor + this._promptLength;
+  if (!columns) return [pos, 0];
 
+  var lineNum = Math.floor(pos / columns);
+  var colNum = pos-lineNum*columns;
+  return [colNum, lineNum];
+};
+
+
+Interface.prototype._moveCursor = function(dx) {
   var oldcursor = this.cursor;
+  var oldLine = this._getCursorPos()[1];
   this.cursor += dx;
+  var newLine = this._getCursorPos()[1];
 
   // check if cursors are in the same line
-  var oldLine = (this.cursor + this._promptLength) % columns;
-  var newLine = (oldcursor + this._promptLength) % columns;
   if (oldLine == newLine) {
     this.output.moveCursor(dx, 0);
   } else {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -188,7 +188,7 @@ Interface.prototype._addHistory = function() {
 
 
 Interface.prototype._recalcUsedLines = function() {
-  var line = this._prompt+this.line;
+  var line = this._prompt + this.line;
   var newcount = Math.ceil(line.length / this.columns);
   if (newcount > this.usedLines) this.usedLines = newcount;
 };
@@ -203,7 +203,7 @@ Interface.prototype._refreshLine = function() {
   this._recalcUsedLines();
   if (oldLines != this.usedLines) {
     this.output.cursorTo(0, this.rows - 1);
-    for (var i=oldLines; i<this.usedLines; i++) {
+    for (var i = oldLines; i < this.usedLines; i++) {
       this.output.write('\r\n');
     }
   }
@@ -214,25 +214,25 @@ Interface.prototype._refreshLine = function() {
   } else {
     this.output.cursorTo(0, this.rows - this.usedLines);
   }
-  
+
   // Write the prompt and the current buffer content.
   var buffer = this._prompt + this.line;
   this.output.write(buffer);
 
   // Erase to right.
   this.output.clearLine(1);
-  var clearLinesCount = this.usedLines - Math.floor(buffer.length/columns) - 1;
-  for (var i = this.rows-clearLinesCount; i<this.rows; i++) {
+  var clearLinesCnt = this.usedLines - Math.floor(buffer.length / columns) - 1;
+  for (var i = this.rows - clearLinesCnt; i < this.rows; i++) {
     this.output.cursorTo(0, i);
     this.output.clearLine(0);
   }
 
   // Move cursor to original position.
-  var cursorPos = this._getCursorPos();
+  var curPos = this._getCursorPos();
   if (this.usedLines === 1) {
-    this.output.cursorTo(cursorPos[0]);
+    this.output.cursorTo(curPos[0]);
   } else {
-    this.output.cursorTo(cursorPos[0], this.rows - this.usedLines + cursorPos[1]);
+    this.output.cursorTo(curPos[0], this.rows - this.usedLines + curPos[1]);
   }
 };
 
@@ -498,7 +498,7 @@ Interface.prototype._getCursorPos = function() {
   if (!columns) return [pos, 0];
 
   var lineNum = Math.floor(pos / columns);
-  var colNum = pos-lineNum*columns;
+  var colNum = pos - lineNum * columns;
   return [colNum, lineNum];
 };
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -95,13 +95,18 @@ function Interface(input, output, completer) {
     this.history = [];
     this.historyIndex = -1;
 
+    // a number of lines used by current command
+    this.usedLines = 1;
+
     var winSize = output.getWindowSize();
     exports.columns = winSize[0];
+    exports.rows = winSize[1];
 
     if (process.listeners('SIGWINCH').length === 0) {
       process.on('SIGWINCH', function() {
         var winSize = output.getWindowSize();
         exports.columns = winSize[0];
+        exports.rows = winSize[1];
       });
     }
   }
@@ -111,6 +116,10 @@ inherits(Interface, EventEmitter);
 
 Interface.prototype.__defineGetter__('columns', function() {
   return exports.columns;
+});
+
+Interface.prototype.__defineGetter__('rows', function() {
+  return exports.rows;
 });
 
 Interface.prototype.setPrompt = function(prompt, length) {
@@ -178,19 +187,55 @@ Interface.prototype._addHistory = function() {
 };
 
 
-Interface.prototype._refreshLine = function() {
-  // Cursor to left edge.
-  this.output.cursorTo(0);
+Interface.prototype._recalcUsedLines = function() {
+  var line = this._prompt+this.line;
+  var newcount = Math.ceil(line.length / this.columns);
+  if (newcount > this.usedLines) this.usedLines = newcount;
+};
 
+
+Interface.prototype._refreshLine = function() {
+  var columns = this.columns;
+  if (!columns) columns = Infinity;
+
+  // See if a number of used lines has changed
+  var oldLines = this.usedLines;
+  this._recalcUsedLines();
+  if (oldLines != this.usedLines) {
+    this.output.cursorTo(0, this.rows - 1);
+    for (var i=oldLines; i<this.usedLines; i++) {
+      this.output.write('\r\n');
+    }
+  }
+
+  // Cursor to left edge.
+  if (this.usedLines === 1) {
+    this.output.cursorTo(0);
+  } else {
+    this.output.cursorTo(0, this.rows - this.usedLines);
+  }
+  
   // Write the prompt and the current buffer content.
-  this.output.write(this._prompt);
-  this.output.write(this.line);
+  var buffer = this._prompt + this.line;
+  this.output.write(buffer);
 
   // Erase to right.
   this.output.clearLine(1);
+  var clearLinesCount = this.usedLines - Math.floor(buffer.length/columns) - 1;
+  for (var i = this.rows-clearLinesCount; i<this.rows; i++) {
+    this.output.cursorTo(0, i);
+    this.output.clearLine(0);
+  }
 
   // Move cursor to original position.
-  this.output.cursorTo(this._promptLength + this.cursor);
+  var cursor = this._promptLength + this.cursor;
+
+  var cursorLine = Math.floor(cursor / columns);
+  if (cursorLine+1 === this.usedLines) {
+    this.output.cursorTo(cursor % columns);
+  } else {
+    this.output.cursorTo(cursor % columns, this.rows - this.usedLines + cursorLine);
+  }
 };
 
 
@@ -242,6 +287,7 @@ Interface.prototype._insertString = function(c) {
     this.line += c;
     this.cursor += c.length;
     this.output.write(c);
+    this._recalcUsedLines();
   }
 };
 
@@ -415,6 +461,7 @@ Interface.prototype._deleteLineRight = function() {
 Interface.prototype._line = function() {
   var line = this._addHistory();
   this.output.write('\r\n');
+  this.usedLines = 1;
   this._onLine(line);
 };
 
@@ -441,6 +488,24 @@ Interface.prototype._historyPrev = function() {
     this.line = this.history[this.historyIndex];
     this.cursor = this.line.length; // set cursor to end of line.
 
+    this._refreshLine();
+  }
+};
+
+
+Interface.prototype._moveCursor = function(dx) {
+  var columns = this.columns;
+  if (!columns) columns = Infinity;
+
+  var oldcursor = this.cursor;
+  this.cursor += dx;
+
+  // check if cursors are in the same line
+  var oldLine = (this.cursor + this._promptLength) % columns;
+  var newLine = (oldcursor + this._promptLength) % columns;
+  if (oldLine == newLine) {
+    this.output.moveCursor(dx, 0);
+  } else {
     this._refreshLine();
   }
 };
@@ -616,15 +681,13 @@ Interface.prototype._ttyWrite = function(s, key) {
 
       case 'left':
         if (this.cursor > 0) {
-          this.cursor--;
-          this.output.moveCursor(-1, 0);
+          this._moveCursor(-1);
         }
         break;
 
       case 'right':
         if (this.cursor != this.line.length) {
-          this.cursor++;
-          this.output.moveCursor(1, 0);
+          this._moveCursor(1);
         }
         break;
 


### PR DESCRIPTION
Currently readline.js behaves like user's input is always one line. It will cause problems if user's input is very long line that's splitted into multiple lines in the terminal. 

If you're writing a long line in REPL and then try to edit it, insert something, etc., you will notice some strange behaviour like that: http://screens.jggt.co.cc/4f97f046.png .

This patch uses information about terminal's size to fix this issue.
