### PR TITLE
product.wxs - updated npm path to include trailing backslash

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -35,7 +35,7 @@
                          Name="PATH" 
                          Part="last" 
                          System="yes" 
-                         Value="[AppDataFolder]npm" />
+                         Value="[AppDataFolder]npm\" />
             <Environment Id="node_env"
                          Action="set"             
                          Name="PATH" 


### PR DESCRIPTION
As other's have reported (https://github.com/joyent/node/issues/2377), I experienced the $PATH issue when using the Nodejs MSI installer.  npm is set without a trailing backslash, where nodejs is set with the trailing backslash.

Although the presence or abscence of this should not make a difference, it does appear to.  I have merely appending the trailing backslash for npm in the product.wxs.
