### PR TITLE
issue #2697: have 'make install' set npm shebang to use its node

### DIFF
--- a/tools/installer.js
+++ b/tools/installer.js
@@ -53,18 +53,41 @@ function remove(files) {
   });
 }
 
+// Add/update shebang (#!) line
+function shebang(line, file) {
+  var content = fs.readFileSync(file, 'utf8');
+  var firstLine = content.split(/\n/, 1)[0];
+  var newContent;
+  if (firstLine.slice(0, 2) === '#!') {
+    newContent = line + content.slice(firstLine.length);
+  } else {
+    newContent = line + '\n' + content;
+  }
+  if (content !== newContent) {
+    fs.writeFileSync(file, newContent, 'utf8');
+  }
+}
+
 // Run every command in queue, one-by-one
 function run() {
   var cmd = queue.shift();
   if (!cmd) return;
 
-  console.log(cmd);
-  exec(cmd, function(err, stdout, stderr) {
-    if (stderr) console.error(stderr);
-    if (err) process.exit(1);
-
+  if (Array.isArray(cmd) && cmd[0] instanceof Function) {
+    var func = cmd[0];
+    var args = cmd.slice(1);
+    console.log.apply(null, [func.name].concat(args));
+    func.apply(null, args);
     run();
-  });
+  } else {
+    console.log(cmd);
+    exec(cmd, function(err, stdout, stderr) {
+      if (stderr) console.error(stderr);
+      if (err) process.exit(1);
+
+      run();
+    });
+  }
 }
 
 if (cmd === 'install') {
@@ -109,6 +132,8 @@ if (cmd === 'install') {
     copy('deps/npm', 'lib/node_modules/npm');
     queue.push('ln -sf ../lib/node_modules/npm/bin/npm-cli.js ' +
                path.join(node_prefix, 'bin/npm'));
+    queue.push([shebang, '#!' + path.join(node_prefix, 'bin/node'),
+               path.join(node_prefix, 'lib/node_modules/npm/bin/npm-cli.js')]);
   }
 } else {
   remove([


### PR DESCRIPTION
As discussed on the ticket.

The end of 'make install' looks like this (where my prefix is `/Users/trentm/opt/node-master`):

```
...
cp -rf tools/node-waf /Users/trentm/opt/node-master/bin/node-waf
mkdir -p /Users/trentm/opt/node-master/lib/node_modules/
cp -rf deps/npm /Users/trentm/opt/node-master/lib/node_modules/npm
ln -sf ../lib/node_modules/npm/bin/npm-cli.js /Users/trentm/opt/node-master/bin/npm
shebang #!/Users/trentm/opt/node-master/bin/node /Users/trentm/opt/node-master/lib/node_modules/npm/bin/npm-cli.js
```
