### PR TITLE
Add `process.shared`

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -256,6 +256,17 @@ Will output:
       ev: '4.4',
       openssl: '1.0.0e-fips' }
 
+## proces.shared
+
+A property exposing how node's dependencies were compiled against the
+current node executable. For example, if node was compiled with `--shared-zlib`,
+then `process.shared` will look like:
+
+    { http_parser: false,
+      v8: false,
+      uv: false,
+      zlib: true,
+      openssl: false }
 
 ## process.installPrefix
 

--- a/node.gyp
+++ b/node.gyp
@@ -129,7 +129,10 @@
           'sources': [ 'src/node_crypto.cc' ],
           'conditions': [
             [ 'node_use_system_openssl=="false"', {
+              'defines': [ 'NODE_SHARED_OPENSSL=0' ],
               'dependencies': [ './deps/openssl/openssl.gyp:openssl' ],
+            }, {
+              'defines': [ 'NODE_SHARED_OPENSSL=1' ],
             }]]
         }, {
           'defines': [ 'HAVE_OPENSSL=0' ]
@@ -146,11 +149,13 @@
         }],
 
         [ 'node_shared_v8=="true"', {
+          'defines': [ 'NODE_SHARED_V8=1' ],
           'sources': [
             '<(node_shared_v8_includes)/v8.h',
             '<(node_shared_v8_includes)/v8-debug.h',
           ],
         }, {
+          'defines': [ 'NODE_SHARED_V8=0' ],
           'sources': [
             'deps/v8/include/v8.h',
             'deps/v8/include/v8-debug.h',
@@ -159,7 +164,10 @@
         }],
 
         [ 'node_shared_zlib=="false"', {
+          'defines': [ 'NODE_SHARED_ZLIB=0' ],
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
+        }, {
+          'defines': [ 'NODE_SHARED_ZLIB=1' ],
         }],
 
         [ 'OS=="win"', {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2077,8 +2077,8 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   module_load_list = Persistent<Array>::New(Array::New());
   process->Set(String::NewSymbol("moduleLoadList"), module_load_list);
 
+  // process.versions
   Local<Object> versions = Object::New();
-  char buf[20];
   process->Set(String::NewSymbol("versions"), versions);
   versions->Set(String::NewSymbol("http_parser"), String::New(
                NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR) "."
@@ -2087,8 +2087,9 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   versions->Set(String::NewSymbol("node"), String::New(NODE_VERSION+1));
   versions->Set(String::NewSymbol("v8"), String::New(V8::GetVersion()));
   versions->Set(String::NewSymbol("ares"), String::New(ARES_VERSION_STR));
-  snprintf(buf, 20, "%d.%d", UV_VERSION_MAJOR, UV_VERSION_MINOR);
-  versions->Set(String::NewSymbol("uv"), String::New(buf));
+  versions->Set(String::NewSymbol("uv"), String::New(
+               NODE_STRINGIFY(UV_VERSION_MAJOR) "."
+               NODE_STRINGIFY(UV_VERSION_MINOR)));
   versions->Set(String::NewSymbol("zlib"), String::New(ZLIB_VERSION));
 #if HAVE_OPENSSL
   // Stupid code to slice out the version string.

--- a/src/node.cc
+++ b/src/node.cc
@@ -2109,6 +2109,20 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 #endif
 
 
+  // process.shared
+  Local<Object> shared = Object::New();
+  process->Set(String::NewSymbol("shared"), shared);
+  // can't build node with shared http_parser
+  shared->Set(String::NewSymbol("http_parser"), Boolean::New(false));
+  shared->Set(String::NewSymbol("v8"), Boolean::New(NODE_SHARED_V8));
+  // can't build node with shared libuv
+  shared->Set(String::NewSymbol("uv"), Boolean::New(false));
+  shared->Set(String::NewSymbol("zlib"), Boolean::New(NODE_SHARED_ZLIB));
+#if HAVE_OPENSSL
+  shared->Set(String::NewSymbol("openssl"), Boolean::New(NODE_SHARED_OPENSSL));
+#endif
+
+
 
   // process.arch
   process->Set(String::NewSymbol("arch"), String::New(ARCH));


### PR DESCRIPTION
This adds a `process.shared` object, which looks a little something like this:

``` js
> process.shared
{ http_parser: false,
  v8: false,
  uv: false,
  zlib: true,
  openssl: true }
```

For the `node` running above ^, I compiled with `--shared-zlib --openssl-use-sys=1`, and thus `zlib` and `openssl` are "true" above.
