### PR TITLE
Fix util.pump and Stream.pipe multiple arguments missing

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -33,9 +33,9 @@ Stream.Stream = Stream;
 Stream.prototype.pipe = function(dest, options) {
   var source = this;
 
-  function ondata(chunk) {
+  function ondata() {
     if (dest.writable) {
-      if (false === dest.write(chunk) && source.pause) {
+      if (false === dest.write.apply(dest, arguments) && source.pause) {
         source.pause();
       }
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -454,8 +454,8 @@ exports.pump = function(readStream, writeStream, callback) {
     }
   }
 
-  readStream.addListener('data', function(chunk) {
-    if (writeStream.write(chunk) === false) readStream.pause();
+  readStream.addListener('data', function() {
+    if (writeStream.write.apply(writeStream, arguments) === false) readStream.pause();
   });
 
   writeStream.addListener('drain', function() {

--- a/test/simple/test-pump-multiple-arguments.js
+++ b/test/simple/test-pump-multiple-arguments.js
@@ -1,0 +1,17 @@
+var assert = require('assert')
+  , util = require('util')
+  ;
+
+var src = new process.EventEmitter
+  , dst = new process.EventEmitter
+  ;
+
+function assert_all_argument_passed_through(arg1, arg2, arg3) {
+  assert.equal("a", arg1);
+  assert.equal("b", arg2);
+  assert.equal("c", arg3);
+}
+src.on('data', assert_all_argument_passed_through);
+dst.write =    assert_all_argument_passed_through;
+util.pump(src, dst);
+src.emit('data', 'a', 'b', 'c');

--- a/test/simple/test-stream-multiple-arguments.js
+++ b/test/simple/test-stream-multiple-arguments.js
@@ -1,0 +1,20 @@
+var assert = require('assert')
+  , stream = require('stream')
+  ;
+
+var src = new stream.Stream
+  , dst = new stream.Stream
+  ;
+
+src.readable = true;
+dst.writable = true;
+
+function assert_all_argument_passed_through(arg1, arg2, arg3) {
+  assert.equal("a", arg1);
+  assert.equal("b", arg2);
+  assert.equal("c", arg3);
+}
+src.on('data', assert_all_argument_passed_through);
+dst.write =    assert_all_argument_passed_through;
+src.pipe(dst);
+src.emit('data', 'a', 'b', 'c');


### PR DESCRIPTION
currently only the first argument of "data" event is pumped through. all arguments should pass through instead.
