### PR TITLE
Fix 64-bit SmartOS build

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -310,7 +310,7 @@
       'target_name': 'node_dtrace_ustack',
       'type': 'none',
       'conditions': [
-        [ 'node_use_dtrace=="true"', {
+        [ 'node_use_dtrace=="true" and target_arch=="ia32"', {
           'actions': [
             {
               'action_name': 'node_dtrace_ustack_constants',


### PR DESCRIPTION
This change fixes an issue where the 64-bit SmartOS build would fail trying to build the ustack helper (which is not supported on 64-bit) _after_ successfully building out/Release/node.  The reason is that Node's Makefile builds all targets in the GYP file by default, so although nothing was depending on the ustack helper in 64-bit, GYP tried to build it anyway.  The solution is to make this target's actions predicated on being 32-bit, similar to the way several of them are already predicated on using DTrace.
