### PR TITLE
tcp: getsockname() returns its address family name

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -168,9 +168,11 @@ event.
 
 ### server.address()
 
-Returns the bound address and port of the server as reported by the operating system.
+Returns the bound address, the address family name and port of the server
+as reported by the operating system.
 Useful to find which port was assigned when giving getting an OS-assigned address.
-Returns an object with two properties, e.g. `{"address":"127.0.0.1", "port":2121}`
+Returns an object with three properties, e.g.
+`{ port: 12346, family: 'AF_INET', address: '127.0.0.1' }`
 
 Example:
 
@@ -356,9 +358,10 @@ initialDelay will leave the value unchanged from the default
 
 ### socket.address()
 
-Returns the bound address and port of the socket as reported by the operating
-system. Returns an object with two properties, e.g.
-`{"address":"192.168.57.1", "port":62053}`
+Returns the bound address, the address family name and port of the 
+socket as reported by the operating system. Returns an object with 
+three properties, e.g.
+`{ port: 12346, family: 'AF_INET', address: '127.0.0.1' }`
 
 ### socket.remoteAddress
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -323,8 +323,8 @@ event.
 
 ### server.address()
 
-Returns the bound address and port of the server as reported by the operating
-system.
+Returns the bound address, the address family name and port of the 
+server as reported by the operating system.
 See [net.Server.address()](net.html#server.address) for more information.
 
 ### server.addContext(hostname, credentials)
@@ -414,9 +414,10 @@ information.
 
 ### cleartextStream.address()
 
-Returns the bound address and port of the underlying socket as reported by the
-operating system. Returns an object with two properties, e.g.
-`{"address":"192.168.57.1", "port":62053}`
+Returns the bound address, the address family name and port of the 
+underlying socket as reported by the operating system. Returns an 
+object with three properties, e.g.
+`{ port: 12346, family: 'AF_INET', address: '127.0.0.1' }`
 
 ### cleartextStream.remoteAddress
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -189,12 +189,12 @@ Handle<Value> TCPWrap::GetSockName(const Arguments& args) {
       struct sockaddr_in* addrin = (struct sockaddr_in*)&address;
       uv_inet_ntop(AF_INET, &(addrin->sin_addr), ip, INET6_ADDRSTRLEN);
       port = ntohs(addrin->sin_port);
-      family_name = "AF_INET";
+      family_name = "IPv4";
     } else if (family == AF_INET6) {
       struct sockaddr_in6* addrin6 = (struct sockaddr_in6*)&address;
       uv_inet_ntop(AF_INET6, &(addrin6->sin6_addr), ip, INET6_ADDRSTRLEN);
       port = ntohs(addrin6->sin6_port);
-      family_name = "AF_INET6";
+      family_name = "IPv6";
     } else {
       assert(0 && "bad address family");
       abort();

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -170,7 +170,8 @@ Handle<Value> TCPWrap::GetSockName(const Arguments& args) {
   int family;
   int port;
   char ip[INET6_ADDRSTRLEN];
-
+  const char *family_name;
+  
   UNWRAP
 
   int addrlen = sizeof(address);
@@ -188,17 +189,19 @@ Handle<Value> TCPWrap::GetSockName(const Arguments& args) {
       struct sockaddr_in* addrin = (struct sockaddr_in*)&address;
       uv_inet_ntop(AF_INET, &(addrin->sin_addr), ip, INET6_ADDRSTRLEN);
       port = ntohs(addrin->sin_port);
+      family_name = "AF_INET";
     } else if (family == AF_INET6) {
       struct sockaddr_in6* addrin6 = (struct sockaddr_in6*)&address;
       uv_inet_ntop(AF_INET6, &(addrin6->sin6_addr), ip, INET6_ADDRSTRLEN);
       port = ntohs(addrin6->sin6_port);
+      family_name = "AF_INET6";
     } else {
       assert(0 && "bad address family");
       abort();
     }
 
     sockname->Set(port_symbol, Integer::New(port));
-    sockname->Set(family_symbol, Integer::New(family));
+    sockname->Set(family_symbol, String::New(family_name));
     sockname->Set(address_symbol, String::New(ip));
   }
 

--- a/test/simple/test-net-server-address.js
+++ b/test/simple/test-net-server-address.js
@@ -25,7 +25,7 @@ var net = require('net');
 
 // Test on IPv4 Server
 var localhost_ipv4 = '127.0.0.1';
-var family_ipv4 = 'AF_INET';
+var family_ipv4 = 'IPv4';
 var server_ipv4 = net.createServer();
 
 server_ipv4.on('error', function(e) {
@@ -42,7 +42,7 @@ server_ipv4.listen(common.PORT, localhost_ipv4, function() {
 
 // Test on IPv6 Server
 var localhost_ipv6 = '::1';
-var family_ipv6 = 'AF_INET6';
+var family_ipv6 = 'IPv6';
 var server_ipv6 = net.createServer();
 
 server_ipv6.on('error', function(e) {

--- a/test/simple/test-net-server-address.js
+++ b/test/simple/test-net-server-address.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+// Test on IPv4 Server
+var localhost_ipv4 = '127.0.0.1';
+var family_ipv4 = 'AF_INET';
+var server_ipv4 = net.createServer();
+
+server_ipv4.on('error', function(e) {
+  console.log('Error on ipv4 socket: ' + e.toString());
+});
+
+server_ipv4.listen(common.PORT, localhost_ipv4, function() {
+  var address_ipv4 = server_ipv4.address();
+  assert.strictEqual(address_ipv4.address, localhost_ipv4);
+  assert.strictEqual(address_ipv4.port, common.PORT);
+  assert.strictEqual(address_ipv4.family, family_ipv4);
+  server_ipv4.close();
+});
+
+// Test on IPv6 Server
+var localhost_ipv6 = '::1';
+var family_ipv6 = 'AF_INET6';
+var server_ipv6 = net.createServer();
+
+server_ipv6.on('error', function(e) {
+  console.log('Error on ipv6 socket: ' + e.toString());
+});
+
+server_ipv6.listen(common.PORT, localhost_ipv6, function() {
+  var address_ipv6 = server_ipv6.address();
+  assert.strictEqual(address_ipv6.address, localhost_ipv6);
+  assert.strictEqual(address_ipv6.port, common.PORT);
+  assert.strictEqual(address_ipv6.family, family_ipv6);
+  server_ipv6.close();
+});
+


### PR DESCRIPTION
`TCP.getsockname()` return an object of which property has an integer of its address family as 
`{ port: 12345, family: 2, address: '127.0.0.1' }` 
and its description in the doc was missing. This patch changes its value to a string  as
`{ port: 12345, family: 'AF_INET', address: '127.0.0.1' }`
for easy to be recognized. And it also adds the doc.
