### PR TITLE
addon: provide unregister function

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1780,6 +1780,9 @@ Handle<Value> DLOpen(const v8::Arguments& args) {
 
   // Execute the C++ module
   mod->register_func(target);
+  if (mod->unregister_func) {
+    mod->unregister_func();
+  }
 
   // Tell coverity that 'handle' should not be freed when we return.
   // coverity[leaked_storage]
@@ -2765,6 +2768,33 @@ char** Init(int argc, char *argv[]) {
   return argv;
 }
 
+class AtExitCallback;
+static AtExitCallback* at_exit_functions_ = NULL;
+
+class AtExitCallback {
+  AtExitCallback* next_;
+  ExitCallbackFunc cb_;
+  void* arg_;
+
+  public:
+  AtExitCallback(ExitCallbackFunc cb, void* arg) : cb_(cb), arg_(arg) {
+    next_ = at_exit_functions_;
+    at_exit_functions_ = this;
+  }
+
+  ~AtExitCallback(){
+    cb_(arg_);
+    delete next_;
+  }
+};
+
+inline void AtExit(ExitCallbackFunc cb, void* arg) {
+  new AtExitCallback(cb, arg);
+}
+
+inline void RunAtExit() {
+  delete at_exit_functions_;
+}
 
 void EmitExit(v8::Handle<v8::Object> process_l) {
   // process.emit('exit')
@@ -2845,6 +2875,7 @@ int Start(int argc, char *argv[]) {
   uv_run(uv_default_loop());
 
   EmitExit(process_l);
+  RunAtExit();
 
 #ifndef NDEBUG
   // Clean up.


### PR DESCRIPTION
Lets native addons register unregister hooks that run after the event loop has quit
but before the VM is disposed.

Fixes #3147.
