### PR TITLE
process: expose the zlib version in use in process.versions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -55,7 +55,7 @@ typedef int mode_t;
 #endif
 #include <errno.h>
 #include <sys/types.h>
-#include <zlib.h>
+#include "zlib.h"
 
 #ifdef __POSIX__
 # include <pwd.h> /* getpwnam() */

--- a/src/node.cc
+++ b/src/node.cc
@@ -55,6 +55,7 @@ typedef int mode_t;
 #endif
 #include <errno.h>
 #include <sys/types.h>
+#include <zlib.h>
 
 #ifdef __POSIX__
 # include <pwd.h> /* getpwnam() */
@@ -2085,6 +2086,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   versions->Set(String::NewSymbol("ares"), String::New(ARES_VERSION_STR));
   snprintf(buf, 20, "%d.%d", UV_VERSION_MAJOR, UV_VERSION_MINOR);
   versions->Set(String::NewSymbol("uv"), String::New(buf));
+  versions->Set(String::NewSymbol("zlib"), String::New(ZLIB_VERSION));
 #if HAVE_OPENSSL
   // Stupid code to slice out the version string.
   int c, l = strlen(OPENSSL_VERSION_TEXT);


### PR DESCRIPTION
I'm guessing this was just an oversight :)
