### PR TITLE
Change error handler from `throw` to `callback` - dns.js

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -144,10 +144,11 @@ exports.lookup = function(domain, family, callback) {
   var wrap = cares.getaddrinfo(domain, family);
 
   if (!wrap) {
-    throw errnoException(errno, 'getaddrinfo');
+    callback(errnoException(errno, 'getaddrinfo'));
   }
-
-  wrap.oncomplete = onanswer;
+  else {
+    wrap.oncomplete = onanswer;
+  }
 
   callback.immediately = true;
   return wrap;


### PR DESCRIPTION
Fixes #2900
