### PR TITLE
expose ares_get_servers in cares_wrap

### DIFF
--- a/test/simple/test-c-ares.js
+++ b/test/simple/test-c-ares.js
@@ -51,3 +51,7 @@ if (process.platform != 'win32') {
     assert.ok(Array.isArray(domains));
   });
 }
+
+process.binding('cares_wrap').getServers(function(servers) {
+  assert.ok(Array.isArray(servers));
+});


### PR DESCRIPTION
This exposes ares_get_servers as cares_wrap.getServers which passes to a callback an array of IPs that ares is currently using for resolution.

It's callback based with an eye towards #3018 where ares would be initialized on the thread pool during platform initialization only to retrieve relevant platform information and then be immediately disposed.
