### PR TITLE
Avoiding strdup in process_wrap.cc

### DIFF
--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -107,9 +107,9 @@ class ProcessWrap : public HandleWrap {
 
     // options.file
     Local<Value> file_v = js_options->Get(String::New("file"));
-    if (!file_v.IsEmpty() && file_v->IsString()) {
-      String::Utf8Value file(file_v->ToString());
-      options.file = strdup(*file);
+    String::Utf8Value file(!file_v.IsEmpty() && file_v->IsString() ? file_v : Local<Value>());
+    if (file.length() > 0) {
+      options.file = *file;
     }
 
     // options.args
@@ -128,11 +128,9 @@ class ProcessWrap : public HandleWrap {
 
     // options.cwd
     Local<Value> cwd_v = js_options->Get(String::New("cwd"));
-    if (!cwd_v.IsEmpty() && cwd_v->IsString()) {
-      String::Utf8Value cwd(cwd_v->ToString());
-      if (cwd.length() > 0) {
-        options.cwd = strdup(*cwd);
-      }
+    String::Utf8Value cwd(!cwd_v.IsEmpty() && cwd_v->IsString() ? cwd_v : Local<Value>());
+    if (cwd.length() > 0) {
+      options.cwd = *cwd;
     }
 
     // options.env
@@ -190,9 +188,6 @@ class ProcessWrap : public HandleWrap {
       for (int i = 0; options.args[i]; i++) free(options.args[i]);
       delete [] options.args;
     }
-
-    free(options.cwd);
-    free((void*)options.file);
 
     if (options.env) {
       for (int i = 0; options.env[i]; i++) free(options.env[i]);

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -107,7 +107,7 @@ class ProcessWrap : public HandleWrap {
 
     // options.file
     Local<Value> file_v = js_options->Get(String::New("file"));
-    String::Utf8Value file(!file_v.IsEmpty() && file_v->IsString() ? file_v : Local<Value>());
+    String::Utf8Value file(file_v->IsString() ? file_v : Local<Value>());
     if (file.length() > 0) {
       options.file = *file;
     }
@@ -128,7 +128,7 @@ class ProcessWrap : public HandleWrap {
 
     // options.cwd
     Local<Value> cwd_v = js_options->Get(String::New("cwd"));
-    String::Utf8Value cwd(!cwd_v.IsEmpty() && cwd_v->IsString() ? cwd_v : Local<Value>());
+    String::Utf8Value cwd( cwd_v->IsString() ? cwd_v : Local<Value>());
     if (cwd.length() > 0) {
       options.cwd = *cwd;
     }


### PR DESCRIPTION
file and cwd can be directly used from Utf8Value without strdup
