### PR TITLE
doc: correct the description of assert.ok()

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -11,7 +11,7 @@ Throws an exception that displays the values for `actual` and `expected` separat
 
 ## assert(value, message), assert.ok(value, [message])
 
-Tests if value is a `true` value, it is equivalent to `assert.equal(true, value, message);`
+Tests if value is truthy, it is equivalent to `assert.equal(true, !!value, message);`
 
 ## assert.equal(actual, expected, [message])
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -116,7 +116,7 @@ assert.fail = fail;
 // 4. Pure assertion tests whether a value is truthy, as determined
 // by !!guard.
 // assert.ok(guard, message_opt);
-// This statement is equivalent to assert.equal(true, guard,
+// This statement is equivalent to assert.equal(true, !!guard,
 // message_opt);. To test strictly for the value true, use
 // assert.strictEqual(true, guard, message_opt);.
 


### PR DESCRIPTION
Current doc says:

> assert(value, message), assert.ok(value, [message])
> 
> Tests if value is a `true` value, it is equivalent to `assert.equal(true, value, message);`

Apparently, that's wrong.

```
assert.ok(2);             // pass
assert.equal(true, 2);    // fail
assert.equal(true, !!2);  // pass
```

Other truthy values that can't be converted to 1 (e.g. [], {}, "a") fail as well.
