### PR TITLE
debugger: exit process on repl exit

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -755,6 +755,10 @@ function Interface(stdin, stdout, args) {
                                   this.controlEval.bind(this), false, true);
 
   // Kill child process when main process dies
+  this.repl.on('exit', function() {
+    process.exit(0);
+  });
+
   process.on('exit', function() {
     self.killChild();
   });
@@ -1486,7 +1490,7 @@ Interface.prototype.repl = function() {
   self.print('Press Ctrl + C to leave debug repl');
 
   // Don't display any default messages
-  var listeners = this.repl.rli.listeners('SIGINT');
+  var listeners = this.repl.rli.listeners('SIGINT').slice(0);
   this.repl.rli.removeAllListeners('SIGINT');
 
   // Exit debug repl on Ctrl + C

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -754,6 +754,9 @@ function Interface(stdin, stdout, args) {
   this.repl = new repl.REPLServer('debug> ', streams,
                                   this.controlEval.bind(this), false, true);
 
+  // Do not print useless warning
+  repl._builtinLibs.splice(repl._builtinLibs.indexOf('repl'), 1);
+
   // Kill child process when main process dies
   this.repl.on('exit', function() {
     process.exit(0);

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -678,6 +678,7 @@ var commands = [
     'kill',
     'list',
     'scripts',
+    'breakOnException',
     'breakpoints',
     'version'
   ]
@@ -1308,6 +1309,19 @@ Interface.prototype.watchers = function() {
   }
 };
 
+// Break on exception
+Interface.prototype.breakOnException = function breakOnException() {
+  if (!this.requireConnection()) return;
+
+  var self = this;
+
+  // Break on exceptions
+  this.pause();
+  this.client.reqSetExceptionBreak('all', function(err, res) {
+    self.resume();
+  });
+};
+
 // Add breakpoint
 Interface.prototype.setBreakpoint = function(script, line,
                                              condition, silent) {
@@ -1626,12 +1640,6 @@ Interface.prototype.trySpawn = function(cb) {
       self.setBreakpoint(bp.scriptId, bp.line, bp.condition, true);
     });
 
-    // Break on exceptions
-    client.reqSetExceptionBreak('all', function(err, res) {
-      cb && cb();
-      self.resume();
-    });
-
     client.on('close', function() {
       self.pause();
       self.print('program terminated');
@@ -1639,6 +1647,9 @@ Interface.prototype.trySpawn = function(cb) {
       self.client = null;
       self.killChild();
     });
+
+    if (cb) cb();
+    self.resume();
   });
 
   client.on('unhandledResponse', function(res) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -69,7 +69,7 @@ module.paths = require('module')._nodeModulePaths(module.filename);
 // Can overridden with custom print functions, such as `probe` or `eyes.js`
 exports.writer = util.inspect;
 
-var builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
+exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
   'crypto', 'dgram', 'dns', 'events', 'fs', 'http', 'https', 'net',
   'os', 'path', 'punycode', 'querystring', 'readline', 'repl',
   'string_decoder', 'tls', 'tty', 'url', 'util', 'vm', 'zlib'];
@@ -181,7 +181,7 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
     // Check if a builtin module name was used and then include it
     // if there's no conflict.
-    if (~builtinLibs.indexOf(cmd)) {
+    if (exports._builtinLibs.indexOf(cmd) !== -1) {
       var lib = require(cmd);
       if (cmd in self.context && lib !== self.context[cmd]) {
         self.outputStream.write('A different "' + cmd +
@@ -456,7 +456,7 @@ REPLServer.prototype.complete = function(line, callback) {
     }
 
     if (!subdir) {
-      completionGroups.push(builtinLibs);
+      completionGroups.push(exports._builtinLibs);
     }
 
     completionGroupsLoaded();


### PR DESCRIPTION
- When entering repl - clone 'SIGINT' listeners array (instead of using
  existing), as it will be spliced in .removeAllListeners() call later.

Please review.
