### PR TITLE
Bug with space autocompletion in REPL

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -589,6 +589,8 @@ REPLServer.prototype.complete = function(line, callback) {
     } else {
       completionGroupsLoaded();
     }
+  } else {
+    completionGroupsLoaded();
   }
 
   // Will be called when all completionGroups are in place

--- a/test/simple/test-repl-tab-complete.js
+++ b/test/simple/test-repl-tab-complete.js
@@ -190,3 +190,16 @@ putIn.run([
 testMe.complete('str.len', function(error, data) {
   assert.deepEqual(data, [['str.length'], 'str.len']);
 });
+
+putIn.run(['.clear']);
+
+// tab completion should not break on spaces
+var spaceTimeout = setTimeout(function() {
+  throw new Error('timeout');
+}, 1000);
+
+testMe.complete(' ', function(error, data) {
+  assert.deepEqual(data, [[],undefined]);
+  clearTimeout(spaceTimeout);
+});
+


### PR DESCRIPTION
Open REPL of any node (including stable 0.6.x), press space and then press tab, and node silently exits. :)

That's because of the callback that never runs. This patch fixes it.
