### PR TITLE
Turn REPLServer into an EventEmitter and emit "exit"

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -29,8 +29,8 @@ For example, you could add this to your bashrc file:
 
 ## repl.start([prompt], [stream], [eval], [useGlobal], [ignoreUndefined])
 
-Starts a REPL with `prompt` as the prompt and `stream` for all I/O.  `prompt`
-is optional and defaults to `> `.  `stream` is optional and defaults to
+Returns and starts a REPL with `prompt` as the prompt and `stream` for all I/O.
+`prompt` is optional and defaults to `> `.  `stream` is optional and defaults to
 `process.stdin`. `eval` is optional too and defaults to async wrapper for
 `eval()`.
 
@@ -75,6 +75,20 @@ TCP sockets.
 
 By starting a REPL from a Unix socket-based server instead of stdin, you can
 connect to a long-running node process without restarting it.
+
+### Event: 'exit'
+
+`function () {}`
+
+Emitted when the user exits the REPL in any of the defined ways. Namely, typing
+`.exit` at the repl, or pressing Ctrl+C twice to signal SIGINT.
+
+Example of listening for `exit`:
+
+    r.on('exit', function () {
+      console.log('Got "exit" event from repl!');
+      process.exit();
+    });
 
 
 ## REPL Features

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -59,7 +59,7 @@ var context;
 exports.disableColors = process.env.NODE_DISABLE_COLORS ? true : false;
 
 // hack for require.resolve("./relative") to work properly.
-module.filename = process.cwd() + '/repl';
+module.filename = path.resolve('repl');
 
 // hack for repl require to work properly with node_modules folders
 module.paths = require('module')._nodeModulePaths(module.filename);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -140,19 +140,21 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
   rli.on('SIGINT', function() {
     rli.output.write('\n');
 
-    if (sawSIGINT) {
-      rli.pause();
-      self.emit('exit');
+    if (!(self.bufferedCommand && self.bufferedCommand.length > 0) &&
+        rli.line.length === 0) {
+      if (sawSIGINT) {
+        rli.pause();
+        self.emit('exit');
+        sawSIGINT = false;
+        return;
+      }
+      rli.output.write('(^C again to quit)\n');
+      sawSIGINT = true;
+    } else {
       sawSIGINT = false;
-      return;
     }
 
     rli.line = '';
-
-    if (!(self.bufferedCommand && self.bufferedCommand.length > 0)) {
-      rli.output.write('(^C again to quit)\n');
-      sawSIGINT = true;
-    }
 
     self.bufferedCommand = '';
     self.displayPrompt();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -41,10 +41,12 @@
  */
 
 var util = require('util');
+var inherits = require('util').inherits;
 var vm = require('vm');
 var path = require('path');
 var fs = require('fs');
 var rl = require('readline');
+var EventEmitter = require('events').EventEmitter;
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -74,6 +76,8 @@ var builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
 
 
 function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
+  EventEmitter.call(this);
+
   var self = this;
 
   self.useGlobal = useGlobal;
@@ -264,6 +268,7 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
   self.displayPrompt();
 }
+inherits(REPLServer, EventEmitter);
 exports.REPLServer = REPLServer;
 
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -149,8 +149,7 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
     rli.line = '';
 
-    if (!(self.bufferedCommand && self.bufferedCommand.length > 0) &&
-        rli.line.length === 0) {
+    if (!(self.bufferedCommand && self.bufferedCommand.length > 0)) {
       rli.output.write('(^C again to quit)\n');
       sawSIGINT = true;
     }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -138,6 +138,8 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
   var sawSIGINT = false;
   rli.on('SIGINT', function() {
+    rli.output.write('\n');
+
     if (sawSIGINT) {
       rli.pause();
       self.emit('exit');
@@ -149,10 +151,8 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
     if (!(self.bufferedCommand && self.bufferedCommand.length > 0) &&
         rli.line.length === 0) {
-      rli.output.write('\n(^C again to quit)\n');
+      rli.output.write('(^C again to quit)\n');
       sawSIGINT = true;
-    } else {
-      rli.output.write('\n');
     }
 
     self.bufferedCommand = '';

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -140,7 +140,9 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
   rli.on('SIGINT', function() {
     if (sawSIGINT) {
       rli.pause();
-      process.exit();
+      self.emit('exit');
+      sawSIGINT = false;
+      return;
     }
 
     rli.line = '';
@@ -766,6 +768,7 @@ function defineDefaultCommands(repl) {
     help: 'Exit the repl',
     action: function() {
       this.rli.pause();
+      this.emit('exit');
     }
   });
 

--- a/src/node.js
+++ b/src/node.js
@@ -100,6 +100,9 @@
       if (NativeModule.require('tty').isatty(0)) {
         // REPL
         var repl = Module.requireRepl().start('> ', null, null, true);
+        repl.on('exit', function() {
+          process.exit();
+        });
 
       } else {
         // Read all of stdin - execute it.


### PR DESCRIPTION
1. The first commit (ac77cc08) fixes a very minor Windows bug.
2. Second turns REPLServer into an EventEmitter
3. Third makes REPLServer emit 'exit' events instead of 1) manually killing the processes (_very bad!_) or 2) simply pausing the stream (derefs stdout, but simply pauses a net.Socket).
4. The next 3 could probably be squashed. They alter the behavior of when "SIGINT" is received on the readline socket. I think this new behavior is more expected. ae49ad43 shows the before and after.

This pull alone isn't enough to make a full featured repl work over a `net.Socket` with a clean API, but it's an unobtrusive start, and makes this hacky gist work for the time being: https://gist.github.com/2026110
