### PR TITLE
Fix gyp_addon from across filesystems on Windows.

### DIFF
--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -4,9 +4,9 @@
     'product_extension': 'node',
     'product_prefix': '',
     'include_dirs': [
-      '../src',
-      '../deps/uv/include',
-      '../deps/v8/include'
+      '<(node_root_dir)/src',
+      '<(node_root_dir)/deps/uv/include',
+      '<(node_root_dir)/deps/v8/include'
     ],
 
     'conditions': [


### PR DESCRIPTION
This essentially works around a gyp bug where it's not relativizing properly
across filesystems. See TooTallNate/node-gyp#15 for the gory details.
