### PR TITLE
Noting that `stream.pause` is advisory.

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -57,7 +57,10 @@ Makes the data event emit a string instead of a `Buffer`. `encoding` can be
 
 ### stream.pause()
 
-Pauses the incoming `'data'` events.
+Pauses the incoming `'data'` events. NOTE: this is only advisory; some
+`'data'` events may be emitted before the pausing can actually take place.
+See [this discussion](https://groups.google.com/forum/?fromgroups#!topic/nodejs/yv6Dl-O-wYk)
+for more information.
 
 ### stream.resume()
 


### PR DESCRIPTION
This should help save future users much confusion.

See [some discussion on the mailing list](https://groups.google.com/forum/?fromgroups#!topic/nodejs/yv6Dl-O-wYk) and, as a bonus, [the massive confusion I managed to cause for myself](http://stackoverflow.com/questions/9812993/nodejs-stream-pausing-resuming-does-not-work-with-xmlhttprequest-but-works-with).

I'll go sign that CLA thing.
