### PR TITLE
fs: fix scope of encoding in readSync

### DIFF
--- a/test/simple/test-fs-read.js
+++ b/test/simple/test-fs-read.js
@@ -43,6 +43,10 @@ var r = fs.readSync(fd, expected.length, 0, 'utf-8');
 assert.equal(r[0], expected);
 assert.equal(r[1], expected.length);
 
+var b = new Buffer(4);
+r = fs.readSync(fd, b, 0, b.length, null);
+assert.equal(r, 4);
+
 process.on('exit', function() {
   assert.equal(readCalled, 1);
 });


### PR DESCRIPTION
With the new buffer based `readSync()`, the call to `buffer.toString()` throws an unknown var as `encoding` is only set with legacy.
