### PR TITLE
add missing Uint8ClampedArray

### DIFF
--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -339,6 +339,15 @@ class TypedArray {
         reinterpret_cast<float*>(ptr)[index] = (float) args[1]->NumberValue();
       else if (TEAType == v8::kExternalDoubleArray)
         reinterpret_cast<double*>(ptr)[index] = (double) args[1]->NumberValue();
+      else if (TEAType == v8::kExternalPixelArray) {
+        int value = args[1]->Int32Value();
+        if (value < 0)
+          value = 0;
+        else if (value > 255)
+          value = 255;
+        reinterpret_cast<unsigned char*>(ptr)[index] =
+            (unsigned char) value;
+      }
     } else if (args[0]->IsObject()) {
       v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(args[0]);
 
@@ -439,6 +448,7 @@ class TypedArray {
       case v8::kExternalUnsignedIntArray: return "Uint32Array";
       case v8::kExternalFloatArray: return "Float32Array";
       case v8::kExternalDoubleArray: return "Float64Array";
+      case v8::kExternalPixelArray: return "Uint8ClampedArray";
     }
     abort();
   }
@@ -446,6 +456,8 @@ class TypedArray {
 
 class Int8Array : public TypedArray<1, v8::kExternalByteArray> { };
 class Uint8Array : public TypedArray<1, v8::kExternalUnsignedByteArray> { };
+class Uint8ClampedArray : public TypedArray<1,
+v8::kExternalPixelArray> { };
 class Int16Array : public TypedArray<2, v8::kExternalShortArray> { };
 class Uint16Array : public TypedArray<2, v8::kExternalUnsignedShortArray> { };
 class Int32Array : public TypedArray<4, v8::kExternalIntArray> { };
@@ -799,6 +811,8 @@ void AttachBindings(v8::Handle<v8::Object> obj) {
            Int8Array::GetTemplate()->GetFunction());
   obj->Set(v8::String::New("Uint8Array"),
            Uint8Array::GetTemplate()->GetFunction());
+  obj->Set(v8::String::New("Uint8ClampedArray"),
+           Uint8ClampedArray::GetTemplate()->GetFunction());
   obj->Set(v8::String::New("Int16Array"),
            Int16Array::GetTemplate()->GetFunction());
   obj->Set(v8::String::New("Uint16Array"),

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -456,8 +456,7 @@ class TypedArray {
 
 class Int8Array : public TypedArray<1, v8::kExternalByteArray> { };
 class Uint8Array : public TypedArray<1, v8::kExternalUnsignedByteArray> { };
-class Uint8ClampedArray : public TypedArray<1,
-v8::kExternalPixelArray> { };
+class Uint8ClampedArray : public TypedArray<1, v8::kExternalPixelArray> { };
 class Int16Array : public TypedArray<2, v8::kExternalShortArray> { };
 class Uint16Array : public TypedArray<2, v8::kExternalUnsignedShortArray> { };
 class Int32Array : public TypedArray<4, v8::kExternalIntArray> { };

--- a/test/common.js
+++ b/test/common.js
@@ -111,6 +111,7 @@ process.on('exit', function() {
     knownGlobals.push(ArrayBuffer);
     knownGlobals.push(Int8Array);
     knownGlobals.push(Uint8Array);
+    knownGlobals.push(Uint8ClampedArray);
     knownGlobals.push(Int16Array);
     knownGlobals.push(Uint16Array);
     knownGlobals.push(Int32Array);

--- a/test/simple/test-typed-arrays.js
+++ b/test/simple/test-typed-arrays.js
@@ -37,7 +37,8 @@ var assert = require('assert');
   'Int32Array',
   'Uint32Array',
   'Float32Array',
-  'Float64Array'
+  'Float64Array',
+  'Uint8ClampedArray'
 ].forEach(function(name) {
   var expected = '[object ' + name + ']';
   var clazz = global[name];
@@ -145,3 +146,17 @@ uint8.set([0x0a, 0x0b], 2);
 assert.equal(uint8.get(1), 0x09);
 assert.equal(uint8.get(2), 0x0a);
 assert.equal(uint8.get(3), 0x0b);
+
+// test clamped array
+var uint8c = new Uint8ClampedArray(buffer);
+uint8c[0] = -1;
+uint8c[1] = 257;
+
+assert.equal(uint8c[0], 0);
+assert.equal(uint8c[1], 255);
+
+uint8c.set(0, -10);
+uint8c.set(1, 260);
+
+assert.equal(uint8c[0], 0);
+assert.equal(uint8c[1], 255);


### PR DESCRIPTION
Uint8ClampedArray, one of the typed arrays, was missing.
It is implemented using kExternalPixelArray, as in browsers.
Added code and updated tests.
