### PR TITLE
Fixes broken node-waf and npm installation caused by tools/installer.js

### DIFF
--- a/tools/installer.js
+++ b/tools/installer.js
@@ -118,13 +118,13 @@ if (cmd === 'install') {
   copy('out/Release/node', 'bin/node');
 
   // Install node-waf
-  if (variables.node_install_waf == 'true') {
+  if (variables.node_install_waf) {
     copy('tools/wafadmin', 'lib/node/');
     copy('tools/node-waf', 'bin/node-waf');
   }
 
   // Install npm (eventually)
-  if (variables.node_install_npm == 'true') {
+  if (variables.node_install_npm) {
     copy('deps/npm', 'lib/node_modules/npm');
     queue.push('ln -sf ../lib/node_modules/npm/bin/npm-cli.js ' +
                path.join(node_prefix, 'bin/npm'));


### PR DESCRIPTION
`tools/installer.js` tested a boolean against a string, resulting in node-waf and npm to never be installed, since:

```
> true == 'true'
false
> true == 'false'
false
> false == 'true'
false
> false == 'false'
false
```
