### PR TITLE
Fix to make ReadLine's Interface only fire 'line' events after a \n is recieved

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -264,8 +264,8 @@ Interface.prototype.write = function(d, key) {
   this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d, key);
 };
 
-// telnet on windows sends every single keystroke seperately, so we need to buffer them
-// and only fire the 'line' event when a \n is sent
+// telnet on windows sends every single keystroke seperately, so we need 
+// to buffer them and only fire the 'line' event when a \n is sent
 Interface.prototype._line_buffer = '';
 
 Interface.prototype._normalWrite = function(b) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -269,18 +269,18 @@ Interface.prototype.write = function(d, key) {
 Interface.prototype._line_buffer = '';
 
 Interface.prototype._normalWrite = function(b) {
-    if(b === undefined) {
-        return;
-    }
-    this._line_buffer += b.toString();
-    if(this._line_buffer.indexOf('\n')) {
-        var lines = this._line_buffer.split('\n');
-        // either '' or (concievably) the unfinished portion of the next line
-        this._line_buffer = lines.pop();
-        lines.forEach(function(line) {
-            this._onLine(line + '\n');
-        }, this);
-    }
+  if (b === undefined) {
+    return;
+  }
+  this._line_buffer += b.toString();
+  if (this._line_buffer.indexOf('\n')) {
+    var lines = this._line_buffer.split('\n');
+    // either '' or (concievably) the unfinished portion of the next line
+    this._line_buffer = lines.pop();
+    lines.forEach(function(line) {
+      this._onLine(line + '\n');
+    }, this);
+  }
 };
 
 Interface.prototype._insertString = function(c) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -273,7 +273,7 @@ Interface.prototype._normalWrite = function(b) {
     return;
   }
   this._line_buffer += b.toString();
-  if (this._line_buffer.indexOf('\n')) {
+  if (this._line_buffer.indexOf('\n') !== -1) {
     var lines = this._line_buffer.split('\n');
     // either '' or (concievably) the unfinished portion of the next line
     this._line_buffer = lines.pop();

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -264,12 +264,23 @@ Interface.prototype.write = function(d, key) {
   this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d, key);
 };
 
+// telnet on windows sends every single keystroke seperately, so we need to buffer them
+// and only fire the 'line' event when a \n is sent
+Interface.prototype._line_buffer = '';
 
 Interface.prototype._normalWrite = function(b) {
-  // Very simple implementation right now. Should try to break on
-  // new lines.
-  if (b !== undefined)
-    this._onLine(b.toString());
+    if(b === undefined) {
+        return;
+    }
+    this._line_buffer += b.toString();
+    if(this._line_buffer.indexOf('\n')) {
+        var lines = this._line_buffer.split('\n');
+        // either '' or (concievably) the unfinished portion of the next line
+        this._line_buffer = lines.pop();
+        lines.forEach(function(line) {
+            this._onLine(line + '\n');
+        }, this);
+    }
 };
 
 Interface.prototype._insertString = function(c) {

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -21,9 +21,6 @@
 
 
 
-
-// Can't test this when 'make test' doesn't assign a tty to the stdout.
-// Yet another use-case for require('tty').spawn ?
 var assert = require('assert');
 var readline = require('readline');
 var EventEmitter = require('events').EventEmitter;

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -1,0 +1,98 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+// Can't test this when 'make test' doesn't assign a tty to the stdout.
+// Yet another use-case for require('tty').spawn ?
+var assert = require('assert');
+var readline = require('readline');
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('util').inherits;
+
+function FakeInput() {
+  EventEmitter.call(this);
+}
+inherits(FakeInput, EventEmitter);
+FakeInput.prototype.resume = function(){};
+
+var fi;
+var rli;
+var called;
+
+// sending a full line
+fi = new FakeInput();
+rli = new readline.Interface(fi, {});
+called = false;
+rli.on('line', function(line) {
+  called = true;
+  assert.equal(line, 'asdf\n');
+});
+fi.emit('data', 'asdf\n');
+assert.ok(called);
+
+// sending a single character with no newline
+fi = new FakeInput();
+rli = new readline.Interface(fi, {});
+called = false;
+rli.on('line', function(line) {
+  called = true;
+});
+fi.emit('data', 'a');
+assert.ok(!called);
+
+// sending a single character with no newline and then a newline
+fi = new FakeInput();
+rli = new readline.Interface(fi, {});
+called = false;
+rli.on('line', function(line) {
+  called = true;
+  assert.equal(line, 'a\n');
+});
+fi.emit('data', 'a');
+assert.ok(!called);
+fi.emit('data', '\n');
+assert.ok(called);
+
+// sending multiple newlines at once
+fi = new FakeInput();
+rli = new readline.Interface(fi, {});
+var expectedLines = ['foo\n','bar\n','baz\n'];
+var callCount = 0;
+rli.on('line', function(line) {
+  assert.equal(line, expectedLines[callCount]);
+  callCount++;
+});
+fi.emit('data', expectedLines.join(''));
+assert.equal(callCount, expectedLines.length);
+
+// sending multiple newlines at once that does not end with a new line
+fi = new FakeInput();
+rli = new readline.Interface(fi, {});
+var expectedLines = ['foo\n','bar\n','baz\n','bat'];
+var callCount = 0;
+rli.on('line', function(line) {
+  assert.equal(line, expectedLines[callCount]);
+  callCount++;
+});
+fi.emit('data', expectedLines.join(''));
+assert.equal(callCount, expectedLines.length - 1);

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -22,7 +22,7 @@
 
 
 var assert = require('assert');
-var readline = require('readline');
+var readline = require('../../lib/readline');
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 
@@ -45,6 +45,17 @@ rli.on('line', function(line) {
   assert.equal(line, 'asdf\n');
 });
 fi.emit('data', 'asdf\n');
+assert.ok(called);
+
+// sending a blank line
+fi = new FakeInput();
+rli = new readline.Interface(fi, {});
+called = false;
+rli.on('line', function(line) {
+  called = true;
+  assert.equal(line, '\n');
+});
+fi.emit('data', '\n');
 assert.ok(called);
 
 // sending a single character with no newline

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -30,7 +30,7 @@ function FakeInput() {
   EventEmitter.call(this);
 }
 inherits(FakeInput, EventEmitter);
-FakeInput.prototype.resume = function(){};
+FakeInput.prototype.resume = function() {};
 
 var fi;
 var rli;
@@ -84,7 +84,7 @@ assert.ok(called);
 // sending multiple newlines at once
 fi = new FakeInput();
 rli = new readline.Interface(fi, {});
-var expectedLines = ['foo\n','bar\n','baz\n'];
+var expectedLines = ['foo\n', 'bar\n', 'baz\n'];
 var callCount = 0;
 rli.on('line', function(line) {
   assert.equal(line, expectedLines[callCount]);
@@ -96,7 +96,7 @@ assert.equal(callCount, expectedLines.length);
 // sending multiple newlines at once that does not end with a new line
 fi = new FakeInput();
 rli = new readline.Interface(fi, {});
-var expectedLines = ['foo\n','bar\n','baz\n','bat'];
+var expectedLines = ['foo\n', 'bar\n', 'baz\n', 'bat'];
 var callCount = 0;
 rli.on('line', function(line) {
   assert.equal(line, expectedLines[callCount]);

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -22,7 +22,7 @@
 
 
 var assert = require('assert');
-var readline = require('../../lib/readline');
+var readline = require('readline');
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 


### PR DESCRIPTION
This fixing ReadLine's Interface._normalWrite() to buffer keystrokes and only fire _onLine() when a \n is sent. (And fire it multiple times if multiple lines arrive at once.)

This is necessary because the Windows telnet client sends every single keystroke as it's typed - see http://stackoverflow.com/questions/9962197/node-js-readline-not-waiting-for-a-full-line-on-socket-connections/ for more info.
