### PR TITLE
Response object for HTTP Upgrade/CONNECT

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -287,6 +287,42 @@ function connectionListener(socket) {
   var outgoing = [];
   var incoming = [];
 
+  function createResponse(req, shouldKeepAlive) {
+    incoming.push(req);
+
+    var res = new ServerResponse(req);
+
+    res.shouldKeepAlive = shouldKeepAlive;
+    DTRACE_HTTP_SERVER_REQUEST(req, socket);
+    COUNTER_HTTP_SERVER_REQUEST();
+
+    if (socket._httpMessage) {
+      // There are already pending outgoing res, append.
+      outgoing.push(res);
+    } else {
+      res.assignSocket(socket);
+    }
+
+    res.on('finish', function() {
+      // Usually the first incoming element should be our request.  it may
+      // be that in the case abortIncoming() was called that the incoming
+      // array will be empty.
+      assert(incoming.length == 0 || incoming[0] === req);
+
+      incoming.shift();
+
+      // if the user never called req.read(), and didn't pipe() or
+      // .resume() or .on('data'), then we call req._dump() so that the
+      // bytes will be pulled off the wire.
+      if (!req._consuming)
+        req._dump();
+
+      res.detachSocket(socket);
+    });
+
+    return res;
+  }
+
   function abortIncoming() {
     while (incoming.length) {
       var req = incoming.shift();
@@ -360,14 +396,41 @@ function connectionListener(socket) {
       freeParser(parser, req);
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-      if (EventEmitter.listenerCount(self, eventName) > 0) {
-        var bodyHead = d.slice(bytesParsed, d.length);
-
-        self.emit(eventName, req, req.socket, bodyHead);
-      } else {
+      if (EventEmitter.listenerCount(self, eventName) === 0) {
         // Got upgrade header or CONNECT method, but have no handler.
         socket.destroy();
+        return;
       }
+
+      // This is start + byteParsed
+      var bodyHead = d.slice(bytesParsed, d.length);
+      socket.unshift(bodyHead);
+
+      // 'shouldKeepAlive == false' ensures we send 'Connection: close' for
+      // responses that don't successfully switch protocols.
+      var res = createResponse(req, false);
+      res.useChunkedEncodingByDefault = false;
+
+      // The alternate exit for a handler that accepts the upgrade.
+      var switchCb = null;
+      res.switchProtocols = function(fn) {
+        req._consuming = true;
+        switchCb = fn;
+        this.end();
+      };
+
+      // When finished, either upgrade, or close the socket.
+      res.on('finish', function() {
+        socket.removeListener('close', serverSocketCloseListener);
+
+        if (switchCb) {
+          switchCb(socket);
+        } else {
+          socket.destroySoon();
+        }
+      });
+
+      self.emit(eventName, req, res);
     }
   };
 
@@ -398,39 +461,11 @@ function connectionListener(socket) {
   // new message. In this callback we setup the response object and pass it
   // to the user.
   parser.onIncoming = function(req, shouldKeepAlive) {
-    incoming.push(req);
-
-    var res = new ServerResponse(req);
-
-    res.shouldKeepAlive = shouldKeepAlive;
-    DTRACE_HTTP_SERVER_REQUEST(req, socket);
-    COUNTER_HTTP_SERVER_REQUEST();
-
-    if (socket._httpMessage) {
-      // There are already pending outgoing res, append.
-      outgoing.push(res);
-    } else {
-      res.assignSocket(socket);
-    }
+    var res = createResponse(req, shouldKeepAlive);
 
     // When we're finished writing the response, check if this is the last
-    // respose, if so destroy the socket.
+    // response, if so destroy the socket.
     res.on('finish', function() {
-      // Usually the first incoming element should be our request.  it may
-      // be that in the case abortIncoming() was called that the incoming
-      // array will be empty.
-      assert(incoming.length == 0 || incoming[0] === req);
-
-      incoming.shift();
-
-      // if the user never called req.read(), and didn't pipe() or
-      // .resume() or .on('data'), then we call req._dump() so that the
-      // bytes will be pulled off the wire.
-      if (!req._consuming)
-        req._dump();
-
-      res.detachSocket(socket);
-
       if (res._last) {
         socket.destroySoon();
       } else {

--- a/test/simple/test-http-after-connect.js
+++ b/test/simple/test-http-after-connect.js
@@ -37,13 +37,15 @@ var server = http.createServer(function(req, res) {
     res.end(req.url);
   }, 50);
 });
-server.on('connect', function(req, socket, firstBodyChunk) {
+server.on('connect', function(req, res) {
   common.debug('Server got CONNECT request');
   serverConnected = true;
-  socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
-  socket.resume();
-  socket.on('end', function() {
-    socket.end();
+  res.writeHead(200, 'Connection established');
+  res.switchProtocols(function(socket) {
+    socket.resume();
+    socket.on('end', function() {
+      socket.end();
+    });
   });
 });
 server.listen(common.PORT, function() {

--- a/test/simple/test-http-connect.js
+++ b/test/simple/test-http-connect.js
@@ -29,20 +29,21 @@ var clientGotConnect = false;
 var server = http.createServer(function(req, res) {
   assert(false);
 });
-server.on('connect', function(req, socket, firstBodyChunk) {
+server.on('connect', function(req, res) {
   assert.equal(req.method, 'CONNECT');
   assert.equal(req.url, 'google.com:443');
   common.debug('Server got CONNECT request');
   serverGotConnect = true;
 
-  socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
-
-  var data = firstBodyChunk.toString();
-  socket.on('data', function(buf) {
-    data += buf.toString();
-  });
-  socket.on('end', function() {
-    socket.end(data);
+  res.writeHead(200, 'Connection Established');
+  res.switchProtocols(function(socket) {
+    var data = '';
+    socket.on('data', function(buf) {
+      data += buf.toString();
+    });
+    socket.on('end', function() {
+      socket.end(data);
+    });
   });
 });
 server.listen(common.PORT, function() {

--- a/test/simple/test-http-pipelined-upgrade.js
+++ b/test/simple/test-http-pipelined-upgrade.js
@@ -1,0 +1,75 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var http = require('http');
+
+var agent = new http.Agent({ maxSockets: 1 });
+
+var gotRegularResponse = false;
+var gotUpgradeResponse = false;
+
+var server = http.createServer(function(req, res) {
+  common.debug('Server got regular request');
+  setTimeout(function() {
+    common.debug('Server finished regular request');
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('Hello World\n');
+  }, 500);
+});
+server.on('upgrade', function(req, sock, head) {
+  common.debug('Server got upgrade request');
+  sock.end('HTTP/1.1 101 Switching Protocols\r\n' +
+             'Upgrade: dummy\r\n' +
+             'Connection: Upgrade\r\n' +
+             '\r\n\r\n');
+  server.close();
+});
+server.listen(common.PORT, function() {
+  var conn = net.createConnection(common.PORT);
+
+  conn.on('connect', function() {
+    conn.write('GET / HTTP/1.1\r\n' +
+               '\r\n' +
+               'GET / HTTP/1.1\r\n' +
+               'Upgrade: WebSocket\r\n' +
+               'Connection: Upgrade\r\n' +
+               '\r\n');
+  });
+
+  conn.setEncoding('utf8');
+  var data = '';
+  conn.on('data', function(chunk) {
+    data += chunk;
+  });
+
+  conn.on('end', function() {
+    conn.end();
+
+    var regularIndex = data.indexOf('Hello World');
+    var upgradeIndex = data.indexOf('Upgrade');
+    assert.notEqual(regularIndex, -1);
+    assert.notEqual(upgradeIndex, -1);
+    assert.ok(regularIndex < upgradeIndex);
+  });
+});

--- a/test/simple/test-http-pipelined-upgrade.js
+++ b/test/simple/test-http-pipelined-upgrade.js
@@ -37,13 +37,17 @@ var server = http.createServer(function(req, res) {
     res.end('Hello World\n');
   }, 500);
 });
-server.on('upgrade', function(req, sock, head) {
+server.on('upgrade', function(req, res) {
   common.debug('Server got upgrade request');
-  sock.end('HTTP/1.1 101 Switching Protocols\r\n' +
-             'Upgrade: dummy\r\n' +
-             'Connection: Upgrade\r\n' +
-             '\r\n\r\n');
-  server.close();
+  res.writeHead(101, {
+   'Upgrade': 'dummy',
+   'Connection': 'Upgrade'
+  });
+  res.switchProtocols(function(sock) {
+    common.debug('Server finished update request');
+    sock.end();
+    server.close();
+  });
 });
 server.listen(common.PORT, function() {
   var conn = net.createConnection(common.PORT);

--- a/test/simple/test-http-upgrade-client2.js
+++ b/test/simple/test-http-upgrade-client2.js
@@ -26,12 +26,19 @@ var http = require('http');
 var CRLF = '\r\n';
 
 var server = http.createServer();
-server.on('upgrade', function(req, socket, head) {
-  socket.write('HTTP/1.1 101 Ok' + CRLF +
-               'Connection: Upgrade' + CRLF +
-               'Upgrade: Test' + CRLF + CRLF + 'head');
-  socket.on('end', function() {
-    socket.end();
+server.on('upgrade', function(req, res) {
+  res.writeHead(101, {
+    'Connection': 'Upgrade',
+    'Upgrade': 'Test'
+  });
+  res.switchProtocols(function(socket) {
+    socket.write('head');
+    socket.on('readable', function() {
+        socket.read();
+    });
+    socket.on('end', function() {
+      socket.end();
+    });
   });
 });
 

--- a/test/simple/test-http-upgrade-server.js
+++ b/test/simple/test-http-upgrade-server.js
@@ -49,22 +49,23 @@ function testServer() {
     res.end();
   });
 
-  server.on('upgrade', function(req, socket, upgradeHead) {
-    socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
-                 'Upgrade: WebSocket\r\n' +
-                 'Connection: Upgrade\r\n' +
-                 '\r\n\r\n');
+  server.on('upgrade', function(req, res) {
+    res.writeHead(101, {
+      'Upgrade': 'WebSocket',
+      'Connection': 'Upgrade'
+    });
+    res.switchProtocols(function(socket) {
+      request_upgradeHead = socket.read();
 
-    request_upgradeHead = upgradeHead;
-
-    socket.ondata = function(d, start, end) {
-      var data = d.toString('utf8', start, end);
-      if (data == 'kill') {
-        socket.end();
-      } else {
-        socket.write(data, 'utf8');
-      }
-    };
+      socket.ondata = function(d, start, end) {
+        var data = d.toString('utf8', start, end);
+        if (data == 'kill') {
+          socket.end();
+        } else {
+          socket.write(data, 'utf8');
+        }
+      };
+    });
   });
 }
 

--- a/test/simple/test-http-upgrade-server2.js
+++ b/test/simple/test-http-upgrade-server2.js
@@ -29,7 +29,7 @@ var server = http.createServer(function(req, res) {
   throw new Error('This shouldn\'t happen.');
 });
 
-server.on('upgrade', function(req, socket, upgradeHead) {
+server.on('upgrade', function(req, res) {
   common.error('got upgrade event');
   // test that throwing an error from upgrade gets
   // is uncaught


### PR DESCRIPTION
I started a thread on nodejs-dev about this, but it looks like my posts are still in the moderator queue. Will link it here once it gets through.

Briefly:
- The first commit is a test showing that a pipelined Upgrade request to a Node server can cause an out-of-order response. This is because the `upgrade` handler gets immediate access to the socket, while other requests may still be processing async.
- The second commit fixes this by providing a response object even for Upgrade, that is also queued properly along with other responses.
- In addition to fixing the test, I find it makes sense to have a response here. Per the spec, CONNECT and Upgrade **must** be followed by a proper response, before handover.

Regarding `make test`, I have one failing test both before and after this patch set, namely `simple/test-http-full-response`. I consider this a platform irk. `make test-debug` plain crashes the test suite on `simple/test-repl` (also before and after), but a fair amount of HTTP tests do pass.
