### PR TITLE
Make UNWRAP macro generic and move to node.h

### DIFF
--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -28,17 +28,6 @@ using namespace v8;
 
 namespace node {
 
-#define UNWRAP                                                              \
-  assert(!args.Holder().IsEmpty());                                         \
-  assert(args.Holder()->InternalFieldCount() > 0);                          \
-  FSEventWrap* wrap =                                                       \
-      static_cast<FSEventWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) {                                                              \
-    uv_err_t err;                                                           \
-    err.code = UV_EBADF;                                                    \
-    SetErrno(err);                                                          \
-    return scope.Close(Integer::New(-1));                                   \
-  }
 
 class FSEventWrap: public HandleWrap {
 public:
@@ -101,7 +90,7 @@ Handle<Value> FSEventWrap::New(const Arguments& args) {
 Handle<Value> FSEventWrap::Start(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(FSEventWrap);
 
   if (args.Length() < 1 || !args[0]->IsString()) {
     return ThrowException(Exception::TypeError(String::New("Bad arguments")));
@@ -172,7 +161,7 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
 Handle<Value> FSEventWrap::Close(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(FSEventWrap);
 
   if (!wrap->initialized_)
     return Undefined();

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -39,18 +39,6 @@ using v8::Arguments;
 using v8::Integer;
 
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  HandleWrap* wrap =  \
-      static_cast<HandleWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 
 void HandleWrap::Initialize(Handle<Object> target) {
   /* Doesn't do anything at the moment. */
@@ -62,7 +50,7 @@ void HandleWrap::Initialize(Handle<Object> target) {
 Handle<Value> HandleWrap::Unref(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(HandleWrap);
 
   // Calling unnecessarily is a no-op
   if (wrap->unref) {
@@ -80,7 +68,7 @@ Handle<Value> HandleWrap::Unref(const Arguments& args) {
 Handle<Value> HandleWrap::Ref(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(HandleWrap);
 
   // Calling multiple times is a no-op
   if (!wrap->unref) {
@@ -97,18 +85,19 @@ Handle<Value> HandleWrap::Ref(const Arguments& args) {
 Handle<Value> HandleWrap::Close(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  HandleWrap *wrap = static_cast<HandleWrap*>(args.Holder()->GetPointerFromInternalField(0));
 
-  // guard against uninitialized handle or double close
-  if (wrap->handle__ == NULL) return v8::Null();
-  assert(!wrap->object_.IsEmpty());
-  uv_close(wrap->handle__, OnClose);
-  wrap->handle__ = NULL;
+  if (wrap) {
+    // guard against uninitialized handle or double close
+    if (wrap->handle__ == NULL) return v8::Null();
+    assert(!wrap->object_.IsEmpty());
+    uv_close(wrap->handle__, OnClose);
+    wrap->handle__ = NULL;
 
-  HandleWrap::Ref(args);
+    HandleWrap::Ref(args);
 
-  wrap->StateChange();
-
+    wrap->StateChange();
+  }
   return v8::Null();
 }
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -23,7 +23,7 @@
 #define SRC_NODE_INTERNALS_H_
 
 #include "v8.h"
-
+#include <stdlib.h> //abort()
 namespace node {
 
 #ifdef _WIN32
@@ -80,6 +80,18 @@ inline static v8::Handle<v8::Value> ThrowTypeError(const char* errmsg) {
 inline static v8::Handle<v8::Value> ThrowRangeError(const char* errmsg) {
   THROW_ERROR(v8::Exception::RangeError);
 }
+
+
+#define UNWRAP(type) \
+  assert(!args.Holder().IsEmpty()); \
+  assert(args.Holder()->InternalFieldCount() > 0); \
+  type* wrap =  \
+      static_cast<type*>(args.Holder()->GetPointerFromInternalField(0)); \
+  if (!wrap) { \
+    fprintf(stderr, #type " :Aborting due to unwrap failure at %s:%d\n", __FILE__, __LINE__);\
+    abort();\
+  } \
+  while(0)
 
 } // namespace node
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -26,18 +26,6 @@
 #include "stream_wrap.h"
 #include "pipe_wrap.h"
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  PipeWrap* wrap =  \
-      static_cast<PipeWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Object;
@@ -142,7 +130,7 @@ PipeWrap::PipeWrap(Handle<Object> object, bool ipc)
 Handle<Value> PipeWrap::Bind(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap);
 
   String::AsciiValue name(args[0]);
 
@@ -159,7 +147,7 @@ Handle<Value> PipeWrap::Bind(const Arguments& args) {
 Handle<Value> PipeWrap::SetPendingInstances(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap);
 
   int instances = args[0]->Int32Value();
 
@@ -173,7 +161,7 @@ Handle<Value> PipeWrap::SetPendingInstances(const Arguments& args) {
 Handle<Value> PipeWrap::Listen(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap);
 
   int backlog = args[0]->Int32Value();
 
@@ -256,7 +244,7 @@ void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
 Handle<Value> PipeWrap::Open(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap);
 
   int fd = args[0]->IntegerValue();
 
@@ -269,7 +257,7 @@ Handle<Value> PipeWrap::Open(const Arguments& args) {
 Handle<Value> PipeWrap::Connect(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap);
 
   String::AsciiValue name(args[0]);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -25,18 +25,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  ProcessWrap* wrap =  \
-      static_cast<ProcessWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Object;
@@ -94,7 +82,7 @@ class ProcessWrap : public HandleWrap {
   static Handle<Value> Spawn(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(ProcessWrap);
 
     Local<Object> js_options = args[0]->ToObject();
 
@@ -200,7 +188,7 @@ class ProcessWrap : public HandleWrap {
   static Handle<Value> Kill(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(ProcessWrap);
 
     int signal = args[0]->Int32Value();
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -49,20 +49,6 @@ using v8::Context;
 using v8::Arguments;
 using v8::Integer;
 
-
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  StreamWrap* wrap =  \
-      static_cast<StreamWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
-
 typedef class ReqWrap<uv_shutdown_t> ShutdownWrap;
 typedef class ReqWrap<uv_write_t> WriteWrap;
 
@@ -112,7 +98,7 @@ void StreamWrap::UpdateWriteQueueSize() {
 Handle<Value> StreamWrap::ReadStart(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap);
 
   bool ipc_pipe = wrap->stream_->type == UV_NAMED_PIPE &&
                   ((uv_pipe_t*)wrap->stream_)->ipc;
@@ -133,7 +119,7 @@ Handle<Value> StreamWrap::ReadStart(const Arguments& args) {
 Handle<Value> StreamWrap::ReadStop(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap);
 
   int r = uv_read_stop(wrap->stream_);
 
@@ -219,7 +205,7 @@ void StreamWrap::OnRead2(uv_pipe_t* handle, ssize_t nread, uv_buf_t buf,
 Handle<Value> StreamWrap::Write(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap);
 
   bool ipc_pipe = wrap->stream_->type == UV_NAMED_PIPE &&
                   ((uv_pipe_t*)wrap->stream_)->ipc;
@@ -315,7 +301,7 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
 Handle<Value> StreamWrap::Shutdown(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap);
 
   ShutdownWrap* req_wrap = new ShutdownWrap();
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -43,18 +43,6 @@
 # define uv_inet_ntop inet_ntop
 #endif
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  TCPWrap* wrap =  \
-      static_cast<TCPWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Arguments;
@@ -171,7 +159,7 @@ Handle<Value> TCPWrap::GetSockName(const Arguments& args) {
   int port;
   char ip[INET6_ADDRSTRLEN];
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   int addrlen = sizeof(address);
   int r = uv_tcp_getsockname(&wrap->handle_,
@@ -213,7 +201,7 @@ Handle<Value> TCPWrap::GetPeerName(const Arguments& args) {
   int port;
   char ip[INET6_ADDRSTRLEN];
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   int addrlen = sizeof(address);
   int r = uv_tcp_getpeername(&wrap->handle_,
@@ -251,7 +239,7 @@ Handle<Value> TCPWrap::GetPeerName(const Arguments& args) {
 Handle<Value> TCPWrap::SetNoDelay(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   int r = uv_tcp_nodelay(&wrap->handle_, 1);
   if (r)
@@ -264,7 +252,7 @@ Handle<Value> TCPWrap::SetNoDelay(const Arguments& args) {
 Handle<Value> TCPWrap::SetKeepAlive(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   int enable = args[0]->Int32Value();
   unsigned int delay = args[1]->Uint32Value();
@@ -281,7 +269,7 @@ Handle<Value> TCPWrap::SetKeepAlive(const Arguments& args) {
 Handle<Value> TCPWrap::SetSimultaneousAccepts(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   bool enable = args[0]->BooleanValue();
 
@@ -297,7 +285,7 @@ Handle<Value> TCPWrap::SetSimultaneousAccepts(const Arguments& args) {
 Handle<Value> TCPWrap::Bind(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
@@ -315,7 +303,7 @@ Handle<Value> TCPWrap::Bind(const Arguments& args) {
 Handle<Value> TCPWrap::Bind6(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   String::AsciiValue ip6_address(args[0]);
   int port = args[1]->Int32Value();
@@ -333,7 +321,7 @@ Handle<Value> TCPWrap::Bind6(const Arguments& args) {
 Handle<Value> TCPWrap::Listen(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   int backlog = args[0]->Int32Value();
 
@@ -411,7 +399,7 @@ void TCPWrap::AfterConnect(uv_connect_t* req, int status) {
 Handle<Value> TCPWrap::Connect(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
@@ -441,7 +429,7 @@ Handle<Value> TCPWrap::Connect(const Arguments& args) {
 Handle<Value> TCPWrap::Connect6(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap);
 
   String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -22,17 +22,6 @@
 #include "node.h"
 #include "handle_wrap.h"
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  TimerWrap* wrap =  \
-      static_cast<TimerWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
 
 namespace node {
 
@@ -124,7 +113,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Start(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap);
 
     int64_t timeout = args[0]->IntegerValue();
     int64_t repeat = args[1]->IntegerValue();
@@ -142,7 +131,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Stop(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap);
 
     int r = uv_timer_stop(&wrap->handle_);
 
@@ -156,7 +145,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Again(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap);
 
     int r = uv_timer_again(&wrap->handle_);
 
@@ -170,7 +159,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> SetRepeat(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap);
 
     int64_t repeat = args[0]->IntegerValue();
 
@@ -182,7 +171,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> GetRepeat(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap);
 
     int64_t repeat = uv_timer_get_repeat(&wrap->handle_);
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -42,18 +42,6 @@ using v8::Arguments;
 using v8::Integer;
 using v8::Undefined;
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  TTYWrap* wrap =  \
-      static_cast<TTYWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 
 class TTYWrap : StreamWrap {
  public:
@@ -118,7 +106,7 @@ class TTYWrap : StreamWrap {
   static Handle<Value> GetWindowSize(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TTYWrap);
 
     int width, height;
     int r = uv_tty_get_winsize(&wrap->handle_, &width, &height);
@@ -138,7 +126,7 @@ class TTYWrap : StreamWrap {
   static Handle<Value> SetRawMode(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TTYWrap);
 
     int r = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -49,18 +49,6 @@ using namespace v8;
 
 namespace node {
 
-#define UNWRAP                                                              \
-  assert(!args.Holder().IsEmpty());                                         \
-  assert(args.Holder()->InternalFieldCount() > 0);                          \
-  UDPWrap* wrap =                                                           \
-      static_cast<UDPWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) {                                                              \
-    uv_err_t err;                                                           \
-    err.code = UV_EBADF;                                                    \
-    SetErrno(err);                                                          \
-    return scope.Close(Integer::New(-1));                                   \
-  }
-
 typedef ReqWrap<uv_udp_send_t> SendWrap;
 
 Local<Object> AddressToJS(const sockaddr* addr);
@@ -168,7 +156,7 @@ Handle<Value> UDPWrap::DoBind(const Arguments& args, int family) {
   HandleScope scope;
   int r;
 
-  UNWRAP
+  UNWRAP(UDPWrap);
 
   // bind(ip, port, flags)
   assert(args.Length() == 3);
@@ -209,7 +197,7 @@ Handle<Value> UDPWrap::Bind6(const Arguments& args) {
 #define X(name, fn)                                                           \
   Handle<Value> UDPWrap::name(const Arguments& args) {                        \
     HandleScope scope;                                                        \
-    UNWRAP                                                                    \
+    UNWRAP(UDPWrap);                                                                   \
     assert(args.Length() == 1);                                               \
     int flag = args[0]->Int32Value();                                         \
     int r = fn(&wrap->handle_, flag);                                         \
@@ -228,7 +216,7 @@ X(SetMulticastLoopback, uv_udp_set_multicast_loop)
 Handle<Value> UDPWrap::SetMembership(const Arguments& args,
                                      uv_membership membership) {
   HandleScope scope;
-  UNWRAP
+  UNWRAP(UDPWrap);
 
   assert(args.Length() == 2);
 
@@ -267,7 +255,7 @@ Handle<Value> UDPWrap::DoSend(const Arguments& args, int family) {
   // send(buffer, offset, length, port, address)
   assert(args.Length() == 5);
 
-  UNWRAP
+  UNWRAP(UDPWrap);
 
   assert(Buffer::HasInstance(args[0]));
   Local<Object> buffer_obj = args[0]->ToObject();
@@ -326,7 +314,7 @@ Handle<Value> UDPWrap::Send6(const Arguments& args) {
 Handle<Value> UDPWrap::RecvStart(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(UDPWrap);
 
   // UV_EALREADY means that the socket is already bound but that's okay
   int r = uv_udp_recv_start(&wrap->handle_, OnAlloc, OnRecv);
@@ -342,7 +330,7 @@ Handle<Value> UDPWrap::RecvStart(const Arguments& args) {
 Handle<Value> UDPWrap::RecvStop(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(UDPWrap);
 
   int r = uv_udp_recv_stop(&wrap->handle_);
 
@@ -354,7 +342,7 @@ Handle<Value> UDPWrap::GetSockName(const Arguments& args) {
   HandleScope scope;
   struct sockaddr_storage address;
 
-  UNWRAP
+  UNWRAP(UDPWrap);
 
   int addrlen = sizeof(address);
   int r = uv_udp_getsockname(&wrap->handle_,


### PR DESCRIPTION
UNWRAP macro is defined in many files with the implementation,
only difference the "type" being unwrapped. Now UNWRAP is generic
macro which will take "type" as parameter
