### PR TITLE
addon: use ConfigurationName to get the build type

### DIFF
--- a/tools/addon.gypi
+++ b/tools/addon.gypi
@@ -14,7 +14,7 @@
         'libraries': [ '-undefined dynamic_lookup' ],
       }],
       [ 'OS=="win"', {
-        'libraries': [ '-l<(node_root_dir)/$(Configuration)/node.lib' ],
+        'libraries': [ '-l<(node_root_dir)/$(ConfigurationName)/node.lib' ],
       }],
       [ 'OS=="freebsd" or OS=="openbsd" or OS=="solaris" or (OS=="linux" and target_arch!="ia32")', {
         'cflags': [ '-fPIC' ],


### PR DESCRIPTION
just Configuration was causing problems on Windows machines where multiple
versions of MSVS are installed at once (2008 and 2010 at once were reported).

see TooTallNate/node-gyp#35.
