### PR TITLE
Fix build error on windows due to incomplete port of v8 regex fix

### DIFF
--- a/deps/v8/src/regexp-macro-assembler-tracer.cc
+++ b/deps/v8/src/regexp-macro-assembler-tracer.cc
@@ -38,7 +38,7 @@ RegExpMacroAssemblerTracer::RegExpMacroAssemblerTracer(
   assembler_(assembler) {
   unsigned int type = assembler->Implementation();
   ASSERT(type < 5);
-  const char* impl_names[4] = {"IA32", "ARM", "MIPS", "X64", "Bytecode"};
+  const char* impl_names[] = {"IA32", "ARM", "MIPS", "X64", "Bytecode"};
   PrintF("RegExpMacroAssembler%s();\n", impl_names[type]);
 }
 


### PR DESCRIPTION
5d69bbf ported over a v8 fix to the node v0.6 branch, but the v8 fix (http://codereview.chromium.org/8116001) had a build error that was fixed in the following v8 revision: http://code.google.com/p/v8/source/detail?r=9505#

This pull brings that fix over as well.
