### PR TITLE
Avoiding unnecessary ToString() calls

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -555,7 +555,7 @@ static Handle<Value> Query(const Arguments& args) {
   // object reference, causing wrap->GetObject() to return undefined.
   Local<Object> object = Local<Object>::New(wrap->GetObject());
 
-  String::Utf8Value name(args[0]->ToString());
+  String::Utf8Value name(args[0]);
 
   int r = wrap->Send(*name);
   if (r) {
@@ -584,7 +584,7 @@ static Handle<Value> QueryWithFamily(const Arguments& args) {
   // object reference, causing wrap->GetObject() to return undefined.
   Local<Object> object = Local<Object>::New(wrap->GetObject());
 
-  String::Utf8Value name(args[0]->ToString());
+  String::Utf8Value name(args[0]);
   int family = args[1]->Int32Value();
 
   int r = wrap->Send(*name, family);
@@ -688,7 +688,7 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
 static Handle<Value> GetAddrInfo(const Arguments& args) {
   HandleScope scope;
 
-  String::Utf8Value hostname(args[0]->ToString());
+  String::Utf8Value hostname(args[0]);
 
   int fam = AF_UNSPEC;
   if (args[1]->IsInt32()) {

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -107,7 +107,7 @@ Handle<Value> FSEventWrap::Start(const Arguments& args) {
     return ThrowException(Exception::TypeError(String::New("Bad arguments")));
   }
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   int r = uv_fs_event_init(uv_default_loop(), &wrap->handle_, *path, OnEvent, 0);
   if (r == 0) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1019,7 +1019,7 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
 
   if (!encoding_v->IsString()) return _default;
 
-  String::Utf8Value encoding(encoding_v->ToString());
+  String::Utf8Value encoding(encoding_v);
 
   if (strcasecmp(*encoding, "utf8") == 0) {
     return UTF8;
@@ -1230,8 +1230,8 @@ static void ReportException(TryCatch &try_catch, bool show_line) {
       fprintf(stderr, "%s: ", *name);
     }
 
-    String::Utf8Value msg(!isErrorObject ? er->ToString()
-                         : er->ToObject()->Get(String::New("message"))->ToString());
+    String::Utf8Value msg(!isErrorObject ? er
+                         : er->ToObject()->Get(String::New("message")));
     fprintf(stderr, "%s\n", *msg);
   }
 
@@ -1272,7 +1272,7 @@ static Handle<Value> Chdir(const Arguments& args) {
     return ThrowException(Exception::Error(String::New("Bad argument.")));
   }
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   uv_err_t r = uv_chdir(*path);
 
@@ -1372,7 +1372,7 @@ static Handle<Value> SetGid(const Arguments& args) {
   if (args[0]->IsNumber()) {
     gid = args[0]->Int32Value();
   } else if (args[0]->IsString()) {
-    String::Utf8Value grpnam(args[0]->ToString());
+    String::Utf8Value grpnam(args[0]);
     struct group grp, *grpp = NULL;
     int err;
 
@@ -1412,7 +1412,7 @@ static Handle<Value> SetUid(const Arguments& args) {
   if (args[0]->IsNumber()) {
     uid = args[0]->Int32Value();
   } else if (args[0]->IsString()) {
-    String::Utf8Value pwnam(args[0]->ToString());
+    String::Utf8Value pwnam(args[0]);
     struct passwd pwd, *pwdp = NULL;
     int err;
 
@@ -1619,7 +1619,7 @@ Handle<Value> DLOpen(const v8::Arguments& args) {
     return ThrowException(exception);
   }
 
-  String::Utf8Value filename(args[0]->ToString()); // Cast
+  String::Utf8Value filename(args[0]); // Cast
   Local<Object> target = args[1]->ToObject(); // Cast
 
   err = uv_dlopen(*filename, &lib);
@@ -1640,7 +1640,7 @@ Handle<Value> DLOpen(const v8::Arguments& args) {
     return ThrowException(exception);
   }
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
   base = *path;
 
   /* Find the shared library filename within the full path. */
@@ -1854,7 +1854,7 @@ static void ProcessTitleSetter(Local<String> property,
                                Local<Value> value,
                                const AccessorInfo& info) {
   HandleScope scope;
-  String::Utf8Value title(value->ToString());
+  String::Utf8Value title(value);
   // TODO: protect with a lock
   uv_set_process_title(*title);
 }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -589,7 +589,7 @@ Handle<Value> Buffer::Base64Write(const Arguments &args) {
             "Argument must be a string")));
   }
 
-  String::AsciiValue s(args[0]->ToString());
+  String::AsciiValue s(args[0]);
   size_t offset = args[1]->Int32Value();
   size_t max_length = args[2]->IsUndefined() ? buffer->length_ - offset
                                              : args[2]->Uint32Value();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -170,7 +170,7 @@ Handle<Value> SecureContext::Init(const Arguments& args) {
   OPENSSL_CONST SSL_METHOD *method = SSLv23_method();
 
   if (args.Length() == 1 && args[0]->IsString()) {
-    String::Utf8Value sslmethod(args[0]->ToString());
+    String::Utf8Value sslmethod(args[0]);
 
     if (strcmp(*sslmethod, "SSLv2_method") == 0) {
 #ifndef OPENSSL_NO_SSL2
@@ -234,7 +234,7 @@ static BIO* LoadBIO (Handle<Value> v) {
   int r = -1;
 
   if (v->IsString()) {
-    String::Utf8Value s(v->ToString());
+    String::Utf8Value s(v);
     r = BIO_write(bio, *s, s.length());
   } else if (Buffer::HasInstance(v)) {
     Local<Object> buffer_obj = v->ToObject();
@@ -287,7 +287,7 @@ Handle<Value> SecureContext::SetKey(const Arguments& args) {
   BIO *bio = LoadBIO(args[0]);
   if (!bio) return False();
 
-  String::Utf8Value passphrase(args[1]->ToString());
+  String::Utf8Value passphrase(args[1]);
 
   EVP_PKEY* key = PEM_read_bio_PrivateKey(bio, NULL, NULL,
                                           len == 1 ? NULL : *passphrase);
@@ -514,7 +514,7 @@ Handle<Value> SecureContext::SetCiphers(const Arguments& args) {
     return ThrowException(Exception::TypeError(String::New("Bad parameter")));
   }
 
-  String::Utf8Value ciphers(args[0]->ToString());
+  String::Utf8Value ciphers(args[0]);
   SSL_CTX_set_cipher_list(sc->ctx_, *ciphers);
 
   return True();
@@ -545,7 +545,7 @@ Handle<Value> SecureContext::SetSessionIdContext(const Arguments& args) {
     return ThrowException(Exception::TypeError(String::New("Bad parameter")));
   }
 
-  String::Utf8Value sessionIdContext(args[0]->ToString());
+  String::Utf8Value sessionIdContext(args[0]);
   const unsigned char* sid_ctx = (const unsigned char*) *sessionIdContext;
   unsigned int sid_ctx_len = sessionIdContext.length();
 
@@ -930,7 +930,7 @@ Handle<Value> Connection::New(const Arguments& args) {
   if (is_server) {
     SSL_CTX_set_tlsext_servername_callback(sc->ctx_, SelectSNIContextCallback_);
   } else {
-    String::Utf8Value servername(args[2]->ToString());
+    String::Utf8Value servername(args[2]);
     SSL_set_tlsext_host_name(p->ssl_, *servername);
   }
 #endif
@@ -2016,7 +2016,7 @@ class Cipher : public ObjectWrap {
     ssize_t key_written = DecodeWrite(key_buf, key_buf_len, args[1], BINARY);
     assert(key_written == key_buf_len);
 
-    String::Utf8Value cipherType(args[0]->ToString());
+    String::Utf8Value cipherType(args[0]);
 
     bool r = cipher->CipherInit(*cipherType, key_buf, key_buf_len);
 
@@ -2066,7 +2066,7 @@ class Cipher : public ObjectWrap {
     ssize_t iv_written = DecodeWrite(iv_buf, iv_len, args[2], BINARY);
     assert(iv_written == iv_len);
 
-    String::Utf8Value cipherType(args[0]->ToString());
+    String::Utf8Value cipherType(args[0]);
 
     bool r = cipher->CipherInitIv(*cipherType, key_buf,key_len,iv_buf,iv_len);
 
@@ -2429,7 +2429,7 @@ class Decipher : public ObjectWrap {
     ssize_t key_written = DecodeWrite(key_buf, key_len, args[1], BINARY);
     assert(key_written == key_len);
 
-    String::Utf8Value cipherType(args[0]->ToString());
+    String::Utf8Value cipherType(args[0]);
 
     bool r = cipher->DecipherInit(*cipherType, key_buf,key_len);
 
@@ -2479,7 +2479,7 @@ class Decipher : public ObjectWrap {
     ssize_t iv_written = DecodeWrite(iv_buf, iv_len, args[2], BINARY);
     assert(iv_written == iv_len);
 
-    String::Utf8Value cipherType(args[0]->ToString());
+    String::Utf8Value cipherType(args[0]);
 
     bool r = cipher->DecipherInitIv(*cipherType, key_buf,key_len,iv_buf,iv_len);
 
@@ -2782,7 +2782,7 @@ class Hmac : public ObjectWrap {
       return ThrowException(exception);
     }
 
-    String::Utf8Value hashType(args[0]->ToString());
+    String::Utf8Value hashType(args[0]);
 
     bool r;
 
@@ -2946,7 +2946,7 @@ class Hash : public ObjectWrap {
         "Must give hashtype string as argument")));
     }
 
-    String::Utf8Value hashType(args[0]->ToString());
+    String::Utf8Value hashType(args[0]);
 
     Hash *hash = new Hash();
     if (!hash->HashInit(*hashType)) {
@@ -3139,7 +3139,7 @@ class Sign : public ObjectWrap {
         "Must give signtype string as argument")));
     }
 
-    String::Utf8Value signType(args[0]->ToString());
+    String::Utf8Value signType(args[0]);
 
     bool r = sign->SignInit(*signType);
 
@@ -3390,7 +3390,7 @@ class Verify : public ObjectWrap {
         "Must give verifytype string as argument")));
     }
 
-    String::Utf8Value verifyType(args[0]->ToString());
+    String::Utf8Value verifyType(args[0]);
 
     bool r = verify->VerifyInit(*verifyType);
 
@@ -3589,7 +3589,7 @@ class DiffieHellman : public ObjectWrap {
           String::New("No group name given")));
     }
 
-    String::Utf8Value group_name(args[0]->ToString());
+    String::Utf8Value group_name(args[0]);
 
     modp_group* it = modp_groups;
 

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -54,7 +54,7 @@ using namespace v8;
     return (ThrowException(Exception::Error(String::New("expected " \
       "object for " #obj " to contain string member " #member)))); \
   } \
-  String::Utf8Value _##member(obj->Get(String::New(#member))->ToString()); \
+  String::Utf8Value _##member(obj->Get(String::New(#member))); \
   if ((*(const char **)valp = *_##member) == NULL) \
     *(const char **)valp = "<unknown>";
 
@@ -203,7 +203,7 @@ Handle<Value> DTRACE_HTTP_SERVER_REQUEST(const Arguments& args) {
       "object for request to contain string member headers"))));
 
   Local<Value> strfwdfor = headers->Get(String::New("x-forwarded-for"));
-  String::Utf8Value fwdfor(strfwdfor->ToString());
+  String::Utf8Value fwdfor(strfwdfor);
 
   if (!strfwdfor->IsString() || (req.forwardedFor = *fwdfor) == NULL)
     req.forwardedFor = const_cast<char*>("");

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -354,7 +354,7 @@ static Handle<Value> Stat(const Arguments& args) {
   if (args.Length() < 1) return TYPE_ERROR("path required");
   if (!args[0]->IsString()) return TYPE_ERROR("path must be a string");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
     ASYNC_CALL(stat, args[1], *path)
@@ -370,7 +370,7 @@ static Handle<Value> LStat(const Arguments& args) {
   if (args.Length() < 1) return TYPE_ERROR("path required");
   if (!args[0]->IsString()) return TYPE_ERROR("path must be a string");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
     ASYNC_CALL(lstat, args[1], *path)
@@ -406,12 +406,12 @@ static Handle<Value> Symlink(const Arguments& args) {
   if (!args[0]->IsString()) return TYPE_ERROR("dest path must be a string");
   if (!args[1]->IsString()) return TYPE_ERROR("src path must be a string");
 
-  String::Utf8Value dest(args[0]->ToString());
-  String::Utf8Value path(args[1]->ToString());
+  String::Utf8Value dest(args[0]);
+  String::Utf8Value path(args[1]);
   int flags = 0;
 
   if (args[2]->IsString()) {
-    String::Utf8Value mode(args[2]->ToString());
+    String::Utf8Value mode(args[2]);
     if (memcmp(*mode, "dir\0", 4) == 0) {
       flags |= UV_FS_SYMLINK_DIR;
     }
@@ -434,8 +434,8 @@ static Handle<Value> Link(const Arguments& args) {
   if (!args[0]->IsString()) return TYPE_ERROR("dest path must be a string");
   if (!args[1]->IsString()) return TYPE_ERROR("src path must be a string");
 
-  String::Utf8Value orig_path(args[0]->ToString());
-  String::Utf8Value new_path(args[1]->ToString());
+  String::Utf8Value orig_path(args[0]);
+  String::Utf8Value new_path(args[1]);
 
   if (args[2]->IsFunction()) {
     ASYNC_CALL(link, args[2], *orig_path, *new_path)
@@ -451,7 +451,7 @@ static Handle<Value> ReadLink(const Arguments& args) {
   if (args.Length() < 1) return TYPE_ERROR("path required");
   if (!args[0]->IsString()) return TYPE_ERROR("path must be a string");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
     ASYNC_CALL(readlink, args[1], *path)
@@ -470,8 +470,8 @@ static Handle<Value> Rename(const Arguments& args) {
   if (!args[0]->IsString()) return TYPE_ERROR("old path must be a string");
   if (!args[1]->IsString()) return TYPE_ERROR("new path must be a string");
   
-  String::Utf8Value old_path(args[0]->ToString());
-  String::Utf8Value new_path(args[1]->ToString());
+  String::Utf8Value old_path(args[0]);
+  String::Utf8Value new_path(args[1]);
 
   if (args[2]->IsFunction()) {
     ASYNC_CALL(rename, args[2], *old_path, *new_path)
@@ -555,7 +555,7 @@ static Handle<Value> Unlink(const Arguments& args) {
   if (args.Length() < 1) return TYPE_ERROR("path required");
   if (!args[0]->IsString()) return TYPE_ERROR("path must be a string");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
     ASYNC_CALL(unlink, args[1], *path)
@@ -571,7 +571,7 @@ static Handle<Value> RMDir(const Arguments& args) {
   if (args.Length() < 1) return TYPE_ERROR("path required");
   if (!args[0]->IsString()) return TYPE_ERROR("path must be a string");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
     ASYNC_CALL(rmdir, args[1], *path)
@@ -588,7 +588,7 @@ static Handle<Value> MKDir(const Arguments& args) {
     return THROW_BAD_ARGS;
   }
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
@@ -629,7 +629,7 @@ static Handle<Value> ReadDir(const Arguments& args) {
   if (args.Length() < 1) return TYPE_ERROR("path required");
   if (!args[0]->IsString()) return TYPE_ERROR("path must be a string");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
     ASYNC_CALL(readdir, args[1], *path, 0 /*flags*/)
@@ -667,7 +667,7 @@ static Handle<Value> Open(const Arguments& args) {
   if (!args[1]->IsInt32()) return TYPE_ERROR("flags must be an int");
   if (!args[2]->IsInt32()) return TYPE_ERROR("mode must be an int");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
   int flags = args[1]->Int32Value();
   int mode = static_cast<int>(args[2]->Int32Value());
 
@@ -821,7 +821,7 @@ static Handle<Value> Chmod(const Arguments& args) {
   if(args.Length() < 2 || !args[0]->IsString() || !args[1]->IsInt32()) {
     return THROW_BAD_ARGS;
   }
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if(args[2]->IsFunction()) {
@@ -868,7 +868,7 @@ static Handle<Value> Chown(const Arguments& args) {
   if (!args[1]->IsInt32()) return TYPE_ERROR("uid must be an int");
   if (!args[2]->IsInt32()) return TYPE_ERROR("gid must be an int");
 
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
   int uid = static_cast<int>(args[1]->Int32Value());
   int gid = static_cast<int>(args[2]->Int32Value());
 
@@ -919,7 +919,7 @@ static Handle<Value> UTimes(const Arguments& args) {
   if (!args[1]->IsNumber()) return TYPE_ERROR("atime must be a number");
   if (!args[2]->IsNumber()) return TYPE_ERROR("mtime must be a number");
 
-  const String::Utf8Value path(args[0]->ToString());
+  const String::Utf8Value path(args[0]);
   const double atime = static_cast<double>(args[1]->NumberValue());
   const double mtime = static_cast<double>(args[2]->NumberValue());
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -78,7 +78,7 @@ Handle<Value> StatWatcher::Start(const Arguments& args) {
   }
 
   StatWatcher *handler = ObjectWrap::Unwrap<StatWatcher>(args.Holder());
-  String::Utf8Value path(args[0]->ToString());
+  String::Utf8Value path(args[0]);
 
   assert(handler->path_ == NULL);
   handler->path_ = strdup(*path);

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -144,7 +144,7 @@ Handle<Value> PipeWrap::Bind(const Arguments& args) {
 
   UNWRAP
 
-  String::AsciiValue name(args[0]->ToString());
+  String::AsciiValue name(args[0]);
 
   int r = uv_pipe_bind(&wrap->handle_, *name);
 
@@ -271,7 +271,7 @@ Handle<Value> PipeWrap::Connect(const Arguments& args) {
 
   UNWRAP
 
-  String::AsciiValue name(args[0]->ToString());
+  String::AsciiValue name(args[0]);
 
   ConnectWrap* req_wrap = new ConnectWrap();
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -120,7 +120,7 @@ class ProcessWrap : public HandleWrap {
       // Heap allocate to detect errors. +1 is for NULL.
       options.args = new char*[argc + 1];
       for (int i = 0; i < argc; i++) {
-        String::Utf8Value arg(js_argv->Get(i)->ToString());
+        String::Utf8Value arg(js_argv->Get(i));
         options.args[i] = strdup(*arg);
       }
       options.args[argc] = NULL;
@@ -140,7 +140,7 @@ class ProcessWrap : public HandleWrap {
       int envc = env->Length();
       options.env = new char*[envc + 1]; // Heap allocated to detect errors.
       for (int i = 0; i < envc; i++) {
-        String::Utf8Value pair(env->Get(i)->ToString());
+        String::Utf8Value pair(env->Get(i));
         options.env[i] = strdup(*pair);
       }
       options.env[envc] = NULL;

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -298,7 +298,7 @@ Handle<Value> TCPWrap::Bind(const Arguments& args) {
 
   UNWRAP
 
-  String::AsciiValue ip_address(args[0]->ToString());
+  String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
 
   struct sockaddr_in address = uv_ip4_addr(*ip_address, port);
@@ -316,7 +316,7 @@ Handle<Value> TCPWrap::Bind6(const Arguments& args) {
 
   UNWRAP
 
-  String::AsciiValue ip6_address(args[0]->ToString());
+  String::AsciiValue ip6_address(args[0]);
   int port = args[1]->Int32Value();
 
   struct sockaddr_in6 address = uv_ip6_addr(*ip6_address, port);
@@ -412,7 +412,7 @@ Handle<Value> TCPWrap::Connect(const Arguments& args) {
 
   UNWRAP
 
-  String::AsciiValue ip_address(args[0]->ToString());
+  String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
 
   struct sockaddr_in address = uv_ip4_addr(*ip_address, port);
@@ -442,7 +442,7 @@ Handle<Value> TCPWrap::Connect6(const Arguments& args) {
 
   UNWRAP
 
-  String::AsciiValue ip_address(args[0]->ToString());
+  String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
 
   struct sockaddr_in6 address = uv_ip6_addr(*ip_address, port);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -185,7 +185,7 @@ Handle<Value> UDPWrap::DoBind(const Arguments& args, int family) {
   // bind(ip, port, flags)
   assert(args.Length() == 3);
 
-  String::Utf8Value address(args[0]->ToString());
+  String::Utf8Value address(args[0]);
   const int port = args[1]->Uint32Value();
   const int flags = args[2]->Uint32Value();
 
@@ -244,8 +244,8 @@ Handle<Value> UDPWrap::SetMembership(const Arguments& args,
 
   assert(args.Length() == 2);
 
-  String::Utf8Value address(args[0]->ToString());
-  String::Utf8Value iface(args[1]->ToString());
+  String::Utf8Value address(args[0]);
+  String::Utf8Value iface(args[1]);
 
   const char* iface_cstr = *iface;
   if (args[1]->IsUndefined() || args[1]->IsNull()) {
@@ -296,7 +296,7 @@ Handle<Value> UDPWrap::DoSend(const Arguments& args, int family) {
                              length);
 
   const unsigned short port = args[3]->Uint32Value();
-  String::Utf8Value address(args[4]->ToString());
+  String::Utf8Value address(args[4]);
 
   switch (family) {
   case AF_INET:


### PR DESCRIPTION
String::Utf8Value and String::AsciiValue constructors take Handle<Value>
So no need to convert to Handle<String>
