### PR TITLE
Add `process.config`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/z
 	tools/gyp_node -f make
 
 install: all
-	out/Release/node tools/installer.js ./config.gypi install
+	out/Release/node tools/installer.js install
 
 uninstall:
-	out/Release/node tools/installer.js ./config.gypi uninstall
+	out/Release/node tools/installer.js uninstall
 
 clean:
 	-rm -rf out/Makefile node node_g out/$(BUILDTYPE)/node

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -256,6 +256,33 @@ Will output:
       ev: '4.4',
       openssl: '1.0.0e-fips' }
 
+## process.config
+
+An Object containing the JavaScript representation of the configure options
+that were used to compile the current node executable. This is the same as
+the "config.gypi" file that was produced when running the `./configure` script.
+
+An example of the possible output looks like:
+
+    { target_defaults:
+       { cflags: [],
+         default_configuration: 'Release',
+         defines: [],
+         include_dirs: [],
+         libraries: [] },
+      variables:
+       { host_arch: 'x64',
+         node_install_npm: 'true',
+         node_install_waf: 'true',
+         node_prefix: '',
+         node_shared_v8: 'false',
+         node_shared_zlib: 'false',
+         node_use_dtrace: 'false',
+         node_use_openssl: 'true',
+         node_use_system_openssl: 'false',
+         strict_aliasing: 'true',
+         target_arch: 'x64',
+         v8_use_snapshot: 'true' } }
 
 ## process.installPrefix
 

--- a/node.gyp
+++ b/node.gyp
@@ -219,8 +219,8 @@
           'action_name': 'node_js2c',
 
           'inputs': [
-            './tools/js2c.py',
             '<@(library_files)',
+            './config.gypi',
           ],
 
           'outputs': [
@@ -237,14 +237,14 @@
                 'python',
                 'tools/js2c.py',
                 '<@(_outputs)',
-                '<@(library_files)'
+                '<@(_inputs)',
               ],
             }, { # No Dtrace
               'action': [
                 'python',
                 'tools/js2c.py',
                 '<@(_outputs)',
-                '<@(library_files)',
+                '<@(_inputs)',
                 'src/macros.py'
               ],
             }]

--- a/src/node.js
+++ b/src/node.js
@@ -37,6 +37,7 @@
     startup.globalConsole();
 
     startup.processAssert();
+    startup.processConfig();
     startup.processNextTick();
     startup.processStdio();
     startup.processKillAndExit();
@@ -176,6 +177,15 @@
       if (!x) throw new Error(msg || 'assertion error');
     };
   };
+
+  startup.processConfig = function() {
+    config = config.split('\n').slice(1).join('\n').replace(/'/g, '"');
+    process.config = JSON.parse(config, function(key, value) {
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      return value;
+    });
+  }
 
   startup.processNextTick = function() {
     var nextTickQueue = [];
@@ -466,6 +476,10 @@
 
   NativeModule._source = process.binding('natives');
   NativeModule._cache = {};
+
+  // used for `process.config`, but not a real module
+  var config = NativeModule._source.config;
+  delete NativeModule._source.config;
 
   NativeModule.require = function(id) {
     if (id == 'native_module') {

--- a/test/simple/test-process-config.js
+++ b/test/simple/test-process-config.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+
+// check for existence
+assert(process.hasOwnProperty('config'));
+
+// ensure that `process.config` is an Object
+assert(Object(process.config) === process.config);
+
+var configPath = path.resolve(__dirname, '..', '..', 'config.gypi');
+var config = fs.readFileSync(configPath, 'utf8');
+
+// clean up comment at the first line
+config = config.split('\n').slice(1).join('\n').replace(/'/g, '"');
+config = JSON.parse(config, function(key, value) {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+});
+
+assert.deepEqual(config, process.config);

--- a/tools/installer.js
+++ b/tools/installer.js
@@ -1,21 +1,15 @@
 var fs = require('fs'),
     path = require('path'),
     exec = require('child_process').exec,
-    options = fs.readFileSync(process.argv[2]).toString(),
-    cmd = process.argv[3];
+    cmd = process.argv[2];
 
 if (cmd !== 'install' && cmd !== 'uninstall') {
   console.error('Unknown command: ' + cmd);
   process.exit(1);
 }
 
-// Python pprint.pprint() uses single quotes instead of double.
-// awful.
-options = options.replace(/'/gi, '"')
-
-// Parse options file and remove first comment line
-options = JSON.parse(options.split('\n').slice(1).join(''));
-var variables = options.variables,
+// Use the built-in config reported by the current process
+var variables = process.config.variables,
     node_prefix = variables.node_prefix || '/usr/local';
 
 // Execution queue

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -288,7 +288,7 @@ def JS2C(source, target):
     lines = ExpandMacros(lines, macros)
     lines = CompressScript(lines, do_jsmin)
     data = ToCArray(s, lines)
-    id = (os.path.split(str(s))[1])[:-3]
+    id = os.path.basename(str(s)).split('.')[0]
     if delay: id = id[:-6]
     if delay:
       delay_ids.append((id, len(lines)))


### PR DESCRIPTION
This pull adds a `process.config` object. It looks like:

``` js
> process.config
{ target_defaults: 
   { cflags: [],
     default_configuration: 'Release',
     defines: [],
     include_dirs: [],
     libraries: [] },
  variables: 
   { host_arch: 'x64',
     node_install_npm: true,
     node_install_waf: true,
     node_prefix: '',
     node_shared_v8: false,
     node_shared_zlib: false,
     node_use_dtrace: false,
     node_use_openssl: false,
     strict_aliasing: true,
     target_arch: 'x64',
     v8_use_snapshot: true } }
```

Relatively straightforward changes, though I am sort of abusing `js2c` by stuffing the `config.gypi` file in there. But hey, it works well! Cheers!
