### PR TITLE
Improved dns.lookup documentation

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -45,6 +45,11 @@ is a string representation of a IP v4 or v6 address. The `family` argument
 is either the integer 4 or 6 and denotes the family of `address` (not
 necessarily the value initially passed to `lookup`).
 
+On error, `err` would be an instanceof `Error` object. Keep in mind that
+`err.errno` will be set to ENOENT not only when the domain does not exist
+but also when the lookup failes in other ways such as no available file
+descriptors.
+
 
 ## dns.resolve(domain, [rrtype], callback)
 


### PR DESCRIPTION
Added some documentation about possible errors of `dns.lookup()`.

Not knowing that `dns.lookup()` would also return ENOENT when node was out of file descriptors kept me busy for quite some time.
