### PR TITLE
proccess.tick should the current turn of the event loop

### DIFF
--- a/test/simple/test-process.tick.js
+++ b/test/simple/test-process.tick.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+console.log('     start tick:' + process.tick);
+
+function ohMy() {
+  console.log('20 timeout tick:' + process.tick);
+  setTimeout(function() {
+    console.log('30 timeout tick:' + process.tick);
+  }, 30);
+}
+
+setTimeout(ohMy, 20);
+
+setTimeout(function() {
+  console.log('10 timeout tick:' + process.tick);
+  setTimeout(function() {
+    console.log('15 timeout tick:' + process.tick);
+  }, 5);
+}, 10);
+
+process.nextTick(function() {
+  console.log('     next tick:' + process.tick);
+});


### PR DESCRIPTION
This depends on libuv:[373](https://github.com/joyent/libuv/pull/373)

I've been thinking about long stack traces for a long time now.  The performance hit of trying to calculate the entire trace in production is unacceptable.  However in a production system it is often desirable to unwind a transaction to determine just what happend.  In some cases this may mean a long stack trace of the offending transaction, in others it may be sufficient to be able to trace through the log.

Given that asynchronous events produce logs that are... challenging for humans to read I wanted to come up with something that could help.  Given the non-opinionated nature of core it needs to be small and non-invasive.

It is at this time that I will point out that I do not claim to be wise, nor do I know if this problem has already been solved sufficiently in userland.  I would also like to be clear that I believe the proper domain for a complete solution is going to be userland.  However I do think that a little help is in order.

The problem with unwinding an asynchronous log is order.  To that end I am proposing to expose a monotonically increasing counter or tick count on the process object.  Every turn of the event loop will increase the counter.  Any non-blocking function like `process.nextTick` will also increase this value.

I have not done so in this pull, but I would also like to discuss the possibility of exposing the value of `tick` when a given callback was "primed" or a `tock` value  e.g.

``` javascript
// process.tick === 0
process.nextTick(function() {
  // process.tick === 1
  // process.tock === 0
})
```

If you've read all the way to the end of this, I thank you for your time, I'm sure we are all lovers of wisdom as it were, so comments are not just welcomed, but desired.  Really, what I'm after is:  If you know where you are, and where you were, that should be enough to draw a line into the past to find out what happend.
