### PR TITLE
fix using legacy api in the buffer doc

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -156,7 +156,7 @@ buffer object.  It does not change when the contents of the buffer are changed.
     buf = new Buffer(1234);
 
     console.log(buf.length);
-    buf.write("some string", "ascii", 0);
+    buf.write("some string", 0, "ascii");
     console.log(buf.length);
 
     // 1234


### PR DESCRIPTION
buffer.markdown is still using a legacy API.
