### PR TITLE
doc: fix # links from (and within) api/fs (v0.6)

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -137,7 +137,7 @@ Synchronous lchmod(2).
 ## fs.stat(path, [callback])
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a [fs.Stats](#fs.Stats) object.  See the [fs.Stats](#fs.Stats)
+`stats` is a [fs.Stats](#fs_class_fs_stats) object.  See the [fs.Stats](#fs_class_fs_stats)
 section below for more information.
 
 ## fs.lstat(path, [callback])
@@ -552,7 +552,7 @@ An example to read the last 10 bytes of a file which is 100 bytes long:
 
 ## Class: fs.ReadStream
 
-`ReadStream` is a [Readable Stream](stream.html#readable_stream).
+`ReadStream` is a [Readable Stream](stream.html#stream_readable_stream).
 
 ### Event: 'open'
 
@@ -578,7 +578,7 @@ default mode `w`.
 
 ## fs.WriteStream
 
-`WriteStream` is a [Writable Stream](stream.html#writable_stream).
+`WriteStream` is a [Writable Stream](stream.html#stream_writable_stream).
 
 ### Event: 'open'
 
@@ -605,7 +605,7 @@ Stop watching for changes on the given `fs.FSWatcher`.
 * `filename` {String} The filename that changed (if relevant/available)
 
 Emitted when something changes in a watched directory or file.
-See more details in [fs.watch](#fs.watch).
+See more details in [fs.watch](#fs_fs_watch_filename_options_listener).
 
 ### Event: 'error'
 


### PR DESCRIPTION
Not just a v0.6 problem, do you need a PR for master too on this or can you just merge this there too?

The same problem probably also exists in other doc files cause of recent doc build changes but I just happen to be using _fs_ right now so I noticed it there.
