### PR TITLE
Allow module reload from repl useful during development.

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -291,7 +291,13 @@ REPLServer.prototype.createContext = function() {
   }
 
   context.module = module;
-  context.require = require;
+  context.require = function(id, options) {
+    // Remove module from cache if reload is requested.
+    if (options && options.reload)
+      delete require.cache[require.resolve(id)];
+
+    return require(id);
+  };
   context.global = context;
   context.global.global = context;
 


### PR DESCRIPTION
Very often during development I use repl, but then changes to modules I work on don't reflect in my repl session which forces me to either restart session or manually delete module from cache. This change modifies require in repl so that extra option will force reload of module:

``` js
require('./foo', { reload: true })
```
