### PR TITLE
Add a "module_root_dir" variable for native modules to use in their gyp files

### DIFF
--- a/tools/gyp_addon
+++ b/tools/gyp_addon
@@ -4,8 +4,9 @@ import sys
 
 script_dir = os.path.dirname(__file__)
 node_root  = os.path.abspath(os.path.join(script_dir, os.pardir))
+module_root = os.getcwd()
 if sys.platform == 'win32':
-  output_dir = os.path.join(os.getcwd(), 'build')
+  output_dir = os.path.join(module_root, 'build')
 else:
   output_dir = 'build'
 
@@ -24,6 +25,7 @@ if __name__ == '__main__':
   args.extend(['-Dlibrary=shared_library'])
   args.extend(['-Dvisibility=default'])
   args.extend(['-Dnode_root_dir=%s' % node_root])
+  args.extend(['-Dmodule_root_dir=%s' % module_root])
   args.extend(['--depth=.']);
 
   # Tell gyp to write the Makefile/Solution files into output_dir


### PR DESCRIPTION
This new `module_root_dir` gives the absolute path to the root of the module directory, i.e. where your
main binding.gyp file is located.

This seems helpful for some modules where the build system is more advanced
and using absolute paths is a requirement. Most modules probably won't need to use it though.
