### PR TITLE
Made example `filter` shorter.

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -49,6 +49,15 @@ is supposed to return an Array with 2 entries:
 Which ends up looking something like:
 `[[substr1, substr2, ...], originalsubstring]`.
 
+Example:
+
+    function completer(line) {
+      var completions = '.help .error .exit .quit .q'.split(' ')
+      var hits = completions.filter(function(c) { return c.indexOf(line) == 0 })
+      // show all completions if none found
+      return [hits.length ? hits : completions, line]
+    }
+
 Also `completer` can be run in async mode if it accepts two arguments:
 
     function completer(linePartial, callback) {
@@ -117,8 +126,6 @@ Resumes the readline `input` stream.
 Writes to `output` stream.
 
 This will also resume the `input` stream if it has been paused.
-
-## Events
 
 ### Event: 'line'
 
@@ -228,8 +235,6 @@ Example of listening for `SIGCONT`:
       rl.prompt();
     });
 
-
-## Example: Tiny CLI
 
 Here's an example of how to use all these together to craft a tiny command
 line interface:

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -118,6 +118,8 @@ Writes to `output` stream.
 
 This will also resume the `input` stream if it has been paused.
 
+## Events
+
 ### Event: 'line'
 
 `function (line) {}`
@@ -226,6 +228,8 @@ Example of listening for `SIGCONT`:
       rl.prompt();
     });
 
+
+## Example: Tiny CLI
 
 Here's an example of how to use all these together to craft a tiny command
 line interface:


### PR DESCRIPTION
Commits:

ea89a65c    : Makes example `filter` code shorter.
3ace1550  : Adds "Events" and "Example" headers

Let me know if you do want the headers.
Please merge or close previous pull request 
https://github.com/joyent/node/pull/3084/files#r688955
