### PR TITLE
readline fix for cmd.exe

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -269,7 +269,12 @@ Interface.prototype._insertString = function(c) {
   } else {
     this.line += c;
     this.cursor += c.length;
-    this.output.write(c);
+
+    if (this._getCursorPos().cols === 0) {
+        this._refreshLine();
+    } else {
+        this.output.write(c);
+    } 
 
     // a hack to get the line refreshed if it's needed
     this._moveCursor(0);
@@ -508,7 +513,7 @@ Interface.prototype._moveCursor = function(dx) {
   var newPos = this._getCursorPos();
 
   // check if cursors are in the same line
-  if (oldPos.rows == newPos.rows && newPos.cols != 0) {
+  if (oldPos.rows === newPos.rows) {
     this.output.moveCursor(this.cursor - oldcursor, 0);
     this.prevRows = newPos.rows;
   } else {


### PR DESCRIPTION
#2959

The problem was: windows terminal automatically inserts new line when previous is full. Unix terminals don't. I mean for 80x30 and cursor on 80:1 next character will be 81:1 (out of line) on unix and 80:2 (in the next line) on windows.

I believe that it's finally over. :)
