### PR TITLE
Stream.prototype.pipe: Don't stop piping when the destination stream emits 'end'

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -112,7 +112,6 @@ Stream.prototype.pipe = function(dest, options) {
   source.on('end', cleanup);
   source.on('close', cleanup);
 
-  dest.on('end', cleanup);
   dest.on('close', cleanup);
 
   dest.emit('pipe', source);


### PR DESCRIPTION
The 'end' event has nothing to do with the "writable stream-ness" of an object, and the current behavior breaks a number of use cases with readable/writable streams. Specifically when the readable stream ends while there's an ongoing pipe into the writable stream. The piping simply stops at that point, even though there's still work to be done.

Here's a test case that's failing for me because of this: https://github.com/papandreou/express-hijackresponse/blob/master/test/hijack-test.js#L100-126

Let me know if you'd like me to construct a simpler test case demonstrating the problem.

@mikeal: As far as I can tell the offending line was introduced by accident in 2a65d29. Any insight?
