### PR TITLE
Avoiding unnecessary allocations and RAII

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -82,6 +82,8 @@ typedef int mode_t;
 #include "node_script.h"
 #include "v8_typed_array.h"
 
+#include <vector>
+
 using namespace v8;
 
 # ifdef __APPLE__
@@ -951,15 +953,13 @@ Handle<Value> FromConstructorTemplate(Persistent<FunctionTemplate>& t,
   HandleScope scope;
 
   const int argc = args.Length();
-  Local<Value>* argv = new Local<Value>[argc];
+  std::vector<Local<Value> > argv(argc);
 
   for (int i = 0; i < argc; ++i) {
     argv[i] = args[i];
   }
 
-  Local<Object> instance = t->GetFunction()->NewInstance(argc, argv);
-
-  delete[] argv;
+  Local<Object> instance = t->GetFunction()->NewInstance(argc, &argv[0]);
 
   return scope.Close(instance);
 }
@@ -1057,13 +1057,14 @@ Local<Value> Encode(const void *buf, size_t len, enum encoding encoding) {
 
   if (encoding == BINARY) {
     const unsigned char *cbuf = static_cast<const unsigned char*>(buf);
-    uint16_t * twobytebuf = new uint16_t[len];
+    std::vector<uint16_t> bs(len, 0);
+    uint16_t * twobytebuf = &bs[0];
     for (size_t i = 0; i < len; i++) {
       // XXX is the following line platform independent?
       twobytebuf[i] = cbuf[i];
     }
     Local<String> chunk = String::New(twobytebuf, len);
-    delete [] twobytebuf; // TODO use ExternalTwoByteString?
+    //delete [] twobytebuf; // TODO use ExternalTwoByteString?
     return scope.Close(chunk);
   }
 
@@ -1136,7 +1137,9 @@ ssize_t DecodeWrite(char *buf,
 
   assert(encoding == BINARY);
 
-  uint16_t * twobytebuf = new uint16_t[buflen];
+  
+  std::vector<uint16_t> bs(buflen, 0);
+  uint16_t * twobytebuf = &bs[0];
 
   str->Write(twobytebuf, 0, buflen, String::HINT_MANY_WRITES_EXPECTED);
 
@@ -1144,8 +1147,6 @@ ssize_t DecodeWrite(char *buf,
     unsigned char *b = reinterpret_cast<unsigned char*>(&twobytebuf[i]);
     buf[i] = b[0];
   }
-
-  delete [] twobytebuf;
 
   return buflen;
 }
@@ -2146,14 +2147,14 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   }
 
   size_t size = 2*PATH_MAX;
-  char* execPath = new char[size];
+  std::vector<char> e(size, 0);
+  char* execPath = &e[0];
   if (uv_exepath(execPath, &size) != 0) {
     // as a last ditch effort, fallback on argv[0] ?
     process->Set(String::NewSymbol("execPath"), String::New(argv[0]));
   } else {
     process->Set(String::NewSymbol("execPath"), String::New(execPath, size));
   }
-  delete [] execPath;
 
   process->SetAccessor(String::New("debugPort"),
                        DebugPortGetter,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -33,6 +33,7 @@
 # include <arpa/inet.h> // htons, htonl
 #endif
 
+#include <vector>
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 
@@ -308,7 +309,8 @@ Handle<Value> Buffer::Base64Slice(const Arguments &args) {
 
   int n = end - start;
   int out_len = (n + 2 - ((n + 2) % 3)) / 3 * 4;
-  char *out = new char[out_len];
+  std::vector<char> os(out_len, 0);
+  char *out = &os[0];
 
   uint8_t bitbuf[3];
   int i = start; // data() index
@@ -368,7 +370,7 @@ Handle<Value> Buffer::Base64Slice(const Arguments &args) {
   }
 
   Local<String> string = String::New(out, out_len);
-  delete [] out;
+  //delete [] out;
   return scope.Close(string);
 }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -148,7 +148,7 @@ struct StringPtr {
 
   Handle<String> ToString() const {
     if (!str_.empty())
-      return String::New(&str_[0], str_.size());
+      return String::New(str_.c_str(), str_.size());
     else
       return String::Empty();
   }

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -107,10 +107,11 @@ class ProcessWrap : public HandleWrap {
 
     // options.file
     Local<Value> file_v = js_options->Get(String::New("file"));
-    if (!file_v.IsEmpty() && file_v->IsString()) {
-      String::Utf8Value file(file_v->ToString());
-      options.file = strdup(*file);
-    }
+    //if (!file_v.IsEmpty() && file_v->IsString()) {
+      String::Utf8Value file(file_v->IsString() ? file_v : Local<Value>());
+      if (file.length() > 0)
+      options.file = *file;
+    //}
 
     // options.args
     Local<Value> argv_v = js_options->Get(String::New("args"));
@@ -128,12 +129,13 @@ class ProcessWrap : public HandleWrap {
 
     // options.cwd
     Local<Value> cwd_v = js_options->Get(String::New("cwd"));
-    if (!cwd_v.IsEmpty() && cwd_v->IsString()) {
-      String::Utf8Value cwd(cwd_v->ToString());
+    //if (!cwd_v.IsEmpty() && cwd_v->IsString()) {
+      String::Utf8Value cwd(cwd_v->IsString() ? cwd_v : Local<Value>());
+
       if (cwd.length() > 0) {
-        options.cwd = strdup(*cwd);
+        options.cwd = *cwd;
       }
-    }
+    //}
 
     // options.env
     Local<Value> env_v = js_options->Get(String::New("envPairs"));
@@ -190,9 +192,6 @@ class ProcessWrap : public HandleWrap {
       for (int i = 0; options.args[i]; i++) free(options.args[i]);
       delete [] options.args;
     }
-
-    free(options.cwd);
-    free((void*)options.file);
 
     if (options.env) {
       for (int i = 0; options.env[i]; i++) free(options.env[i]);


### PR DESCRIPTION
Wrapping allocations using c++ standard library
Using vector where dynamic array is required
Can use auto_ptr where single ptr dynamic allocation is required.
We can use more c++ constructs for concise code. This is attempt towards that
