### PR TITLE
doc: Fix default dgram multicast ttl to 1

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -176,7 +176,7 @@ specifically for multicast traffic.  Each router or gateway that forwards a pack
 decrements the TTL. If the TTL is decremented to 0 by a router, it will not be forwarded.
 
 The argument to `setMulticastTTL()` is a number of hops between 0 and 255.  The default on most
-systems is 64.
+systems is 1.
 
 ### dgram.setMulticastLoopback(flag)
 


### PR DESCRIPTION
On most systems, default ip multicast ttl is not 64 but 1 to be restricted on the local subnet.

Linux: http://man7.org/linux/man-pages/man7/ip.7.html

```
IP_MULTICAST_TTL (since Linux 1.2)
Set or read the time-to-live value of outgoing multicast packets for this socket.  It is very important  for  multi‐
cast  packets to set the smallest TTL possible.  The default is 1 which means that multicast packets don't leave the local network unless the user program explicitly requests it. 
```

Windows: http://support.microsoft.com/kb/257460/en-us

```
winsock.h
#define IP_DEFAULT_MULTICAST_TTL   1    /* normally limit m'casts to 1 hop  */ 
```
