### PR TITLE
udp: getsockname() returns its address family name

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -144,7 +144,7 @@ Close the underlying socket and stop listening for data on it.
 ### dgram.address()
 
 Returns an object containing the address information for a socket.  For UDP sockets,
-this object will contain `address` and `port`.
+this object will contain `address` , `family` and `port`.
 
 ### dgram.setBroadcast(flag)
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -67,6 +67,7 @@ Local<Object> AddressToJS(const sockaddr* addr);
 
 static Persistent<String> address_symbol;
 static Persistent<String> port_symbol;
+static Persistent<String> family_symbol;
 static Persistent<String> buffer_sym;
 static Persistent<String> oncomplete_sym;
 static Persistent<String> onmessage_sym;
@@ -134,6 +135,7 @@ void UDPWrap::Initialize(Handle<Object> target) {
   address_symbol = NODE_PSYMBOL("address");
   oncomplete_sym = NODE_PSYMBOL("oncomplete");
   onmessage_sym = NODE_PSYMBOL("onmessage");
+  family_symbol = NODE_PSYMBOL("family");
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -447,6 +449,7 @@ Local<Object> AddressToJS(const sockaddr* addr) {
   const sockaddr_in *a4;
   const sockaddr_in6 *a6;
   int port;
+  const char *family_name;
 
   Local<Object> info = Object::New();
 
@@ -455,7 +458,9 @@ Local<Object> AddressToJS(const sockaddr* addr) {
     a6 = reinterpret_cast<const sockaddr_in6*>(addr);
     uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
     port = ntohs(a6->sin6_port);
+    family_name = "IPv6";
     info->Set(address_symbol, String::New(ip));
+    info->Set(family_symbol, String::New(family_name));
     info->Set(port_symbol, Integer::New(port));
     break;
 
@@ -463,7 +468,9 @@ Local<Object> AddressToJS(const sockaddr* addr) {
     a4 = reinterpret_cast<const sockaddr_in*>(addr);
     uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
     port = ntohs(a4->sin_port);
+    family_name = "IPv4";
     info->Set(address_symbol, String::New(ip));
+    info->Set(family_symbol, String::New(family_name));
     info->Set(port_symbol, Integer::New(port));
     break;
 

--- a/test/simple/test-dgram-address.js
+++ b/test/simple/test-dgram-address.js
@@ -1,0 +1,64 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var dgram = require('dgram');
+
+// IPv4 Test
+var localhost_ipv4 = '127.0.0.1';
+var socket_ipv4 = dgram.createSocket('udp4');
+var family_ipv4 = 'IPv4';
+
+socket_ipv4.on('listening', function() {
+  var address_ipv4 = socket_ipv4.address();
+  assert.strictEqual(address_ipv4.address, localhost_ipv4);
+  assert.strictEqual(address_ipv4.port, common.PORT);
+  assert.strictEqual(address_ipv4.family, family_ipv4);
+  socket_ipv4.close();
+});
+
+socket_ipv4.on('error', function(e) {
+  console.log('Error on udp4 socket. ' + e.toString());
+  socket_ipv4.close();
+});
+
+socket_ipv4.bind(common.PORT, localhost_ipv4);
+
+// IPv6 Test
+var localhost_ipv6 = '::1';
+var socket_ipv6 = dgram.createSocket('udp6');
+var family_ipv6 = 'IPv6';
+
+socket_ipv6.on('listening', function() {
+  var address_ipv6 = socket_ipv6.address();
+  assert.strictEqual(address_ipv6.address, localhost_ipv6);
+  assert.strictEqual(address_ipv6.port, common.PORT);
+  assert.strictEqual(address_ipv6.family, family_ipv6);
+  socket_ipv6.close();
+});
+
+socket_ipv6.on('error', function(e) {
+  console.log('Error on udp6 socket. ' + e.toString());
+  socket_ipv6.close();
+});
+
+socket_ipv6.bind(common.PORT, localhost_ipv6);


### PR DESCRIPTION
As the same reason on #3103, this patch makes dgram.address() return the object as

`{ address: '127.0.0.1', family: 'AF_INET', port: 12346 }`

to be consistent with the format of `socket.address()`.
