### PR TITLE
REPL api doc fix

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -42,7 +42,7 @@ of command if it's `undefined`. Defaults to `false`.
 
 You can use your own `eval` function if it has following signature:
 
-    function eval(cmd, callback) {
+    function eval(cmd, context, filename, callback) {
       callback(null, result);
     }
 


### PR DESCRIPTION
I fixed a line in the doc talks about custom eval's function signature.

Specific line here: https://github.com/joyent/node/blob/master/lib/repl.js#L202
