### PR TITLE
Implement process.execArgv & Command line arguments for Cluster.

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -165,7 +165,7 @@ function nop() { }
 exports.fork = function(modulePath /*, args, options*/) {
 
   // Get options and args arguments.
-  var options, args;
+  var options, args, execArgv;
   if (Array.isArray(arguments[1])) {
     args = arguments[1];
     options = arguments[2] || {};
@@ -174,9 +174,9 @@ exports.fork = function(modulePath /*, args, options*/) {
     options = arguments[1] || {};
   }
 
-  // Copy args and add modulePath
-  args = args.slice(0);
-  args.unshift(modulePath);
+  // Prepare arguments for fork:
+  execArgv = options.execArgv || process.execArgv;
+  args = execArgv.concat([modulePath], args);
 
   // Don't allow stdinStream and customFds since a stdin channel will be used
   if (options.stdinStream) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -91,6 +91,7 @@ cluster.setupMaster = function(options) {
   // Set settings object
   settings = cluster.settings = {
     exec: options.exec || process.argv[1],
+    execArgv: options.execArgv || process.execArgv,
     args: options.args || process.argv.slice(2),
     silent: options.silent || false
   };
@@ -274,7 +275,8 @@ function Worker(customEnv) {
     // fork worker
     this.process = fork(settings.exec, settings.args, {
       'env': envCopy,
-      'silent': settings.silent
+      'silent': settings.silent,
+      'execArgv': settings.execArgv
     });
   } else {
     this.process = process;

--- a/src/node.cc
+++ b/src/node.cc
@@ -2068,6 +2068,15 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   // assign it
   process->Set(String::NewSymbol("argv"), arguments);
 
+  // process.execArgv
+  Local<Array> execArgv = Array::New(option_end_index - 1);
+  for (j = 1, i = 0; j < option_end_index; j++, i++) {
+    execArgv->Set(Integer::New(i), String::New(argv[j]));
+  }
+  // assign it
+  process->Set(String::NewSymbol("execArgv"), execArgv);
+
+
   // create process.env
   Local<ObjectTemplate> envTemplate = ObjectTemplate::New();
   envTemplate->SetNamedPropertyHandler(EnvGetter,
@@ -2655,8 +2664,24 @@ void EmitExit(v8::Handle<v8::Object> process_l) {
 
 
 int Start(int argc, char *argv[]) {
+  // Logic to duplicate argv as Init() modifies arguments
+  // that are passed into it.
+  char **argv_copy = new char*[argc];
+
+  for (int i = 0; i < argc; i++) {
+    // Rare edge case that argv[0] is inaccessible.
+    if (argv[i] == NULL) {
+      argv_copy[i] = NULL;
+    } else {
+      argv_copy[i] = (char *) malloc ( strlen(argv[i]) );
+      strcpy (argv_copy[i], argv[i]);
+    }
+  }
+
+
   // This needs to run *before* V8::Initialize()
-  argv = Init(argc, argv);
+  // Use copy here as to not modify the original argv:
+  Init(argc, argv_copy);
 
   V8::Initialize();
   Persistent<Context> context;
@@ -2668,6 +2693,7 @@ int Start(int argc, char *argv[]) {
     Persistent<Context> context = Context::New();
     Context::Scope context_scope(context);
 
+    // Use original argv, as we're just copying values out of it.
     Handle<Object> process_l = SetupProcessObject(argc, argv);
     v8_typed_array::AttachBindings(context->Global());
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2702,9 +2702,6 @@ int Start(int argc, char *argv[]) {
   // Use copy here as to not modify the original argv:
   Init(argc, argv_copy);
 
-  // Clean up the copy:
-  free(argv_copy);
-
   V8::Initialize();
   Persistent<Context> context;
   {
@@ -2740,6 +2737,9 @@ int Start(int argc, char *argv[]) {
   // Clean up.
   V8::Dispose();
 #endif  // NDEBUG
+
+  // Clean up the copy:
+  free(argv_copy);
 
   return 0;
 }

--- a/test/simple/test-child-process-fork-exec-argv.js
+++ b/test/simple/test-child-process-fork-exec-argv.js
@@ -1,0 +1,46 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var child_process = require('child_process');
+var spawn = child_process.spawn;
+var fork = child_process.fork;
+
+if (process.argv[2] === 'fork') {
+  process.stdout.write(JSON.stringify(process.execArgv));
+  process.exit();
+} else if (process.argv[2] === 'child') {
+  fork(__filename, ['fork']);
+} else {
+  var execArgv = ['--harmony_proxies', '--max-stack-size=0'];
+  var args = [__filename, 'child', 'arg0'];
+
+  var child = spawn(process.execPath, execArgv.concat(args));
+  var out = '';
+
+  child.stdout.on('data', function (chunk) {
+    out += chunk;
+  });
+
+  child.on('exit', function () {
+    assert.deepEqual(JSON.parse(out), execArgv);
+  });
+}

--- a/test/simple/test-process-exec-argv.js
+++ b/test/simple/test-process-exec-argv.js
@@ -1,0 +1,40 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+if (process.argv[2] === 'child') {
+  process.stdout.write(JSON.stringify(process.execArgv));
+} else {
+  var execArgv = ['--harmony_proxies', '--max-stack-size=0'];
+  var args = [__filename, 'child', 'arg0'];
+  var child = spawn(process.execPath, execArgv.concat(args));
+  var out = '';
+
+  child.stdout.on('data', function (chunk) {
+    out += chunk;
+  });
+
+  child.on('exit', function () {
+    assert.deepEqual(JSON.parse(out), execArgv);
+  });
+}


### PR DESCRIPTION
This pull request enables the use of the new cluster api with command line arguments such as v8 flags (e.g., `--harmony_proxies`) or node flags (e.g., `--max-stack-size`).

The bulk of this change is to how node handles argv on startup, at present, we're mutating the original argv array, such that we cannot retrieve the original arguments that were passed into the program. This pull request fixes this issue by running the mutations on a copy of the argv array.

We can't easily change node to not mutate a `argv` style array, as the mutated argv array is then used to set the v8 options (using V8::SetFlagsFromCommandLine). There is potentially a future change that would make this pull request redundant, which is the rewrite of node's argument handling, however, this is a massive amount of work, and out of scope of what we needed to do, which was to use the cluster api with harmony proxies.

---

This pull request can't be merged until EqualMedia LTD sign the CLA, which should be done sometime tomorrow. This is because the work done by me (micheil smith) was done on the company time of EqualMedia LTD, and hence sponsored by them. I will comment on the pull request once we have signed the CLA.
