### PR TITLE
Show error message of Signal Events unsupported on Windows

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -53,6 +53,8 @@ stay running forever, `uncaughtException` can be a useful safety mechanism.
 <!--type=event-->
 <!--name=SIGINT, SIGUSR1, etc.-->
 
+**This does not work on Windows.**
+
 Emitted when the processes receives a signal. See sigaction(2) for a list of
 standard POSIX signal names such as SIGINT, SIGUSR1, etc.
 

--- a/src/node.js
+++ b/src/node.js
@@ -384,6 +384,10 @@
     process.on = process.addListener = function(type, listener) {
       var ret = addListener.apply(this, arguments);
       if (isSignal(type)) {
+        if (process.platform === 'win32') {
+          throw new Error('Signal Event: ' + type + ' is not yet supported on Windows.');
+        }
+        
         if (!signalWatchers.hasOwnProperty(type)) {
           var b = process.binding('signal_watcher');
           var w = new b.SignalWatcher(startup.lazyConstants()[type]);

--- a/test/simple/test-signal-handler.js
+++ b/test/simple/test-signal-handler.js
@@ -18,17 +18,25 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-// SIGUSR1 and SIGHUP are not supported on Windows
-if (process.platform === 'win32') {
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
 
 console.log('process.pid: ' + process.pid);
+
+// SIGINT is not yet supported on Windows.
+if (process.platform === 'win32') {
+  var errmsg = 'Signal Event: SIGINT is not yet supported on Windows.';
+  assert.throws(function() {
+    process.on('SIGINT', function() {});
+  }, function(err) {
+    if (err instanceof Error) {
+      assert.strictEqual(err.message, errmsg);
+      return true;
+    }
+  });
+  // Rest of tests are not supported on Windows.
+  process.exit(0);
+}
 
 var first = 0,
     second = 0;


### PR DESCRIPTION
As discussed #1553, signal events are not yet supported on Windows. 
The current error message of

```
process.on('SIGINT', function() {});
```

 is shown on Windows as

```
C:\Users\ohtsu\Desktop\node\node>Release\node.exe test.js

node.js:197
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: No such module
    at EventEmitter.<anonymous> (node.js:388:27)
    at Object.<anonymous> (C:\Users\ohtsu\Desktop\node\node\test.js:1:71)
    at Module._compile (module.js:443:26)
    at Object..js (module.js:461:10)
    at Module.load (module.js:350:32)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:481:10)
    at EventEmitter._tickCallback (node.js:188:41)
```

The error description of  "No such module"  is too ambiguous for users. 
This patch shows it more clearly as

```
C:\Users\ohtsu\Desktop\shigeki>Release\node.exe test.js

node.js:197
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: Signal Event: SIGINT is not yet supported on Windows.
    at EventEmitter.<anonymous> (node.js:388:17)
    at Object.<anonymous> (C:\Users\ohtsu\Desktop\shigeki\test.js:1:71)
    at Module._compile (module.js:443:26)
    at Object..js (module.js:461:10)
    at Module.load (module.js:350:32)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:481:10)
    at EventEmitter._tickCallback (node.js:188:41)
```

I also add notes on doc that signal events are not yet supported on Windows.
