### PR TITLE
Make defaultMaxListeners accessible

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -30,7 +30,7 @@ exports.EventEmitter = EventEmitter;
 //
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.
-var defaultMaxListeners = 10;
+EventEmitter.prototype.defaultMaxListeners = 10;
 EventEmitter.prototype.setMaxListeners = function(n) {
   if (!this._events) this._events = {};
   this._maxListeners = n;
@@ -128,7 +128,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
     if (this._maxListeners !== undefined) {
       m = this._maxListeners;
     } else {
-      m = defaultMaxListeners;
+      m = this.defaultMaxListeners;
     }
 
     if (m && m > 0 && this._events[type].length > m) {


### PR DESCRIPTION
It's impossible to access `setMaxListeners` when an EventEmitter is buried deep within dependencies. This change allows us to set the default max listeners independently and to prevent the warnings from being logged if we're not interested in them
