### PR TITLE
path.exists*() as 2nd level head not 3rd

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -142,7 +142,7 @@ an empty string.  Examples:
     // returns
     ''
 
-### path.exists(p, [callback])
+## path.exists(p, [callback])
 
 Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
@@ -152,6 +152,6 @@ Then call the `callback` argument with either true or false.  Example:
     });
 
 
-### path.existsSync(p)
+## path.existsSync(p)
 
 Synchronous version of `path.exists`.


### PR DESCRIPTION
I know these are moved to `fs` for 0.7 but for the 0.6 documentation they are indented underneath `path.extname()`. See TOC on http://nodejs.org/api/path.html
