### PR TITLE
minor copy/paste style typo on domain.markdown

### DIFF
--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -125,7 +125,7 @@ with a single error handler in a single place.
     var d = domain.create();
 
     function readSomeFile(filename, cb) {
-      fs.readFile(filename, d.bind(function(er, data) {
+      fs.readFile(filename, d.intercept(function(er, data) {
         // if this throws, it will also be passed to the domain
         // additionally, we know that 'er' will always be null,
         // so the error-handling logic can be moved to the 'error'


### PR DESCRIPTION
`d.bind()` in the `intercept()` example

good stuff though, I really like `intercept()`; `if (err) return cb(err)` can get old pretty quickly.
