### PR TITLE
Add doc and test of cleartextStream.getCipher() and fix cipher names in doc in tls

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -95,7 +95,7 @@ The `options` object has these possibilities:
     it is recommended that you use this option in conjunction with the
     `honorCipherOrder` option described below to prioritize the RC4 algorithm,
     since it is a non-CBC cipher. A recommended cipher list follows:
-    `ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM`
+    `ECDHE-RSA-AES256-SHA:AES256-SHA:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM`
 
   - `honorCipherOrder` :
 	When choosing a cipher, use the server's preferences instead of the client

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -401,6 +401,17 @@ Example:
 If the peer does not provide a certificate, it returns `null` or an empty
 object.
 
+### cleartextStream.getCipher()
+Returns an object representing the cipher name and the SSL/TLS
+protocol version of the current connection. 
+
+Example:
+{ name: 'AES256-SHA', version: 'TLSv1/SSLv3' }
+
+See SSL_CIPHER_get_name() and SSL_CIPHER_get_version() in
+http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_CIPHERS for more
+information.
+
 ### cleartextStream.address()
 
 Returns the bound address and port of the underlying socket as reported by the

--- a/test/simple/test-tls-getcipher.js
+++ b/test/simple/test-tls-getcipher.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+var cipher_list = ['RC4-SHA', 'AES256-SHA'];
+var cipher_version_pattern = /TLS|SSL/;
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+  ciphers: cipher_list.join(':'),
+  honorCipherOrder: true
+};
+
+var nconns = 0;
+
+process.on('exit', function() {
+  assert.equal(nconns, 1);
+});
+
+var server = tls.createServer(options, function(cleartextStream) {
+  nconns++;
+});
+
+server.listen(common.PORT, '127.0.0.1', function() {
+  var client = tls.connect(common.PORT, '127.0.0.1',  function() {
+    var cipher = client.getCipher(); 
+    assert.equal(cipher.name, cipher_list[0]);
+    assert(cipher_version_pattern.test(cipher.version));
+    client.end();
+    server.close();
+  });
+});


### PR DESCRIPTION
cleartextStream.getCipher() is a good method to see the cipher name and the SSL/TLS protocol version of the current connection but it is not documented yet. 
I added a doc and a test to check if it works fine.

The test also includes {honorCipherOrder: true} in its option to see the cipher order but #2844 indicates to use openssl command. Is there any specific reason to invoke openssl? If not, I can add more tests for the cipher order.

Another commit was added in this PR to fix the mistakes of cipher names, ECDHE-RSA-AES256-SHA384 and AES256-SHA256, in the doc. The proper names where openssl supports have no number in the end as 

```
> openssl ciphers -v | grep -e ^ECDHE-RSA-AES256 -e ^AES256-SHA
ECDHE-RSA-AES256-SHA    SSLv3 Kx=ECDH     Au=RSA  Enc=AES(256)  Mac=SHA1
AES256-SHA              SSLv3 Kx=RSA      Au=RSA  Enc=AES(256)  Mac=SHA1
```
