### PR TITLE
Adding a cross platform EOL member to the os module.

### DIFF
--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -129,3 +129,8 @@ Get a list of network interfaces:
       vmnet8: [ { address: '10.88.88.1', family: 'IPv4', internal: false } ],
       ppp0: [ { address: '10.2.0.231', family: 'IPv4', internal: false } ] }
 
+## os.EOL
+
+A constant defining the appropriate End-of-line marker for the operating system.
+
+

--- a/lib/os.js
+++ b/lib/os.js
@@ -42,3 +42,16 @@ exports.getNetworkInterfaces = function() {
 };
 module.deprecate('getNetworkInterfaces',
                  'It is now called `os.networkInterfaces`.');
+
+exports.EOL = (function() {
+	switch(process.platform) {
+		case "darwin":
+			return "\n";
+		case "linux":
+			return "\n";
+		case "win32":
+			return "\r\n";
+		default:
+			return "\n";
+	}
+}());

--- a/lib/os.js
+++ b/lib/os.js
@@ -43,15 +43,4 @@ exports.getNetworkInterfaces = function() {
 module.deprecate('getNetworkInterfaces',
                  'It is now called `os.networkInterfaces`.');
 
-exports.EOL = (function() {
-	switch(process.platform) {
-		case "darwin":
-			return "\n";
-		case "linux":
-			return "\n";
-		case "win32":
-			return "\r\n";
-		default:
-			return "\n";
-	}
-}());
+exports.EOL = process.platform === 'win32' ? '\r\n' : '\n';

--- a/test/simple/test-os.js
+++ b/test/simple/test-os.js
@@ -79,3 +79,6 @@ switch (platform) {
     assert.deepEqual(actual, expected);
     break;
 }
+
+var EOL = os.EOL;
+assert.ok(EOL.length > 0);


### PR DESCRIPTION
Using something like this in your code is considered good practice when writing cross platform code. Also, it makes it easy to support new platforms (eg. sunos).

Hope you agree.
