### PR TITLE
remove ClientRequest.prototype.pause

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1431,12 +1431,6 @@ ClientRequest.prototype.setNoDelay = function() {
 ClientRequest.prototype.setSocketKeepAlive = function() {
   this._deferToConnect('setKeepAlive', arguments);
 };
-ClientRequest.prototype.pause = function() {
-  var self = this;
-  self._deferToConnect(null, null, function() {
-    OutgoingMessage.prototype.pause.apply(self, []);
-  });
-};
 
 
 exports.request = function(options, cb) {


### PR DESCRIPTION
ClientRequest.prototype.pause is not needed.
Because ClientRequest is a writable stream and the method is broken.
