### PR TITLE
Add keypress event in tty, deprecation warning and  doc changes of stability in tty and readline 

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -1,6 +1,6 @@
 # Readline
 
-    Stability: 3 - Stable
+    Stability: 2 - Unstable
 
 To use this module, do `require('readline')`. Readline allows reading of a
 stream (such as `process.stdin`) on a line-by-line basis.

--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -1,6 +1,6 @@
 # TTY
 
-    Stability: 3 - Stable
+    Stability: 2 - Unstable
 
 The `tty` module houses the `tty.ReadStream` and `tty.WriteStream` classes. In
 most cases, you will not need to use this module directly.

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -48,6 +48,8 @@ function ReadStream(fd) {
   this.readable = true;
   this.writable = false;
   this.isRaw = false;
+  // backwards-compat
+  require('readline').emitKeypressEvents(this);
 }
 inherits(ReadStream, net.Socket);
 

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -37,6 +37,7 @@ exports.setRawMode = function(flag) {
   }
   process.stdin.setRawMode(flag);
 };
+module.deprecate('setRawMode', 'Use `tty.ReadStream#setRawMode` instead.');
 
 
 function ReadStream(fd) {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -106,7 +106,7 @@ WriteStream.prototype._refreshSize = function() {
     this.rows = newRows;
     this.emit('resize');
   }
-}
+};
 
 
 // backwards-compat


### PR DESCRIPTION
aad12d0b265c9b06ae029d6ee168849260a91dd6 changed tty and readline api a lot. This PR has the following 4 commits.
- keypress event was missed in tty.Readstream that was emitted before. The first patch fixed it for backward compatibility.
- module.deprecate() was added to  tty.setRawMode() in order to show warning to user.
- doc of the stability index of tty and readline should be changed to  **2:Unstable** because tty.setrRawMode() was deprecated  and  the argument and its property of readline.createInterface() was changed.
  It seems more than minor change and breaks guarantee of back-ward compatibility.
- Fix minor warning of jslint caused by missing a semi colon.
