### PR TITLE
Update doc sets to new format

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -1,37 +1,29 @@
 # Addons
+<!-- type=misc -->
 
-Addons are dynamically linked shared objects. They can provide glue to C and
-C++ libraries. The API (at the moment) is rather complex, involving
+Addons are dynamically linked shared objects. They can provide glue to C and 
+C++ libraries. The API (at the moment) is rather complex, involving 
 knowledge of several libraries:
 
- - V8 JavaScript, a C++ library. Used for interfacing with JavaScript:
-   creating objects, calling functions, etc.  Documented mostly in the
-   `v8.h` header file (`deps/v8/include/v8.h` in the Node source tree),
-   which is also available [online](http://izs.me/v8-docs/main.html).
+ - V8 Javascript, a C++ library. Used for interfacing with Javascript: 
+ creating objects, calling functions, etc. These are documented mostly in 
+ the `v8.h` header file (`deps/v8/include/v8.h` in the Node.js source tree), 
+ and also available [online](http://izs.me/v8-docs/main.html).
 
- - [libuv](https://github.com/joyent/libuv), C event loop library. Anytime one
-   needs to wait for a file descriptor to become readable, wait for a timer, or
-   wait for a signal to received one will need to interface with libuv. That is,
-   if you perform any I/O, libuv will need to be used.
+ - [libuv](https://github.com/joyent/libuv), a C event loop library. Anytime one 
+ needs to wait for a file descriptor to become readable, wait for a timer, or wait for a signal to received one needs to interface with libuv. That is, if you perform any I/O, libuv needs to be used.
 
- - Internal Node libraries. Most importantly is the `node::ObjectWrap`
-   class which you will likely want to derive from.
+ - Internal Node libraries. Most importantly is the `node::ObjectWrap` class which you will likely want to derive from.
 
- - Others. Look in `deps/` for what else is available.
+ - Additional libraries are located the `deps/` folder.
 
-Node statically compiles all its dependencies into the executable. When
-compiling your module, you don't need to worry about linking to any of these
-libraries.
+Node.js statically compiles all its dependencies into the executable. When compiling your module, you don't need to worry about linking to any of these libraries.
 
-
-## Hello world
-
-To get started let's make a small Addon which is the C++ equivalent of
-the following Javascript code:
+First, let's make a small Addon which is the C++ equivalent of the following Javascript code:
 
     exports.hello = function() { return 'world'; };
 
-First we create a file `hello.cc`:
+To get started, we'll create a file `hello.cc`:
 
     #include <node.h>
     #include <v8.h>
@@ -44,581 +36,43 @@ First we create a file `hello.cc`:
     }
 
     void init(Handle<Object> target) {
-      target->Set(String::NewSymbol("hello"),
-          FunctionTemplate::New(Method)->GetFunction());
+      NODE_SET_METHOD(target, "hello", Method);
     }
     NODE_MODULE(hello, init)
 
-Note that all Node addons must export an initialization function:
+Note that all Node.js addons must export an initialization function:
 
     void Initialize (Handle<Object> target);
     NODE_MODULE(module_name, Initialize)
 
-There is no semi-colon after `NODE_MODULE` as it's not a function (see `node.h`).
+There is no semi-colon after `NODE_MODULE`, as it's not a function (for more information, see `node.h`).
 
-The `module_name` needs to match the filename of the final binary (minus the
-.node suffix).
+The source code needs to be built into `hello.node`, the binary Addon. To do this we create a file called `wscript` which is python code and looks like this:
+    srcdir = '.'
+    blddir = 'build'
+    VERSION = '0.0.1'
 
-The source code needs to be built into `hello.node`, the binary Addon. To
-do this we create a file called `binding.gyp` which describes the configuration
-to build your module in a JSON-like format. This file gets compiled by
-[node-gyp](https://github.com/TooTallNate/node-gyp).
+    def set_options(opt):
+      opt.tool_options('compiler_cxx')
 
-    {
-      "targets": [
-        {
-          "target_name": "hello",
-          "sources": [ "hello.cc" ]
-        }
-      ]
-    }
+    def configure(conf):
+      conf.check_tool('compiler_cxx')
+      conf.check_tool('node_addon')
 
-The next step is to generate the appropriate project build files for the
-current platform. Use `node-gyp configure` for that.
+    def build(bld):
+      obj = bld.new_task_gen('cxx', 'shlib', 'node_addon')
+      obj.target = 'hello'
+      obj.source = 'hello.cc'
 
-Now you will have either a `Makefile` (on Unix platforms) or a `vcxproj` file
-(on Windows) in the `build/` directory. Next invoke the `node-gyp build`
-command.
+Running `node-waf configure build` will create a file `build/default/hello.node` which is our Addon.
 
-Now you have your compiled `.node` bindings file! The compiled bindings end up
-in `build/Release/`.
+`node-waf` is just [WAF](http://code.google.com/p/waf), the Python-based build system. `node-waf` is provided for developers to easily access it.
 
-You can now use the binary addon in a Node project `hello.js` by pointing `require` to
-the recently built `hello.node` module:
+You can now use the binary addon in a Node project `hello.js` by pointing `require` to the recently built module:
 
     var addon = require('./build/Release/hello');
 
     console.log(addon.hello()); // 'world'
 
-Please see patterns below for further information or
-<https://github.com/arturadib/node-qt> for an example in production.
-
-
-## Addon patterns
-
-Below are some addon patterns to help you get started. Consult the online
-[v8 reference](http://izs.me/v8-docs/main.html) for help with the various v8
-calls, and v8's [Embedder's Guide](http://code.google.com/apis/v8/embed.html)
-for an explanation of several concepts used such as handles, scopes,
-function templates, etc.
-
-In order to use these examples you need to compile them using `node-gyp`.
-Create the following `binding.gyp` file:
-
-    {
-      "targets": [
-        {
-          "target_name": "addon",
-          "sources": [ "addon.cc" ]
-        }
-      ]
-    }
-
-In cases where there is more than one `.cc` file, simply add the file name to the
-`sources` array, e.g.:
-
-    "sources": ["addon.cc", "myexample.cc"]
-
-Now that you have your `binding.gyp` ready, you can configure and build the
-addon:
-
-    $ node-gyp configure build
-
-
-### Function arguments
-
-The following pattern illustrates how to read arguments from JavaScript
-function calls and return a result. This is the main and only needed source
-`addon.cc`:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-
-    using namespace v8;
-
-    Handle<Value> Add(const Arguments& args) {
-      HandleScope scope;
-
-      if (args.Length() < 2) {
-        ThrowException(Exception::TypeError(String::New("Wrong number of arguments")));
-        return scope.Close(Undefined());
-      }
-
-      if (!args[0]->IsNumber() || !args[1]->IsNumber()) {
-        ThrowException(Exception::TypeError(String::New("Wrong arguments")));
-        return scope.Close(Undefined());
-      }
-
-      Local<Number> num = Number::New(args[0]->NumberValue() +
-          args[1]->NumberValue());
-      return scope.Close(num);
-    }
-
-    void Init(Handle<Object> target) {
-      target->Set(String::NewSymbol("add"),
-          FunctionTemplate::New(Add)->GetFunction());
-    }
-
-    NODE_MODULE(addon, Init)
-
-You can test it with the following JavaScript snippet:
-
-    var addon = require('./build/Release/addon');
-
-    console.log( 'This should be eight:', addon.add(3,5) );
-
-
-### Callbacks
-
-You can pass JavaScript functions to a C++ function and execute them from
-there. Here's `addon.cc`:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-
-    using namespace v8;
-
-    Handle<Value> RunCallback(const Arguments& args) {
-      HandleScope scope;
-
-      Local<Function> cb = Local<Function>::Cast(args[0]);
-      const unsigned argc = 1;
-      Local<Value> argv[argc] = { Local<Value>::New(String::New("hello world")) };
-      cb->Call(Context::GetCurrent()->Global(), argc, argv);
-
-      return scope.Close(Undefined());
-    }
-
-    void Init(Handle<Object> target) {
-      target->Set(String::NewSymbol("runCallback"),
-          FunctionTemplate::New(RunCallback)->GetFunction());
-    }
-
-    NODE_MODULE(addon, Init)
-
-To test it run the following JavaScript snippet:
-
-    var addon = require('./build/Release/addon');
-
-    addon.runCallback(function(msg){
-      console.log(msg); // 'hello world'
-    });
-
-
-### Object factory
-
-You can create and return new objects from within a C++ function with this
-`addon.cc` pattern, which returns an object with property `msg` that echoes
-the string passed to `createObject()`:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-
-    using namespace v8;
-
-    Handle<Value> CreateObject(const Arguments& args) {
-      HandleScope scope;
-
-      Local<Object> obj = Object::New();
-      obj->Set(String::NewSymbol("msg"), args[0]->ToString());
-
-      return scope.Close(obj);
-    }
-
-    void Init(Handle<Object> target) {
-      target->Set(String::NewSymbol("createObject"),
-          FunctionTemplate::New(CreateObject)->GetFunction());
-    }
-
-    NODE_MODULE(addon, Init)
-
-To test it in JavaScript:
-
-    var addon = require('./build/Release/addon');
-
-    var obj1 = addon.createObject('hello');
-    var obj2 = addon.createObject('world');
-    console.log(obj1.msg+' '+obj2.msg); // 'hello world'
-
-
-### Function factory
-
-This pattern illustrates how to create and return a JavaScript function that
-wraps a C++ function:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-
-    using namespace v8;
-
-    Handle<Value> MyFunction(const Arguments& args) {
-      HandleScope scope;
-      return scope.Close(String::New("hello world"));
-    }
-
-    Handle<Value> CreateFunction(const Arguments& args) {
-      HandleScope scope;
-
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(MyFunction);
-      Local<Function> fn = tpl->GetFunction();
-      fn->SetName(String::NewSymbol("theFunction")); // omit this to make it anonymous
-
-      return scope.Close(fn);
-    }
-
-    void Init(Handle<Object> target) {
-      target->Set(String::NewSymbol("createFunction"),
-          FunctionTemplate::New(CreateFunction)->GetFunction());
-    }
-
-    NODE_MODULE(addon, Init)
-
-
-To test:
-
-    var addon = require('./build/Release/addon');
-
-    var fn = addon.createFunction();
-    console.log(fn()); // 'hello world'
-
-
-### Wrapping C++ objects
-
-Here we will create a wrapper for a C++ object/class `MyObject` that can be
-instantiated in JavaScript through the `new` operator. First prepare the main
-module `addon.cc`:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-    #include "myobject.h"
-
-    using namespace v8;
-
-    void InitAll(Handle<Object> target) {
-      MyObject::Init(target);
-    }
-
-    NODE_MODULE(addon, InitAll)
-
-Then in `myobject.h` make your wrapper inherit from `node::ObjectWrap`:
-
-    #ifndef MYOBJECT_H
-    #define MYOBJECT_H
-
-    #include <node.h>
-
-    class MyObject : public node::ObjectWrap {
-     public:
-      static void Init(v8::Handle<v8::Object> target);
-
-     private:
-      MyObject();
-      ~MyObject();
-
-      static v8::Handle<v8::Value> New(const v8::Arguments& args);
-      static v8::Handle<v8::Value> PlusOne(const v8::Arguments& args);
-      double counter_;
-    };
-
-    #endif
-
-And in `myobject.cc` implement the various methods that you want to expose.
-Here we expose the method `plusOne` by adding it to the constructor's
-prototype:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-    #include "myobject.h"
-
-    using namespace v8;
-
-    MyObject::MyObject() {};
-    MyObject::~MyObject() {};
-
-    void MyObject::Init(Handle<Object> target) {
-      // Prepare constructor template
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
-      tpl->SetClassName(String::NewSymbol("MyObject"));
-      tpl->InstanceTemplate()->SetInternalFieldCount(1);
-      // Prototype
-      tpl->PrototypeTemplate()->Set(String::NewSymbol("plusOne"),
-          FunctionTemplate::New(PlusOne)->GetFunction());
-
-      Persistent<Function> constructor = Persistent<Function>::New(tpl->GetFunction());
-      target->Set(String::NewSymbol("MyObject"), constructor);
-    }
-
-    Handle<Value> MyObject::New(const Arguments& args) {
-      HandleScope scope;
-
-      MyObject* obj = new MyObject();
-      obj->counter_ = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
-      obj->Wrap(args.This());
-
-      return args.This();
-    }
-
-    Handle<Value> MyObject::PlusOne(const Arguments& args) {
-      HandleScope scope;
-
-      MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
-      obj->counter_ += 1;
-
-      return scope.Close(Number::New(obj->counter_));
-    }
-
-Test it with:
-
-    var addon = require('./build/Release/addon');
-
-    var obj = new addon.MyObject(10);
-    console.log( obj.plusOne() ); // 11
-    console.log( obj.plusOne() ); // 12
-    console.log( obj.plusOne() ); // 13
-
-
-### Factory of wrapped objects
-
-This is useful when you want to be able to create native objects without
-explicitly instantiating them with the `new` operator in JavaScript, e.g.
-
-    var obj = addon.createObject();
-    // instead of:
-    // var obj = new addon.Object();
-
-Let's register our `createObject` method in `addon.cc`:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-    #include "myobject.h"
-
-    using namespace v8;
-
-    Handle<Value> CreateObject(const Arguments& args) {
-      HandleScope scope;
-      return scope.Close(MyObject::NewInstance(args));
-    }
-
-    void InitAll(Handle<Object> target) {
-      MyObject::Init();
-
-      target->Set(String::NewSymbol("createObject"),
-          FunctionTemplate::New(CreateObject)->GetFunction());
-    }
-
-    NODE_MODULE(addon, InitAll)
-
-In `myobject.h` we now introduce the static method `NewInstance` that takes
-care of instantiating the object (i.e. it does the job of `new` in JavaScript):
-
-    #define BUILDING_NODE_EXTENSION
-    #ifndef MYOBJECT_H
-    #define MYOBJECT_H
-
-    #include <node.h>
-
-    class MyObject : public node::ObjectWrap {
-     public:
-      static void Init();
-      static v8::Handle<v8::Value> NewInstance(const v8::Arguments& args);
-
-     private:
-      MyObject();
-      ~MyObject();
-
-      static v8::Persistent<v8::Function> constructor;
-      static v8::Handle<v8::Value> New(const v8::Arguments& args);
-      static v8::Handle<v8::Value> PlusOne(const v8::Arguments& args);
-      double counter_;
-    };
-
-    #endif
-
-The implementation is similar to the above in `myobject.cc`:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-    #include "myobject.h"
-
-    using namespace v8;
-
-    MyObject::MyObject() {};
-    MyObject::~MyObject() {};
-
-    Persistent<Function> MyObject::constructor;
-
-    void MyObject::Init() {
-      // Prepare constructor template
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
-      tpl->SetClassName(String::NewSymbol("MyObject"));
-      tpl->InstanceTemplate()->SetInternalFieldCount(1);
-      // Prototype
-      tpl->PrototypeTemplate()->Set(String::NewSymbol("plusOne"),
-          FunctionTemplate::New(PlusOne)->GetFunction());
-
-      constructor = Persistent<Function>::New(tpl->GetFunction());
-    }
-
-    Handle<Value> MyObject::New(const Arguments& args) {
-      HandleScope scope;
-
-      MyObject* obj = new MyObject();
-      obj->counter_ = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
-      obj->Wrap(args.This());
-
-      return args.This();
-    }
-
-    Handle<Value> MyObject::NewInstance(const Arguments& args) {
-      HandleScope scope;
-
-      const unsigned argc = 1;
-      Handle<Value> argv[argc] = { args[0] };
-      Local<Object> instance = constructor->NewInstance(argc, argv);
-
-      return scope.Close(instance);
-    }
-
-    Handle<Value> MyObject::PlusOne(const Arguments& args) {
-      HandleScope scope;
-
-      MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
-      obj->counter_ += 1;
-
-      return scope.Close(Number::New(obj->counter_));
-    }
-
-Test it with:
-
-    var addon = require('./build/Release/addon');
-
-    var obj = addon.createObject(10);
-    console.log( obj.plusOne() ); // 11
-    console.log( obj.plusOne() ); // 12
-    console.log( obj.plusOne() ); // 13
-
-    var obj2 = addon.createObject(20);
-    console.log( obj2.plusOne() ); // 21
-    console.log( obj2.plusOne() ); // 22
-    console.log( obj2.plusOne() ); // 23
-
-
-### Passing wrapped objects around
-
-In addition to wrapping and returning C++ objects, you can pass them around
-by unwrapping them with Node's `node::ObjectWrap::Unwrap` helper function.
-In the following `addon.cc` we introduce a function `add()` that can take on two
-`MyObject` objects:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-    #include "myobject.h"
-
-    using namespace v8;
-
-    Handle<Value> CreateObject(const Arguments& args) {
-      HandleScope scope;
-      return scope.Close(MyObject::NewInstance(args));
-    }
-
-    Handle<Value> Add(const Arguments& args) {
-      HandleScope scope;
-
-      MyObject* obj1 = node::ObjectWrap::Unwrap<MyObject>(
-          args[0]->ToObject());
-      MyObject* obj2 = node::ObjectWrap::Unwrap<MyObject>(
-          args[1]->ToObject());
-
-      double sum = obj1->Val() + obj2->Val();
-      return scope.Close(Number::New(sum));
-    }
-
-    void InitAll(Handle<Object> target) {
-      MyObject::Init();
-
-      target->Set(String::NewSymbol("createObject"),
-          FunctionTemplate::New(CreateObject)->GetFunction());
-
-      target->Set(String::NewSymbol("add"),
-          FunctionTemplate::New(Add)->GetFunction());
-    }
-
-    NODE_MODULE(addon, InitAll)
-
-To make things interesting we introduce a public method in `myobject.h` so we
-can probe private values after unwrapping the object:
-
-    #define BUILDING_NODE_EXTENSION
-    #ifndef MYOBJECT_H
-    #define MYOBJECT_H
-
-    #include <node.h>
-
-    class MyObject : public node::ObjectWrap {
-     public:
-      static void Init();
-      static v8::Handle<v8::Value> NewInstance(const v8::Arguments& args);
-      double Val() const { return val_; }
-
-     private:
-      MyObject();
-      ~MyObject();
-
-      static v8::Persistent<v8::Function> constructor;
-      static v8::Handle<v8::Value> New(const v8::Arguments& args);
-      double val_;
-    };
-
-    #endif
-
-The implementation of `myobject.cc` is similar as before:
-
-    #define BUILDING_NODE_EXTENSION
-    #include <node.h>
-    #include "myobject.h"
-
-    using namespace v8;
-
-    MyObject::MyObject() {};
-    MyObject::~MyObject() {};
-
-    Persistent<Function> MyObject::constructor;
-
-    void MyObject::Init() {
-      // Prepare constructor template
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
-      tpl->SetClassName(String::NewSymbol("MyObject"));
-      tpl->InstanceTemplate()->SetInternalFieldCount(1);
-
-      constructor = Persistent<Function>::New(tpl->GetFunction());
-    }
-
-    Handle<Value> MyObject::New(const Arguments& args) {
-      HandleScope scope;
-
-      MyObject* obj = new MyObject();
-      obj->val_ = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
-      obj->Wrap(args.This());
-
-      return args.This();
-    }
-
-    Handle<Value> MyObject::NewInstance(const Arguments& args) {
-      HandleScope scope;
-
-      const unsigned argc = 1;
-      Handle<Value> argv[argc] = { args[0] };
-      Local<Object> instance = constructor->NewInstance(argc, argv);
-
-      return scope.Close(instance);
-    }
-
-Test it with:
-
-    var addon = require('./build/Release/addon');
-
-    var obj1 = addon.createObject(10);
-    var obj2 = addon.createObject(20);
-    var result = addon.add(obj1, obj2);
-
-    console.log(result); // 30
+For the moment, that is all the documentation on addons. Please see
+<https://github.com/ry/node_postgres> for a real example.

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -1,84 +1,111 @@
-# Assert
+## assert
 
     Stability: 5 - Locked
 
-This module is used for writing unit tests for your applications, you can
-access it with `require('assert')`.
+All of the `assert` methods basically compare two different states—an expected one, and an actual one—and return a Boolean condition. If the comparisson is `true`, the condition passes. If an assert method is `false`, the entire Node.js app crashes.
 
-## assert.fail(actual, expected, message, operator)
+Some methods have an additional `message` parameter, which sends text out to the console when the assert fails.
+
+#### Example: Testing for equivalency
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/assert/assert.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+### assert.fail(actual, expected, message, operator)
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
+- operator {String} The operator used to separate the `actual` and `expected` values in the `message`
 
 Throws an exception that displays the values for `actual` and `expected` separated by the provided operator.
 
-## assert(value, message), assert.ok(value, [message])
 
-Tests if value is truthy, it is equivalent to `assert.equal(true, !!value, message);`
+#### Example
 
-## assert.equal(actual, expected, [message])
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/assert/assert.fail.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### assert.assert(value, message)
+- value {Object} The value you receive
+- message {String} The message to send to the console if the comparisson fails
+(alias of: asset.ok)
+
+Tests if value is a `true` value. This is equivalent to `assert.equal(true, value, message)`. This is the same as `assert.ok()`, except that `message` is required.
+
+### assert.ok(value, [message])
+- value {Object} The value you receive
+- message {String} The message to send to the console if the comparisson fails
+(alias of: assert.assert)
+
+Tests if value is a `true` value. This is equivalent to `assert.equal(true, value, message);`. This is the same as `assert()`, except that `message` is not required.
+
+### assert.equal(actual, expected [, message])
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
 
 Tests shallow, coercive equality with the equal comparison operator ( `==` ).
 
-## assert.notEqual(actual, expected, [message])
+### assert.notEqual(actual, expected, [message])
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
 
 Tests shallow, coercive non-equality with the not equal comparison operator ( `!=` ).
 
-## assert.deepEqual(actual, expected, [message])
+### assert.deepEqual(actual, expected, [message])
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
 
 Tests for deep equality.
 
-## assert.notDeepEqual(actual, expected, [message])
+### assert.notDeepEqual(actual, expected, [message])
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
 
-Tests for any deep inequality.
+Tests for any deep inequality. 
 
-## assert.strictEqual(actual, expected, [message])
+### assert.strictEqual(actual, expected, [message])
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
 
-Tests strict equality, as determined by the strict equality operator ( `===` )
+Tests strict equality, as determined by the strict equality operator ( `===` ).
 
-## assert.notStrictEqual(actual, expected, [message])
+### assert.notStrictEqual(actual, expected, [message])
+- actual {Object} The value you receive
+- expected {Object} The expected value you're looking for
+- message {String} The message to send to the console if the comparisson fails
 
-Tests strict non-equality, as determined by the strict not equal operator ( `!==` )
+Tests strict non-equality, as determined by the strict not equal operator ( `!==` ).
 
-## assert.throws(block, [error], [message])
+### assert.throws(block, [error], [message])
+- block {Function} A block of code to check against
+- error {Function | RegExp | Function} The expected error that's thrown; this can be a constructor, regexp, or validation function
+- message {String} The message to send to the console if the comparisson fails
 
-Expects `block` to throw an error. `error` can be constructor, regexp or 
-validation function.
+If `block`throws an error, then the assertion passes.
 
-Validate instanceof using constructor:
+#### Example: Validate `instanceof` using a constructor:
 
-    assert.throws(
-      function() {
-        throw new Error("Wrong value");
-      },
-      Error
-    );
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/assert/assert.throws_1.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Validate error message using RegExp:
+#### Example: Validate an error message using regular expressions:
 
-    assert.throws(
-      function() {
-        throw new Error("Wrong value");
-      },
-      /value/
-    );
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/assert/assert.throws_2.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Custom error validation:
+#### Example: Custom error validation:
 
-    assert.throws(
-      function() {
-        throw new Error("Wrong value");
-      },
-      function(err) {
-        if ( (err instanceof Error) && /value/.test(err) ) {
-          return true;
-        }
-      },
-      "unexpected error"
-    );
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/assert/assert.throws_3.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## assert.doesNotThrow(block, [error], [message])
+### assert.doesNotThrow(block, [error], [message])
+- block {Function} A block of code to check against
+- error {RegExp | Function} The expected error that's thrown; this can be a constructor, regexp, or validation function
+- message {String} The message to send to the console if the comparisson fails
 
-Expects `block` not to throw an error, see assert.throws for details.
+Expects `block` not to throw an error; for more details, see `assert.throws()`.
 
-## assert.ifError(value)
+### assert.ifError(value)
+- value {Object} The value to check against 
 
-Tests if value is not a false value, throws if it is a true value. Useful when
-testing the first argument, `error` in callbacks.
+Tests if value is `false`; throws an error if it is `true`. Useful when testing the first argument, `error`, in callbacks.

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -1,645 +1,449 @@
-# Buffer
+## Buffer
 
     Stability: 3 - Stable
 
-Pure Javascript is Unicode friendly but not nice to binary data.  When
-dealing with TCP streams or the file system, it's necessary to handle octet
-streams. Node has several strategies for manipulating, creating, and
-consuming octet streams.
+Pure Javascript is Unicode friendly, but not nice to binary data.  When dealing with TCP streams or the file system, it's often necessary to handle octet streams. Node has several strategies for manipulating, creating, and consuming octet streams.
 
-Raw data is stored in instances of the `Buffer` class. A `Buffer` is similar
-to an array of integers but corresponds to a raw memory allocation outside
-the V8 heap. A `Buffer` cannot be resized.
+Raw data is stored in instances of the `Buffer` class. A `Buffer` is similar to an array of integers, but corresponds to a raw memory allocation outside the V8 heap. A `Buffer` cannot be resized.
 
-The `Buffer` class is a global, making it very rare that one would need
-to ever `require('buffer')`.
+The `Buffer` class is a global, making it very rare that one would need to ever `require('buffer')`.
 
-Converting between Buffers and JavaScript string objects requires an explicit
-encoding method.  Here are the different string encodings.
+Converting between Buffers and JavaScript string objects requires an explicit encoding method.  These encoding methods are:
 
-* `'ascii'` - for 7 bit ASCII data only.  This encoding method is very fast, and
-  will strip the high bit if set.
-  Note that this encoding converts a null character (`'\0'` or `'\u0000'`) into
-  `0x20` (character code of a space). If you want to convert a null character
-  into `0x00`, you should use `'utf8'`.
+* `'ascii'` - for 7 bit ASCII data only.  This encoding method is very fast, and will strip the high bit if set.
+  Note that this encoding converts a null character (`'\0'` or `'\u0000'`) into `0x20` (character code of a space). If you want to convert a null character into `0x00`, you should use `'utf8'`.
+
+* `'base64'`: Base64 string encoding
+
+* `'binary'`: A way of encoding raw binary data into strings by using only the first 8 bits of each character. This encoding method is deprecated and should be avoided in favor of `Buffer` objects where possible. This encoding is going to be removed in future versions of Node.js.
+
+* `'hex'`: Encodes each byte as two hexidecimal characters.
+
+* `'ucs2'`: 2-bytes, little endian encoded Unicode characters. It can encode only BMP (Basic Multilingual Plane—from U+0000 to U+FFFF).
 
 * `'utf8'` - Multi byte encoded Unicode characters.  Many web pages and other document formats use UTF-8.
 
-* `'ucs2'` - 2-bytes, little endian encoded Unicode characters. It can encode
-  only BMP(Basic Multilingual Plane, U+0000 - U+FFFF).
+In most cases, the default of `'utf8'` is used.
 
-* `'base64'` - Base64 string encoding.
-
-* `'binary'` - A way of encoding raw binary data into strings by using only
-  the first 8 bits of each character. This encoding method is deprecated and
-  should be avoided in favor of `Buffer` objects where possible. This encoding
-  will be removed in future versions of Node.
-
-* `'hex'` - Encode each byte as two hexidecimal characters.
-
-## Class: Buffer
-
-The Buffer class is a global type for dealing with binary data directly.
-It can be constructed in a variety of ways.
-
-### new Buffer(size)
-
-* `size` Number
-
-Allocates a new buffer of `size` octets.
-
+For more information, see [this article on manipulating buffers](../nodejs_dev_guide/manipulating_buffers.html).
+ 
 ### new Buffer(array)
+### new Buffer(size)
+### new Buffer(str, encoding='utf8')
 
-* `array` Array
+Allocates a new buffer object.
 
-Allocates a new buffer using an `array` of octets.
+You can use either:
 
-### new Buffer(str, [encoding])
+- an `array` of octects
+- allocation of a specific `size`
+- conversion from a `string` with the specified `encoding`
+ 
+#### Example
 
-* `str` String - string to encode.
-* `encoding` String - encoding to use, Optional.
+    var bBuffer = new Buffer("This is a Buffer.", "utf8");
 
-Allocates a new buffer containing the given `str`.
-`encoding` defaults to `'utf8'`.
+Buffer.byteLength(string, encoding='utf8'), Number
+- string {String}  The string to check
+- encoding {String}  The encoding that the string is in
 
-### buf.write(string, [offset], [length], [encoding])
+Gives the actual byte length of a string.  This is not the same as `String.length` since that returns the number of _characters_ in a string.
 
-* `string` String - data to be written to buffer
-* `offset` Number, Optional, Default: 0
-* `length` Number, Optional
-* `encoding` String, Optional, Default: 'utf8'
+#### Example
 
-Writes `string` to the buffer at `offset` using the given encoding.
-`offset` defaults to `0`, `encoding` defaults to `'utf8'`. `length` is
-the number of bytes to write. Returns number of octets written. If `buffer` did
-not contain enough space to fit the entire string, it will write a partial
-amount of the string. `length` defaults to `buffer.length - offset`.
-The method will not write partial characters.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.byteLength.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
+#### Returns
 
-    buf = new Buffer(256);
-    len = buf.write('\u00bd + \u00bc = \u00be', 0);
-    console.log(len + " bytes: " + buf.toString('utf8', 0, len));
+Returns the byte length of a buffer
 
-The number of characters written (which may be different than the number of
-bytes written) is set in `Buffer._charsWritten` and will be overwritten the
-next time `buf.write()` is called.
+### Buffer.copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
+- targetBuffer {Buffer}  The buffer to copy into
+- targetStart {Number}  The offset to start at for the buffer you're copying into
+- sourceStart {Number} The offset to start at for the buffer you're copying from
+- sourceEnd {Number}  The number of bytes to read from the originating buffer. Defaults to the length of the buffer
 
+Performs a copy between buffers. The source and target regions can overlap.
 
-### buf.toString([encoding], [start], [end])
+#### Example: Building two buffers
 
-* `encoding` String, Optional, Default: 'utf8'
-* `start` Number, Optional, Default: 0
-* `end` Number, Optional
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.copy.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Decodes and returns a string from buffer data encoded with `encoding`
-(defaults to `'utf8'`) beginning at `start` (defaults to `0`) and ending at
-`end` (defaults to `buffer.length`).
+### Buffer.fill(value, offset=0, end=buffer.length)
+- value {Object}  The value to use to fill the buffer
+- offset {Number}  The position in the buffer to start filling at
+- end {Number}  The position in the buffer to stop filling at
 
-See `buffer.write()` example, above.
+Fills the buffer with the specified value. If the offset and end are not given, this fills the entire buffer.
 
+#### Example
 
-### buf[index]
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.fill.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+    
 
-<!--type=property-->
-<!--name=[index]-->
+### Buffer.isBuffer(obj), Boolean
+- obj {Object}  The object to check
 
-Get and set the octet at `index`. The values refer to individual bytes,
-so the legal range is between `0x00` and `0xFF` hex or `0` and `255`.
-
-Example: copy an ASCII string into a buffer, one byte at a time:
-
-    str = "node.js";
-    buf = new Buffer(str.length);
-
-    for (var i = 0; i < str.length ; i++) {
-      buf[i] = str.charCodeAt(i);
-    }
-
-    console.log(buf);
-
-    // node.js
-
-### Class Method: Buffer.isBuffer(obj)
-
-* `obj` Object
-* Return: Boolean
-
-Tests if `obj` is a `Buffer`.
-
-### Class Method: Buffer.byteLength(string, [encoding])
-
-* `string` String
-* `encoding` String, Optional, Default: 'utf8'
-* Return: Number
-
-Gives the actual byte length of a string. `encoding` defaults to `'utf8'`.
-This is not the same as `String.prototype.length` since that returns the
-number of *characters* in a string.
-
-Example:
-
-    str = '\u00bd + \u00bc = \u00be';
-
-    console.log(str + ": " + str.length + " characters, " +
-      Buffer.byteLength(str, 'utf8') + " bytes");
-
-    // ½ + ¼ = ¾: 9 characters, 12 bytes
-
-### buf.length
-
-* Number
-
-The size of the buffer in bytes.  Note that this is not necessarily the size
-of the contents. `length` refers to the amount of memory allocated for the
-buffer object.  It does not change when the contents of the buffer are changed.
-
-    buf = new Buffer(1234);
-
-    console.log(buf.length);
-    buf.write("some string", 0, "ascii");
-    console.log(buf.length);
-
-    // 1234
-    // 1234
-
-### buf.copy(targetBuffer, [targetStart], [sourceStart], [sourceEnd])
-
-* `targetBuffer` Buffer object - Buffer to copy into
-* `targetStart` Number, Optional, Default: 0
-* `sourceStart` Number, Optional, Default: 0
-* `sourceEnd` Number, Optional, Default: 0
-
-Does copy between buffers. The source and target regions can be overlapped.
-`targetStart` and `sourceStart` default to `0`.
-`sourceEnd` defaults to `buffer.length`.
-
-Example: build two Buffers, then copy `buf1` from byte 16 through byte 19
-into `buf2`, starting at the 8th byte in `buf2`.
-
-    buf1 = new Buffer(26);
-    buf2 = new Buffer(26);
-
-    for (var i = 0 ; i < 26 ; i++) {
-      buf1[i] = i + 97; // 97 is ASCII a
-      buf2[i] = 33; // ASCII !
-    }
-
-    buf1.copy(buf2, 8, 16, 20);
-    console.log(buf2.toString('ascii', 0, 25));
-
-    // !!!!!!!!qrst!!!!!!!!!!!!!
+Returns `true` if `obj` is a `Buffer`.
 
 
-### buf.slice([start], [end])
+### Buffer.readDoubleBE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-* `start` Number, Optional, Default: 0
-* `end` Number, Optional, Default: 0
+Reads a 64-bit double from the buffer at the specified offset in big endian notation.
+ 
+#### Example
 
-Returns a new buffer which references the same memory as the old, but offset
-and cropped by the `start` (defaults to `0`) and `end` (defaults to
-`buffer.length`) indexes.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readDoubleBELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
+### Buffer.readDoubleLE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-**Modifying the new buffer slice will modify memory in the original buffer!**
 
-Example: build a Buffer with the ASCII alphabet, take a slice, then modify one
-byte from the original Buffer.
+Reads a 64 bit double from the buffer at the specified offset in little endian notation.
 
-    var buf1 = new Buffer(26);
+#### Example
 
-    for (var i = 0 ; i < 26 ; i++) {
-      buf1[i] = i + 97; // 97 is ASCII a
-    }
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readDoubleBELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
+### Buffer.readFloatBE(offset, noAssert=false), String
+- offset {Number}  The starting position
+* noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    var buf2 = buf1.slice(0, 3);
-    console.log(buf2.toString('ascii', 0, buf2.length));
-    buf1[0] = 33;
-    console.log(buf2.toString('ascii', 0, buf2.length));
 
-    // abc
-    // !bc
+Reads a 32 bit float from the buffer at the specified offset in big endian notation.
+ 
+#### Example
 
-### buf.readUInt8(offset, [noAssert])
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readFloatBELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>    
+ 
+### Buffer.readFloatLE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+Reads a 32 bit float from the buffer at the specified offset in little endian notation.
+
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readFloatBELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>      
+ 
+### Buffer.readInt8(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
+
+Reads a signed 8 bit integer from the buffer at the specified offset.
+ 
+This function also works as [[Buffer.readUInt8 `buffer.readUInt8()`]], except buffer contents are treated as two's complement signed values. 
+
+
+### Buffer.readInt16BE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
+
+Reads a signed 16 bit integer from the buffer at the specified offset in big endian notation.
+
+This function also works as [[Buffer.readUInt16BE `buffer.readUInt16BE()`]], except buffer contents are treated as a two's complement signed values.
+
+
+### Buffer.readInt16LE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
+
+Reads a signed 16 bit integer from the buffer at the specified offset in little endian notation.
+
+This function also works as [[Buffer.readUInt16LE `buffer.readUInt16LE()`]], except buffer contents are treated as a two'scomplement signed values.
+
+### Buffer.readInt32BE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
+
+Reads a signed 32-bit integer from the buffer at the specified offset in big endian notation.
+
+This function works like [[Buffer.readUInt32BE `buffer.readUInt32BE()`]], except buffer contents are treated as a two's complement signed values.
+
+### Buffer.readInt32LE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
+
+
+Reads a signed 32 bit integer from the buffer at the specified offset in little endian notation.
+
+This function works like [[Buffer.readUInt32LE `buffer.readUInt32LE()`]], except buffer contents are treated as a two's complement signed values.
+
+
+### Buffer.readUInt8(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
+
 
 Reads an unsigned 8 bit integer from the buffer at the specified offset.
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+#### Example
 
-Example:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readUInt8.js?linestart=3&lineend=0&showlines=false' defer='defer'></script> 
 
-    var buf = new Buffer(4);
+### Buffer.readUInt16BE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    buf[0] = 0x3;
-    buf[1] = 0x4;
-    buf[2] = 0x23;
-    buf[3] = 0x42;
+Reads an unsigned 16 bit integer from the buffer at the specified offset in the big endian format.
 
-    for (ii = 0; ii < buf.length; ii++) {
-      console.log(buf.readUInt8(ii));
-    }
+#### Example
 
-    // 0x3
-    // 0x4
-    // 0x23
-    // 0x42
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readUInt16BELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script> 
 
-### buf.readUInt16LE(offset, [noAssert])
-### buf.readUInt16BE(offset, [noAssert])
+### Buffer.readUInt16LE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+Reads an unsigned 16 bit integer from the buffer at the specified offset in the little endian format.
+ 
+#### Example
 
-Reads an unsigned 16 bit integer from the buffer at the specified offset with
-specified endian format.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readUInt16BELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script> 
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+### Buffer.readUInt32BE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-Example:
+Reads an unsigned 32 bit integer from the buffer at the specified offset in the big endian format.
 
-    var buf = new Buffer(4);
+#### Example
 
-    buf[0] = 0x3;
-    buf[1] = 0x4;
-    buf[2] = 0x23;
-    buf[3] = 0x42;
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readUInt32BELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+   
 
-    console.log(buf.readUInt16BE(0));
-    console.log(buf.readUInt16LE(0));
-    console.log(buf.readUInt16BE(1));
-    console.log(buf.readUInt16LE(1));
-    console.log(buf.readUInt16BE(2));
-    console.log(buf.readUInt16LE(2));
+### Buffer.readUInt32LE(offset, noAssert=false), String
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    // 0x0304
-    // 0x0403
-    // 0x0423
-    // 0x2304
-    // 0x2342
-    // 0x4223
+Reads an unsigned 32 bit integer from the buffer at the specified offset in the little endian format.
 
-### buf.readUInt32LE(offset, [noAssert])
-### buf.readUInt32BE(offset, [noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+#### Example
 
-Reads an unsigned 32 bit integer from the buffer at the specified offset with
-specified endian format.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readUInt32BELE.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>   
+    
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+### Buffer.slice(start, end=buffer.length), Buffer
+- start {Number}  The offset in the buffer to start from
+- end {Number}  The position of the last byte to slice. Defaults to the length of the buffer
 
-Example:
+Returns a new buffer that references the same memory as the old, but offset and cropped by the `start` and `end` indexes.
 
-    var buf = new Buffer(4);
+Note: Modifying the new buffer slice modifies memory in the original buffer!
 
-    buf[0] = 0x3;
-    buf[1] = 0x4;
-    buf[2] = 0x23;
-    buf[3] = 0x42;
+#### Example
 
-    console.log(buf.readUInt32BE(0));
-    console.log(buf.readUInt32LE(0));
+Building a `Buffer` with the ASCII alphabet, taking a slice, then modifying one byte from the original `Buffer`:
 
-    // 0x03042342
-    // 0x42230403
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.readUInt32BELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>   
+    
+### Buffer.toString(encoding="utf8", start=0, end=buffer.length), String
+- encoding {String}  The encoding to use; defaults to `utf8`
+- start {Number}  The starting byte offset; defaults to `0`
+- end {Number}  The number of bytes to write; defaults to the length of the buffer
+(related to: buffer.write)
 
-### buf.readInt8(offset, [noAssert])
+Decodes and returns a string from buffer data encoded with `encoding` beginning at `start` and ending at `end`.
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
 
-Reads a signed 8 bit integer from the buffer at the specified offset.
+### Buffer.write(string, offset=0, length = startPos, encoding="utf8"), Number
+- string {String}  The string to write
+- offset {Number}  The starting byte offset
+- length {Number}  The number of bytes to write; defaults to the length of the buffer minus any offset (`buffer.length` - `buffer.offset`)
+- encoding {String}  The encoding to use; defaults to `utf8`
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+Writes a `string` to the buffer at `offset` using the given encoding. `length` is the number of bytes to write. If `buffer` does not contain enough space to fit the entire string, it instead writes a partial amount of the string. The method doesn't write partial characters.
 
-Works as `buffer.readUInt8`, except buffer contents are treated as two's
-complement signed values.
 
-### buf.readInt16LE(offset, [noAssert])
-### buf.readInt16BE(offset, [noAssert])
+#### Example
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+Writing a utf8 string into a buffer, then printing it:
 
-Reads a signed 16 bit integer from the buffer at the specified offset with
-specified endian format.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.write.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+#### Returns
 
-Works as `buffer.readUInt16*`, except buffer contents are treated as two's
-complement signed values.
+Returns number of octets written.
 
-### buf.readInt32LE(offset, [noAssert])
-### buf.readInt32BE(offset, [noAssert])
+### Buffer.writeDoubleBE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+Writes `value` to the buffer at the specified offset in the big endian format. Note that `value` must be a valid 64 bit double.
+ 
+#### Example
 
-Reads a signed 32 bit integer from the buffer at the specified offset with
-specified endian format.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeDoubleBELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+### Buffer.writeDoubleLE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-Works as `buffer.readUInt32*`, except buffer contents are treated as two's
-complement signed values.
+Writes `value` to the buffer at the specified offset in the little endian format. Note that `value` must be a valid 64 bit double.
 
-### buf.readFloatLE(offset, [noAssert])
-### buf.readFloatBE(offset, [noAssert])
+#### Example
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeDoubleBELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-Reads a 32 bit float from the buffer at the specified offset with specified
-endian format.
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+### Buffer.writeFloatBE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-Example:
+Writes `value` to the buffer at the specified offset in the big endian format. Note that `value` must be a valid 32 bit float.
 
-    var buf = new Buffer(4);
+#### Example
 
-    buf[0] = 0x00;
-    buf[1] = 0x00;
-    buf[2] = 0x80;
-    buf[3] = 0x3f;
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeFloatBELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
+   
+### Buffer.writeFloatLE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    console.log(buf.readFloatLE(0));
+Writes `value` to the buffer at the specified offset in the little endian format. Note that `value` must be a valid 32 bit float.
 
-    // 0x01
+#### Example
 
-### buf.readDoubleLE(offset, [noAssert])
-### buf.readDoubleBE(offset, [noAssert])
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeFloatBELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+### Buffer.writeInt8(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-Reads a 64 bit double from the buffer at the specified offset with specified
-endian format.
+Writes `value` to the buffer at the specified offset. Note that `value` must be a valid signed 8 bit integer.
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+Works as `buffer.writeUInt8()`, except value is written out as a two's complement signed integer into `buffer`.
 
-Example:
+### Buffer.writeInt16BE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    var buf = new Buffer(8);
+Writes `value` to the buffer at the specified offset in the big endian format. Note that `value` must be a valid signed 16 bit integer.
 
-    buf[0] = 0x55;
-    buf[1] = 0x55;
-    buf[2] = 0x55;
-    buf[3] = 0x55;
-    buf[4] = 0x55;
-    buf[5] = 0x55;
-    buf[6] = 0xd5;
-    buf[7] = 0x3f;
+This function also works as `buffer.writeUInt16*()`, except value is written out as a two's complement signed integer into `buffer`.
 
-    console.log(buf.readDoubleLE(0));
 
-    // 0.3333333333333333
+### Buffer.writeInt16LE(value, offset, noAssert=alse)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-### buf.writeUInt8(value, offset, [noAssert])
+Writes `value` to the buffer at the specified offset in the little endian format. Note that `value` must be a valid signed 16 bit integer.
+ 
+This function also works as `buffer.writeUInt16*()`, except value is written out as a two's complement signed integer into `buffer`.
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
 
-Writes `value` to the buffer at the specified offset. Note, `value` must be a
-valid unsigned 8 bit integer.
+### Buffer.writeInt32BE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+Writes `value` to the buffer at the specified offset in the big endian format. Note that `value` must be a valid signed 32 bit integer.
 
-Example:
+This function also works as `buffer.writeUInt32*`, except value is written out as a two's complement signed integer into `buffer`.
 
-    var buf = new Buffer(4);
-    buf.writeUInt8(0x3, 0);
-    buf.writeUInt8(0x4, 1);
-    buf.writeUInt8(0x23, 2);
-    buf.writeUInt8(0x42, 3);
+### Buffer.writeInt32LE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    console.log(buf);
+Writes `value` to the buffer at the specified offset in the little endian format. Note that `value` must be a valid signed 32 bit integer.
 
-    // <Buffer 03 04 23 42>
+This function also works as `buffer.writeUInt32*`, except value is written out as a two's complement signed integer into `buffer`.
 
-### buf.writeUInt16LE(value, offset, [noAssert])
-### buf.writeUInt16BE(value, offset, [noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+### Buffer.writeUInt8(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid unsigned 16 bit integer.
+Writes `value` to the buffer at the specified offset. Note that `value` must be a valid unsigned 8 bit integer.
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+#### Example
 
-Example:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeUInt8.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-    var buf = new Buffer(4);
-    buf.writeUInt16BE(0xdead, 0);
-    buf.writeUInt16BE(0xbeef, 2);
 
-    console.log(buf);
+### Buffer.writeUInt16BE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    buf.writeUInt16LE(0xdead, 0);
-    buf.writeUInt16LE(0xbeef, 2);
+Writes `value` to the buffer at the specified offset in the big endian format. Note that `value` must be a valid unsigned 16 bit integer.
 
-    console.log(buf);
+#### Example
 
-    // <Buffer de ad be ef>
-    // <Buffer ad de ef be>
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeUInt16BELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-### buf.writeUInt32LE(value, offset, [noAssert])
-### buf.writeUInt32BE(value, offset, [noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+### Buffer.writeUInt16LE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}   If `true`, skips the validation of the offset 
 
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid unsigned 32 bit integer.
+Writes `value` to the buffer at the specified offset in the little endian format. Note that `value` must be a valid unsigned 16 bit integer.
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+#### Example
 
-Example:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeUInt16BELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-    var buf = new Buffer(4);
-    buf.writeUInt32BE(0xfeedface, 0);
 
-    console.log(buf);
+### Buffer.writeUInt32BE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}  If `true`, skips the validation of the offset. This means that `offset` may be beyond the end of the buffer, and is typically not recommended.
 
-    buf.writeUInt32LE(0xfeedface, 0);
+Writes `value` to the buffer at the specified offset in the big endian format. Note that `value` must be a valid unsigned 32 bit integer.
 
-    console.log(buf);
+#### Example
 
-    // <Buffer fe ed fa ce>
-    // <Buffer ce fa ed fe>
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeUInt32BELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-### buf.writeInt8(value, offset, [noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+### Buffer.writeUInt32LE(value, offset, noAssert=false)
+- value {String}  The content to write
+- offset {Number}  The starting position
+- noAssert {Boolean}   If `true`, skips the validation of the offset 
 
-Writes `value` to the buffer at the specified offset. Note, `value` must be a
-valid signed 8 bit integer.
+Writes `value` to the buffer at the specified offset in the little endian format. Note that `value` must be a valid unsigned 32 bit integer.
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+#### Example
 
-Works as `buffer.writeUInt8`, except value is written out as a two's complement
-signed integer into `buffer`.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.writeUInt32BELE.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
+ 
+### Buffer.index, Number
 
-### buf.writeInt16LE(value, offset, [noAssert])
-### buf.writeInt16BE(value, offset, [noAssert])
+Gets and sets the octet at `index` in an array format. The values refer to individual bytes, so the legal range is between `0x00` and `0xFF` hex or `0` and `255`.
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+#### Example: Copy an ASCII string into a buffer, one byte at a time
 
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid signed 16 bit integer.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.index.js?linestart=4&lineend=0&showlines=false' defer='defer'></script>
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+### Buffer._charsWritten, Number
 
-Works as `buffer.writeUInt16*`, except value is written out as a two's
-complement signed integer into `buffer`.
+The number of characters written by [[Buffer.write `buffer.write()`]]. This value is overwritten each time `buffer.write()` is called.
 
-### buf.writeInt32LE(value, offset, [noAssert])
-### buf.writeInt32BE(value, offset, [noAssert])
+### Buffer.length, Number
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
 
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid signed 32 bit integer.
+The size of the buffer in bytes.  Note that this is not necessarily the size of the contents. `length` refers to the amount of memory allocated for the buffer object.  It does not change when the contents of the buffer are changed.
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+#### Example
 
-Works as `buffer.writeUInt32*`, except value is written out as a two's
-complement signed integer into `buffer`.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/buffer/buffer.length.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+     
+### Buffer.INSPECT_MAX_BYTES, Number
 
-### buf.writeFloatLE(value, offset, [noAssert])
-### buf.writeFloatBE(value, offset, [noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid 32 bit float.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Example:
-
-    var buf = new Buffer(4);
-    buf.writeFloatBE(0xcafebabe, 0);
-
-    console.log(buf);
-
-    buf.writeFloatLE(0xcafebabe, 0);
-
-    console.log(buf);
-
-    // <Buffer 4f 4a fe bb>
-    // <Buffer bb fe 4a 4f>
-
-### buf.writeDoubleLE(value, offset, [noAssert])
-### buf.writeDoubleBE(value, offset, [noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid 64 bit double.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Example:
-
-    var buf = new Buffer(8);
-    buf.writeDoubleBE(0xdeadbeefcafebabe, 0);
-
-    console.log(buf);
-
-    buf.writeDoubleLE(0xdeadbeefcafebabe, 0);
-
-    console.log(buf);
-
-    // <Buffer 43 eb d5 b7 dd f9 5f d7>
-    // <Buffer d7 5f f9 dd b7 d5 eb 43>
-
-### buf.fill(value, [offset], [end])
-
-* `value`
-* `offset` Number, Optional
-* `end` Number, Optional
-
-Fills the buffer with the specified value. If the `offset` (defaults to `0`)
-and `end` (defaults to `buffer.length`) are not given it will fill the entire
-buffer.
-
-    var b = new Buffer(50);
-    b.fill("h");
-
-## buffer.INSPECT_MAX_BYTES
-
-* Number, Default: 50
-
-How many bytes will be returned when `buffer.inspect()` is called. This can
-be overridden by user modules.
-
-Note that this is a property on the buffer module returned by
-`require('buffer')`, not on the Buffer global, or a buffer instance.
-
-## Class: SlowBuffer
-
-This class is primarily for internal use.  JavaScript programs should
-use Buffer instead of using SlowBuffer.
-
-In order to avoid the overhead of allocating many C++ Buffer objects for
-small blocks of memory in the lifetime of a server, Node allocates memory
-in 8Kb (8192 byte) chunks.  If a buffer is smaller than this size, then it
-will be backed by a parent SlowBuffer object.  If it is larger than this,
-then Node will allocate a SlowBuffer slab for it directly.
+The number of bytes returned when `buffer.inspect()` is called; the default is 50. This can be overridden by user modules.

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -1,44 +1,134 @@
-# Crypto
+## crypto
 
     Stability: 3 - Stable
 
-Use `require('crypto')` to access this module.
+The `crypto` module offers a way of encapsulating secure credentials to be used as part of a secure HTTPS net or HTTP connection. To access this module, add `require('crypto')` to your code. 
 
-The crypto module requires OpenSSL to be available on the underlying platform.
-It offers a way of encapsulating secure credentials to be used as part
-of a secure HTTPS net or http connection.
+ The module also offers a set of wrappers for OpenSSL's methods, which actually contains these objects:
 
-It also offers a set of wrappers for OpenSSL's hash, hmac, cipher, decipher, sign and verify methods.
+* [[cipher Cipher]]
+* [[decipher Decipher]]
+* [[diffieHellman Diffie-Hellman]]
+* [[hash Hash]]
+* [[hmac HMAC]] 
+* [[signer Signer]]
+* [[verifier Verifier]]
 
-## crypto.createCredentials(details)
+This documentation is organized to describe those objects within their own sections.
 
-Creates a credentials object, with the optional details being a dictionary with keys:
+Note: All `algorithm` parameter implementations below are dependent on the OpenSSL version installed on the platform. Some common examples of these algoritihms are `'sha1'`, `'md5'`, `'sha256'`, and `'sha512'`. On recent Node.js releases, `openssl list-message-digest-algorithms` displays the available digest algorithms.
 
-* `key` : A string holding the PEM encoded private key
-* `passphrase` : A string of passphrase for the private key
-* `cert` : A string holding the PEM encoded certificate
-* `ca` : Either a string or list of strings of PEM encoded CA certificates to trust.
-* `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate Revocation List)
-* `ciphers`: A string describing the ciphers to use or exclude. Consult
-  <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for details
-  on the format.
+#### Example
 
-If no 'ca' details are given, then node.js will use the default publicly trusted list of CAs as given in
-<http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### crypto.createCipher(algorithm, password), cipher
+- algorithm {String}   The algorithm to use
+- password {String}   The password to use
+
+Creates and returns a cipher object with the given algorithm and password.
+
+The `password` is used to derive both the key and IV, which must be a binary-encoded string. For more information, see the section on [[Buffer buffers]].
+
+### crypto.createCipheriv(algorithm, key, iv), cipher
+- algorithm {String}  The algorithm to use
+- key {String}  A raw key used in the algorithm
+- iv {String}  The [initialization vector](http://en.wikipedia.org/wiki/Initialization_vector)
+
+Creates and returns a cipher object, with the given algorithm, key, and IV.
+
+Both `key` and `iv` must be a binary-encoded string. For more information, see the section on [[Buffer buffers]].
 
 
-## crypto.createHash(algorithm)
+### crypto.createCredentials([details]), Object
+- details {String}  A dictionary of fields to populate the credential with
 
-Creates and returns a hash object, a cryptographic hash with the given algorithm
-which can be used to generate hash digests.
+Creates a credentials object, with  `details` being a dictionary with the following keys:
 
-`algorithm` is dependent on the available algorithms supported by the version
-of OpenSSL on the platform. Examples are `'sha1'`, `'md5'`, `'sha256'`, `'sha512'`, etc.
-On recent releases, `openssl list-message-digest-algorithms` will display the available digest algorithms.
+- key {String}  A string holding the PEM encoded private key file
+- cert {String}  A string holding the PEM encoded certificate file
+- ca {String}  Either a string or list of strings of PEM encoded CA certificates to trust
+- ciphers (String: A string describing the ciphers to use or exclude. Consult [OpenSSL.org](http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT) for details on the format
 
-Example: this program that takes the sha1 sum of a file
+If no `ca` details are given, then Node.js uses the default publicly trusted list of CAs as given by [Mozilla](http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt).
 
-    var filename = process.argv[2];
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createCredentials.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### crypto.createDecipher(algorithm, password), decipher
+- algorithm {String}  The algorithm to use
+- password {String}  The password to use
+
+Creates and returns a decipher object, with the given algorithm and key.
+
+### crypto.createDecipheriv(algorithm, key, iv), decipher
+- algorithm {String}  The algorithm to use
+- key {String}  A raw key used in the algorithm
+- iv {String}  The [initialization vector](http://en.wikipedia.org/wiki/Initialization_vector)
+
+Creates and returns a decipher object, with the given algorithm, key, and iv.
+
+### crypto.createDiffieHellman(prime_length), diffieHellman
+### crypto.createDiffieHellman(prime, encoding='binary'), diffieHellman
+- prime_length {Number} The bit length to calculate with
+- prime {Number} The prime to calculate with
+- encoding {Number} The encoding to use; defaults to `'binary'`
+
+Creates a Diffie-Hellman key exchange object and generates a prime of the given bit length. The generator used is `2`.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createDiffieHellman.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### crypto.getDiffieHellman(group_name), diffieHellman
+- group_name {String} One of the following group names:  
+  * `'modp1'`, as defined in [RFC 2412](http://www.rfc-editor.org/rfc/rfc2412.txt)
+  * `'modp2'`, as defined in [RFC 2412](http://www.rfc-editor.org/rfc/rfc2412.txt)
+  * `'modp5'`, as defined in [RFC 2412](http://www.rfc-editor.org/rfc/rfc2412.txt)
+  * `'modp14'`, as defined in [RFC 3526](http://www.rfc-editor.org/rfc/rfc3526.txt)
+  * `'modp15'`, as defined in [RFC 3526](http://www.rfc-editor.org/rfc/rfc3526.txt)
+  * `'modp16'`, as defined in [RFC 3526](http://www.rfc-editor.org/rfc/rfc3526.txt)
+  * `'modp17'`, as defined in [RFC 3526](http://www.rfc-editor.org/rfc/rfc3526.txt)
+  * `'modp18'`, as defined in [RFC 3526](http://www.rfc-editor.org/rfc/rfc3526.txt)
+
+Creates a predefined Diffie-Hellman key exchange object.
+
+The returned object mimics the interface of objects created by
+[[crypto.createDiffieHellman `createDiffieHellman()`]], but will not allow you to change the keys (for example, with
+[[diffieHellman.setPublicKey `diffieHellman.setPublicKey()`]]).
+
+The advantage of using this routine is that the parties don't have to generate nor exchange group modulus beforehand, saving both processor and communication time.
+
+#### Example: Obtaining a shared secret:
+
+    var crypto = require('crypto');
+    var alice = crypto.getDiffieHellman('modp5');
+    var bob = crypto.getDiffieHellman('modp5');
+
+    alice.generateKeys();
+    bob.generateKeys();
+
+    var alice_secret = alice.computeSecret(bob.getPublicKey(), 'binary', 'hex');
+    var bob_secret = bob.computeSecret(alice.getPublicKey(), 'binary', 'hex');
+
+    /* alice_secret and bob_secret should be the same */
+    console.log(alice_secret == bob_secret);
+
+### crypto.createHash(algorithm), hash
+- algorithm {String}  The hash algorithm to use
+
+Creates and returns a cryptographic hash object with the given algorithm. The object can be used to generate hash digests.
+
+#### Examples
+
+Testing an MD5 Hash:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createHash.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+This program takes the sha1 sum of a file:
+
+    var filename = "my_secret_file.txt";
     var crypto = require('crypto');
     var fs = require('fs');
 
@@ -54,310 +144,286 @@ Example: this program that takes the sha1 sum of a file
       console.log(d + '  ' + filename);
     });
 
-## Class: Hash
+### crypto.createSign(algorithm), signer
+- algorithm (String) : The algorithm to use
 
-The class for creating hash digests of data.
-
-Returned by `crypto.createHash`.
-
-### hash.update(data, [input_encoding])
-
-Updates the hash content with the given `data`, the encoding of which is given
-in `input_encoding` and can be `'utf8'`, `'ascii'` or `'binary'`.
-Defaults to `'binary'`.
-This can be called many times with new data as it is streamed.
-
-### hash.digest([encoding])
-
-Calculates the digest of all of the passed data to be hashed.
-The `encoding` can be `'hex'`, `'binary'` or `'base64'`.
-Defaults to `'binary'`.
-
-Note: `hash` object can not be used after `digest()` method been called.
+Creates and returns a signing object string, with the given `algorithm`.
 
 
-## crypto.createHmac(algorithm, key)
+### crypto.createHmac(algorithm, key), hmac
+- algorithm {String}  The algorithm to use
+- key {String}  The HMAC key to be used
 
-Creates and returns a hmac object, a cryptographic hmac with the given algorithm and key.
+Creates and returns a cryptographic HMAC object with the given algorithm and key. For more information on HMAC, see [this article](http://en.wikipedia.org/wiki/HMAC).
 
-`algorithm` is dependent on the available algorithms supported by OpenSSL - see createHash above.
-`key` is the hmac key to be used.
+#### Example
 
-## Class: Hmac
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createHmac.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Class for creating cryptographic hmac content.
+### crypto.pbkdf2(password, salt, iterations, keylen, callback(err, derivedKey))
+- password {String}  The password to use
+- salt {String}  The salt to use
+- iterations {String}  The number of iterations to use
+- keylen {String}  The final key length
+- callback {Function}  The callback to execute when finished
+- err {Error}  The error object
+- derivedKey {String}  The resulting key
 
-Returned by `crypto.createHmac`.
+An asynchronous PBKDF2 function that applies pseudorandom function HMAC-SHA1 to derive a key of the given length from the given password, salt, and number of iterations.
 
-### hmac.update(data)
+#### Example
 
-Update the hmac content with the given `data`.
-This can be called many times with new data as it is streamed.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.pbkdf2.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-### hmac.digest([encoding])
+### crypto.randomBytes(size [, callback(ex, buf)]), String | Void
+- size {Number}  The size of the cryptographic data
+- callback {Function}  The callback to execute when finished
+- ex {Error}  The error object
+- buf {String}  The resulting crypto data
 
-Calculates the digest of all of the passed data to the hmac.
-The `encoding` can be `'hex'`, `'binary'` or `'base64'`.
-Defaults to `'binary'`.
+Generates cryptographically strong pseudo-random data, either asynchronously or synchronously.
 
-Note: `hmac` object can not be used after `digest()` method been called.
+#### Example
 
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.randomBytes.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## crypto.createCipher(algorithm, password)
+### crypto.createVerify(algorithim), verifier
+- algorithm (String) : The algorithm to use
 
-Creates and returns a cipher object, with the given algorithm and password.
+Creates and returns a verification object, with the given algorithm.
 
-`algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc.
-On recent releases, `openssl list-cipher-algorithms` will display the
-available cipher algorithms.
-`password` is used to derive key and IV, which must be `'binary'` encoded
-string (See the [Buffer section](buffer.html) for more information).
+This is the mirror of the [[signer `signer`]] object.
 
-## crypto.createCipheriv(algorithm, key, iv)
+## cipher
+  
+A class for encrypting data. It's a representation of the [OpenSSL implementation of cipher](http://www.openssl.org/docs/apps/ciphers.html). It can be created as a returned value from [[crypto.createCipher `crypto.createCipher()`]] or [[crypto.createCipheriv `crypto.createCipheriv()`]].
+  
+#### Example
 
-Creates and returns a cipher object, with the given algorithm, key and iv.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/cipher.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-`algorithm` is the same as the `createCipher()`. `key` is a raw key used in
-algorithm. `iv` is an Initialization vector. `key` and `iv` must be `'binary'`
-encoded string (See the [Buffer section](buffer.html) for more information).
+### cipher.final([output_encoding='binary']), String
+- output_encoding {String}  The encoding to use for the output; defaults to binary
 
-## Class: Cipher
+Returns any remaining enciphered contents. `output_encoding` can be `'binary'`, `'base64'`, or `'hex'`.
 
-Class for encrypting data.
+Note: The `cipher` object can't be used after the `final()` method has been called.
 
-Returned by `crypto.createCipher` and `crypto.createCipheriv`.
+### cipher.update(data, [input_encoding='binary'], [output_encoding='binary']), cipher
+- data {String}  The data to use for an update
+- input_encoding {String}  Defines how the input is encoded; can be `'utf8'`, `'ascii'` or `'binary'`
+- output_encoding {String}  Defines how the output is encoded; can be `'binary'`, `'base64'` or `'hex'`
+(chainable)
 
-### cipher.update(data, [input_encoding], [output_encoding])
-
-Updates the cipher with `data`, the encoding of which is given in
-`input_encoding` and can be `'utf8'`, `'ascii'` or `'binary'`.
-Defaults to `'binary'`.
-
-The `output_encoding` specifies the output format of the enciphered data,
-and can be `'binary'`, `'base64'` or `'hex'`. Defaults to `'binary'`.
-
-Returns the enciphered contents, and can be called many times with new data as it is streamed.
-
-### cipher.final([output_encoding])
-
-Returns any remaining enciphered contents, with `output_encoding` being one of:
-`'binary'`, `'base64'` or `'hex'`. Defaults to `'binary'`.
-
-Note: `cipher` object can not be used after `final()` method been called.
+Updates the cipher with `data`. This returns the enciphered contents, and can be called many times with new data as it is streamed.
 
 ### cipher.setAutoPadding(auto_padding=true)
+- auto_padding {Boolean} Specifies wheter automatic padding is on, or not
 
-You can disable automatic padding of the input data to block size. If `auto_padding` is false,
-the length of the entire input data must be a multiple of the cipher's block size or `final` will fail.
-Useful for non-standard padding, e.g. using `0x0` instead of PKCS padding. You must call this before `cipher.final`.
+You can disable automatic padding of the input data to block size. 
 
+If `auto_padding` is false, the length of the entire input data must be a multiple of the cipher's block size or `final` will fail.
 
-## crypto.createDecipher(algorithm, password)
+This is useful for non-standard padding, _e.g._ using `0x0` instead of PKCS padding. You must call this before `cipher.final`.
 
-Creates and returns a decipher object, with the given algorithm and key.
-This is the mirror of the [createCipher()](#crypto.createCipher) above.
+## decipher
 
-## crypto.createDecipheriv(algorithm, key, iv)
+A class for decrypting data. It's used to decipher previously created [[cipher `cipher`]] objects. It can be created as a returned value from [[crypto.createDecipher `crypto.createDeipher()`]] or [[crypto.createDecipheriv `crypto.createDecipheriv()`]].
 
-Creates and returns a decipher object, with the given algorithm, key and iv.
-This is the mirror of the [createCipheriv()](#crypto.createCipheriv) above.
+#### Example
 
-## Class: Decipher
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/cipher.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Class for decrypting data.
+### decipher.update(data, [input_encoding='binary'], [output_encoding='binary']), decipher
+- data {String}  The data to use for an update
+- input_encoding {String}  Defines how the input is encoded
+- output_encoding {String}  Defines how the output is encoded
+(chainable)
 
-Returned by `crypto.createDecipher` and `crypto.createDecipheriv`.
+Updates the decipher with `data`.
 
-### decipher.update(data, [input_encoding], [output_encoding])
+The `input_encoding` can be `'binary'`, `'base64'` or `'hex'`. 
+The `output_encoding` can be `'binary'`, `'ascii'` or `'utf8'`.
 
-Updates the decipher with `data`, which is encoded in `'binary'`, `'base64'`
-or `'hex'`. Defaults to `'binary'`.
+### decipher.final([output_encoding='binary']), String
+- output_encoding {String}  The encoding to use for the output; can be either `'binary'`, `'ascii'`, or `'utf8'`
 
-The `output_decoding` specifies in what format to return the deciphered
-plaintext: `'binary'`, `'ascii'` or `'utf8'`. Defaults to `'binary'`.
+Returns any remaining plaintext which is deciphered.
 
-### decipher.final([output_encoding])
-
-Returns any remaining plaintext which is deciphered,
-with `output_encoding` being one of: `'binary'`, `'ascii'` or `'utf8'`.
-Defaults to `'binary'`.
-
-Note: `decipher` object can not be used after `final()` method been called.
+Note: The `decipher` object can't be used after the `final()` method been called.
 
 ### decipher.setAutoPadding(auto_padding=true)
+- auto_padding {Boolean} Specifies wheter automatic padding is on, or not
 
 You can disable auto padding if the data has been encrypted without standard block padding to prevent
 `decipher.final` from checking and removing it. Can only work if the input data's length is a multiple of the
 ciphers block size. You must call this before streaming data to `decipher.update`.
 
-## crypto.createSign(algorithm)
+## diffieHellman
 
-Creates and returns a signing object, with the given algorithm.
-On recent OpenSSL releases, `openssl list-public-key-algorithms` will display
-the available signing algorithms. Examples are `'RSA-SHA256'`.
+This is a class for creating Diffie-Hellman key exchanges. It's a representation of the [OpenSSL implementation of diffie-Hellman](http://www.openssl.org/docs/crypto/dh.html#). It can be created as a returned value from [[crypto.createDiffieHellman `crypto.createDiffieHellman()`]].
 
-## Class: Signer
+#### Example
 
-Class for generating signatures.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createDiffieHellman.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Returned by `crypto.createSign`.
+### diffieHellman.computeSecret(other_public_key, [input_encoding='binary'], [output_encoding='input_encoding']), String
+- other_public_key {String}  The other party's public key
+- input_encoding {String}  The encoding used to interprate the public key; can be `'binary'`, `'base64'`, or `'hex'`. 
+- output_encoding {String}  The encoding of the returned computation; defaults to the `input_encoding`
 
-### signer.update(data)
+Computes the shared secret and returns the computed shared secret. 
 
-Updates the signer object with data.
-This can be called many times with new data as it is streamed.
+### diffieHellman.getGenerator([encoding='binary']), String
+- encoding (String) : The encoding to use; can be `'binary'`, `'hex'`, or `'base64'`
 
-### signer.sign(private_key, [output_format])
+Returns the Diffie-Hellman prime in the specified encoding.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/diffieHellman.getGenerator.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### diffieHellman.getPrime([encoding='binary']), String
+- encoding {String}  The encoding to use;  can be `'binary'`, `'hex'`, or `'base64'`
+
+Returns the Diffie-Hellman prime in the specified encoding.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/diffieHellman.getPrime.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### diffieHellman.getPrivateKey([encoding='binary']), String
+- encoding {String}  The encoding to use;  can be `'binary'`, `'hex'`, or `'base64'`
+
+Returns the Diffie-Hellman private key in the specified encoding.
+
+### diffieHellman.getPublicKey([encoding='binary']), String
+- encoding {String}  The encoding to use;  can be `'binary'`, `'hex'`, or `'base64'`
+
+Returns the Diffie-Hellman public key in the specified encoding.
+
+### diffieHellman.generateKeys([encoding='binary']), String
+- encoding {String}  The encoding to use;  can be `'binary'`, `'hex'`, or `'base64'`
+
+Generates private and public Diffie-Hellman key values, and returns the public key in the specified encoding. This key should be transferred to the other party.
+
+### diffieHellman.setPrivateKey(public_key, [encoding='binary'])
+- public_key {String}  The public key that's shared
+- encoding {String}  The encoding to use;  can be `'binary'`, `'hex'`, or `'base64'`
+
+Sets the Diffie-Hellman private key. 
+
+### diffieHellman.setPublicKey(public_key, [encoding='binary'])
+- public_key {String}  The public key that's shared
+- encoding {String}  The encoding to use;  can be `'binary'`, `'hex'`, or `'base64'`
+
+Sets the Diffie-Hellman public key.
+
+## hash
+
+The class for creating hash digests of data. It's class a representation of the [OpenSSL implementation of hash](http://www.openssl.org/docs/crypto/crypto.html#item_AUTHENTICATION) algorithms. It can be created as a returned value from [[crypto.createHash `crypto.createHash()`]].
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createHash.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### hash.digest([encoding='binary'])
+- encoding {String}  The encoding to use; can be `'binary'`, `'hex'`, or `'base64'`
+
+Calculates the digest of all of the passed data to be hashed.
+
+Note: The `hash` object can't be used after the `digest()` method been called.
+
+
+### hash.update(data, [input_encoding]), String
+- data {String}  The data to use for an update
+- input_encoding {String}  The encoding to use; can be `'binary'`, `'hex'`, or `'base64'`
+(chainable)
+
+Updates the hash content with the given `data`. This can be called many times with new data as it is streamed.
+ 
+## hmac
+
+A class for creating cryptographic hmac content. It's a representation of the [OpenSSL implementation of hmac](http://www.openssl.org/docs/crypto/hmac.html#) algorithms. It can be created as a returned value from [[crypto.createHmac `crypto.createHmac()`]].
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/crypto/crypto.createHmac.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+### hmac.digest([encoding='binary']), String
+- encoding {String}  The encoding to use; can be `'hex'`, `'binary'` or `'base64'`
+
+Calculates the digest of all of the passed data to the hmac.
+
+Note: The `hmac` object can't be used after the `digest()` method been called.
+
+### hmac.update(data), hmac
+- data {String}  The data to use for an update
+(chainable)
+
+Update the HMAC content with the given `data`. This can be called many times with new data as it is streamed.
+
+## signer
+
+This class is used to generate certificates for OpenSSL. It can be created as a returned value from [[crypto.createSign `crypto.createSign()`]].
+
+#### Example
+
+
+  var s1 = crypto.createSign('RSA-SHA1')
+             .update('Test123')
+             .sign(keyPem, 'base64');
+  var verified = crypto.createVerify('RSA-SHA1')
+                   .update('Test')
+                   .update('123')
+                   .verify(certPem, s1, 'base64');
+  assert.strictEqual(verified, true, 'sign and verify (base 64)');
+
+### signer.sign(private_key, [output_format='binary']), String
+- private_key {String} A string containing the PEM encoded private key for signing
+- output_format {String}  The output encoding format; can be `'binary'`, `'hex'` or `'base64'`
 
 Calculates the signature on all the updated data passed through the signer.
-`private_key` is a string containing the PEM encoded private key for signing.
 
-Returns the signature in `output_format` which can be `'binary'`, `'hex'` or
-`'base64'`. Defaults to `'binary'`.
+Note: The `signer` object can not be used after the `sign()` method has been called.
 
-Note: `signer` object can not be used after `sign()` method been called.
+#### Returns
 
-## crypto.createVerify(algorithm)
+ The signature in a format defined by `output_format`.
 
-Creates and returns a verification object, with the given algorithm.
-This is the mirror of the signing object above.
+### signer.update(data), signer
+- data (String) : The data to use for an update
+(chainable)
 
-## Class: Verify
+Updates the signer object with data. This can be called many times with new data as it is streamed.
 
-Class for verifying signatures.
+## verifier
 
-Returned by `crypto.createVerify`.
+This class is used to verify signed certificates for OpenSSL. It can be created as a returned value from [[crypto.createVerify `crypto.createVerify()`]].
 
-### verifier.update(data)
+#### Example
 
-Updates the verifier object with data.
-This can be called many times with new data as it is streamed.
 
-### verifier.verify(object, signature, [signature_format])
+  var s1 = crypto.createSign('RSA-SHA1')
+             .update('Test123')
+             .sign(keyPem, 'base64');
+  var verified = crypto.createVerify('RSA-SHA1')
+                   .update('Test')
+                   .update('123')
+                   .verify(certPem, s1, 'base64');
+  assert.strictEqual(verified, true, 'sign and verify (base 64)');
 
-Verifies the signed data by using the `object` and `signature`. `object` is  a
-string containing a PEM encoded object, which can be one of RSA public key,
-DSA public key, or X.509 certificate. `signature` is the previously calculated
-signature for the data, in the `signature_format` which can be `'binary'`,
-`'hex'` or `'base64'`. Defaults to `'binary'`.
+### verifier.verify(object, signature, [signature_format='binary']), Boolean
+- object {String} A string containing a PEM encoded object, which can be one of the following: an RSA public key, a DSA public key or an X.509 certificate
+- signature {String} The previously calculated signature for the data
+- signature_format {String} The format of the signature; can be `'binary'`, `'hex'`, or `'base64'`
 
-Returns true or false depending on the validity of the signature for the data and public key.
+Returns `true` or `false` depending on the validity of the signature for the data and public key.
 
-Note: `verifier` object can not be used after `verify()` method been called.
+Note: The `verifier` object can't be used after the `verify()` method has been called.
 
-## crypto.createDiffieHellman(prime_length)
+### verifier.update(data), verifier
+- data {String} The data to use for an update
+(chainable)
 
-Creates a Diffie-Hellman key exchange object and generates a prime of the
-given bit length. The generator used is `2`.
-
-## crypto.createDiffieHellman(prime, [encoding])
-
-Creates a Diffie-Hellman key exchange object using the supplied prime. The
-generator used is `2`. Encoding can be `'binary'`, `'hex'`, or `'base64'`.
-Defaults to `'binary'`.
-
-## Class: DiffieHellman
-
-The class for creating Diffie-Hellman key exchanges.
-
-Returned by `crypto.createDiffieHellman`.
-
-### diffieHellman.generateKeys([encoding])
-
-Generates private and public Diffie-Hellman key values, and returns the
-public key in the specified encoding. This key should be transferred to the
-other party. Encoding can be `'binary'`, `'hex'`, or `'base64'`.
-Defaults to `'binary'`.
-
-### diffieHellman.computeSecret(other_public_key, [input_encoding], [output_encoding])
-
-Computes the shared secret using `other_public_key` as the other party's
-public key and returns the computed shared secret. Supplied key is
-interpreted using specified `input_encoding`, and secret is encoded using
-specified `output_encoding`. Encodings can be `'binary'`, `'hex'`, or
-`'base64'`. The input encoding defaults to `'binary'`.
-If no output encoding is given, the input encoding is used as output encoding.
-
-### diffieHellman.getPrime([encoding])
-
-Returns the Diffie-Hellman prime in the specified encoding, which can be
-`'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
-
-### diffieHellman.getGenerator([encoding])
-
-Returns the Diffie-Hellman prime in the specified encoding, which can be
-`'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
-
-### diffieHellman.getPublicKey([encoding])
-
-Returns the Diffie-Hellman public key in the specified encoding, which can
-be `'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
-
-### diffieHellman.getPrivateKey([encoding])
-
-Returns the Diffie-Hellman private key in the specified encoding, which can
-be `'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
-
-### diffieHellman.setPublicKey(public_key, [encoding])
-
-Sets the Diffie-Hellman public key. Key encoding can be `'binary'`, `'hex'`,
-or `'base64'`. Defaults to `'binary'`.
-
-### diffieHellman.setPrivateKey(public_key, [encoding])
-
-Sets the Diffie-Hellman private key. Key encoding can be `'binary'`, `'hex'`,
-or `'base64'`. Defaults to `'binary'`.
-
-## crypto.getDiffieHellman(group_name)
-
-Creates a predefined Diffie-Hellman key exchange object.
-The supported groups are: `'modp1'`, `'modp2'`, `'modp5'`
-(defined in [RFC 2412](http://www.rfc-editor.org/rfc/rfc2412.txt ))
-and `'modp14'`, `'modp15'`, `'modp16'`, `'modp17'`, `'modp18'`
-(defined in [RFC 3526](http://www.rfc-editor.org/rfc/rfc3526.txt )).
-The returned object mimics the interface of objects created by
-[crypto.createDiffieHellman()](#crypto.createDiffieHellman) above, but
-will not allow to change the keys (with
-[diffieHellman.setPublicKey()](#diffieHellman.setPublicKey) for example).
-The advantage of using this routine is that the parties don't have to
-generate nor exchange group modulus beforehand, saving both processor and
-communication time.
-
-Example (obtaining a shared secret):
-
-    var crypto = require('crypto');
-    var alice = crypto.getDiffieHellman('modp5');
-    var bob = crypto.getDiffieHellman('modp5');
-
-    alice.generateKeys();
-    bob.generateKeys();
-
-    var alice_secret = alice.computeSecret(bob.getPublicKey(), 'binary', 'hex');
-    var bob_secret = bob.computeSecret(alice.getPublicKey(), 'binary', 'hex');
-
-    /* alice_secret and bob_secret should be the same */
-    console.log(alice_secret == bob_secret);
-
-## crypto.pbkdf2(password, salt, iterations, keylen, callback)
-
-Asynchronous PBKDF2 applies pseudorandom function HMAC-SHA1 to derive
-a key of given length from the given password, salt and iterations.
-The callback gets two arguments `(err, derivedKey)`.
-
-## crypto.randomBytes(size, [callback])
-
-Generates cryptographically strong pseudo-random data. Usage:
-
-    // async
-    crypto.randomBytes(256, function(ex, buf) {
-      if (ex) throw ex;
-      console.log('Have %d bytes of random data: %s', buf.length, buf);
-    });
-
-    // sync
-    try {
-      var buf = crypto.randomBytes(256);
-      console.log('Have %d bytes of random data: %s', buf.length, buf);
-    } catch (ex) {
-      // handle error
-    }
+Updates the verifier object with data. This can be called many times with new data as it is streamed. 

--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -1,13 +1,12 @@
 # Debugger
+<!-- type=misc -->
 
     Stability: 3 - Stable
 
-<!-- type=misc -->
 
-V8 comes with an extensive debugger which is accessible out-of-process via a
-simple [TCP protocol](http://code.google.com/p/v8/wiki/DebuggerProtocol).
-Node has a built-in client for this debugger. To use this, start Node with the
-`debug` argument; a prompt will appear:
+V8 comes with an extensive debugger which is accessible out-of-process via a simple [TCP protocol](http://code.google.com/p/v8/wiki/DebuggerProtocol). 
+
+Node.js has a built-in client for this debugger. To use this, start Node.js with the `debug` argument; a prompt appears, ready to take your command:
 
     % node debug myscript.js
     < debugger listening on port 5858
@@ -18,9 +17,7 @@ Node has a built-in client for this debugger. To use this, start Node with the
       3   debugger;
     debug>
 
-Node's debugger client doesn't support the full range of commands, but
-simple step and inspection is possible. By putting the statement `debugger;`
-into the source code of your script, you will enable a breakpoint.
+Node's debugger client doesn't support the full range of commands, but simple step and inspection is possible. By putting the statement `debugger;` into the source code of your script, you will enable a breakpoint.
 
 For example, suppose `myscript.js` looked like this:
 
@@ -74,65 +71,53 @@ Then once the debugger is run, it will break on line 4.
     %
 
 
-The `repl` command allows you to evaluate code remotely. The `next` command
-steps over to the next line. There are a few other commands available and more
-to come. Type `help` to see others.
+The `repl` command allows you to evaluate code remotely. The `next` command steps over to the next line. There are a few other commands available and more to come. Type `help` to see others.
 
+There are some online JavaScript IDEs, like [Cloud9 IDE](http://www.c9.io), which provide the Node.js standard debugging mechanisms, as well as more.
 ## Watchers
 
-You can watch expression and variable values while debugging your code.
-On every breakpoint each expression from the watchers list will be evaluated
-in the current context and displayed just before the breakpoint's source code
-listing.
+You can watch expressions and variable values while debugging your code.
 
-To start watching an expression, type `watch("my_expression")`. `watchers`
-prints the active watchers. To remove a watcher, type
-`unwatch("my_expression")`.
+On every breakpoint each expression from the watchers list will be evaluated in the current context and displayed just before the breakpoint's source code listing.
 
-## Commands reference
+To start watching an expression, type `watch("my_expression")`. `watchers` prints the active watchers. To remove a watcher, type `unwatch("my_expression")`.
+
+## Commands Reference
 
 ### Stepping
 
-* `cont`, `c` - Continue execution
-* `next`, `n` - Step next
-* `step`, `s` - Step in
-* `out`, `o` - Step out
-* `pause` - Pause running code (like pause button in Developer TOols)
+* `cont`, `c`: Continue
+* `next`, `n`: Step next
+* `step`, `s`: Step in
+* `out`, `o`: Step out
 
 ### Breakpoints
 
-* `setBreakpoint()`, `sb()` - Set breakpoint on current line
-* `setBreakpoint(line)`, `sb(line)` - Set breakpoint on specific line
-* `setBreakpoint('fn()')`, `sb(...)` - Set breakpoint on a first statement in
-functions body
-* `setBreakpoint('script.js', 1)`, `sb(...)` - Set breakpoint on first line of
-script.js
-* `clearBreakpoint`, `cb(...)` - Clear breakpoint
+* `setBreakpoint()`, `sb()`: Sets a breakpoint on the current line
+* `setBreakpoint('fn()')`, `sb(...)`: Sets a breakpoint on the first statement in the function's body
+* `setBreakpoint('script.js', 1)`, `sb(...)`: Sets a  breakpoint on the first line of `script.js`
+* `clearBreakpoint`, `cb(...)`: Clears a breakpoint
 
 ### Info
 
-* `backtrace`, `bt` - Print backtrace of current execution frame
-* `list(5)` - List scripts source code with 5 line context (5 lines before and
-after)
-* `watch(expr)` - Add expression to watch list
-* `unwatch(expr)` - Remove expression from watch list
-* `watchers` - List all watchers and their values (automatically listed on each
-breakpoint)
-* `repl` - Open debugger's repl for evaluation in debugging script's context
+* `backtrace`, `bt`: Prints a backtrace of the current execution frame
+* `list(c)`: Lists the script's source code with a five line context (five lines before and after)
+* `watch(expr)`: Adds an expression to the watch list
+* `unwatch(expr)`: Removes am expression from the watch list
+* `watchers`: Lists all the watchers and their values (automatically listed on each breakpoint)
+* `repl`: Open the debugger's REPL for evaluation in debugging a script's context
 
 ### Execution control
 
-* `run` - Run script (automatically runs on debugger's start)
-* `restart` - Restart script
-* `kill` - Kill script
+* `run`: Run a script (automatically runs on debugger's start)
+* `restart`: Restart a script
+* `kill`: Kill a script
 
 ### Various
 
-* `scripts` - List all loaded scripts
-* `version` - Display v8's version
+* `scripts`: List all the loaded scripts
+* `version`: Display the V8 version
 
 ## Advanced Usage
 
-The V8 debugger can be enabled and accessed either by starting Node with
-the `--debug` command-line flag or by signaling an existing Node process
-with `SIGUSR1`.
+The V8 debugger can be enabled and accessed either by starting Node.js with the `--debug` command-line flag or by signaling an existing Node.js process with `SIGUSR1`.

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -1,148 +1,127 @@
-# DNS
+## dns
 
     Stability: 3 - Stable
 
-Use `require('dns')` to access this module. All methods in the dns module
-use C-Ares except for `dns.lookup` which uses `getaddrinfo(3)` in a thread
-pool. C-Ares is much faster than `getaddrinfo` but the system resolver is
-more constant with how other programs operate. When a user does
-`net.connect(80, 'google.com')` or `http.get({ host: 'google.com' })` the
-`dns.lookup` method is used. Users who need to do a large number of look ups
-quickly should use the methods that go through C-Ares.
+DNS is the backbone of all operations on the Internet. To access this module, include `require('dns')` in your code.
 
-Here is an example which resolves `'www.google.com'` then reverse
-resolves the IP addresses which are returned.
+Whenever a Node.js developer does something like `net.connect(80, 'google.com')` or `http.get({ host: 'google.com' })`, the [[dns.lookup `dns.lookup()`]] method is used.  All methods in the dns module use C-Ares—except for `dns.lookup()` which uses [`getaddrinfo(3)`](http://www.kernel.org/doc/man-pages/online/pages/man3/getaddrinfo.3.html) in a thread pool. C-Ares is much faster than `getaddrinfo`, but the system resolver is more constant with how other programs operate. Users who need to do a large number of look ups quickly should use the methods that go through C-Ares.
 
-    var dns = require('dns');
+#### Example: Resolving `'www.google.com'`, and then reverse resolving the IP addresses that are returned:
 
-    dns.resolve4('www.google.com', function (err, addresses) {
-      if (err) throw err;
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/dns/dns.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-      console.log('addresses: ' + JSON.stringify(addresses));
+### dns.lookup(domain, [family=null], callback(err, address, family))
+- domain {String}  The domain to resolve
+- family {Number}  Indicates whether to use IPv4 (`4`) or IPv6 (`6`)
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The error object
+- address {String}  A string representation of an IPv4 or IPv6 address
+- family {Number}  Either the integer `4` or `6`, and donates the address family (not necessarily the value initially passed to `lookup`)
 
-      addresses.forEach(function (a) {
-        dns.reverse(a, function (err, domains) {
-          if (err) {
-            throw err;
-          }
+Resolves a domain (e.g. `'google.com'`) into the first found A (IPv4) or AAAA (IPv6) record.
 
-          console.log('reverse for ' + a + ': ' + JSON.stringify(domains));
-        });
-      });
-    });
+#### Example
 
-## dns.lookup(domain, [family], callback)
-
-Resolves a domain (e.g. `'google.com'`) into the first found A (IPv4) or
-AAAA (IPv6) record.
-The `family` can be the integer `4` or `6`. Defaults to `null` that indicates
-both Ip v4 and v6 address family.
-
-The callback has arguments `(err, address, family)`.  The `address` argument
-is a string representation of a IP v4 or v6 address. The `family` argument
-is either the integer 4 or 6 and denotes the family of `address` (not
-necessarily the value initially passed to `lookup`).
-
-On error, `err` is an `Error` object, where `err.code` is the error code.
-Keep in mind that `err.code` will be set to `'ENOENT'` not only when
-the domain does not exist but also when the lookup fails in other ways
-such as no available file descriptors.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/dns/dns.lookup.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
 
-## dns.resolve(domain, [rrtype], callback)
+### dns.resolve(domain, [rrtype='A'], callback(err, addresses))
+- domain {String}  The domain to resolve
+- rrtype {String}  The record type to use
+- callback {Function}   The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {String}  Determined by the record type and described in each corresponding lookup method
 
-Resolves a domain (e.g. `'google.com'`) into an array of the record types
-specified by rrtype. Valid rrtypes are `'A'` (IPV4 addresses, default),
-`'AAAA'` (IPV6 addresses), `'MX'` (mail exchange records), `'TXT'` (text
-records), `'SRV'` (SRV records), `'PTR'` (used for reverse IP lookups),
-`'NS'` (name server records) and `'CNAME'` (canonical name records).
+Resolves a domain (e.g. `'google.com'`) into an array of the record types specified by `rrtype`. Valid rrtypes are:
 
-The callback has arguments `(err, addresses)`.  The type of each item
-in `addresses` is determined by the record type, and described in the
-documentation for the corresponding lookup methods below.
+* `A` (IPV4 addresses)
+* `AAAA` (IPV6 addresses)
+* `MX` (mail exchange records)
+* `TXT` (text records)
+* `SRV` (SRV records)
+* `PTR` (used for reverse IP lookups)
+* `NS` (name server records)
+* `CNAME` (canonical name records)
 
-On error, `err` is an `Error` object, where `err.code` is
-one of the error codes listed below.
+#### Example
 
-
-## dns.resolve4(domain, callback)
-
-The same as `dns.resolve()`, but only for IPv4 queries (`A` records).
-`addresses` is an array of IPv4 addresses (e.g.
-`['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
-
-## dns.resolve6(domain, callback)
-
-The same as `dns.resolve4()` except for IPv6 queries (an `AAAA` query).
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/dns/dns.resolve.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
 
-## dns.resolveMx(domain, callback)
+### dns.resolve4(domain, callback(err, addresses))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of IPv4 addresses (_e.g._ `['74.125.79.104', '74.125.79.105', '74.125.79.106']`)
 
-The same as `dns.resolve()`, but only for mail exchange queries (`MX` records).
+The same as [[dns.resolve `dns.resolve()`]], but only for IPv4 queries (`A` records).
 
-`addresses` is an array of MX records, each with a priority and an exchange
-attribute (e.g. `[{'priority': 10, 'exchange': 'mx.example.com'},...]`).
 
-## dns.resolveTxt(domain, callback)
+### dns.resolve6(domain, callback(err, addresses))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of IPv6 addresses
 
-The same as `dns.resolve()`, but only for text queries (`TXT` records).
-`addresses` is an array of the text records available for `domain` (e.g.,
-`['v=spf1 ip4:0.0.0.0 ~all']`).
+The same as [[dns.resolve4 `dns.resolve4()`]] except for IPv6 queries (an `AAAA` query).
 
-## dns.resolveSrv(domain, callback)
 
-The same as `dns.resolve()`, but only for service records (`SRV` records).
-`addresses` is an array of the SRV records available for `domain`. Properties
-of SRV records are priority, weight, port, and name (e.g.,
-`[{'priority': 10, {'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]`).
+### dns.resolveMx(domain, callback(err, addresses))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of MX records, each with a priority and an exchange attribute (_e.g._ `[{'priority' : 10, 'exchange' : 'mx.example.com'},{...}]`)
 
-## dns.resolveNs(domain, callback)
+The same as [[dns.resolve `dns.resolve()`]], but only for mail exchange queries (`MX` records).
 
-The same as `dns.resolve()`, but only for name server records (`NS` records).
-`addresses` is an array of the name server records available for `domain`
-(e.g., `['ns1.example.com', 'ns2.example.com']`).
 
-## dns.resolveCname(domain, callback)
+### dns.resolveTxt(domain, callback(err, addresses))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of text records available for `domain` (_e.g._ `['v=spf1 ip4 0.0.0.0 ~all']`)
 
-The same as `dns.resolve()`, but only for canonical name records (`CNAME`
-records). `addresses` is an array of the canonical name records available for
-`domain` (e.g., `['bar.example.com']`).
+The same as [[dns.resolve `dns.resolve()`]], but only for text queries (`TXT` records).
 
-## dns.reverse(ip, callback)
 
-Reverse resolves an ip address to an array of domain names.
+### dns.resolveSrv(domain, callback(err, addresses))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of the SRV records available for `domain`. Properties of SRV records are priority, weight, port, and name (_e.g._ `[{'priority' : 10, 'weight' : 5, 'port' : 21223, 'name' : 'service.example.com'}, {...}]`)
 
-The callback has arguments `(err, domains)`.
+The same as [[dns.resolve `dns.resolve()`]], but only for service records (`SRV` records).
 
-On error, `err` is an `Error` object, where `err.code` is
-one of the error codes listed below.
+### dns.reverse(ip, callback(err, domains))
+- ip {String}  The IP address to reverse
+- callback {Function}   The function to execute once the method completes
+- err {Error}  The `Error` object
+- domains {Array}  An array of possible domain names
 
-## Error codes
+Reverse resolves an IP address to an array of domain names.
+
+### dns.resolveNs(domain, callback(err, domains))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of the name server records available for `domain` (_e.g_ `['ns1.example.com', 'ns2.example.com']`)
+
+The same as [[dns.resolve `dns.resolve()`]], but only for name server records (`NS` records).
+
+
+### dns.resolveCname(domain, callback(err, domains))
+- domain {String}  The domain to resolve
+- callback {Function}  The function to execute once the method completes
+- err {Error}  The `Error` object
+- addresses {Array}  An array of the canonical name records available for `domain` (e.g. `['bar.example.com']`)
+
+The same as [[dns.resolve `dns.resolve()`]], but only for canonical name records (`CNAME` records).
 
 Each DNS query can return one of the following error codes:
 
-- `dns.NODATA`: DNS server returned answer with no data.
-- `dns.FORMERR`: DNS server claims query was misformatted.
-- `dns.SERVFAIL`: DNS server returned general failure.
-- `dns.NOTFOUND`: Domain name not found.
-- `dns.NOTIMP`: DNS server does not implement requested operation.
-- `dns.REFUSED`: DNS server refused query.
-- `dns.BADQUERY`: Misformatted DNS query.
-- `dns.BADNAME`: Misformatted domain name.
-- `dns.BADFAMILY`: Unsupported address family.
-- `dns.BADRESP`: Misformatted DNS reply.
-- `dns.CONNREFUSED`: Could not contact DNS servers.
-- `dns.TIMEOUT`: Timeout while contacting DNS servers.
-- `dns.EOF`: End of file.
-- `dns.FILE`: Error reading file.
-- `dns.NOMEM`: Out of memory.
-- `dns.DESTRUCTION`: Channel is being destroyed.
-- `dns.BADSTR`: Misformatted string.
-- `dns.BADFLAGS`: Illegal flags specified.
-- `dns.NONAME`: Given hostname is not numeric.
-- `dns.BADHINTS`: Illegal hints flags specified.
-- `dns.NOTINITIALIZED`: c-ares library initialization not yet performed.
-- `dns.LOADIPHLPAPI`: Error loading iphlpapi.dll.
-- `dns.ADDRGETNETWORKPARAMS`: Could not find GetNetworkParams function.
-- `dns.CANCELLED`: DNS query cancelled.
-
+- `dns.TEMPFAIL`: timeout, SERVFAIL or similar.
+- `dns.PROTOCOL`: got garbled reply.
+- `dns.NXDOMAIN`: domain does not exists.
+- `dns.NODATA`: domain exists but no data of reqd type.
+- `dns.NOMEM`: out of memory while processing.
+- `dns.BADQUERY`: the query is malformed.

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -1,56 +1,86 @@
-# Events
+## eventemitter
 
     Stability: 4 - API Frozen
 
-<!--type=module-->
+Many objects in Node.js emit events. Some examples include:
 
-Many objects in Node emit events: a `net.Server` emits an event each time
-a peer connects to it, a `fs.readStream` emits an event when the file is
-opened. All objects which emit events are instances of `events.EventEmitter`.
-You can access this module by doing: `require("events");`
+* [[net.Server `net.Server`]], which emits an event each time a peer connects to it
+* [[fs.ReadStream `fs.ReadStream`]], which emits an event when the file is opened. 
 
-Typically, event names are represented by a camel-cased string, however,
-there aren't any strict restrictions on that, as any string will be accepted.
+All objects that emit events are instances of `events.EventEmitter`.
 
-Functions can then be attached to objects, to be executed when an event
-is emitted. These functions are called _listeners_.
+Typically, event names are represented by a camel-cased string. However, there aren't any strict restrictions on that, as any string is accepted.
 
+These functions can then be attached to objects, to be executed when an event is emitted. Such functions are called _listeners_.
 
-## Class: events.EventEmitter
+To inherit from `EventEmitter`, add `require('events').EventEmitter` to your code.
 
-To access the EventEmitter class, `require('events').EventEmitter`.
+When an `EventEmitter` instance experiences an error, the typical action is to emit an `'error'` event. Error events are treated as a special case in Node.js. If there is no listener for it, then the default action is to print a stack trace and exit the program.
 
-When an `EventEmitter` instance experiences an error, the typical action is
-to emit an `'error'` event.  Error events are treated as a special case in node.
-If there is no listener for it, then the default action is to print a stack
-trace and exit the program.
+All EventEmitters automatically emit the event `'newListener'` when new listeners are added.
 
-All EventEmitters emit the event `'newListener'` when new listeners are
-added.
+#### Example
 
-### emitter.addListener(event, listener)
-### emitter.on(event, listener)
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/event_emitter/eventemitter.js?linestart=0&lineend=0&showlines=false' defer='defer'></script>
+
+### eventemitter@newListener(event, listener)
+- event {String}  The event to emit
+- listener {Function}  The attaching listener
+
+This event is emitted any time someone adds a new listener, but *before* the listener is attached.
+
+### eventemitter.addListener(event, callback())
+- event {String}   The event to listen for
+- callback {Function}   The listener callback to execute
+(alias of: eventemitter.on)
 
 Adds a listener to the end of the listeners array for the specified event.
 
-    server.on('connection', function (stream) {
-      console.log('someone connected!');
-    });
+#### Example
 
-### emitter.once(event, listener)
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/event_emitter/eventemitter.addlistener.js?linestart=0&lineend=0&showlines=false' defer='defer'></script>
 
-Adds a **one time** listener for the event. This listener is
-invoked only the next time the event is fired, after which
-it is removed.
+### eventemitter.emit(event [, arg...])
+- event {String}  The event to listen for
+- arg {Object}   Any optional arguments for the listeners
+
+Execute each of the subscribed listeners in order with the supplied arguments.
+
+### eventemitter.listeners(event)
+- event {String}  The event type to listen for
+
+Returns an array of listeners for the specified event. This array can be manipulated, e.g. to remove listeners.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/event_emitter/eventemitter.listeners.js?linestart=0&lineend=0&showlines=false' defer='defer'></script>
+    
+### eventemitter.once(event, listener)
+- event {String}   The event to listen for
+- callback {Function}   The listener callback to execute
+
+Adds a **one time** listener for the event. This listener is invoked only the next time the event is fired, after which it is removed.
+
+#### Example
 
     server.once('connection', function (stream) {
       console.log('Ah, we have our first user!');
     });
 
-### emitter.removeListener(event, listener)
+### eventemitter.removeAllListeners([event])
+- event {String}  An optional event type to remove
+
+Removes all listeners, or those of the specified event.
+
+### eventemitter.removeListener(event, listener)
+- event {String}   The event to listen for
+- callback {Function}   The listener callback to execute
 
 Remove a listener from the listener array for the specified event.
-**Caution**: changes array indices in the listener array behind the listener.
+
+Warning: This can change array indices in the listener array behind the listener.
+
+#### Example
 
     var callback = function(stream) {
       console.log('someone connected!');
@@ -59,37 +89,13 @@ Remove a listener from the listener array for the specified event.
     // ...
     server.removeListener('connection', callback);
 
+### eventemitter.setMaxListeners(n)
+- n {Number}  The maximum number of listeners
 
-### emitter.removeAllListeners([event])
+By default, EventEmitters print a warning if more than 10 listeners are added for a particular event. This is a useful default which helps finding memory leaks.
 
-Removes all listeners, or those of the specified event.
+Obviously, not all Emitters should be limited to 10. This function allows that to be increased. Set it to `0` for unlimited listeners.
 
+#### Example
 
-### emitter.setMaxListeners(n)
-
-By default EventEmitters will print a warning if more than 10 listeners are
-added for a particular event. This is a useful default which helps finding memory leaks.
-Obviously not all Emitters should be limited to 10. This function allows
-that to be increased. Set to zero for unlimited.
-
-
-### emitter.listeners(event)
-
-Returns an array of listeners for the specified event. This array can be
-manipulated, e.g. to remove listeners.
-
-    server.on('connection', function (stream) {
-      console.log('someone connected!');
-    });
-    console.log(util.inspect(server.listeners('connection'))); // [ [Function] ]
-
-### emitter.emit(event, [arg1], [arg2], [...])
-
-Execute each of the listeners in order with the supplied arguments.
-
-### Event: 'newListener'
-
-* `event` {String} The event name
-* `listener` {Function} The event handler function
-
-This event is emitted any time someone adds a new listener.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/event_emitter/eventemitter.setMaxListeners.js?linestart=0&lineend=0&showlines=false' defer='defer'></script>

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -1,51 +1,40 @@
-# File System
+## fs
 
     Stability: 3 - Stable
 
-<!--name=fs-->
+In Node.js, file input and output is provided by simple wrappers around standard [POSIX functions](http://en.wikipedia.org/wiki/POSIX). All the read and write methods methods have asynchronous and synchronous forms. To use this module, include `require('fs')` in your code. 
 
-File I/O is provided by simple wrappers around standard POSIX functions.  To
-use this module do `require('fs')`. All the methods have asynchronous and
-synchronous forms.
+The asynchronous form always take a completion callback as its last argument. The arguments passed to the completion callback depend on the method, but the first argument is always reserved for an exception. If the operation was completed successfully, then the first argument will be `null` or `undefined`.
 
-The asynchronous form always take a completion callback as its last argument.
-The arguments passed to the completion callback depend on the method, but the
-first argument is always reserved for an exception. If the operation was
-completed successfully, then the first argument will be `null` or `undefined`.
+When using the synchronous form, any exceptions are immediately thrown. You can use `try/catch` to handle exceptions, or allow them to bubble up. 
 
-When using the synchronous form any exceptions are immediately thrown.
-You can use try/catch to handle exceptions or allow them to bubble up.
+In busy processes, the programmer is **strongly encouraged** to use the asynchronous versions of these calls. The synchronous versions block the entire process until they complete—halting all connections. However, with the asynchronous methods, there is no guaranteed ordering.
 
-Here is an example of the asynchronous version:
+Note: When processing files, relative paths to filename can be used; however, this path is relative to [[process.cwd `process.cwd()`]].
 
-    var fs = require('fs');
+#### Example: An asynchronous file delete:
 
-    fs.unlink('/tmp/hello', function (err) {
-      if (err) throw err;
-      console.log('successfully deleted /tmp/hello');
-    });
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/fs/fs.ex.1.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Here is the synchronous version:
+#### Example: A synchronous file delete:
 
-    var fs = require('fs');
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/fs/fs.ex.2.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    fs.unlinkSync('/tmp/hello')
-    console.log('successfully deleted /tmp/hello');
+#### Example: Handling timing issues with callback
 
-With the asynchronous methods there is no guaranteed ordering. So the
-following is prone to error:
+Here's an example of the **wrong** way to perform more than one asynchronous operation:
 
     fs.rename('/tmp/hello', '/tmp/world', function (err) {
       if (err) throw err;
       console.log('renamed complete');
     });
+		// ERROR: THIS IS NOT CORRECT!
     fs.stat('/tmp/world', function (err, stats) {
       if (err) throw err;
       console.log('stats: ' + JSON.stringify(stats));
     });
 
-It could be that `fs.stat` is executed before `fs.rename`.
-The correct way to do this is to chain the callbacks.
+In the example above, it could be that `fs.stat` is executed before `fs.rename`. The correct way to do this is to chain the callbacks, like this:
 
     fs.rename('/tmp/hello', '/tmp/world', function (err) {
       if (err) throw err;
@@ -55,503 +44,832 @@ The correct way to do this is to chain the callbacks.
       });
     });
 
-In busy processes, the programmer is _strongly encouraged_ to use the
-asynchronous versions of these calls. The synchronous versions will block
-the entire process until they complete--halting all connections.
 
-Relative path to filename can be used, remember however that this path will be relative
-to `process.cwd()`.
+### fs.rename(path1, path2 [, callback])
+- path1 {String}  The original filename and path
+- path2 {String}  The new filename and path
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error} The possible exception
 
-## fs.rename(oldPath, newPath, [callback])
+An asynchronous [rename(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/rename.2.html) operation. Turns `path1` into `path2`.
 
-Asynchronous rename(2). No arguments other than a possible exception are given
-to the completion callback.
 
-## fs.renameSync(oldPath, newPath)
 
-Synchronous rename(2).
+ 
 
-## fs.truncate(fd, len, [callback])
 
-Asynchronous ftruncate(2). No arguments other than a possible exception are
-given to the completion callback.
+### fs.renameSync(path1, path2)
+- path1 {String}  The original filename and path
+- path2 {String}  The new filename and path
 
-## fs.truncateSync(fd, len)
+A synchronous [rename(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/rename.2.html) operation. Turns `path1` into `path2`.
 
-Synchronous ftruncate(2).
+ 
 
-## fs.chown(path, uid, gid, [callback])
+### fs.truncate(fd, len [, callback(err)])
+- fd {Number}  The file descriptor
+- len {Number}  The final file length
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-Asynchronous chown(2). No arguments other than a possible exception are given
-to the completion callback.
+An asynchronous [ftruncate(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/truncate.2.html). It truncates a file to the specified length.
 
-## fs.chownSync(path, uid, gid)
+ 
 
-Synchronous chown(2).
 
-## fs.fchown(fd, uid, gid, [callback])
 
-Asynchronous fchown(2). No arguments other than a possible exception are given
-to the completion callback.
+### fs.truncateSync(fd, len)
+- fd {Number}  The file descriptor
+- len {Number}  The final file length 
 
-## fs.fchownSync(fd, uid, gid)
+A synchronous [ftruncate(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/truncate.2.html). It truncates a file to the specified length.
 
-Synchronous fchown(2).
+ 
 
-## fs.lchown(path, uid, gid, [callback])
 
-Asynchronous lchown(2). No arguments other than a possible exception are given
-to the completion callback.
 
-## fs.lchownSync(path, uid, gid)
+### fs.chown(path, uid, gid [, callback(err)])
+- path {String}  The path to the file
+- uid {Number}  The new owner id
+- gid {Number}  The new group id
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-Synchronous lchown(2).
+An asynchronous [chown(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/chown.2.html). This changes the ownership of the file specified by `path`, which is de-referenced if it is a symbolic link.
 
-## fs.chmod(path, mode, [callback])
+ 
 
-Asynchronous chmod(2). No arguments other than a possible exception are given
-to the completion callback.
 
-## fs.chmodSync(path, mode)
 
-Synchronous chmod(2).
+### fs.chownSync(path, uid, gid)
+- path {String}  The path to the file
+- uid {Number}  The new owner id
+- gid {Number}  The new group id
 
-## fs.fchmod(fd, mode, [callback])
+A synchronous [chown(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/chown.2.html). This changes the ownership of the file specified by `path`, which is dereferenced if it is a symbolic link
 
-Asynchronous fchmod(2). No arguments other than a possible exception
-are given to the completion callback.
+ 
 
-## fs.fchmodSync(fd, mode)
 
-Synchronous fchmod(2).
+### fs.fchown(fd, uid, gid, [callback(err)])
+- path {String}  The path to the file
+- uid {Number}  The new owner id
+- gid {Number}  The new group id
+- callback {Function}  An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-## fs.lchmod(path, mode, [callback])
+An asynchronous [fchown(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/fchown.2.html). This changes the ownership of the file referred to by the open file descriptor fd.
 
-Asynchronous lchmod(2). No arguments other than a possible exception
-are given to the completion callback.
+ 
 
-## fs.lchmodSync(path, mode)
 
-Synchronous lchmod(2).
+### fs.fchownSync(fd, uid, gid)
+- path {String}  The path to the file
+- uid {Number}  The new owner id
+- gid {Number}  The new group id
 
-## fs.stat(path, [callback])
+A synchronous [fchown(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/fchown.2.html). This changes the ownership of the file referred to by the open file descriptor fd.
 
-Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a [fs.Stats](#fs_class_fs_stats) object.  See the [fs.Stats](#fs_class_fs_stats)
-section below for more information.
+ 
 
-## fs.lstat(path, [callback])
 
-Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a `fs.Stats` object. `lstat()` is identical to `stat()`, except that if
-`path` is a symbolic link, then the link itself is stat-ed, not the file that it
-refers to.
 
-## fs.fstat(fd, [callback])
+### fs.lchown(path, uid, gid, [callback(err)])
+- path {String}  The path to the file
+- uid {Number}  The new owner id
+- gid {Number}  The new group id
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a `fs.Stats` object. `fstat()` is identical to `stat()`, except that
-the file to be stat-ed is specified by the file descriptor `fd`.
+An asynchronous [lchown(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/lchown.2.html). This is like [[fs.chown `chown()`]], but doesn't dereference symbolic links.
 
-## fs.statSync(path)
+ 
 
-Synchronous stat(2). Returns an instance of `fs.Stats`.
 
-## fs.lstatSync(path)
 
-Synchronous lstat(2). Returns an instance of `fs.Stats`.
+### fs.lchownSync(path, uid, gid)
+- path {String}  The path to the file
+- uid {Number}  The new owner id
+- gid {Number}  The new group id
 
-## fs.fstatSync(fd)
+Synchronous [lchown(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/lchown.2.html). This is like [[fs.chownSync `chownSync()`]], but doesn't dereference symbolic links
 
-Synchronous fstat(2). Returns an instance of `fs.Stats`.
+ 
 
-## fs.link(srcpath, dstpath, [callback])
 
-Asynchronous link(2). No arguments other than a possible exception are given to
-the completion callback.
 
-## fs.linkSync(srcpath, dstpath)
+### fs.chmod(path, mode, [callback(err)])
+- path {String}  The path to the file
+- mode {Number}  The new permissions
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-Synchronous link(2).
+An asynchronous [chmod(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/chmod.2.html). This changes the permissions of the file specified whose, which is dereferenced if it is a symbolic link.
 
-## fs.symlink(destination, path, [type], [callback])
+ 
 
-Asynchronous symlink(2). No arguments other than a possible exception are given
-to the completion callback.
-`type` argument can be either `'dir'` or `'file'` (default is `'file'`).  It is only 
-used on Windows (ignored on other platforms).
 
-## fs.symlinkSync(destination, path, [type])
 
-Synchronous symlink(2).
+### fs.chmodSync(path, mode)
+- path {String}  The path to the file
+- mode {Number}  The new permissions
 
-## fs.readlink(path, [callback])
+A synchronous [chmod(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/chmod.2.html). This changes the permissions of the file specified whose, which is dereferenced if it is a symbolic link.
 
-Asynchronous readlink(2). The callback gets two arguments `(err,
-linkString)`.
+ 
 
-## fs.readlinkSync(path)
 
-Synchronous readlink(2). Returns the symbolic link's string value.
 
-## fs.realpath(path, [cache], callback)
+### fs.fchmod(fd, mode, [callback(err)])
+- fd {Number}  The file descriptor
+- mode {Number}  The new permissions
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-Asynchronous realpath(2). The `callback` gets two arguments `(err,
-resolvedPath)`. May use `process.cwd` to resolve relative paths. `cache` is an
-object literal of mapped paths that can be used to force a specific path
-resolution or avoid additional `fs.stat` calls for known real paths.
+An asynchronous [fchmod(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/fchmod.2.html). This changes the permissions of the file referred to by the open file descriptor.
 
-Example:
+ 
 
-    var cache = {'/etc':'/private/etc'};
-    fs.realpath('/etc/passwd', cache, function (err, resolvedPath) {
-      if (err) throw err;
-      console.log(resolvedPath);
-    });
 
-## fs.realpathSync(path, [cache])
 
-Synchronous realpath(2). Returns the resolved path.
+### fs.fchmodSync(fd, mode)
+- fd {Number}  The file descriptor
+- mode {Number}  The new permissions
 
-## fs.unlink(path, [callback])
+A synchronous [fchmod(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/fchmod.2.html). This changes the permissions of the file referred to by the open file descriptor.
 
-Asynchronous unlink(2). No arguments other than a possible exception are given
-to the completion callback.
+ 
 
-## fs.unlinkSync(path)
 
-Synchronous unlink(2).
 
-## fs.rmdir(path, [callback])
+### fs.lchmod(path, mode, [callback()])
+- path {String}  The path to the file
+- mode {Number}  The new permissions
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-Asynchronous rmdir(2). No arguments other than a possible exception are given
-to the completion callback.
+An asynchronous [lchmod(2)](http://www.daemon-systems.org/man/lchmod.2.html). This is like [[fs.chmod `chmod()`]] except in the case where the named file is a symbolic link, in which case `lchmod()` sets the permission bits of the link, while `chmod()` sets the bits of the file the link references.
 
-## fs.rmdirSync(path)
+ 
 
-Synchronous rmdir(2).
 
-## fs.mkdir(path, [mode], [callback])
 
-Asynchronous mkdir(2). No arguments other than a possible exception are given
-to the completion callback. `mode` defaults to `0777`.
+### fs.lchmodSync(path, mode)
+- path {String}  The path to the file
+- mode {Number}  The new permissions
 
-## fs.mkdirSync(path, [mode])
+A synchronous [lchmod(2)](http://www.daemon-systems.org/man/lchmod.2.html). This is like [[fs.chmodSync `chmodSync()`]]except in the case where the named file is a symbolic link, in which case `lchmod()` sets the permission bits of the link, while `chmod()` sets the bits of the file the link references.
 
-Synchronous mkdir(2).
+ 
 
-## fs.readdir(path, [callback])
 
-Asynchronous readdir(3).  Reads the contents of a directory.
-The callback gets two arguments `(err, files)` where `files` is an array of
-the names of the files in the directory excluding `'.'` and `'..'`.
 
-## fs.readdirSync(path)
+### fs.stat(path, [callback(err, stats)]), fs.Stats
+- path {String}  The path to the file
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- stats {fs.Stats}   An [[fs.Stats `fs.Stats`] object.
 
-Synchronous readdir(3). Returns an array of filenames excluding `'.'` and
-`'..'`.
+An asynchronous [stat(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html). 
 
-## fs.close(fd, [callback])
+ 
 
-Asynchronous close(2).  No arguments other than a possible exception are given
-to the completion callback.
 
-## fs.closeSync(fd)
 
-Synchronous close(2).
+### fs.lstat(path, [callback(err, stats)]), fs.Stats
+- path {String}  The path to the file
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- stats {fs.Stats}   An [[fs.Stats `fs.Stats`] object.
 
-## fs.open(path, flags, [mode], [callback])
+An asynchronous [lstat(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html). 
 
-Asynchronous file open. See open(2). `flags` can be:
 
-* `'r'` - Open file for reading.
-An exception occurs if the file does not exist.
+ 
 
-* `'r+'` - Open file for reading and writing.
-An exception occurs if the file does not exist.
 
-* `'w'` - Open file for writing.
-The file is created (if it does not exist) or truncated (if it exists).
 
-* `'wx'` - Like `'w'` but opens the file in exclusive mode.
+### fs.fstat(fd, [callback(err, stats)]), fs.Stats
+- fd {Number}  The file descriptor
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- stats {fs.Stats}   An [[fs.Stats `fs.Stats`]] object.
 
-* `'w+'` - Open file for reading and writing.
-The file is created (if it does not exist) or truncated (if it exists).
+An asynchronous [fstat(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html). 
 
-* `'wx+'` - Like `'w+'` but opens the file in exclusive mode.
+ 
 
-* `'a'` - Open file for appending.
-The file is created if it does not exist.
 
-* `'ax'` - Like `'a'` but opens the file in exclusive mode.
 
-* `'a+'` - Open file for reading and appending.
-The file is created if it does not exist.
+### fs.statSync(path), fs.Stats
+- path {String}  The path to the file
 
-* `'ax+'` - Like `'a+'` but opens the file in exclusive mode.
+A synchronous [stat(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html).
 
-`mode` defaults to `0666`. The callback gets two arguments `(err, fd)`.
+ 
 
-Exclusive mode (`O_EXCL`) ensures that `path` is newly created. `fs.open()`
-fails if a file by that name already exists. On POSIX systems, symlinks are
-not followed. Exclusive mode may or may not work with network file systems.
 
-## fs.openSync(path, flags, [mode])
 
-Synchronous open(2).
+### fs.lstatSync(path), fs.Stats
+- path {String}  The path to the file
 
-## fs.utimes(path, atime, mtime, [callback])
-## fs.utimesSync(path, atime, mtime)
+A synchronous [lstat(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html).
 
-Change file timestamps of the file referenced by the supplied path.
+ 
 
-## fs.futimes(fd, atime, mtime, [callback])
-## fs.futimesSync(fd, atime, mtime)
 
-Change the file timestamps of a file referenced by the supplied file
-descriptor.
 
-## fs.fsync(fd, [callback])
+### fs.fstatSync(fd), fs.Stats
+- fd {Number}  The file descriptor
 
-Asynchronous fsync(2). No arguments other than a possible exception are given
-to the completion callback.
+A synchronous [fstat(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html). 
 
-## fs.fsyncSync(fd)
+ 
 
-Synchronous fsync(2).
 
-## fs.write(fd, buffer, offset, length, position, [callback])
 
-Write `buffer` to the file specified by `fd`.
+### fs.link(srcpath, dstpath, [callback(err)])
+- srcpath {String}  The original path of a file
+- dstpath {String}  The new file link path
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-`offset` and `length` determine the part of the buffer to be written.
+An asynchronous [link(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/link.2.html).
 
-`position` refers to the offset from the beginning of the file where this data
-should be written. If `position` is `null`, the data will be written at the
-current position.
-See pwrite(2).
+ 
 
-The callback will be given three arguments `(err, written, buffer)` where `written`
-specifies how many _bytes_ were written from `buffer`.
 
-Note that it is unsafe to use `fs.write` multiple times on the same file
-without waiting for the callback. For this scenario,
-`fs.createWriteStream` is strongly recommended.
 
-## fs.writeSync(fd, buffer, offset, length, position)
+### fs.linkSync(srcpath, dstpath)
+- srcpath {String}  The original path of a file
+- dstpath {String}  The new file link path
 
-Synchronous version of buffer-based `fs.write()`. Returns the number of bytes
-written.
+A synchronous [link(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/link.2.html).
 
-## fs.writeSync(fd, str, position, [encoding])
+ 
 
-Synchronous version of string-based `fs.write()`. `encoding` defaults to
-`'utf8'`. Returns the number of _bytes_ written.
 
-## fs.read(fd, buffer, offset, length, position, [callback])
 
-Read data from the file specified by `fd`.
+### fs.symlink(linkdata, path, [type='file'], [callback(err)])
+- linkdata {String}  The original path of a file
+- path {String}  The new file link path
+- type {String}  This can be either `'dir'` or `'file'`.  It is only used on Windows ( andignored on other platforms)
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
 
-`buffer` is the buffer that the data will be written to.
+An asynchronous [symlink(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/symlink.2.html).
 
-`offset` is offset within the buffer where writing will start.
+ 
 
-`length` is an integer specifying the number of bytes to read.
 
-`position` is an integer specifying where to begin reading from in the file.
-If `position` is `null`, data will be read from the current file position.
 
-The callback is given the three arguments, `(err, bytesRead, buffer)`.
+### fs.symlinkSync(linkdata, path, [type='file'])
+- linkdata {String}  The original path of a file
+- path {String}  The new file link path
+- type {String}  This can be either `'dir'` or `'file'`.  It is only used on Windows ( andignored on other platforms)
 
-## fs.readSync(fd, buffer, offset, length, position)
+A synchronous [symlink(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/symlink.2.html).
 
-Synchronous version of buffer-based `fs.read`. Returns the number of
-`bytesRead`.
+ 
 
-## fs.readSync(fd, length, position, encoding)
 
-Synchronous version of string-based `fs.read`. Returns the number of
-`bytesRead`.
 
-## fs.readFile(filename, [encoding], [callback])
+### fs.readlink(path, [callback(err, linkString)])
+- path {String}  The original path of a link
+- callback {Function}   An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- linkString {String} T he symlink's string value
+ 
+An asynchronous [readlink(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/readlink.2.html).
 
-Asynchronously reads the entire contents of a file. Example:
+ 
+
+
+
+### fs.readlinkSync(path), String
+- path {String}  The original path of a link
+
+A synchronous [readlink(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/readlink.2.html).
+
+#### Returns
+
+The symbolic link's string value.
+
+ 
+
+
+
+### fs.realpath(path, [callback(err, resolvedPath)])
+- path {String}  A path to a file
+- callback {Function}   An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- resolvedPath {String} The resolved path string
+
+An asynchronous [realpath(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/realpath.3.html). You can use [[process.cwd `process.cwd()`]] to resolve relative paths.
+
+
+ 
+
+
+
+### fs.realpathSync(path), String
+- path {String}  A path to a file
+
+A synchronous [realpath(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/realpath.3.html).
+
+#### Returns
+
+The resolved path.
+
+ 
+
+
+
+### fs.unlink(path, [callback(err)])
+- srcpath {String}  The path to a file
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+
+An asynchronous [unlink(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/unlink.2.html).
+
+ 
+
+
+
+### fs.unlinkSync(path)
+- srcpath {String}  The path to a file
+
+A synchronous [unlink(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/unlink.2.html).
+
+ 
+
+
+
+### fs.rmdir(path [, callback(err)])
+- path {String}  The path to a directory
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+
+An asynchronous [rmdir(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/rmdir.2.html).
+
+ 
+
+
+
+### fs.rmdirSync(path)
+- path {String}  The path to a directory
+
+A synchronous [rmdir(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/rmdir.2.html).
+ 
+
+
+### fs.mkdir(path [, mode=777] [, callback(err)])
+- path {String}  The path to the new directory
+- mode {Number}  An optional permission to set
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+
+An asynchronous [mkdir(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/mkdir.2.html). 
+
+ 
+
+
+
+### fs.mkdirSync(path [, mode=777])
+- path {String}  The path to the new directory
+- mode {Number}  An optional permission to set
+
+A synchronous [mkdir(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/mkdir.2.html).
+
+ 
+
+
+
+### fs.readdir(path, [callback(err, files)])
+- path {String}  The path to the directory
+- callback {Function}   An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- files {Array}  An array of the names of the files in the directory (excluding `'.'` and `'..'`)
+
+An asynchronous [readdir(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/readdir.3.html).  It reads the contents of a directory.
+
+ 
+
+
+
+### fs.readdirSync(path)
+- path {String}  The path to the directory
+
+
+A synchronous [readdir(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/readdir.3.html). Returns an array of filenames, excluding `'.'` and `'..'`.
+
+ 
+
+
+
+### fs.close(fd, [callback(err)])
+- fd {Number}  The file descriptor
+- callback {Function}    An optional callback to execute once the function completes
+- err {Error}  The possible exception
+ 
+
+An asynchronous file close; for more information, see [close(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/close.2.html).
+
+ 
+
+
+
+### fs.closeSync(fd)
+- fd {Number}  The file descriptor
+
+A synchronous file close; for more information, see [close(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/close.2.html).
+
+ 
+
+
+
+### fs.open(path, flags [, mode=666] [, callback(err, fd)])
+- path {String}  The path to the file
+- flags {String}  A string indicating how to open the file
+- mode {Number}   The optional permissions to give the file if it's created
+- callback {Function}  An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- fd {Number}  An open file descriptor
+
+An asynchronous file open; for more information, see [open(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/open.2.html). 
+
+`flags` can be one of the following:
+
+* `'r'`: Opens the file for reading. An exception occurs if the file does not exist.
+
+* `'r+'`: Opens the file for reading and writing. An exception occurs if the file does not exist.
+
+* `'w'`: Opens the file for writing. The file is created (if it does not exist) or truncated (if it exists).
+
+* `'w+'`: Opens the file for reading and writing. The file is created (if it doesn't exist) or truncated (if it exists).
+
+* `'a'`: Opens the file for appending. The file is created if it doesn't exist.
+
+* `'a+'`: Opens the file for reading and appending. The file is created if it doesn't exist.
+
+ 
+
+
+
+### fs.openSync(path, flags, [mode=666]), Number
+- path {String}  The path to the file
+- flags {String}  A string indicating how to open the file
+- mode {Number}   The optional permissions to give the file if it's created
+
+A synchronous file open; for more information, see [open(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/open.2.html).
+
+`flags` can be one of the following:
+
+* `'r'`: Opens the file for reading. An exception occurs if the file does not exist.
+
+* `'r+'`: Opens the file for reading and writing. An exception occurs if the file does not exist.
+
+* `'w'`: Opens the file for writing. The file is created (if it does not exist) or truncated (if it exists).
+
+* `'w+'`: Opens the file for reading and writing. The file is created (if it doesn't exist) or truncated (if it exists).
+
+* `'a'`: Opens the file for appending. The file is created if it doesn't exist.
+
+* `'a+'`: Opens the file for reading and appending. The file is created if it doesn't exist.
+
+#### Returns
+
+An open file descriptor.
+
+ 
+
+
+
+### fs.utimes(path, atime, mtime, [callback()])
+- path {String}  The path to the file
+- atime {Number}  The new access time
+- mtime {Number}  The new modification time
+- callback {Function}  An optional callback to execute once the function completes
+
+An asynchronous [utime(2)](http://kernel.org/doc/man-pages/online/pages/man2/utime.2.html). Changes the timestamps of the file referenced by the supplied path.
+
+ 
+
+
+
+### fs.utimesSync(path, atime, mtime)
+- path {String}  The path to the file
+- atime {Number}  The new access time
+- mtime {Number}  The new modification time
+
+A synchronous [utime(2)](http://kernel.org/doc/man-pages/online/pages/man2/utime.2.html). Change the timestamps of the file referenced by the supplied path.
+
+ 
+
+
+
+### fs.futimes(fd, atime, mtime, [callback()])
+- fd {Number}  The file descriptor
+- atime {Number}  The new access time
+- mtime {Number}  The new modification time
+- callback {Function}   An optional callback to execute once the function completes
+
+An asynchronous [futimes(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/lutimes.3.html). Change the file timestamps of a file referenced by the supplied file descriptor.
+
+ 
+
+
+
+### fs.futimesSync(fd, atime, mtime)
+- fd {Number}  The file descriptor
+- atime {Number}  The new access time
+- mtime {Number}  The new modification time
+
+
+A synchronous [futimes(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/lutimes.3.html). Change the file timestamps of a file referenced by the supplied file descriptor.
+
+ 
+
+
+
+### fs.fsync(fd, [callback(err)])
+- fd {Number}  The file descriptor
+- callback {Function}  An optional callback to execute once the function completes
+
+
+An asynchronous [fsync(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/fsync.2.html).
+
+ 
+
+
+
+### fs.fsyncSync(fd)
+- fd {Number}  The file descriptor
+
+
+A synchronous [fsync(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/fsync.2.html).
+ 
+ 
+
+
+
+### fs.write(fd, buffer, offset, length, position, [callback(err, written, buffer)])
+- fd {Number}  The file descriptor
+- buffer {Buffer}  The buffer to write
+- offset {Number}  Indicates where in the buffer to start at
+- length {Number}  Indicates how much of the buffer to use
+- position {Number}  The offset from the beginning of the file where this data should be written
+- callback {Function}   An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- written {Number} Specifies how many bytes were written from `buffer`
+- buffer {Buffer}  The remaining contents of the buffer 
+
+Writes `buffer` to the file specified by `fd`. Note that it's unsafe to use `fs.write` multiple times on the same file without waiting for the callback. For this scenario, [[fs.createWriteStream `fs.createWriteStream()`]] is strongly recommended.
+
+For more information, see [pwrite(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/pwrite.2.html).
+
+ 
+
+### fs.writeSync(fd, buffer, offset, length, position), Number
+### fs.writeSync(fd, str, position, [encoding='utf8']), Number
+- fd {Number}  The file descriptor
+- buffer {Buffer}  The buffer to write
+- offset {Number}  Indicates where in the buffer to start at
+- length {Number}  Indicates how much of the buffer to use
+- position {Number}  The offset from the beginning of the file where this data should be written
+- str {String}  The string to write
+- encoding {Number}  The encoding to use during the write
+
+A synchronous version of the buffer-based [[fs.write `fs.write()`]].
+
+#### Returns
+
+Returns the number of bytes written.
+
+ 
+ 
+
+
+
+### fs.read(fd, buffer, offset, length, position, [callback()])
+- fd {Number}  The file descriptor to read from
+- buffer {Buffer}  The buffer to write to
+- offset {Number}  Indicates where in the buffer to start writing at
+- length {Number}  Indicates the number of bytes to read
+- position {Number}  The offset from the beginning of the file where the reading should begin
+- callback {Function}  An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- bytesRead {Number}  Specifies how many bytes were read from `buffer`
+- buffer {Buffer}  The rest of the buffer
+
+Read data from the file specified by `fd` and writes it to `buffer`. If `position` is `null`, data will be read from the current file position.
+
+ 
+
+
+
+### fs.readSync(fd, buffer, offset, length, position), Number
+### fs.readSync(fd, length, position, encoding), Number
+- fd {Number}  The file descriptor to read from
+- buffer {Buffer}  The buffer to write to
+- offset {Number}  Indicates where in the buffer to start writing at
+- length {Number}  Indicates the number of bytes to read
+- position {Number}  The offset from the beginning of the file where the reading should begin
+- encoding {String}  The encoding to use 
+
+The synchronous version of buffer-based [[fs.read `fs.read()`]]. Reads data from the file specified by `fd` and writes it to `buffer`. If `position` is `null`, data will be read from the current file position.
+
+
+#### Returns
+
+The number of bytes read.
+
+ 
+
+
+
+### fs.readFile(filename, [encoding], [callback(err, data)])
+- filename {String}  The name of the file to read
+- encoding {String}  The encoding to use
+- callback {Function}   An optional callback to execute once the function completes
+- err {Error}  The possible exception
+- data {Buffer}  The contents of the file
+
+
+Asynchronously reads the entire contents of a file. If no encoding is specified, then the raw buffer is returned.
+
+#### Example
 
     fs.readFile('/etc/passwd', function (err, data) {
       if (err) throw err;
       console.log(data);
     });
 
-The callback is passed two arguments `(err, data)`, where `data` is the
-contents of the file.
-
-If no encoding is specified, then the raw buffer is returned.
+ 
 
 
-## fs.readFileSync(filename, [encoding])
 
-Synchronous version of `fs.readFile`. Returns the contents of the `filename`.
+### fs.readFileSync(filename, [encoding]), String | Buffer
+- filename {String}  The name of the file to read
+- encoding {String}  The encoding to use
+ 
 
-If `encoding` is specified then this function returns a string. Otherwise it
-returns a buffer.
+Synchronous version of [[fs.readFile `fs.readFile()`]]. Returns the contents of the `filename`.
+
+#### Returns
+
+The contents of the `filename`. If `encoding` is specified, then this function returns a string. Otherwise it returns a [[Buffer buffer]].
+ 
 
 
-## fs.writeFile(filename, data, [encoding], [callback])
+
+### fs.writeFile(filename, data, [encoding='utf8'], [callback()])
+- filename {String}  The name of the file to write to
+- data {String | Buffer}  The data to write (this can be a string or a buffer)
+- encoding {String}  The encoding to use (this is ignored if `data` is a buffer)
+- callback {Function}   An optional callback to execute once the function completes
 
 Asynchronously writes data to a file, replacing the file if it already exists.
-`data` can be a string or a buffer. The `encoding` argument is ignored if
-`data` is a buffer. It defaults to `'utf8'`.
 
-Example:
+#### Example
 
-    fs.writeFile('message.txt', 'Hello Node', function (err) {
-      if (err) throw err;
-      console.log('It\'s saved!');
-    });
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/fs/fs.writefile.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## fs.writeFileSync(filename, data, [encoding])
+ 
 
-The synchronous version of `fs.writeFile`.
 
-## fs.appendFile(filename, data, encoding='utf8', [callback])
 
-Asynchronously append data to a file, creating the file if it not yet exists.
-`data` can be a string or a buffer. The `encoding` argument is ignored if
-`data` is a buffer.
+### fs.writeFileSync(filename, data, [encoding='utf8'])
+- filename {String}  The name of the file to write to
+- data {String | Buffer}  The data to write (this can be a string or a buffer)
+- encoding {String}  The encoding to use (this is ignored if `data` is a buffer)
 
-Example:
 
-    fs.appendFile('message.txt', 'data to append', function (err) {
-      if (err) throw err;
-      console.log('The "data to append" was appended to file!');
-    });
+The synchronous version of [[fs.writeFile `fs.writeFile()`]].
 
-## fs.appendFileSync(filename, data, encoding='utf8')
+ 
 
-The synchronous version of `fs.appendFile`.
 
-## fs.watchFile(filename, [options], listener)
+
+### fs.watchFile(filename, [options={ persistent: true, interval: 0 }], listener(curr, prev))
+- filename {String}  The name of the file to watch
+- options {Object}   Any optional arguments indicating how often to watch
+- listener {Function}   The callback to execute each time the file is accessed
+- curr {fs.Stats}  The current `stats` object
+- prev {fs.Stats}  The previous `stats` object
+
+Watches for changes on `filename`. 
 
     Stability: 2 - Unstable.  Use fs.watch instead, if available.
 
-Watch for changes on `filename`. The callback `listener` will be called each
-time the file is accessed.
+`options`, if provided, should be an object containing two boolean members: `persistent` and `interval`:
+* `persistent` indicates whether the process should continue to run as long as files are being watched
+* `interval` indicates how often the target should be polled, in milliseconds.
 
-The second argument is optional. The `options` if provided should be an object
-containing two members a boolean, `persistent`, and `interval`. `persistent`
-indicates whether the process should continue to run as long as files are
-being watched. `interval` indicates how often the target should be polled,
-in milliseconds. (On Linux systems with inotify, `interval` is ignored.) The
-default is `{ persistent: true, interval: 0 }`.
+On Linux systems with [inotify](http://en.wikipedia.org/wiki/Inotify), `interval` is ignored.
 
-The `listener` gets two arguments the current stat object and the previous
-stat object:
+#### Example
 
     fs.watchFile('message.text', function (curr, prev) {
-      console.log('the current mtime is: ' + curr.mtime);
-      console.log('the previous mtime was: ' + prev.mtime);
+      console.log('the current modification time is: ' + curr.mtime);
+      console.log('the previous modification time was: ' + prev.mtime);
     });
 
-These stat objects are instances of `fs.Stat`.
 
-If you want to be notified when the file was modified, not just accessed
-you need to compare `curr.mtime` and `prev.mtime`.
+ 
 
 
-## fs.unwatchFile(filename)
+
+### fs.unwatchFile(filename)
+- filename {String}  The filename to watch
+
+Stops watching for changes on `filename`.
+
+    Stability: 2 - Unstable.  Use fs.watch instead, if available. 
+
+
+
+### fs.watch(filename[, options = {persistent: true}], listener(event, filename)), fs.FSWatcher
+- filename {String}  The filename (or directory) to watch
+- options {Object}  An optional arguments indicating how to watch the files
+- listener {Function}   The callback to execute each time the file is accessed
+- event {String}  Either `'rename'` or '`change'`
+- filename {String}  The name of the file which triggered the event
+
+Watch for changes on `filename`.
 
     Stability: 2 - Unstable.  Use fs.watch instead, if available.
 
-Stop watching for changes on `filename`.
+`options`, if provided, should be an object containing a boolean member `persistent`, which indicates whether the process should continue to run as long as files are being watched.
 
-## fs.watch(filename, [options], listener)
+Warning: Providing the `filename` argument in the callback is not supported on every platform (currently it's only supported on Linux and Windows).  Even on supported platforms, `filename` is **not** always guaranteed to be provided. Therefore, don't assume that `filename` argument is always provided in the callback, and have some fallback logic if it is `null`, like in the provided example.
 
-    Stability: 2 - Unstable.  Not available on all platforms.
-
-Watch for changes on `filename`, where `filename` is either a file or a
-directory.  The returned object is a [fs.FSWatcher](#fs_class_fs_fswatcher).
-
-The second argument is optional. The `options` if provided should be an object
-containing a boolean member `persistent`, which indicates whether the process
-should continue to run as long as files are being watched. The default is
-`{ persistent: true }`.
-
-The listener callback gets two arguments `(event, filename)`.  `event` is either
-'rename' or 'change', and `filename` is the name of the file which triggered
-the event.
-
-### Caveats
-
-<!--type=misc-->
-
-The `fs.watch` API is not 100% consistent across platforms, and is
-unavailable in some situations.
-
-#### Availability
-
-<!--type=misc-->
-
-This feature depends on the underlying operating system providing a way
-to be notified of filesystem changes.
-
-* On Linux systems, this uses `inotify`.
-* On BSD systems (including OS X), this uses `kqueue`.
-* On SunOS systems (including Solaris and SmartOS), this uses `event ports`.
-* On Windows systems, this feature depends on `ReadDirectoryChangesW`.
-
-If the underlying functionality is not available for some reason, then
-`fs.watch` will not be able to function.  You can still use
-`fs.watchFile`, which uses stat polling, but it is slower and less
-reliable.
-
-#### Filename Argument
-
-<!--type=misc-->
-
-Providing `filename` argument in the callback is not supported
-on every platform (currently it's only supported on Linux and Windows).  Even
-on supported platforms `filename` is not always guaranteed to be provided.
-Therefore, don't assume that `filename` argument is always provided in the
-callback, and have some fallback logic if it is null.
+#### Example
 
     fs.watch('somedir', function (event, filename) {
-      console.log('event is: ' + event);
-      if (filename) {
-        console.log('filename provided: ' + filename);
-      } else {
+        console.log('event is: ' + event);
+        if (filename) {
+            console.log('filename provided: ' + filename);
+        } else {
         console.log('filename not provided');
-      }
+        }
     });
 
-## fs.exists(path, [callback])
-
-Test whether or not the given path exists by checking with the file system.
-Then call the `callback` argument with either true or false.  Example:
-
-    fs.exists('/etc/passwd', function (exists) {
-      util.debug(exists ? "it's there" : "no passwd!");
-    });
+ 
 
 
-## fs.existsSync(path)
+### fs.createReadStream(path, [options]), fs.ReadStream
+- path {String}  The path to read from
+- options {Object}  Any optional arguments indicating how to read the stream
 
-Synchronous version of `fs.exists`.
 
-## Class: fs.Stats
+Returns a new [[fs.ReadStream `fs.ReadStream`]] object.
 
-Objects returned from `fs.stat()`, `fs.lstat()` and `fs.fstat()` and their
-synchronous counterparts are of this type.
+`options` is an object with the following defaults:
 
- - `stats.isFile()`
- - `stats.isDirectory()`
- - `stats.isBlockDevice()`
- - `stats.isCharacterDevice()`
- - `stats.isSymbolicLink()` (only valid with  `fs.lstat()`)
- - `stats.isFIFO()`
- - `stats.isSocket()`
+    { 
+      flags: 'r',
+      encoding: null,
+      fd: null,
+      mode: 0666,
+      bufferSize: 64 * 1024
+    }
 
-For a regular file `util.inspect(stats)` would return a string very
-similar to this:
+`options` can include `start` and `end` values to read a range of bytes from the file instead of the entire file.  Both `start` and `end` are inclusive and start at 0.
+
+#### Example
+
+Here's an example to read the last 10 bytes of a file which is 100 bytes long:
+
+    fs.createReadStream('sample.txt', {start: 90, end: 99});
+
+
+ 
+
+
+### fs.createWriteStream(path, [options]), fs.WriteStream
+- path {String}  The path to read from
+- options {Object}   Any optional arguments indicating how to write the stream
+
+Returns a new [[streams.WritableStream WriteStream]] object.
+
+`options` is an object with the following defaults:
+
+    { flags: 'w',
+      encoding: null,
+      mode: 0666 }
+
+`options` may also include a `start` option to allow writing data at some position past the beginning of the file.  
+
+Modifying a file rather than replacing it may require a `flags` mode of `r+` rather than the default mode `w`.
+
+
+
+## fs.Stats
+
+Objects returned from [[fs.stat `fs.stat()`]], [[fs.lstat `fs.lstat()`]], and [[fs.fstat `fs.fstat()`]] (and their synchronous counterparts) are of this type. The object contains the following methods:
+
+For a regular file, `util.inspect(fs.Stats)` returns an object similar to [the structure returned by the Unix stat command](http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html):
 
     { dev: 2114,
       ino: 48064969,
@@ -567,101 +885,113 @@ similar to this:
       mtime: Mon, 10 Oct 2011 23:24:11 GMT,
       ctime: Mon, 10 Oct 2011 23:24:11 GMT }
 
-Please note that `atime`, `mtime` and `ctime` are instances
-of [Date][MDN-Date] object and to compare the values of
-these objects you should use appropriate methods. For most
-general uses [getTime()][MDN-Date-getTime] will return
-the number of milliseconds elapsed since _1 January 1970
-00:00:00 UTC_ and this integer should be sufficient for
-any comparison, however there additional methods which can
-be used for displaying fuzzy information. More details can
-be found in the [MDN JavaScript Reference][MDN-Date] page.
 
-[MDN-Date]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
-[MDN-Date-getTime]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime
+Please note that `atime`, `mtime`, and `ctime` are instances of the [[Date]] object, and to compare the values of these objects you should use appropriate methods. For most general uses, `Date.getTime()` returns the number of milliseconds elapsed since _1 January 1970 00:00:00 UTC_, and this integer should be sufficient for any comparison. However, there are additional methods which can be used for displaying fuzzy information.
 
 
-## fs.createReadStream(path, [options])
 
-Returns a new ReadStream object (See `Readable Stream`).
+### fs.Stats.isFile(), Boolean
 
-`options` is an object with the following defaults:
+Indicates if the object is a file.
 
-    { flags: 'r',
-      encoding: null,
-      fd: null,
-      mode: 0666,
-      bufferSize: 64 * 1024
-    }
-
-`options` can include `start` and `end` values to read a range of bytes from
-the file instead of the entire file.  Both `start` and `end` are inclusive and
-start at 0. The `encoding` can be `'utf8'`, `'ascii'`, or `'base64'`.
-
-An example to read the last 10 bytes of a file which is 100 bytes long:
-
-    fs.createReadStream('sample.txt', {start: 90, end: 99});
+ 
 
 
-## Class: fs.ReadStream
+### fs.Stats.isDirectory(), Boolean
 
-`ReadStream` is a [Readable Stream](stream.html#stream_readable_stream).
-
-### Event: 'open'
-
-* `fd` {Integer} file descriptor used by the ReadStream.
-
-Emitted when the ReadStream's file is opened.
+Indicates if the object is a directory.
 
 
-## fs.createWriteStream(path, [options])
+### fs.Stats.isBlockDevice(), Boolean
 
-Returns a new WriteStream object (See `Writable Stream`).
+Indicates if the object is a [block device](http://en.wikipedia.org/wiki/Device_file#Block_devices).
 
-`options` is an object with the following defaults:
 
-    { flags: 'w',
-      encoding: null,
-      mode: 0666 }
+### fs.Stats.isCharacterDevice(), Boolean
 
-`options` may also include a `start` option to allow writing data at
-some position past the beginning of the file.  Modifying a file rather
-than replacing it may require a `flags` mode of `r+` rather than the
-default mode `w`.
+Indicates if the object is a [character device](http://en.wikipedia.org/wiki/Device_file#Character_devices).
+
+
+### fs.Stats.isSymbolicLink(), Boolean
+
+Indicates if the object is a symbolic link; this is only valid with `fs.lstat()` and `fs.lstatSynch()`.
+
+
+### fs.Stats.isFIFO(), Boolean
+
+Indicates if the object is a [named pipe](http://en.wikipedia.org/wiki/Named_pipe).
+
+
+### fs.Stats.isSocket(), Boolean
+
+Indicates if the object is a [socket file](http://en.wikipedia.org/wiki/Unix_file_types#Socket).
+
+
 
 ## fs.WriteStream
 
-`WriteStream` is a [Writable Stream](stream.html#stream_writable_stream).
+This is a [[streams.WritableStream WriteStream]], created from the function [[fs.createWriteStream `fs.createWriteStream()`]].
 
-### Event: 'open'
+ 
 
-* `fd` {Integer} file descriptor used by the WriteStream.
 
-Emitted when the WriteStream's file is opened.
+### fs.WriteStream@open(fd)
+- fd {Number}   The file descriptor used by the `WriteStream`
 
-### file.bytesWritten
+Emitted when a file is opened for writing.
 
-The number of bytes written so far. Does not include data that is still queued
-for writing.
+ 
 
-## Class: fs.FSWatcher
 
-Objects returned from `fs.watch()` are of this type.
 
-### watcher.close()
+### fs.WriteStream.bytesWritten, Number
 
-Stop watching for changes on the given `fs.FSWatcher`.
+The number of bytes written so far. This doesn't include data that is still queued for writing.
 
-### Event: 'change'
+## fs.ReadStream
 
-* `event` {String} The type of fs change
-* `filename` {String} The filename that changed (if relevant/available)
+This is a [[streams.ReadableStream streams.ReadableStream]], created from the function [[fs.createReadStream `fs.createReadStream()`]].
 
-Emitted when something changes in a watched directory or file.
-See more details in [fs.watch](#fs_fs_watch_filename_options_listener).
+ 
 
-### Event: 'error'
 
-* `error` {Error object}
+### fs.ReadStream@open(fd)
+- fd {Number}   The file descriptor used by the `ReadStream`
+
+Emitted when a file is opened.
+
+ 
+
+
+
+## fs.FSWatcher
+
+Objects returned from [[fs.watch `fs.watch()`]] are of this type. You can monitor any changes that occur on a watched file by listening for the events in this object.
+
+
+  
+
+
+### fs.FSWatcher.close()
+
+Stop watching for changes on the given `FSWatcher`.
+ 
+
+
+
+### fs.FSWatcher@change(event, filename)
+- event {String}  The event that occured, either `'rename'` or '`change'`
+- filename {String}  The name of the file which triggered the event
+
+Emitted when something changes in a watched directory or file. See more details in [[fs.watch `fs.watch()`]].
+
+ 
+
+
+
+### fs.FSWatcher@error(exception)
+- exception {Error}  The exception that was caught
 
 Emitted when an error occurs.
+
+ 

--- a/doc/api/globals.markdown
+++ b/doc/api/globals.markdown
@@ -1,150 +1,65 @@
-# Global Objects
-
+# Global_Objects
 <!-- type=misc -->
 
-These objects are available in all modules. Some of these objects aren't
-actually in the global scope but in the module scope - this will be noted.
+These objects are available to all modules. Some of these objects aren't actually in the global scope, but in the module scope; they'll be noted as such below.
 
-## global
-
-<!-- type=global -->
-
-* {Object} The global namespace object.
-
-In browsers, the top-level scope is the global scope. That means that in
-browsers if you're in the global scope `var something` will define a global
-variable. In Node this is different. The top-level scope is not the global
-scope; `var something` inside a Node module will be local to that module.
-
-## process
-
-<!-- type=global -->
-
-* {Object}
-
-The process object. See the [process object](process.html#process) section.
-
-## console
-
-<!-- type=global -->
-
-* {Object}
-
-Used to print to stdout and stderr. See the [stdio](stdio.html) section.
-
-## Class: Buffer
-
-<!-- type=global -->
-
-* {Function}
-
-Used to handle binary data. See the [buffer section](buffer.html).
-
-## require()
-
-<!-- type=var -->
-
-* {Function}
-
-To require modules. See the [Modules](modules.html#modules) section.
-`require` isn't actually a global but rather local to each module.
-
-### require.resolve()
-
-Use the internal `require()` machinery to look up the location of a module,
-but rather than loading the module, just return the resolved filename.
-
-### require.cache
-
-* {Object}
-
-Modules are cached in this object when they are required. By deleting a key
-value from this object, the next `require` will reload the module.
-
-### require.extensions
-
-* {Array}
-
-Instruct `require` on how to handle certain file extensions.
-
-Process files with the extension `.sjs` as `.js`:
-
-    require.extensions['.sjs'] = require.extensions['.js'];
-
-Write your own extension handler:
-
-    require.extensions['.sjs'] = function(module, filename) {
-      var content = fs.readFileSync(filename, 'utf8');
-      // Parse the file content and give to module.exports
-      module.exports = content;
-    };
-
-## __filename
-
-<!-- type=var -->
-
-* {String}
-
-The filename of the code being executed.  This is the resolved absolute path
-of this code file.  For a main program this is not necessarily the same
-filename used in the command line.  The value inside a module is the path
-to that module file.
-
-Example: running `node example.js` from `/Users/mjr`
-
-    console.log(__filename);
-    // /Users/mjr/example.js
-
-`__filename` isn't actually a global but rather local to each module.
-
-## __dirname
-
-<!-- type=var -->
-
-* {String}
-
-The name of the directory that the currently executing script resides in.
-
-Example: running `node example.js` from `/Users/mjr`
-
+<dl> 
+<dt>`__dirname`</dt>
+<dd>The name of the directory that the currently executing script resides in. `__dirname` isn't actually on the global scope, but is local to each module.</dd>
+<dd>For example, if you're running `node example.js` from `/Users/mjr`:
+    
+<pre class="prettyprint">
     console.log(__dirname);
-    // /Users/mjr
+    // prints /Users/mjr
+</pre>
+</dd>
 
-`__dirname` isn't actually a global but rather local to each module.
+<dt>`__filename`</dt>
+<dd>The filename of the code being executed.  This is the resolved absolute path of this code file.  For a main program this is not necessarily the same filename used in the command line.  The value inside a module is the path to that module file.</dd>
+<dd>`__filename` isn't actually on the global scope, but is local to each module.</dd>
+<dd>For example, if you're running `node example.js` from `/Users/mjr`:
+   
+<pre class="prettyprint"> 
+    console.log(__filename);
+    // prints /Users/mjr/example.js
+</pre>
+</dd>
 
+<dt>Buffer</dt>
+<dd>Used to handle binary data. See the [[Buffer Buffers] section for more information.</dd>
 
-## module
+<dt>`console`</dt>
+<dd>Used to print to stdout and stderr. See the [[console console]] section for more information.</dd>
 
-<!-- type=var -->
+<dt>`exports`</dt>
+<dd>An object which is shared between all instances of the current module and made accessible through `require()`.</dd>
+<dd>`exports` is the same as the `module.exports` object. See `src/node.js` for more information.</dd>
+<dd>`exports` isn't actually on the global scope, but is local to each module.</dd>
 
-* {Object}
+<dt>`global`</dt>
+<dd>The global namespace object.</dd>
+<dd>In browsers, the top-level scope is the global scope. That means that in browsers if you're in the global scope `var something` will define a global variable. In Node.js this is different. The top-level scope is not the global scope; `var something` inside a Node.js module is local only to that module.</dd>
 
-A reference to the current module. In particular
-`module.exports` is the same as the `exports` object.
-`module` isn't actually a global but rather local to each module.
+<dt>`module`</dt>
+<dd>A reference to the current module. In particular `module.exports` is the same as the `exports` object. See `src/node.js` for more information.</dd>
+<dd>`module` isn't actually on the global scope, but is local to each module.</dd>
 
-See the [module system documentation](modules.html) for more
-information.
+<dt>`process`</dt>
+<dd>The process object. See the [process object](process.html) section for more information.</dd>
 
-## exports
+<dt>`require()`</dt>
+<dd>This is necessary to require modules. See the [Modules](modules.html) section for more information.</dd>
+<dd>`require` isn't actually on the global scope, but is local to each module.</dd>
 
-<!-- type=var -->
+<dt>`require.cache`</dt>
+<dd>Modules are cached in this object when they are required. By deleting a key value from this object, the next `require` will reload the module.</dd>
 
-An object which is shared between all instances of the current module and
-made accessible through `require()`.
-`exports` is the same as the `module.exports` object.
-`exports` isn't actually a global but rather local to each module.
+<dt>`require.resolve()`</dt>
+<dd>Use the internal `require()` machinery to look up the location of a module, but rather than loading the module, just return the resolved filename.</dd>
 
-See the [module system documentation](modules.html) for more
-information.
-
-See the [module section](modules.html) for more information.
-
-## setTimeout(cb, ms)
-## clearTimeout(t)
-## setInterval(cb, ms)
-## clearInterval(t)
-
-<!--type=global-->
-
-The timer functions are global variables. See the [timers](timers.html) section.
+<dt>`setTimeout(cb, ms)`<br/>
+`clearTimeout(t)`<br/>
+`setInterval(cb, ms)`<br/>
+`clearInterval(t)`</dt>
+<dd>These timer functions are all global variables. See the [[timer `Timers`]] section for more information.</dd>
+</dl>

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -1,467 +1,115 @@
-# HTTP
+## http
 
     Stability: 3 - Stable
-
-To use the HTTP server and client one must `require('http')`.
-
-The HTTP interfaces in Node are designed to support many features
-of the protocol which have been traditionally difficult to use.
-In particular, large, possibly chunk-encoded, messages. The interface is
-careful to never buffer entire requests or responses--the
-user is able to stream data.
+    
+The HTTP interfaces in Node.js are designed to support many features of the protocol which have been traditionally difficult to use. In particular, large, possibly chunk-encoded, messages. The interface is careful to never buffer entire requests or responses—the user is always able to stream data. To use the HTTP server and client, add `require('http')` to your code.
 
 HTTP message headers are represented by an object like this:
 
     { 'content-length': '123',
       'content-type': 'text/plain',
       'connection': 'keep-alive',
-      'accept': '*/*' }
+      'accept': 'text/plain' }
 
-Keys are lowercased. Values are not modified.
+Keys are lowercased, and values are not modifiable.
 
-In order to support the full spectrum of possible HTTP applications, Node's
-HTTP API is very low-level. It deals with stream handling and message
-parsing only. It parses a message into headers and body but it does not
-parse the actual headers or the body.
+In order to support the full spectrum of possible HTTP applications, Node's HTTP API is very low-level. It deals with stream handling and message parsing only. It parses a message into headers and body but it does not parse the actual headers or the body.
 
 
-## http.createServer([requestListener])
+For more information, read [this article on how to create HTTP servers](../nodejs_dev_guide/creating_an_http_server.html).
+
+#### Example: The famous hello world
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/http/http.js?&linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+
+
+
+### http.get(options, callback())
+- options {Object}  Options to pass to the request
+- callback {Function}   The callback to execute once the method finishes 
+
+Since most requests are GET requests without bodies, Node.js provides this convenience method. The only difference between this method and [[http.request `http.request()`]] is that it sets the method to GET and calls `req.end()` automatically.
+
+#### Example
+
+    var options = {
+      host: 'www.google.com',
+      port: 80,
+      path: '/index.html'
+    };
+
+    http.get(options, function(res) {
+      console.log("Got response: " + res.statusCode);
+    }).on('error', function(e) {
+      console.log("Got error: " + e.message);
+    });
+
+ 
+
+
+### http.createServer(requestListener(options, requestListener)), http.Server
+- requestListener {Function}  A function that is automatically added to the `'request'` event
+- options {Object}   Any options you want to pass to the server
+- requestListener {Function}  An optional listener
 
 Returns a new web server object.
 
-The `requestListener` is a function which is automatically
-added to the `'request'` event.
+ 
 
-## Class: http.Server
 
-This is an `EventEmitter` with the following events:
+### http.globalAgent, http.Agent
 
-### Event: 'request'
+This is the global instance of [[http.Agent `http.Agent`]] which is used as the default for all HTTP client requests.
 
-`function (request, response) { }`
+ 
 
-Emitted each time there is a request. Note that there may be multiple requests
-per connection (in the case of keep-alive connections).
- `request` is an instance of `http.ServerRequest` and `response` is
- an instance of `http.ServerResponse`
 
-### Event: 'connection'
+### http.globalAgent.requests, Object
 
-`function (socket) { }`
+An object which contains queues of requests that have not yet been assigned to  sockets. **Don't modify this!**
 
- When a new TCP stream is established. `socket` is an object of type
- `net.Socket`. Usually users will not want to access this event. The
- `socket` can also be accessed at `request.connection`.
 
-### Event: 'close'
 
-`function () { }`
 
- Emitted when the server closes.
+### http.request(options, callback(response)), http.ClientRequest
+- options {Object}  Options to pass to the request
+- callback {Function}   The callback to execute once the method finishes
+- response {http.ClientRequest}  The server's response, including headers and status code
 
-### Event: 'checkContinue'
+Node.js maintains several connections per server to make HTTP requests. This function allows one to transparently issue requests.  
 
-`function (request, response) { }`
+The `options` align with the return value of [[url.parse `url.parse()`]]:
 
-Emitted each time a request with an http Expect: 100-continue is received.
-If this event isn't listened for, the server will automatically respond
-with a 100 Continue as appropriate.
+- `host`: a domain name or IP address of the server to issue the request to. Defaults to `'localhost'`.
+- `hostname`: To support `url.parse()`, `hostname` is preferred over `host`
+- `port`: the port of the remote server. Defaults to `80`.
+- `socketPath`: the Unix Domain Socket (in other words, use either `host:port` or `socketPath`)
+- `method`: a string specifying the HTTP request method. Defaults to `'GET'`.
+- `path`: the request path. Defaults to `'/'`. This should include a query string (if any) For example, `'/index.html?page=12'`
+- `headers`: an object containing request headers
+- `auth`: used for basic authentication. For example, `'user:password'` computes an Authorization header.
+- `agent`: this controls [[http.Agent `http.Agent`]] behavior. When an Agent is used, the request defaults to `Connection: keep-alive`. The possible values are:
+ -- `undefined`: uses [the global Agent](http.html#globalAgent) for this host
+   and port (default).
+ -- `Agent` object: explicitly use the passed in `Agent`
+ -- `false`: opt out of connection pooling with an `Agent`, and default the request to `Connection: close`.
 
-Handling this event involves calling `response.writeContinue` if the client
-should continue to send the request body, or generating an appropriate HTTP
-response (e.g., 400 Bad Request) if the client should not continue to send the
-request body.
+There are a few special headers that should be noted.
 
-Note that when this event is emitted and handled, the `request` event will
-not be emitted.
+* Sending a `'Connection: keep-alive'` notifies Node.js that the connection to the server should be persisted until the next request.
 
-### Event: 'connect'
+* Sending a `'Content-length'` header disables the default chunked encoding.
 
-`function (request, socket, head) { }`
+* Sending an 'Expect' header immediately sends the request headers.
+  Usually, when sending `'Expect: 100-continue'`, you should both set a timeout
+  and listen for the `continue` event. For more information, see [RFC2616 Section 8.2.3](http://tools.ietf.org/html/rfc2616#section-8.2.3).
 
-Emitted each time a client requests a http CONNECT method. If this event isn't
-listened for, then clients requesting a CONNECT method will have their
-connections closed.
+* Sending an Authorization header overrides using the `auth` option to compute basic authentication.
 
-* `request` is the arguments for the http request, as it is in the request
-  event.
-* `socket` is the network socket between the server and client.
-* `head` is an instance of Buffer, the first packet of the tunneling stream,
-  this may be empty.
-
-After this event is emitted, the request's socket will not have a `data`
-event listener, meaning you will need to bind to it in order to handle data
-sent to the server on that socket.
-
-### Event: 'upgrade'
-
-`function (request, socket, head) { }`
-
-Emitted each time a client requests a http upgrade. If this event isn't
-listened for, then clients requesting an upgrade will have their connections
-closed.
-
-* `request` is the arguments for the http request, as it is in the request
-  event.
-* `socket` is the network socket between the server and client.
-* `head` is an instance of Buffer, the first packet of the upgraded stream,
-  this may be empty.
-
-After this event is emitted, the request's socket will not have a `data`
-event listener, meaning you will need to bind to it in order to handle data
-sent to the server on that socket.
-
-### Event: 'clientError'
-
-`function (exception) { }`
-
-If a client connection emits an 'error' event - it will forwarded here.
-
-### server.listen(port, [hostname], [backlog], [callback])
-
-Begin accepting connections on the specified port and hostname.  If the
-hostname is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`).
-
-To listen to a unix socket, supply a filename instead of port and hostname.
-
-Backlog is the maximum length of the queue of pending connections.
-The actual length will be determined by your OS through sysctl settings such as
-`tcp_max_syn_backlog` and `somaxconn` on linux. The default value of this
-parameter is 511 (not 512).
-
-This function is asynchronous. The last parameter `callback` will be added as
-a listener for the ['listening'](net.html#event_listening_) event.
-See also [net.Server.listen()](net.html#server.listen).
-
-
-### server.listen(path, [callback])
-
-Start a UNIX socket server listening for connections on the given `path`.
-
-This function is asynchronous. The last parameter `callback` will be added as
-a listener for the ['listening'](net.html#event_listening_) event.
-See also [net.Server.listen()](net.html#server.listen).
-
-
-### server.close([cb])
-
-Stops the server from accepting new connections.
-See [net.Server.close()](net.html#server.close).
-
-
-### server.maxHeadersCount
-
-Limits maximum incoming headers count, equal to 1000 by default. If set to 0 -
-no limit will be applied.
-
-
-## Class: http.ServerRequest
-
-This object is created internally by a HTTP server -- not by
-the user -- and passed as the first argument to a `'request'` listener.
-
-The request implements the [Readable Stream](stream.html#readable_stream)
-interface. This is an `EventEmitter` with the following events:
-
-### Event: 'data'
-
-`function (chunk) { }`
-
-Emitted when a piece of the message body is received. The chunk is a string if
-an encoding has been set with `request.setEncoding()`, otherwise it's a
-[Buffer](buffer.html).
-
-Note that the __data will be lost__ if there is no listener when a
-`ServerRequest` emits a `'data'` event.
-
-### Event: 'end'
-
-`function () { }`
-
-Emitted exactly once for each request. After that, no more `'data'` events
-will be emitted on the request.
-
-### Event: 'close'
-
-`function () { }`
-
-Indicates that the underlaying connection was terminated before
-`response.end()` was called or able to flush.
-
-Just like `'end'`, this event occurs only once per request, and no more `'data'`
-events will fire afterwards.
-
-Note: `'close'` can fire after `'end'`, but not vice versa.
-
-### request.method
-
-The request method as a string. Read only. Example:
-`'GET'`, `'DELETE'`.
-
-
-### request.url
-
-Request URL string. This contains only the URL that is
-present in the actual HTTP request. If the request is:
-
-    GET /status?name=ryan HTTP/1.1\r\n
-    Accept: text/plain\r\n
-    \r\n
-
-Then `request.url` will be:
-
-    '/status?name=ryan'
-
-If you would like to parse the URL into its parts, you can use
-`require('url').parse(request.url)`.  Example:
-
-    node> require('url').parse('/status?name=ryan')
-    { href: '/status?name=ryan',
-      search: '?name=ryan',
-      query: 'name=ryan',
-      pathname: '/status' }
-
-If you would like to extract the params from the query string,
-you can use the `require('querystring').parse` function, or pass
-`true` as the second argument to `require('url').parse`.  Example:
-
-    node> require('url').parse('/status?name=ryan', true)
-    { href: '/status?name=ryan',
-      search: '?name=ryan',
-      query: { name: 'ryan' },
-      pathname: '/status' }
-
-
-
-### request.headers
-
-Read only.
-
-### request.trailers
-
-Read only; HTTP trailers (if present). Only populated after the 'end' event.
-
-### request.httpVersion
-
-The HTTP protocol version as a string. Read only. Examples:
-`'1.1'`, `'1.0'`.
-Also `request.httpVersionMajor` is the first integer and
-`request.httpVersionMinor` is the second.
-
-
-### request.setEncoding([encoding])
-
-Set the encoding for the request body. Either `'utf8'` or `'binary'`. Defaults
-to `null`, which means that the `'data'` event will emit a `Buffer` object..
-
-
-### request.pause()
-
-Pauses request from emitting events.  Useful to throttle back an upload.
-
-
-### request.resume()
-
-Resumes a paused request.
-
-### request.connection
-
-The `net.Socket` object associated with the connection.
-
-
-With HTTPS support, use request.connection.verifyPeer() and
-request.connection.getPeerCertificate() to obtain the client's
-authentication details.
-
-
-
-## Class: http.ServerResponse
-
-This object is created internally by a HTTP server--not by the user. It is
-passed as the second parameter to the `'request'` event.
-
-The response implements the [Writable  Stream](stream.html#writable_stream)
-interface. This is an `EventEmitter` with the following events:
-
-### Event: 'close'
-
-`function () { }`
-
-Indicates that the underlaying connection was terminated before
-`response.end()` was called or able to flush.
-
-### response.writeContinue()
-
-Sends a HTTP/1.1 100 Continue message to the client, indicating that
-the request body should be sent. See the [checkContinue](#event_checkContinue_) event on
-`Server`.
-
-### response.writeHead(statusCode, [reasonPhrase], [headers])
-
-Sends a response header to the request. The status code is a 3-digit HTTP
-status code, like `404`. The last argument, `headers`, are the response headers.
-Optionally one can give a human-readable `reasonPhrase` as the second
-argument.
-
-Example:
-
-    var body = 'hello world';
-    response.writeHead(200, {
-      'Content-Length': body.length,
-      'Content-Type': 'text/plain' });
-
-This method must only be called once on a message and it must
-be called before `response.end()` is called.
-
-If you call `response.write()` or `response.end()` before calling this, the
-implicit/mutable headers will be calculated and call this function for you.
-
-Note: that Content-Length is given in bytes not characters. The above example
-works because the string `'hello world'` contains only single byte characters.
-If the body contains higher coded characters then `Buffer.byteLength()`
-should be used to determine the number of bytes in a given encoding.
-And Node does not check whether Content-Length and the length of the body
-which has been transmitted are equal or not.
-
-### response.statusCode
-
-When using implicit headers (not calling `response.writeHead()` explicitly), this property
-controls the status code that will be send to the client when the headers get
-flushed.
-
-Example:
-
-    response.statusCode = 404;
-
-After response header was sent to the client, this property indicates the
-status code which was sent out.
-
-### response.setHeader(name, value)
-
-Sets a single header value for implicit headers.  If this header already exists
-in the to-be-sent headers, its value will be replaced.  Use an array of strings
-here if you need to send multiple headers with the same name.
-
-Example:
-
-    response.setHeader("Content-Type", "text/html");
-
-or
-
-    response.setHeader("Set-Cookie", ["type=ninja", "language=javascript"]);
-
-### response.sendDate
-
-When true, the Date header will be automatically generated and sent in 
-the response if it is not already present in the headers. Defaults to true.
-
-This should only be disabled for testing; HTTP requires the Date header
-in responses.
-
-### response.getHeader(name)
-
-Reads out a header that's already been queued but not sent to the client.  Note
-that the name is case insensitive.  This can only be called before headers get
-implicitly flushed.
-
-Example:
-
-    var contentType = response.getHeader('content-type');
-
-### response.removeHeader(name)
-
-Removes a header that's queued for implicit sending.
-
-Example:
-
-    response.removeHeader("Content-Encoding");
-
-
-### response.write(chunk, [encoding])
-
-If this method is called and `response.writeHead()` has not been called, it will
-switch to implicit header mode and flush the implicit headers.
-
-This sends a chunk of the response body. This method may
-be called multiple times to provide successive parts of the body.
-
-`chunk` can be a string or a buffer. If `chunk` is a string,
-the second parameter specifies how to encode it into a byte stream.
-By default the `encoding` is `'utf8'`.
-
-**Note**: This is the raw HTTP body and has nothing to do with
-higher-level multi-part body encodings that may be used.
-
-The first time `response.write()` is called, it will send the buffered
-header information and the first body to the client. The second time
-`response.write()` is called, Node assumes you're going to be streaming
-data, and sends that separately. That is, the response is buffered up to the
-first chunk of body.
-
-### response.addTrailers(headers)
-
-This method adds HTTP trailing headers (a header but at the end of the
-message) to the response.
-
-Trailers will **only** be emitted if chunked encoding is used for the
-response; if it is not (e.g., if the request was HTTP/1.0), they will
-be silently discarded.
-
-Note that HTTP requires the `Trailer` header to be sent if you intend to
-emit trailers, with a list of the header fields in its value. E.g.,
-
-    response.writeHead(200, { 'Content-Type': 'text/plain',
-                              'Trailer': 'Content-MD5' });
-    response.write(fileData);
-    response.addTrailers({'Content-MD5': "7895bf4b8828b55ceaf47747b4bca667"});
-    response.end();
-
-
-### response.end([data], [encoding])
-
-This method signals to the server that all of the response headers and body
-has been sent; that server should consider this message complete.
-The method, `response.end()`, MUST be called on each
-response.
-
-If `data` is specified, it is equivalent to calling `response.write(data, encoding)`
-followed by `response.end()`.
-
-
-## http.request(options, callback)
-
-Node maintains several connections per server to make HTTP requests.
-This function allows one to transparently issue requests.  `options` align
-with [url.parse()](url.html#url.parse).
-
-Options:
-
-- `host`: A domain name or IP address of the server to issue the request to.
-  Defaults to `'localhost'`.
-- `hostname`: To support `url.parse()` `hostname` is preferred over `host`
-- `port`: Port of remote server. Defaults to 80.
-- `localAddress`: Local interface to bind for network connections.
-- `socketPath`: Unix Domain Socket (use one of host:port or socketPath)
-- `method`: A string specifying the HTTP request method. Defaults to `'GET'`.
-- `path`: Request path. Defaults to `'/'`. Should include query string if any.
-  E.G. `'/index.html?page=12'`
-- `headers`: An object containing request headers.
-- `auth`: Basic authentication i.e. `'user:password'` to compute an
-  Authorization header.
-- `agent`: Controls [Agent](#http.Agent) behavior. When an Agent is used
-  request will default to `Connection: keep-alive`. Possible values:
- - `undefined` (default): use [global Agent](#http.globalAgent) for this host
-   and port.
- - `Agent` object: explicitly use the passed in `Agent`.
- - `false`: opts out of connection pooling with an Agent, defaults request to
-   `Connection: close`.
-
-`http.request()` returns an instance of the `http.ClientRequest`
-class. The `ClientRequest` instance is a writable stream. If one needs to
-upload a file with a POST request, then write to the `ClientRequest` object.
-
-Example:
+#### Example
 
     var options = {
       host: 'www.google.com',
@@ -488,68 +136,27 @@ Example:
     req.write('data\n');
     req.end();
 
-Note that in the example `req.end()` was called. With `http.request()` one
-must always call `req.end()` to signify that you're done with the request -
-even if there is no data being written to the request body.
+Note that in the example, `req.end()` was called. With `http.request()` one must always call `req.end()` to signify that you're done with the request—even if there is no data being written to the request body.
 
-If any error is encountered during the request (be that with DNS resolution,
-TCP level errors, or actual HTTP parse errors) an `'error'` event is emitted
-on the returned request object.
+#### Returns
 
-There are a few special headers that should be noted.
+An instance of the `http.ClientRequest` class. The `ClientRequest` instance is a writable stream. If one needs to upload a file with a POST request, then write it to the `ClientRequest` object.
 
-* Sending a 'Connection: keep-alive' will notify Node that the connection to
-  the server should be persisted until the next request.
+If any error is encountered during the request (be that with DNS resolution, TCP level errors, or actual HTTP parse errors) an `'error'` event is emitted on the returned request object.
 
-* Sending a 'Content-length' header will disable the default chunked encoding.
-
-* Sending an 'Expect' header will immediately send the request headers.
-  Usually, when sending 'Expect: 100-continue', you should both set a timeout
-  and listen for the `continue` event. See RFC2616 Section 8.2.3 for more
-  information.
-
-* Sending an Authorization header will override using the `auth` option
-  to compute basic authentication.
-
-## http.get(options, callback)
-
-Since most requests are GET requests without bodies, Node provides this
-convenience method. The only difference between this method and `http.request()` is
-that it sets the method to GET and calls `req.end()` automatically.
-
-Example:
-
-    var options = {
-      host: 'www.google.com',
-      port: 80,
-      path: '/index.html'
-    };
-
-    http.get(options, function(res) {
-      console.log("Got response: " + res.statusCode);
-    }).on('error', function(e) {
-      console.log("Got error: " + e.message);
-    });
+  
 
 
-## Class: http.Agent
 
-In node 0.5.3+ there is a new implementation of the HTTP Agent which is used
-for pooling sockets used in HTTP client requests.
+## http.Agent
 
-Previously, a single agent instance help the pool for single host+port. The
-current implementation now holds sockets for any number of hosts.
+Starting with Node.js version 0.5.3, there's a new implementation of the HTTP Agent which is used for pooling sockets used in HTTP client requests.
 
-The current HTTP Agent also defaults client requests to using
-Connection:keep-alive. If no pending HTTP requests are waiting on a socket
-to become free the socket is closed. This means that node's pool has the
-benefit of keep-alive when under load but still does not require developers
-to manually close the HTTP clients using keep-alive.
+Previously, a single agent instance help the pool for single host+port. The current implementation now holds sockets for any number of hosts.
 
-Sockets are removed from the agent's pool when the socket emits either a
-"close" event or a special "agentRemove" event. This means that if you intend
-to keep one HTTP request open for a long time and don't want it to stay in the
-pool you can do something along the lines of:
+The current HTTP Agent also defaults client requests to using `Connection:keep-alive`. If no pending HTTP requests are waiting on a socket to become free ,the socket is closed. This means that Node's pool has the benefit of keep-alive when under load but still does not require developers to manually close the HTTP clients using keep-alive.
+
+Sockets are removed from the agent's pool when the socket emits either a `'close'` event or a special `'agentRemove'` event. This means that if you intend to keep one HTTP request open for a long time and don't want it to stay in the pool you can do something along the lines of:
 
     http.get(options, function(res) {
       // Do stuff
@@ -559,51 +166,398 @@ pool you can do something along the lines of:
 
 Alternatively, you could just opt out of pooling entirely using `agent:false`:
 
+
     http.get({host:'localhost', port:80, path:'/', agent:false}, function (res) {
       // Do stuff
-    })
-
-### agent.maxSockets
-
-By default set to 5. Determines how many concurrent sockets the agent can have 
-open per host.
-
-### agent.sockets
-
-An object which contains arrays of sockets currently in use by the Agent. Do not 
-modify.
-
-### agent.requests
-
-An object which contains queues of requests that have not yet been assigned to 
-sockets. Do not modify.
-
-## http.globalAgent
-
-Global instance of Agent which is used as the default for all http client
-requests.
+    });
 
 
-## Class: http.ClientRequest
 
-This object is created internally and returned from `http.request()`.  It
-represents an _in-progress_ request whose header has already been queued.  The
-header is still mutable using the `setHeader(name, value)`, `getHeader(name)`,
-`removeHeader(name)` API.  The actual header will be sent along with the first
-data chunk or when closing the connection.
 
-To get the response, add a listener for `'response'` to the request object.
-`'response'` will be emitted from the request object when the response
-headers have been received.  The `'response'` event is executed with one
-argument which is an instance of `http.ClientResponse`.
 
-During the `'response'` event, one can add listeners to the
-response object; particularly to listen for the `'data'` event. Note that
-the `'response'` event is called before any part of the response body is received,
-so there is no need to worry about racing to catch the first part of the
-body. As long as a listener for `'data'` is added during the `'response'`
-event, the entire body will be caught.
 
+### http.Agent.maxSockets, Number
+
+Determines how many concurrent sockets the agent can have open per host. By default, this is set to 5. 
+
+
+
+
+### http.Agent.sockets, Number
+
+An object which contains arrays of sockets currently in use by the Agent. **Don't modify this!**
+
+ 
+
+## http.Server
+
+A representation of the server within the `http` module. To create an HTTP server, you'll need to first call [[http.createServer `http.createServer()`]], with something like this:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/http/http.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+This object is also an [[eventemitter `eventemitter`]].
+
+For more information, read [this article on how to create HTTP servers](../nodejs_dev_guide/creating_an_http_server.html).
+
+ 
+### http.Server@request(request, response)
+- request {http.ServerRequest} An instance of [[http.ServerRequest]]
+- response {http.ServerResponse} An instance of [[http.ServerResponse]]
+
+Emitted each time there is a request. Note that, in the case of keep-alive connections, there may be multiple requests per connection.
+
+
+### http.Server@connection(socket)
+- socket {net.Socket}  An object of type [[net.Socket `net.Socket`]]
+
+Emitted when a new TCP stream is established. Usually users won't want to access this event. The `socket` can also be accessed at [[http.ServerRequest.connection]].
+
+ 
+
+
+### http.Server@close(socket)
+- socket {net.Socket}  An object of type [[net.Socket `net.Socket`]]
+
+Emitted when the server closes.
+ 
+
+
+### http.Server@checkContinue(request, response)
+- request  {http.ServerRequest} An instance of `http.ServerRequest`
+- response {http.ServerResponse}  An instance of `http.ServerResponse`
+
+Emitted each time a request with an `http Expect: 100-continue` is received. If this event isn't listened for, the server will automatically respond with a `100 Continue` as appropriate.
+
+Handling this event involves calling `response.writeContinue` if the client should continue to send the request body, or generating an appropriate HTTP response (_e.g._ `400 Bad Request`) if the client should not continue to send the request body.
+
+Note: When this event is emitted and handled, the `request` event is not be emitted.
+
+ 
+
+
+### http.Server@upgrade(request, socket, head)
+- request {http.ServerRequest}  The arguments for the http request, as it is in the request event
+- socket {Number}  The network socket between the server and client
+- head {Buffer}   The first packet of the upgraded stream; this can be empty
+
+Emitted each time a client requests a http upgrade. If this event isn't listened for, then clients requesting an upgrade will have their connections closed.
+
+After this event is emitted, the request's socket won't have a `data` event listener, meaning you will need to bind to it in order to handle data sent to the server on that socket.
+
+ 
+
+
+### http.Server@clientError(exception)
+- exception {Error}  The exception being thrown
+
+If a client connection emits an `'error'` event, it's forwarded here.
+
+ 
+ 
+
+### http.Server.listen(port [, hostname] [, callback()]) 
+### http.Server.listen(port [, callback()]) 
+- port {Number}  The port to listen to
+- hostname {String}   The hostname to listen to
+- callback {Function}   The function to execute once the server has been bound to the port
+(related to: net.Server.listen)
+
+Begin accepting connections on the specified port and hostname. If the hostname is omitted, the server accepts connections directed to any IPv4 address (`INADDR_ANY`). To listen to a Unix socket, supply a filename instead of port and hostname.
+
+This function is asynchronous. The `callback()` is added as a listener for the [[net.Server@listening `net.Server@listening`]] event.
+
+
+
+ 
+### http.Server.close()
+(related to: net.Server.close)
+
+Stops the server from accepting new connections.
+ 
+
+
+
+## http.ServerRequest
+
+This object is created internally by an HTTP server—not by the user—and passed as the first argument to a `'request'` listener.
+
+The request implements the [[streams.ReadableStream Readable Stream]] interface; it is also an [[eventemitter `eventemitter`]] with the following events:
+
+ 
+
+
+### http.ServerRequest@data(chunk)
+- chunk {String}  The data that's received (as a string)
+
+Emitted when a piece of the message body is received. The chunk is a string if an encoding has been set with [[http.ServerRequest.setEncoding `request.setEncoding()`]], otherwise it's a [Buffer](buffer.html).
+
+Note that the **data will be lost** if there is no listener when a `ServerRequest` emits a `'data'` event.
+
+ 
+
+
+### http.ServerRequest@end()
+
+Emitted exactly once for each request. After that, no more `'data'` events are emitted on the request.
+
+
+ 
+
+
+### http.ServerRequest@close()
+
+Indicates that the underlaying connection was terminated before `response.end()` was called or able to flush.
+
+Just like `'end'`, this event occurs only once per request, and no more `'data'` events will fire afterwards.
+
+Note: `'close'` can fire after `'end'`, but not vice versa.
+ 
+
+read-only
+### http.ServerRequest.method, String
+
+The request method as a string, like `'GET'` or `'DELETE'`.
+
+ 
+
+
+
+### http.ServerRequest.url, String
+
+Request URL string. This contains only the URL that is present in the actual HTTP request. Fo example, if the request is:
+
+    GET /status?name=ryan HTTP/1.1\r\n
+    Accept: text/plain\r\n
+    \r\n
+
+Then `request.url` becomes:
+
+    '/status?name=ryan'
+
+#### Example
+
+If you would like to parse the URL into its parts, you can use `require('url').parse(request.url)`. For example:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/http/http.serverrequest_1.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+If you would like to extract the params from the query string, you can use [[querystring.parse `require('querystring').parse()`]], or pass `true` as the second argument to `require('url').parse`.  For example:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/http/http.serverrequest_2.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+read-only
+### http.ServerRequest.headers, Object
+
+Returns the request header.
+
+
+ 
+
+read-only
+### http.ServerRequest.trailers, Object
+
+Contains the HTTP trailers (if present). Only populated after the `'end'` event.
+
+
+ 
+
+read-only
+### http.ServerRequest.httpVersion, String
+
+The HTTP protocol version as a string; for example: `'1.1'`, `'1.0'`. `request.httpVersionMajor` is the first integer and `request.httpVersionMinor` is the second.
+
+
+ 
+
+
+### http.ServerRequest.setEncoding([encoding=null])
+- encoding {String}  The encoding to use, either `'utf8'` or `'binary'`
+
+Set the encoding for the request body. Defaults to `null`, which means that the `'data'` event emits a `Buffer` object.
+
+ 
+ 
+
+
+### http.ServerRequest.pause()
+
+Pauses request from emitting events.  Useful to throttle back an upload.  
+ 
+
+
+### http.ServerRequest.resume()
+
+Resumes a paused request.
+
+ 
+
+
+### http.ServerRequest.connection, net.Socket
+
+The `net.Socket` object associated with the connection.
+
+With HTTPS support, use `request.connection.verifyPeer()` and `request.connection.getPeerCertificate()` to obtain the client's authentication details.
+
+ 
+
+
+
+## http.ServerResponse
+
+This object is created internally by a HTTP server—not by the user. It is passed as the second parameter to the `'request'` event. It is a [[streams.WritableStream `Writable Stream`]].
+
+ 
+
+
+### http.ServerResponse@close()
+
+If emitted, it it indicates that the underlaying connection was terminated before `response.end()` was called or able to flush.
+
+
+
+
+### http.ServerResponse.writeContinue()
+
+Sends an `HTTP/1.1 100 Continue` message to the client, indicating that the request body should be sent. For more information, see the [[http.Server@checkContinue `http.Server@checkContinue`]] event.
+
+
+
+
+### http.ServerResponse.writeHead(statusCode [, reasonPhrase] [, headers])
+- statusCode {Number}   The 3-digit HTTP status code, like `404`
+- reasonPhrase {String}  A human-readable string describing the status
+- headers {Object}  Any response headers
+
+Sends a response header to the request.
+
+This method must only be called once on a message and it must be called before `response.end()` is called.
+
+If you call `response.write()` or `response.end()` before calling this, the implicit/mutable headers will be calculated and call this function for you.
+
+#### Example 
+
+    var body = 'hello world';
+    response.writeHead(200, {
+      'Content-Length': body.length,
+      'Content-Type': 'text/plain' });
+
+Note: `Content-Length` is given in bytes, not characters. The above example works because the string `'hello world'` contains only single byte characters. If the body contains higher coded characters then `Buffer.byteLength()` should be used to determine the number of bytes in a given encoding. Node.js does not check whether `Content-Length` and the length of the body which has been transmitted are equal or not.
+
+
+ 
+
+
+### http.ServerResponse.statusCode, Number
+
+When using implicit headers (not calling `response.writeHead()` explicitly), this property controls the status code that will be send to the client when the headers get flushed; for example: `response.statusCode = 404;`. 
+
+After the response header is sent to the client, this property indicates the status code which was sent out.
+
+
+
+
+
+### http.ServerResponse.setHeader(name, value)
+- name {String}  The name of the header to set
+- value  (String): The value to set
+
+Sets a single header value for implicit headers. If this header already exists in the to-be-sent headers, its value is replaced.  Use an array of strings here if you need to send multiple headers with the same name.
+
+#### Examples
+
+    response.setHeader("Content-Type", "text/html");
+
+    response.setHeader("Set-Cookie", ["type=ninja", "language=javascript"]);
+
+ 
+
+
+### http.ServerResponse.getHeader(name), String
+- name {String}  The name of the header to retrieve
+
+Reads out a header that's already been queued but not sent to the client.  Note that the name is case-insensitive.  This can only be called before headers get implicitly flushed.
+
+#### Example
+
+    var stringContentType = response.getHeader('content-type');
+
+ 
+
+
+### http.ServerResponse.removeHeader(name)
+- name {String}  The header to remove
+
+Removes a header that's queued for implicit sending.
+   
+#### Example
+
+    response.removeHeader("Content-Encoding");
+
+
+
+
+### http.ServerResponse.write(chunk [, encoding='utf8'])
+- chunk {String | Buffer}  A string or buffer to write
+- encoding {String}  The encoding to use (if `chunk` is a string)
+
+If this method is called and `response.writeHead()` has not been called, it'll switch to implicit header mode and flush the implicit headers.
+
+This sends a chunk of the response body. This method may be called multiple times to provide successive parts of the body.
+
+Note: This is the raw HTTP body and has nothing to do with higher-level multi-part body encodings that may be used.
+
+The first time `response.write()` is called, it sends the buffered header information and the first body to the client. The second time `response.write()` is called, Node.js assumes you're going to be streaming data, and sends that separately. That is, the response is buffered up to the first chunk of body.
+
+
+ 
+
+
+### http.ServerResponse.addTrailers(headers)
+- headers {String}  The trailing header to add
+
+This method adds HTTP trailing headers (a header, but at the end of the message) to the response.
+
+Trailers are only emitted if chunked encoding is used for the response; if it is not (_e.g._ if the request was `'HTTP/1.0'`), they are silently discarded.
+
+#### Example
+
+HTTP requires the `Trailer` header to be sent if you intend to emit trailers, with a list of the header fields in its value. For example:
+
+    response.writeHead(200, { 'Content-Type': 'text/plain',
+                              'Trailer': 'Content-MD5' });
+    response.write(fileData);
+    response.addTrailers({'Content-MD5': "7895bf4b8828b55ceaf47747b4bca667"});
+    response.end();
+
+
+ 
+
+
+### http.ServerResponse.end([data] [, encoding])
+- data {String}  Some data to write before finishing
+- encoding {String}  The encoding for the data
+
+This method signals to the server that all of the response headers and body has been sent; that server should consider this message complete. `response.end()` **must** be called on each response.
+
+If `data` is specified, it is equivalent to calling `response.write(data, encoding)` followed by `response.end()`.
+
+ 
+
+
+
+
+## http.ClientRequest
+
+This object is created internally and returned from [[http.request `http.request()`]].  It represents an _in-progress_ request whose header has already been queued.  The header is still mutable using the `setHeader(name, value)`, `getHeader(name)`, and `removeHeader(name)` methods.  The actual header will be sent along with the first data chunk or when closing the connection. This is both a [[streams.WritableStream `Writable Stream`]] and an [[eventemitter `EventEmitter`]].
+
+To get the response, add a listener for `'response'` to the request object. `'response'` will be emitted from the request object when the response headers have been received.  The `'response'` event is executed with one argument which is an instance of `http.ClientResponse`.
+
+Note: Node.js does not check whether `Content-Length`and the length of the body which has been transmitted are equal or not.
+
+During the `'response'` event, one can add listeners to the response object, particularly to listen for the `'data'` event. Note that the `'response'` event is called before any part of the response body is received, so there is no need to worry about racing to catch the first part of the body. As long as a listener for `'data'` is added during the `'response'` event, the entire body will be caught.
+
+#### Example
 
     // Good
     request.on('response', function (response) {
@@ -621,260 +575,180 @@ event, the entire body will be caught.
       }, 10);
     });
 
-Note: Node does not check whether Content-Length and the length of the body
-which has been transmitted are equal or not.
 
-The request implements the [Writable  Stream](stream.html#writable_stream)
-interface. This is an `EventEmitter` with the following events:
+ 
 
-### Event 'response'
 
-`function (response) { }`
+### http.ClientRequest@response(response)
+- response {http.ClientResponse}  An instance of `http.ClientResponse`
 
-Emitted when a response is received to this request. This event is emitted only once. The
-`response` argument will be an instance of `http.ClientResponse`.
+Emitted when a response is received to this request. This event is emitted only once. 
 
-Options:
+Options include:
 
-- `host`: A domain name or IP address of the server to issue the request to.
-- `port`: Port of remote server.
-- `socketPath`: Unix Domain Socket (use one of host:port or socketPath)
+- host: a domain name or IP address of the server to issue the request to
+- port: the port of remote server
+- socketPath: Unix Domain Socket (use either `host:port` or `socketPath`)
 
-### Event: 'socket'
+ 
 
-`function (socket) { }`
+
+### http.ClientRequest@socket(socket)
+- socket {net.Socket}   The assigned socket
 
 Emitted after a socket is assigned to this request.
 
-### Event: 'connect'
-
-`function (response, socket, head) { }`
-
-Emitted each time a server responds to a request with a CONNECT method. If this
-event isn't being listened for, clients receiving a CONNECT method will have
-their connections closed.
-
-A client server pair that show you how to listen for the `connect` event.
-
-    var http = require('http');
-    var net = require('net');
-    var url = require('url');
-
-    // Create an HTTP tunneling proxy
-    var proxy = http.createServer(function (req, res) {
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('okay');
-    });
-    proxy.on('connect', function(req, cltSocket, head) {
-      // connect to an origin server
-      var srvUrl = url.parse('http://' + req.url);
-      var srvSocket = net.connect(srvUrl.port, srvUrl.hostname, function() {
-        cltSocket.write('HTTP/1.1 200 Connection Established\r\n' +
-                        'Proxy-agent: Node-Proxy\r\n' +
-                        '\r\n');
-        srvSocket.write(head);
-        srvSocket.pipe(cltSocket);
-        cltSocket.pipe(srvSocket);
-      });
-    });
-
-    // now that proxy is running
-    proxy.listen(1337, '127.0.0.1', function() {
-
-      // make a request to a tunneling proxy
-      var options = {
-        port: 1337,
-        host: '127.0.0.1',
-        method: 'CONNECT',
-        path: 'www.google.com:80'
-      };
-
-      var req = http.request(options);
-      req.end();
-
-      req.on('connect', function(res, socket, head) {
-        console.log('got connected!');
-
-        // make a request over an HTTP tunnel
-        socket.write('GET / HTTP/1.1\r\n' +
-                     'Host: www.google.com:80\r\n' +
-                     'Connection: close\r\n' +
-                     '\r\n');
-        socket.on('data', function(chunk) {
-          console.log(chunk.toString());
-        });
-        socket.on('end', function() {
-          proxy.close();
-        });
-      });
-    });
-
-### Event: 'upgrade'
-
-`function (response, socket, head) { }`
-
-Emitted each time a server responds to a request with an upgrade. If this
-event isn't being listened for, clients receiving an upgrade header will have
-their connections closed.
-
-A client server pair that show you how to listen for the `upgrade` event.
-
-    var http = require('http');
-
-    // Create an HTTP server
-    var srv = http.createServer(function (req, res) {
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('okay');
-    });
-    srv.on('upgrade', function(req, socket, head) {
-      socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
-                   'Upgrade: WebSocket\r\n' +
-                   'Connection: Upgrade\r\n' +
-                   '\r\n');
-
-      socket.pipe(socket); // echo back
-    });
-
-    // now that server is running
-    srv.listen(1337, '127.0.0.1', function() {
-
-      // make a request
-      var options = {
-        port: 1337,
-        host: '127.0.0.1',
-        headers: {
-          'Connection': 'Upgrade',
-          'Upgrade': 'websocket'
-        }
-      };
-
-      var req = http.request(options);
-      req.end();
-
-      req.on('upgrade', function(res, socket, upgradeHead) {
-        console.log('got upgraded!');
-        socket.end();
-        process.exit(0);
-      });
-    });
-
-### Event: 'continue'
-
-`function () { }`
-
-Emitted when the server sends a '100 Continue' HTTP response, usually because
-the request contained 'Expect: 100-continue'. This is an instruction that
-the client should send the request body.
-
-### request.write(chunk, [encoding])
-
-Sends a chunk of the body.  By calling this method
-many times, the user can stream a request body to a
-server--in that case it is suggested to use the
-`['Transfer-Encoding', 'chunked']` header line when
-creating the request.
-
-The `chunk` argument should be a [buffer](buffer.html) or a string.
-
-The `encoding` argument is optional and only applies when `chunk` is a string.
-Defaults to `'utf8'`.
+ 
 
 
-### request.end([data], [encoding])
+### http.ClientRequest@upgrade(response, socket, head)
+- response {http.ClientResponse}  The client's response
+- socket {net.Socket}  The assigned socket
+- head {Object}  The upgrade header
 
-Finishes sending the request. If any parts of the body are
-unsent, it will flush them to the stream. If the request is
-chunked, this will send the terminating `'0\r\n\r\n'`.
+Emitted each time a server responds to a request with an upgrade. If this event isn't being listened for, clients receiving an upgrade header will have their connections closed.
 
-If `data` is specified, it is equivalent to calling
-`request.write(data, encoding)` followed by `request.end()`.
+#### Example
 
-### request.abort()
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/http/http.clientrequest.upgrade.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Aborts a request.  (New since v0.3.8.)
+ 
 
-### request.setTimeout(timeout, [callback])
 
-Once a socket is assigned to this request and is connected 
-[socket.setTimeout(timeout, [callback])](net.html#socket.setTimeout)
-will be called.
+### http.ClientRequest@continue()
 
-### request.setNoDelay([noDelay])
+Emitted when the server sends a `'100 Continue'` HTTP response, usually because the request contained `'Expect: 100-continue'`. This is an instruction that the client should send the request body.
 
-Once a socket is assigned to this request and is connected 
-[socket.setNoDelay(noDelay)](net.html#socket.setNoDelay)
-will be called.
+ 
 
-### request.setSocketKeepAlive([enable], [initialDelay])
 
-Once a socket is assigned to this request and is connected 
-[socket.setKeepAlive(enable, [initialDelay])](net.html#socket.setKeepAlive)
-will be called.
+### http.ClientRequest.write(chunk [, encoding='utf8'])
+- chunk {Array}  An array of integers or a string to write
+- encoding {String}  The encoding of the chunk (only needed if it's a string)
+
+Sends a chunk of the body.  By calling this method many times, the user can stream a request body to a server—in that case, it's suggested you use the `['Transfer-Encoding', 'chunked']` header line when creating the request.
+
+
+ 
+
+
+### http.ClientRequest.end([data] [, encoding])
+- data {String}  The data to send at the end
+- encoding {String}  The encoding to use for the data 
+
+Finishes sending the request. If any parts of the body are unsent, it will flush them to the stream. If the request is chunked, this will send the terminating `'0\r\n\r\n'`.
+
+If `data` is specified, it is equivalent to calling `request.write(data, encoding)` followed by `request.end()`.
+
+
+
+
+### http.ClientRequest.abort()
+
+Aborts a request, since NOde.js version 0.3.8.
+
+
+ 
+
+
+### http.ClientRequest.setTimeout(timeout [, callback()])
+- timeout {Number}  The timeout length, in milliseconds
+- callback {Function}  An optional function to execute once the timeout completes
+
+Once a socket is assigned to this request and is connected, [[net.Socket.setTimeout `net.Socket.setTimeout()`]] is called.
+
+
+
+### http.ClientRequest.setNoDelay([noDelay=true]) 
+- noDelay {Boolean}  If `true`, then the data is fired off immediately each time the socket is written
+
+Once a socket is assigned to this request and is connected, [[net.Socket.setNoDelay `net.Socket.setNoDelay()`]] is called.
+
+
+
+### http.ClientRequest.setSocketKeepAlive([enable=false] [, initialDelay])
+- enable {Boolean}  If `true`, then keep-alive funcitonality is set
+- initalDelay {Number}  Sets the initial delay before the first keep-alive probe is sent on an idle socket
+
+Once a socket is assigned to this request and is connected, [[net.Socket.setKeepAlive `net.Socket.setKeepAlive()`]] is called.
+
+
+  
 
 ## http.ClientResponse
 
-This object is created when making a request with `http.request()`. It is
-passed to the `'response'` event of the request object.
+This object is created when making a request with [[http.request `http.request()`]]. It is passed to the `'response'` event of the request object.
 
-The response implements the [Readable Stream](stream.html#readable_stream)
-interface. This is an `EventEmitter` with the following events:
+The response implements the [[streams.ReadableStream `Readable Stream`]] interface.
 
 
-### Event: 'data'
 
-`function (chunk) { }`
+### http.ClientResponse@data(chunk)
+- chunk {Buffer}  The data received
 
 Emitted when a piece of the message body is received.
 
-Note that the __data will be lost__ if there is no listener when a
-`ClientResponse` emits a `'data'` event.
 
 
-### Event: 'end'
 
-`function () { }`
+### http.ClientResponse@end()
+- chunk {Buffer}  The data received
 
-Emitted exactly once for each message. No arguments. After
-emitted no other events will be emitted on the response.
+Emitted exactly once for each message. After it's emitted, no other events are emitted on the response.
 
-### Event: 'close'
 
-`function (err) { }`
 
-Indicates that the underlaying connection was terminated before
-`end` event was emitted.
-See [http.ServerRequest](#http.ServerRequest)'s `'close'` event for more
-information.
 
-### response.statusCode
+### http.ClientResponse@close()
+- err {Error}  The error object
 
-The 3-digit HTTP response status code. E.G. `404`.
+Indicates that the underlaying connection was terminated before the `end` event was emitted.
 
-### response.httpVersion
+For more information, see [[http.ServerRequest]]'s `'close'` event.
 
-The HTTP version of the connected-to server. Probably either
-`'1.1'` or `'1.0'`.
-Also `response.httpVersionMajor` is the first integer and
-`response.httpVersionMinor` is the second.
 
-### response.headers
+
+### http.ClientResponse.statusCode, Number
+
+The 3-digit HTTP response status code, like `200`, `404`, e.t.c.
+
+
+
+
+### http.ClientResponse.httpVersion, String
+
+The HTTP version of the connected-to server. Usually either `'1.1'` or `'1.0'`. `response.httpVersionMajor` is the first integer and `response.httpVersionMinor` is the second.
+
+
+
+
+### http.ClientResponse.header, Object
 
 The response headers object.
 
-### response.trailers
 
-The response trailers object. Only populated after the 'end' event.
 
-### response.setEncoding([encoding])
+### http.ClientResponse.trailers, Object
 
-Set the encoding for the response body. Either `'utf8'`, `'ascii'`, or
-`'base64'`. Defaults to `null`, which means that the `'data'` event will emit
-a `Buffer` object.
+The response trailers object. Only populated after the `end` event.
 
-### response.pause()
 
-Pauses response from emitting events.  Useful to throttle back a download.
 
-### response.resume()
+
+### http.ClientResponse.setEncoding([encoding=null])
+- encoding {String}  The encoding to use. Defaults to `null`, which means that the `'data'` event will emit a `Buffer` object.
+
+Set the encoding for the response body, either `'utf8'`, `'ascii'`, or `'base64'`.
+ 
+
+
+
+### http.ClientResponse.pause()
+
+Pauses the response from emitting events.  Useful to throttle back a download.
+
+
+
+### http.ClientResponse.resume()
 
 Resumes a paused response.

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -1,112 +1,82 @@
-# HTTPS
+## https
 
     Stability: 3 - Stable
+    
+HTTPS is the HTTP protocol over TLS/SSL. In Node.js, this is implemented as a separate module. To use this module, include `require('https')` in your code.
 
-HTTPS is the HTTP protocol over TLS/SSL. In Node this is implemented as a
-separate module.
+Creating HTTPS servers is somewhat complicated and requires generating certificates.
 
-## Class: https.Server
+ #### Examples
 
-This class is a subclass of `tls.Server` and emits events same as
-`http.Server`. See `http.Server` for more information.
-
-## https.createServer(options, [requestListener])
-
-Returns a new HTTPS web server object. The `options` is similar to
-[tls.createServer()](tls.html#tls.createServer).  The `requestListener` is
-a function which is automatically added to the `'request'` event.
-
-Example:
-
-    // curl -k https://localhost:8000/
-    var https = require('https');
-    var fs = require('fs');
-
-    var options = {
-      key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
-      cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
-    };
-
-    https.createServer(options, function (req, res) {
-      res.writeHead(200);
-      res.end("hello world\n");
-    }).listen(8000);
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/https/https.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
 
-## https.request(options, callback)
+### https.createServer(options [, requestListener]), https.Server
+- options {Object}   Any options you want to pass to the server
+- requestListener {Function}  An optional listener
+(related to: tls.createServer)
 
-Makes a request to a secure web server.
-All options from [http.request()](http.html#http.request) are valid.
+Returns a new HTTPS web server object. 
 
-Example:
+The `options` object has a mix of required and optional values:
 
-    var https = require('https');
+  - `key`: A string or `Buffer` containing the private key of the server in a PEM format. (Required)
+  - `cert`: A string or `Buffer` containing the certificate key of the server in a PEM format. (Required)
 
-    var options = {
-      host: 'encrypted.google.com',
-      port: 443,
-      path: '/',
-      method: 'GET'
-    };
+  - `ca`: An array of strings or `Buffer`s of trusted certificates. These are used to authorize connections. If this is omitted, several "well-known root" CAs will be used, like VeriSign. 
 
-    var req = https.request(options, function(res) {
-      console.log("statusCode: ", res.statusCode);
-      console.log("headers: ", res.headers);
+  - `NPNProtocols`: An array of strings or a  `Buffer` containing supported NPN protocols. 
+        `Buffer` should have the following format: `0x05hello0x05world`, where the preceding byte indicates the following protocol name's length. Passing an array is usually much simplier: `['hello', 'world']`. 
+        Protocols should be ordered by their priority.
 
-      res.on('data', function(d) {
-        process.stdout.write(d);
-      });
-    });
-    req.end();
+  - `passphrase`: A string of a passphrase for the private key.
 
-    req.on('error', function(e) {
-      console.error(e);
-    });
+  - `rejectUnauthorized`: If `true` the server rejects any connection that is not authorized with the list of supplied CAs. This option only has an effect if `requestCert` is `true`. This defaults to `false`.
 
-The options argument has the following options
+  - `requestCert`: If `true` the server requests a certificate from clients that connect and attempt to verify that certificate. This defaults to `false`.
 
-- host: IP or domain of host to make request to. Defaults to `'localhost'`.
-- port: port of host to request to. Defaults to 443.
-- path: Path to request. Default `'/'`.
-- method: HTTP request method. Default `'GET'`.
+  - `sessionIdContext`: A string containing an opaque identifier for session resumption. If `requestCert` is `true`, the default is an MD5 hash value generated from the command line. Otherwise, the default is not provided.
 
-- `host`: A domain name or IP address of the server to issue the request to.
-  Defaults to `'localhost'`.
-- `hostname`: To support `url.parse()` `hostname` is preferred over `host`
-- `port`: Port of remote server. Defaults to 443.
-- `method`: A string specifying the HTTP request method. Defaults to `'GET'`.
-- `path`: Request path. Defaults to `'/'`. Should include query string if any.
-  E.G. `'/index.html?page=12'`
-- `headers`: An object containing request headers.
-- `auth`: Basic authentication i.e. `'user:password'` to compute an
-  Authorization header.
-- `agent`: Controls [Agent](#https.Agent) behavior. When an Agent is
-  used request will default to `Connection: keep-alive`. Possible values:
- - `undefined` (default): use [globalAgent](#https.globalAgent) for this
-   host and port.
- - `Agent` object: explicitly use the passed in `Agent`.
- - `false`: opts out of connection pooling with an Agent, defaults request to
-   `Connection: close`.
+  - `SNICallback`: A function that is called if the client supports the SNI TLS extension. Only one argument will be passed to it: `servername`. `SNICallback` should return a SecureContext instance. You can use `crypto.createCredentials(...).context` to get a proper SecureContext. If `SNICallback` wasn't provided, a default callback within the high-level API is used (for more information, see below).
 
-The following options from [tls.connect()](tls.html#tls.connect) can also be
-specified. However, a [globalAgent](#https.globalAgent) silently ignores these.
 
-- `key`: Private key to use for SSL. Default `null`.
-- `passphrase`: A string of passphrase for the private key. Default `null`.
-- `cert`: Public x509 certificate to use. Default `null`.
-- `ca`: An authority certificate or array of authority certificates to check
-  the remote host against.
-- `ciphers`: A string describing the ciphers to use or exclude. Consult
-  <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for
-  details on the format.
-- `rejectUnauthorized`: If `true`, the server certificate is verified against
-  the list of supplied CAs. An `'error'` event is emitted if verification
-  fails. Verification happens at the connection level, *before* the HTTP
-  request is sent. Default `false`.
+### https.request(options, callback())
+- options {Object}  Any options you want to pass to the server
+- callback {Function}   The callback to execute
 
-In order to specify these options, use a custom `Agent`.
+Makes a request to a secure web server. 
 
-Example:
+All options from [http.request `httprequest()`]] are valid for `options`:
+
+- host: a domain name or IP address of the server to issue the request to. Defaults to `'localhost'`.
+- hostname: this supports `url.parse()`; `hostname` is preferred over `host`
+- port: the port of the remote server. Defaults to `80`.
+- socketPath: the Unix Domain Socket (use either `host:port` or `socketPath`)
+- method: a string specifying the HTTP request method. Defaults to `'GET'`.
+- path: the request path. Defaults to `'/'`. This should include a query string (if any) For example, `'/index.html?page=12'`
+- headers: an object containing request headers
+- auth: used for basic authentication. For example, `'user:password'` computes an Authorization header.
+- agent: this controls [[https.Agent `https.Agent`]] behavior. When an Agent is used, the request defaults to `Connection: keep-alive`. The possible values are:
+ - `undefined`: uses [[http.globalAgent globalAgent]] for this host
+   and port (default).
+ - `Agent` object: this explicitlys use the passed in `Agent`
+ - `false`: this opts out of connection pooling with an Agent, and defaults the request to `Connection: close`.
+
+The following options from [tls.connect()](tls.html#tls.connect) can also be specified. However, a [[http.globalAgent globalAgent]] silently ignores these.
+
+  - `key`: A string or `Buffer` containing the private key of the client in aPEM format. The default is `null`.
+
+  - `passphrase`: A string of a passphrase for the private key. The default is `null`.
+
+  - `cert`: A string or `Buffer` containing the certificate key of the client in a PEM format; in other words, the public x509 certificate to use. The default is `null`.
+
+  - `ca`: An array of strings or `Buffer`s of trusted certificates. These are used to authorize connections. If this is omitted, several "well-known root" CAs will be used, like VeriSign. 
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/https/https.request_1.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+Here's an example specifying these options using a custom `Agent`:
 
     var options = {
       host: 'encrypted.google.com',
@@ -122,9 +92,7 @@ Example:
       ...
     }
 
-Or does not use an `Agent`.
-
-Example:
+Or, if you choose not to use an `Agent`:
 
     var options = {
       host: 'encrypted.google.com',
@@ -140,34 +108,99 @@ Example:
       ...
     }
 
-## https.get(options, callback)
 
-Like `http.get()` but for HTTPS.
+### https.get(options, callback())
+- options {Object}  Options to pass to the request
+- callback {Function}  The callback to execute once the method finishes 
 
-Example:
+Exactly like [[http.get `http.get()`]] but for HTTPS.
 
-    var https = require('https');
+Since most requests are GET requests without bodies, Node.js provides this convenience method. The only difference between this method and [[http.request `http.request()`]] is that it sets the method to GET and calls `req.end()` automatically.
 
-    https.get({ host: 'encrypted.google.com', path: '/' }, function(res) {
-      console.log("statusCode: ", res.statusCode);
-      console.log("headers: ", res.headers);
+#### Example
 
-      res.on('data', function(d) {
-        process.stdout.write(d);
-      });
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/https/https.get.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    }).on('error', function(e) {
-      console.error(e);
-    });
+### https.globalAgent, https.Agent
 
+A global instance of the [[https.Agent `https.Agent`]], which is used as the default for all HTTPS client requests.
 
-## Class: https.Agent
-
-An Agent object for HTTPS similar to [http.Agent](http.html#http.Agent).
-See [https.request()](#https.request) for more information.
+## https.Agent
 
 
-## https.globalAgent
+An `Agent` object for HTTPS, similar to [[http.Agent `http.Agent`]]. For more information, see [[https.request `https.request()`]].
 
-Global instance of [https.Agent](#https.Agent) which is used as the default
-for all HTTPS client requests.
+
+### https.Agent.maxSockets, Number
+
+Determines how many concurrent sockets the agent can have open per host. By default, this is set to 5. 
+
+### https.Agent.sockets, Object
+
+An object which contains arrays of sockets currently in use by the Agent. **Don't modify this!**
+
+## https.Server
+
+This class is a subclass of [[tls.Server `tls.Server`]] and emits the same events as [[http.Server `http.Server`]].
+
+Creating HTTPS servers is somewhat complicated and requires generating certificates. 
+
+### https.Server@request(request, response)
+- request {http.ServerRequest}   An instance of [[http.ServerRequest]]
+- response {http.ServerResponse}   An instance of [[http.ServerResponse]]
+
+Emitted each time there is a request. Note that, in the case of keep-alive connections, there may be multiple requests per connection.
+
+### https.Server@connection(socket)
+- socket {net.Socket}  An object of type [[net.Socket `net.Socket`]]
+
+Emitted when a new TCP stream is established. Usually users won't want to access this event. The `socket` can also be accessed at [[http.ServerRequest.connection]].
+
+### https.Server@close(socket)
+- socket {net.Socket}  An object of type [[net.Socket `net.Socket`]]
+
+Emitted when the server closes.
+
+### https.Server@checkContinue(request, response)
+- request  {http.ServerRequest} An instance of `http.ServerRequest`
+- response {http.ServerResponse}  An instance of `http.ServerResponse`
+
+Emitted each time a request with an `http Expect: 100-continue` is received. If this event isn't listened for, the server will automatically respond with a `100 Continue` as appropriate.
+
+Handling this event involves calling `response.writeContinue` if the client should continue to send the request body, or generating an appropriate HTTP response (_e.g._ `400 Bad Request`) if the client should not continue to send the request body.
+
+Note: When this event is emitted and handled, the `request` event is not be emitted.
+
+### https.Server@upgrade(request, socket, head)
+- request {http.ServerRequest}  The arguments for the http request, as it is in the request event
+- socket {Number}  The network socket between the server and client
+- head {Buffer}   The first packet of the upgraded stream; this can be empty
+
+Emitted each time a client requests a http upgrade. If this event isn't listened for, then clients requesting an upgrade will have their connections closed.
+
+After this event is emitted, the request's socket won't have a `data` event listener, meaning you will need to bind to it in order to handle data sent to the server on that socket.
+
+### https.Server@clientError(exception)
+- exception {Error}  The exception being thrown
+
+If a client connection emits an `'error'` event, it's forwarded here.
+
+ 
+
+### https.Server.listen(port [, hostname] [, callback()]) 
+### https.Server.listen(port [, callback()]) 
+- port {Number}  The port to listen to
+- hostname {String}   The hostname to listen to
+- callback {Function}   The function to execute once the server has been bound to the port
+ (related to: net.Server.listen)
+
+Begin accepting connections on the specified port and hostname. If the hostname is omitted, the server accepts connections directed to any IPv4 address (`INADDR_ANY`). To listen to a Unix socket, supply a filename instead of port and hostname.
+
+This function is asynchronous. The `callback()` is added as a listener for the <a href="net.html#event_listening_">'listening'</a> event.
+
+
+
+### https.Server.close()
+(related to: net.Server.close)
+
+Stops the server from accepting new connections.

--- a/doc/api/index.markdown
+++ b/doc/api/index.markdown
@@ -1,1 +1,6 @@
-@include _toc.markdown
+# Index
+<!-- type=misc -->
+
+Node.js is a server-side Javascript environment. It's event-driven, asynchronous, and allows you to write a web server in a relatively quick amount of time.
+
+This section is the Node.js Reference API in its entirety. You can change the version of the Node.js documentation by using the dropdown in the toolbar.

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -1,20 +1,18 @@
-# Modules
+## Modules
 
     Stability: 5 - Locked
 
-<!--name=module-->
+Node.js has a simple module loading system. In Node.js, files and modules are in one-to-one correspondence. 
 
-Node has a simple module loading system.  In Node, files and modules are in
-one-to-one correspondence.  As an example, `foo.js` loads the module
-`circle.js` in the same directory.
+For example, imagine a scenario where `foo.js` loads the module `circle.js` in the same directory.
 
-The contents of `foo.js`:
+The contents of `foo.js` are:
 
     var circle = require('./circle.js');
     console.log( 'The area of a circle of radius 4 is '
                + circle.area(4));
 
-The contents of `circle.js`:
+The contents of `circle.js` are:
 
     var PI = Math.PI;
 
@@ -26,26 +24,15 @@ The contents of `circle.js`:
       return 2 * PI * r;
     };
 
-The module `circle.js` has exported the functions `area()` and
-`circumference()`.  To export an object, add to the special `exports`
-object.
+The module `circle.js` has exported the functions `area()` and `circumference()`.  To export an object, add to the special [`exports`](#module.exports) object.
 
-Variables
-local to the module will be private. In this example the variable `PI` is
-private to `circle.js`.
+Variables local to a module are private. In this example, the variable `PI` is private to `circle.js`.
 
-The module system is implemented in the `require("module")` module.
+#### Cycles
 
-## Cycles
+Whenever there are circular `require()` calls, a module might not be done being executed when it is returned.
 
-<!--type=misc-->
-
-When there are circular `require()` calls, a module might not be
-done being executed when it is returned.
-
-Consider this situation:
-
-`a.js`:
+Consider this situation with the following files. In `a.js':
 
     console.log('a starting');
     exports.done = false;
@@ -54,7 +41,7 @@ Consider this situation:
     exports.done = true;
     console.log('a done');
 
-`b.js`:
+In `b.js`:
 
     console.log('b starting');
     exports.done = false;
@@ -63,21 +50,16 @@ Consider this situation:
     exports.done = true;
     console.log('b done');
 
-`main.js`:
+And in `main.js`:
 
     console.log('main starting');
     var a = require('./a.js');
     var b = require('./b.js');
     console.log('in main, a.done=%j, b.done=%j', a.done, b.done);
 
-When `main.js` loads `a.js`, then `a.js` in turn loads `b.js`.  At that
-point, `b.js` tries to load `a.js`.  In order to prevent an infinite
-loop an **unfinished copy** of the `a.js` exports object is returned to the
-`b.js` module.  `b.js` then finishes loading, and its exports object is
-provided to the `a.js` module.
+When `main.js` loads `a.js`, `a.js` loads `b.js`. At that point, `b.js` tries to load `a.js`.  In order to prevent an infinite loop an "unfinished copy" of the `a.js` exports object is returned to the `b.js` module.  `b.js` then finishes loading, and its exports object is provided to the `a.js` module.
 
-By the time `main.js` has loaded both modules, they're both finished.
-The output of this program would thus be:
+By the time `main.js` finishes loading both modules, they've both finished executing. The output of this program would thus be:
 
     $ node main.js
     main starting
@@ -89,147 +71,80 @@ The output of this program would thus be:
     a done
     in main, a.done=true, b.done=true
 
-If you have cyclic module dependencies in your program, make sure to
-plan accordingly.
+If you have cyclic module dependencies in your program, make sure to plan accordingly.
 
-## Core Modules
+#### Core Modules
 
-<!--type=misc-->
+Node.js has several modules compiled into the binary. These modules are described in greater detail elsewhere in this documentation.
 
-Node has several modules compiled into the binary.  These modules are
-described in greater detail elsewhere in this documentation.
+The core modules are defined in Node's source in the `lib/` folder.
 
-The core modules are defined in node's source in the `lib/` folder.
+Core modules are always preferentially loaded if their identifier is passed to `require()`.  For instance, `require('http')` always returns the built in HTTP module, even if there is a file by that name.
 
-Core modules are always preferentially loaded if their identifier is
-passed to `require()`.  For instance, `require('http')` will always
-return the built in HTTP module, even if there is a file by that name.
+#### File Modules
 
-## File Modules
+If the exact filename is not found, then Node.js attempts to load the required filename with the added extension of `.js`, `.json`, and then `.node`.
 
-<!--type=misc-->
+`.js` files are interpreted as Javascript text files, and `.json` files are parsed as JSON text files. `.node` files are interpreted as compiled addon modules loaded with `dlopen`.
 
-If the exact filename is not found, then node will attempt to load the
-required filename with the added extension of `.js`, `.json`, and then `.node`.
+A module prefixed with `'/'` is an absolute path to the file.  For example, `require('/home/marco/foo.js')` loads the file at `/home/marco/foo.js`.
 
-`.js` files are interpreted as JavaScript text files, and `.json` files are
-parsed as JSON text files. `.node` files are interpreted as compiled addon
-modules loaded with `dlopen`.
+A module prefixed with `'./'` is relative to the file calling `require()`. That is, `circle.js` must be in the same directory as `foo.js` for `require('./circle')` to find it.
 
-A module prefixed with `'/'` is an absolute path to the file.  For
-example, `require('/home/marco/foo.js')` will load the file at
-`/home/marco/foo.js`.
+Without a leading `'/'` or `'./'` to indicate a file, the module is either a "core module" or is loaded from the `node_modules` folder.
 
-A module prefixed with `'./'` is relative to the file calling `require()`.
-That is, `circle.js` must be in the same directory as `foo.js` for
-`require('./circle')` to find it.
-
-Without a leading '/' or './' to indicate a file, the module is either a
-"core module" or is loaded from a `node_modules` folder.
-
-If the given path does not exist, `require()` will throw an Error with its
-`code` property set to `'MODULE_NOT_FOUND'`.
-
-## Loading from `node_modules` Folders
-
-<!--type=misc-->
-
-If the module identifier passed to `require()` is not a native module,
-and does not begin with `'/'`, `'../'`, or `'./'`, then node starts at the
-parent directory of the current module, and adds `/node_modules`, and
-attempts to load the module from that location.
-
-If it is not found there, then it moves to the parent directory, and so
-on, until the root of the tree is reached.
-
-For example, if the file at `'/home/ry/projects/foo.js'` called
-`require('bar.js')`, then node would look in the following locations, in
-this order:
+For example, if the file at `'/home/ry/projects/foo.js'` is called by `require('bar.js')`, then Node.js looks for it in the following locations, in this order:
 
 * `/home/ry/projects/node_modules/bar.js`
 * `/home/ry/node_modules/bar.js`
 * `/home/node_modules/bar.js`
 * `/node_modules/bar.js`
 
-This allows programs to localize their dependencies, so that they do not
-clash.
+This allows programs to localize their dependencies, so that they don't clash.
 
-## Folders as Modules
+#### Folders as Modules
 
-<!--type=misc-->
+It is convenient to organize programs and libraries into self-contained directories, and then provide a single entry point to that library. 
 
-It is convenient to organize programs and libraries into self-contained
-directories, and then provide a single entry point to that library.
-There are three ways in which a folder may be passed to `require()` as
-an argument.
+There are three ways in which a folder may be passed to `require()` as an argument.
 
-The first is to create a `package.json` file in the root of the folder,
-which specifies a `main` module.  An example package.json file might
-look like this:
+The first is to create a `package.json` file in the root of the folder, which specifies a `main` module.  An example `package.json` file might look like this:
 
     { "name" : "some-library",
       "main" : "./lib/some-library.js" }
 
-If this was in a folder at `./some-library`, then
-`require('./some-library')` would attempt to load
-`./some-library/lib/some-library.js`.
+If this was in a folder at `./some-library`, then `require('./some-library')` would attempt to load `./some-library/lib/some-library.js`.
 
-This is the extent of Node's awareness of package.json files.
+This is the extent of Node's awareness of `package.json` files.
 
-If there is no package.json file present in the directory, then node
-will attempt to load an `index.js` or `index.node` file out of that
-directory.  For example, if there was no package.json file in the above
-example, then `require('./some-library')` would attempt to load:
+If there is no `package.json` file present in the directory, then Node.js attempts to load an `index.js` or `index.node` file out of that directory.  For example, if there was no `package.json` file in the above example, then `require('./some-library')` would attempt to load:
 
 * `./some-library/index.js`
 * `./some-library/index.node`
 
-## Caching
+#### Caching
 
-<!--type=misc-->
+Modules are cached after the first time they are loaded.  This means (among other things) that every call to `require('foo')` gets exactly the same object returned, if it would resolve to the same file.
 
-Modules are cached after the first time they are loaded.  This means
-(among other things) that every call to `require('foo')` will get
-exactly the same object returned, if it would resolve to the same file.
+Multiple calls to `require('foo')` may not cause the module code to be executed multiple times.  This is an important feature.  With it, "partially done" objects can be returned, thus allowing transitive dependencies to be loaded even when they would cause cycles.
 
-Multiple calls to `require('foo')` may not cause the module code to be
-executed multiple times.  This is an important feature.  With it,
-"partially done" objects can be returned, thus allowing transitive
-dependencies to be loaded even when they would cause cycles.
+If you want to have a module execute code multiple times, then export a function, and call that function.
 
-If you want to have a module execute code multiple times, then export a
-function, and call that function.
+#### Module Caching Caveats
 
-### Module Caching Caveats
+Modules are cached based on their resolved filename.  Since modules may resolve to a different filename based on the location of the calling module (loading from `node_modules` folders), it is not a guarantee that `require('foo')` always returns the exact same object, if it would resolve to different files.
 
-<!--type=misc-->
+#### The `module` Object
 
-Modules are cached based on their resolved filename.  Since modules may
-resolve to a different filename based on the location of the calling
-module (loading from `node_modules` folders), it is not a *guarantee*
-that `require('foo')` will always return the exact same object, if it
-would resolve to different files.
+In each module, the `module` variable is a reference to the object representing the current module. In particular, `module.exports` is the same as the `exports` object.
 
-## The `module` Object
+`module` isn't actually a global, but rather local to each module.
 
-<!-- type=var -->
-<!-- name=module -->
+<a id="module.exports"></a>
 
-* {Object}
+The `exports` object is created by the Module system. Sometimes, this is not acceptable, as some developers want their module to be an instance of some class. 
 
-In each module, the `module` free variable is a reference to the object
-representing the current module.  In particular
-`module.exports` is the same as the `exports` object.
-`module` isn't actually a global but rather local to each module.
-
-### module.exports
-
-* {Object}
-
-The `exports` object is created by the Module system. Sometimes this is not
-acceptable, many want their module to be an instance of some class. To do this
-assign the desired export object to `module.exports`. For example suppose we
-were making a module called `a.js`
+To do this assign the desired export object to `module.exports`. For example suppose we were making a module called `a.js`
 
     var EventEmitter = require('events').EventEmitter;
 
@@ -241,7 +156,7 @@ were making a module called `a.js`
       module.exports.emit('ready');
     }, 1000);
 
-Then in another file we could do
+Then, in another file we could do
 
     var a = require('./a');
     a.on('ready', function() {
@@ -249,113 +164,71 @@ Then in another file we could do
     });
 
 
-Note that assignment to `module.exports` must be done immediately. It cannot be
-done in any callbacks.  This does not work:
+Note that the assignment to `module.exports` must be done immediately. It can't be done in any callbacks. For example, this does not work:
 
-x.js:
+In a file called `x.js`:
 
     setTimeout(function() {
       module.exports = { a: "hello" };
     }, 0);
 
-y.js:
+In a file called `y.js`:
 
     var x = require('./x');
     console.log(x.a);
 
 
-### module.require(id)
+#### All Together Now
 
-* `id` {String}
-* Return: {Object} `exports` from the resolved module
+To get the exact filename that will be loaded when `require()` is called, use the `require.resolve()` function.
 
-The `module.require` method provides a way to load a module as if
-`require()` was called from the original module.
+Putting together all of the above, here is the high-level algorithm (in pseudocode) of what `require.resolve()` does:
 
-Note that in order to do this, you must get a reference to the `module`
-object.  Since `require()` returns the `exports`, and the `module` is
-typically *only* available within a specific module's code, it must be
-explicitly exported in order to be used.
-
-
-### module.id
-
-* {String}
-
-The identifier for the module.  Typically this is the fully resolved
-filename.
-
-
-### module.filename
-
-* {String}
-
-The fully resolved filename to the module.
-
-
-### module.loaded
-
-* {Boolean}
-
-Whether or not the module is done loading, or is in the process of
-loading.
-
-
-### module.parent
-
-* {Module Object}
-
-The module that required this one.
-
-
-### module.children
-
-* {Array}
-
-The module objects required by this one.
-
-
-
-## All Together...
-
-<!-- type=misc -->
-
-To get the exact filename that will be loaded when `require()` is called, use
-the `require.resolve()` function.
-
-Putting together all of the above, here is the high-level algorithm
-in pseudocode of what require.resolve does:
-
-    require(X) from module at path Y
+<dl>
+<dt>To `require(X)` from module at path Y:</dt>
+<dd>
+    <pre>
     1. If X is a core module,
-       a. return the core module
-       b. STOP
+        a. return the core module
+        b. STOP
     2. If X begins with './' or '/' or '../'
-       a. LOAD_AS_FILE(Y + X)
-       b. LOAD_AS_DIRECTORY(Y + X)
+        a. LOAD_AS_FILE(Y + X)
+        b. LOAD_AS_DIRECTORY(Y + X)
     3. LOAD_NODE_MODULES(X, dirname(Y))
     4. THROW "not found"
-
-    LOAD_AS_FILE(X)
-    1. If X is a file, load X as JavaScript text.  STOP
-    2. If X.js is a file, load X.js as JavaScript text.  STOP
+    </pre>
+</dd>
+<dt>To `LOAD_AS_FILE(X)`:</dt>
+<dd>
+    <pre>
+    1. If X is a file, load X as Javascript text.  STOP
+    2. If X.js is a file, load X.js as Javascript text.  STOP
     3. If X.node is a file, load X.node as binary addon.  STOP
-
-    LOAD_AS_DIRECTORY(X)
+    </pre>
+<dd>
+<dt>To `LOAD_AS_DIRECTORY(X)`:</dt>
+<dd>
+    <pre>
     1. If X/package.json is a file,
        a. Parse X/package.json, and look for "main" field.
        b. let M = X + (json main field)
        c. LOAD_AS_FILE(M)
-    2. If X/index.js is a file, load X/index.js as JavaScript text.  STOP
+    2. If X/index.js is a file, load X/index.js as Javascript text.  STOP
     3. If X/index.node is a file, load X/index.node as binary addon.  STOP
-
-    LOAD_NODE_MODULES(X, START)
+    </pre>
+</dd>
+<dt>To `LOAD_NODE_MODULES(X, START)`: </dt>
+<dd>
+    <pre>
     1. let DIRS=NODE_MODULES_PATHS(START)
     2. for each DIR in DIRS:
        a. LOAD_AS_FILE(DIR/X)
        b. LOAD_AS_DIRECTORY(DIR/X)
-
-    NODE_MODULES_PATHS(START)
+    </pre>
+</dd>
+<dt>To `NODE_MODULES_PATHS(START)`: </dt>
+<dd>
+    <pre>
     1. let PARTS = path split(START)
     2. let ROOT = index of first instance of "node_modules" in PARTS, or 0
     3. let I = count of PARTS - 1
@@ -366,96 +239,81 @@ in pseudocode of what require.resolve does:
        b. DIRS = DIRS + DIR
        c. let I = I - 1
     6. return DIRS
+    </pre>
+</dd>
 
-## Loading from the global folders
+#### Loading from the global folders
 
-<!-- type=misc -->
+If the `NODE_PATH` environment variable is set to a colon-delimited list of absolute paths, then Node.js searches those paths for modules if they are not found elsewhere. (Note: On Windows, `NODE_PATH` is delimited by semicolons instead of colons.)
 
-If the `NODE_PATH` environment variable is set to a colon-delimited list
-of absolute paths, then node will search those paths for modules if they
-are not found elsewhere.  (Note: On Windows, `NODE_PATH` is delimited by
-semicolons instead of colons.)
-
-Additionally, node will search in the following locations:
+Additionally, Node.js searches in the following locations:
 
 * 1: `$HOME/.node_modules`
 * 2: `$HOME/.node_libraries`
 * 3: `$PREFIX/lib/node`
 
-Where `$HOME` is the user's home directory, and `$PREFIX` is node's
-configured `installPrefix`.
+Where `$HOME` is the user's home directory, and `$PREFIX` is Node's configured `installPrefix`.
 
-These are mostly for historic reasons.  You are highly encouraged to
-place your dependencies locally in `node_modules` folders.  They will be
-loaded faster, and more reliably.
+These are mostly for historic reasons. You are highly encouraged to place your dependencies locally in `node_modules` folders.  They will be loaded faster, and more reliably.
 
-## Accessing the main module
+#### Accessing the `main` module
 
-<!-- type=misc -->
-
-When a file is run directly from Node, `require.main` is set to its
-`module`. That means that you can determine whether a file has been run
-directly by testing
+When a file is run directly from Node.js, `require.main` is set to its `module`. That means that you can determine whether a file has been run directly by testing for the following:
 
     require.main === module
 
-For a file `foo.js`, this will be `true` if run via `node foo.js`, but
-`false` if run by `require('./foo')`.
+For a file `foo.js`, this is `true` if run via `node foo.js`, but `false` if run by `require('./foo')`.
 
-Because `module` provides a `filename` property (normally equivalent to
-`__filename`), the entry point of the current application can be obtained
-by checking `require.main.filename`.
+Because `module` provides a `filename` property (normally equivalent to `__filename`), the entry point of the current application can be obtained by checking `require.main.filename`.
 
-## Addenda: Package Manager Tips
+#### Package Manager Tips
 
-<!-- type=misc -->
-
-The semantics of Node's `require()` function were designed to be general
-enough to support a number of sane directory structures. Package manager
-programs such as `dpkg`, `rpm`, and `npm` will hopefully find it possible to
-build native packages from Node modules without modification.
+The semantics of Node's `require()` function were designed to be general enough to support a number of sane directory structures. Package manager programs such as `dpkg`, `rpm`, and `npm` will hopefully find it possible to build native packages from Node modules without modification.
 
 Below we give a suggested directory structure that could work:
 
-Let's say that we wanted to have the folder at
-`/usr/lib/node/<some-package>/<some-version>` hold the contents of a
-specific version of a package.
+Let's say that we wanted to have the folder at `/usr/lib/node/<some-package>/<some-version>` hold the contents of a specific version of a package.
 
-Packages can depend on one another. In order to install package `foo`, you
-may have to install a specific version of package `bar`.  The `bar` package
-may itself have dependencies, and in some cases, these dependencies may even
-collide or form cycles.
+Packages can depend on one another. In order to install package `foo`, you may have to install a specific version of package `bar`.  The `bar` package may itself have dependencies, and in some cases, these dependencies may even collide or form cycles.
 
-Since Node looks up the `realpath` of any modules it loads (that is,
-resolves symlinks), and then looks for their dependencies in the
-`node_modules` folders as described above, this situation is very simple to
-resolve with the following architecture:
+Since Node.js looks up the `realpath` of any modules it loads (that is, resolves symlinks), and then looks for their dependencies in the `node_modules` folders as described above, this situation is very simple to resolve with the following architecture:
 
 * `/usr/lib/node/foo/1.2.3/` - Contents of the `foo` package, version 1.2.3.
-* `/usr/lib/node/bar/4.3.2/` - Contents of the `bar` package that `foo`
-  depends on.
-* `/usr/lib/node/foo/1.2.3/node_modules/bar` - Symbolic link to
-  `/usr/lib/node/bar/4.3.2/`.
-* `/usr/lib/node/bar/4.3.2/node_modules/*` - Symbolic links to the packages
-  that `bar` depends on.
+* `/usr/lib/node/bar/4.3.2/` - Contents of the `bar` package that `foo` depends on.
+* `/usr/lib/node/foo/1.2.3/node_modules/bar` - Symbolic link to `/usr/lib/node/bar/4.3.2/`.
+* `/usr/lib/node/bar/4.3.2/node_modules/*` - Symbolic links to the packages that `bar` depends on.
 
-Thus, even if a cycle is encountered, or if there are dependency
-conflicts, every module will be able to get a version of its dependency
-that it can use.
+Thus, even if a cycle is encountered, or if there are dependency conflicts, every module will be able to get a version of its dependency that it can use.
 
-When the code in the `foo` package does `require('bar')`, it will get the
-version that is symlinked into `/usr/lib/node/foo/1.2.3/node_modules/bar`.
-Then, when the code in the `bar` package calls `require('quux')`, it'll get
-the version that is symlinked into
-`/usr/lib/node/bar/4.3.2/node_modules/quux`.
+When the code in the `foo` package does `require('bar')`, it gets the version that is symlinked into `/usr/lib/node/foo/1.2.3/node_modules/bar`. Then, when the code in the `bar` package calls `require('quux')`, it gets the version that is symlinked into `/usr/lib/node/bar/4.3.2/node_modules/quux`.
 
-Furthermore, to make the module lookup process even more optimal, rather
-than putting packages directly in `/usr/lib/node`, we could put them in
-`/usr/lib/node_modules/<name>/<version>`.  Then node will not bother
-looking for missing dependencies in `/usr/node_modules` or `/node_modules`.
+Furthermore, to make the module lookup process even more optimal, rather than putting packages directly in `/usr/lib/node`, we could put them in `/usr/lib/node_modules/<name>/<version>`.  Then Node.js doesn't bother looking for missing dependencies in `/usr/node_modules` or `/node_modules`.
 
-In order to make modules available to the node REPL, it might be useful to
-also add the `/usr/lib/node_modules` folder to the `$NODE_PATH` environment
-variable.  Since the module lookups using `node_modules` folders are all
-relative, and based on the real path of the files making the calls to
-`require()`, the packages themselves can be anywhere.
+In order to make modules available to the Node.js REPL, it might be useful to also add the `/usr/lib/node_modules` folder to the `$NODE_PATH` environment variable.  Since the module lookups using `node_modules` folders are all relative, and based on the real path of the files making the calls to `require()`, the packages themselves can be anywhere.
+
+### module.require(id), Object
+- id {String}  The name of the module
+
+The `module.require` method provides a way to load a module as if `require()` was called from the original module. The object returned is actually the `exports` from the resolved module.
+
+Note that in order to do this, you must get a reference to the `module` object.  Since `require()` returns the `exports`, and the `module` is typically *only* available within a specific module's code, it must be explicitly exported in order to be used.
+
+### module.id, String
+
+The identifier for the module. Typically this is the fully resolved filename.
+
+### module.filename, String
+
+The fully resolved filename to the module.
+
+### module.loaded, Boolean
+
+Identifies wether or not the module is done loading (`true`), or is in the process of loading.
+
+### module.parent, Object
+
+The module that required this one.
+
+### module.children, Array
+
+The module objects required by this one.

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -1,145 +1,115 @@
-# net
+## net
 
     Stability: 3 - Stable
+    
+The `net` module provides you with an asynchronous network wrapper. It contains methods for creating both servers and clients (called streams). You can include this module in your code with `require('net');`
 
-The `net` module provides you with an asynchronous network wrapper. It contains
-methods for creating both servers and clients (called streams). You can include
-this module with `require('net');`
 
-## net.createServer([options], [connectionListener])
+#### Example
 
-Creates a new TCP server. The `connectionListener` argument is
-automatically set as a listener for the ['connection'](#event_connection_)
-event.
+Here is an example of a echo server which listens for connections on port 8124:
 
-`options` is an object with the following defaults:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/net/net.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    { allowHalfOpen: false
-    }
-
-If `allowHalfOpen` is `true`, then the socket won't automatically send a FIN
-packet when the other end of the socket sends a FIN packet. The socket becomes
-non-readable, but still writable. You should call the `end()` method explicitly.
-See ['end'](#event_end_) event for more information.
-
-Here is an example of a echo server which listens for connections
-on port 8124:
-
-    var net = require('net');
-    var server = net.createServer(function(c) { //'connection' listener
-      console.log('server connected');
-      c.on('end', function() {
-        console.log('server disconnected');
-      });
-      c.write('hello\r\n');
-      c.pipe(c);
-    });
-    server.listen(8124, function() { //'listening' listener
-      console.log('server bound');
-    });
-
-Test this by using `telnet`:
+You can test this by using `telnet`:
 
     telnet localhost 8124
 
-To listen on the socket `/tmp/echo.sock` the third line from the last would
-just be changed to
+To listen on the socket `/tmp/echo.sock` the third line from the last would just be changed to
 
     server.listen('/tmp/echo.sock', function() { //'listening' listener
 
-Use `nc` to connect to a UNIX domain socket server:
+You can use `nc` to connect to a UNIX domain socket server:
 
     nc -U /tmp/echo.sock
 
-## net.connect(options, [connectionListener])
-## net.createConnection(options, [connectionListener])
+### net.createServer([options = {allowHalfOpen: false}] [, connectionListener])
+- options {Object}   An object with any options you want to include
+- connectionListener {Function}  Automatically set as a listener for the [[net.Server@connection `'connection'`]] event
 
-Constructs a new socket object and opens the socket to the given location.
-When the socket is established, the ['connect'](#event_connect_) event will be
-emitted.
+Creates a new TCP server. 
 
-For TCP sockets, `options` argument should be an object which specifies:
+If `allowHalfOpen` is `true`, then the socket won't automatically send FIN packet when the other end of the socket sends a FIN packet. The socket becomes non-readable, but still writable. You should call the `end()` method explicitly. See ['end'](#event_end_) event for more information.
 
-  - `port`: Port the client should connect to (Required).
 
-  - `host`: Host the client should connect to. Defaults to `'localhost'`.
 
-  - `localAddress`: Local interface to bind to for network connections.
+### net.connect(port, [host='localhost'] [, connectionListener()])
+### net.connect(port, [,connectionListener()])
+- port {Number}  The port to connect to
+- host {String}  The name of the host to connect to
+- connectionListener {Function}  Automatically set as a listener for the [[net.Server@connection `'connection'`]] event
+(alias of: createConnection)
 
-For UNIX domain sockets, `options` argument should be an object which specifies:
+Construct a new socket object and opens a socket to the given location. When the socket is established, the `'connect'` event is emitted.
 
-  - `path`: Path the client should connect to (Required).
+The arguments for these methods change the type of connection. For example, if you include `host`, you create a TCP connection to `port` on `host`. If you don't include it, you create a unix socket connection to `path`.
 
-Common options are:
+### net.createConnection(port, [host='localhost'] [, connectionListener()])
+### net.createConnection(port, [,connectionListener()])
+- port {Number}  The port to connect to
+- host {String}  The name of the host to connect to
+- connectionListener {Function}  Automatically set as a listener for the [[net.Server@connection `'connection'`]] event
 
-  - `allowHalfOpen`: if `true`, the socket won't automatically send
-    a FIN packet when the other end of the socket sends a FIN packet.
-    Defaults to `false`.
-    See ['end'](#event_end_) event for more information.
+Construct a new socket object and opens a socket to the given location. When the socket is established, the `'connect'` event is emitted.
 
-The `connectListener` parameter will be added as an listener for the
-['connect'](#event_connect_) event.
+The arguments for these methods change the type of connection. For example, if you include `host`, you create a TCP connection to `port` on `host`. If you don't include it, you create a unix socket connection to `path`.
 
-Here is an example of a client of echo server as described previously:
+### net.isIP(input), String
+- input {String}  The data to check against
 
-    var net = require('net');
-    var client = net.connect({port: 8124},
-        function() { //'connect' listener
-      console.log('client connected');
-      client.write('world!\r\n');
-    });
-    client.on('data', function(data) {
-      console.log(data.toString());
-      client.end();
-    });
-    client.on('end', function() {
-      console.log('client disconnected');
-    });
+Tests if `input` is an IP address. Returns `0` for invalid strings, returns `4` for IP version 4 addresses, and returns `6` for IP version 6 addresses.
 
-To connect on the socket `/tmp/echo.sock` the second line would just be
-changed to
 
-    var client = net.connect({path: '/tmp/echo.sock'},
+### net.isIPv4(input), String
+- input {String}  The data to check against
 
-## net.connect(port, [host], [connectListener])
-## net.createConnection(port, [host], [connectListener])
+Returns `true` if input is a version 4 IP address.
 
-Creates a TCP connection to `port` on `host`. If `host` is omitted,
-`'localhost'` will be assumed.
-The `connectListener` parameter will be added as an listener for the
-['connect'](#event_connect_) event.
+### net.isIPv6(input), String
+- input {String}  The data to check against
 
-## net.connect(path, [connectListener])
-## net.createConnection(path, [connectListener])
+Returns `true` if input is a version 6 IP address. 
 
-Creates unix socket connection to `path`.
-The `connectListener` parameter will be added as an listener for the
-['connect'](#event_connect_) event.
+## net.Server
 
-## Class: net.Server
+This class is used to create a TCP or UNIX server. A server is a `net.Socket` that can listen for new incoming connections.
 
-This class is used to create a TCP or UNIX server.
-A server is a `net.Socket` that can listen for new incoming connections.
+#### Example
 
-### server.listen(port, [host], [backlog], [listeningListener])
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/net/net.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Begin accepting connections on the specified `port` and `host`.  If the
-`host` is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`). A port value of zero will assign a random port.
+### net.Server@listening()
 
-Backlog is the maximum length of the queue of pending connections.
-The actual length will be determined by your OS through sysctl settings such as
-`tcp_max_syn_backlog` and `somaxconn` on linux. The default value of this
-parameter is 511 (not 512).
 
-This function is asynchronous.  When the server has been bound,
-['listening'](#event_listening_) event will be emitted.
-the last parameter `listeningListener` will be added as an listener for the
-['listening'](#event_listening_) event.
+Emitted when the server has been bound after calling `server.listen`.
 
-One issue some users run into is getting `EADDRINUSE` errors. This means that
-another server is already running on the requested port. One way of handling this
-would be to wait a second and then try again. This can be done with
+
+### net.Server@connection(socket)
+- socket {net.Socket}  An instance of `net.Socket`
+
+Emitted when a new connection is made.
+
+### net.Server@close()
+
+Emitted when the server closes.
+
+
+### net.Server@error(exception)
+
+Emitted when an error occurs.  The `'close'` event is called directly following this event.  See an example in the discussion of [[net.Server.listen `net.Server.listen`]]
+
+
+### net.Server.listen(port [, host] [, listeningListener])
+### net.Server.listen(path [, listeningListener])
+- port {Number}  The port to connect to
+- host {String}  The name of the host to connect to
+- connectionListener {Function}  Automatically set as a listener for the [[net.Server@listening `'listening'`]] event
+
+Begin accepting connections on the specified `port` and `host`.  If the `host` is omitted, the server accepts connections directed to any IPv4 address (`INADDR_ANY`). A port value of zero will assign a random port.
+
+This function is asynchronous.  When the server has been bound, the `'listening'` event is emitted.
+
+One issue some users run into is getting `EADDRINUSE` errors. This means that another server is already running on the requested port. One way of handling this would be to wait a second and then try again. This can be done with
 
     server.on('error', function (e) {
       if (e.code == 'EADDRINUSE') {
@@ -151,312 +121,219 @@ would be to wait a second and then try again. This can be done with
       }
     });
 
-(Note: All sockets in Node set `SO_REUSEADDR` already)
+Note: All sockets in Node.js set `SO_REUSEADDR` already.
 
 
-### server.listen(path, [listeningListener])
+### net.Server.pause(msecs=1000)
+- msecs {Number}  The number of milliseconds to pause for
 
-Start a UNIX socket server listening for connections on the given `path`.
+Stop accepting connections for the given number of milliseconds. This could be useful for throttling new connections against DoS attacks or other oversubscriptions.
 
-This function is asynchronous.  When the server has been bound,
-['listening'](#event_listening_) event will be emitted.
-the last parameter `listeningListener` will be added as an listener for the
-['listening'](#event_listening_) event.
+### net.Server.close()
 
-### server.close([cb])
+Stops the server from accepting new connections. This function is asynchronous, and  the server is finally closed when it emits a `'close' event.
 
-Stops the server from accepting new connections and keeps existing
-connections. This function is asynchronous, the server is finally
-closed when all connections are ended and the server emits a `'close'`
-event. Optionally, you can pass a callback to listen for the `'close'`
-event.
 
-### server.address()
+### net.Server.address(), Object
 
-Returns the bound address, the address family name and port of the server
-as reported by the operating system.
-Useful to find which port was assigned when giving getting an OS-assigned address.
-Returns an object with three properties, e.g.
-`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`
+Returns the bound address and port of the server as reported by the operating system. Useful to find which port was assigned when giving getting an OS-assigned address. 
 
-Example:
+This returns an object with two properties, like this:
 
-    var server = net.createServer(function (socket) {
-      socket.end("goodbye\n");
-    });
+    {"address":"127.0.0.1", "port":2121}`
 
-    // grab a random port.
-    server.listen(function() {
-      address = server.address();
-      console.log("opened server on %j", address);
-    });
+#### Example
 
-Don't call `server.address()` until the `'listening'` event has been emitted.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/net/net.server.address.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-### server.maxConnections
 
-Set this property to reject connections when the server's connection count gets
-high.
+### net.Server.maxConnections, Number
 
-### server.connections
+Set this property to reject connections when the server's connection count gets high.
+
+
+### net.Server.connections, Number
 
 The number of concurrent connections on the server.
 
+## net.Socket
 
-`net.Server` is an `EventEmitter` with the following events:
+This object is an abstraction of a TCP or UNIX socket. `net.Socket` instances implement a duplex Stream interface.  They can be created by the user and used as a client (with `connect()`) or they can be created by Node.js and passed to the user through the `'connection'` event of a server.
 
-### Event: 'listening'
-
-Emitted when the server has been bound after calling `server.listen`.
-
-### Event: 'connection'
-
-* {Socket object} The connection object
-
-Emitted when a new connection is made. `socket` is an instance of
-`net.Socket`.
-
-### Event: 'close'
-
-Emitted when the server closes. Note that if connections exist, this
-event is not emitted until all connections are ended.
-
-### Event: 'error'
-
-* {Error Object}
-
-Emitted when an error occurs.  The `'close'` event will be called directly
-following this event.  See example in discussion of `server.listen`.
-
-## Class: net.Socket
-
-This object is an abstraction of a TCP or UNIX socket.  `net.Socket`
-instances implement a duplex Stream interface.  They can be created by the
-user and used as a client (with `connect()`) or they can be created by Node
-and passed to the user through the `'connection'` event of a server.
 
 ### new net.Socket([options])
+- options {Object}  An object of options you can pass
 
-Construct a new socket object.
+Constructs a new socket object.
 
 `options` is an object with the following defaults:
 
-    { fd: null
+    { 
+      fd: null
       type: null
       allowHalfOpen: false
     }
 
-`fd` allows you to specify the existing file descriptor of socket. `type`
-specified underlying protocol. It can be `'tcp4'`, `'tcp6'`, or `'unix'`.
-About `allowHalfOpen`, refer to `createServer()` and `'end'` event.
+where
 
-### socket.connect(port, [host], [connectListener])
-### socket.connect(path, [connectListener])
-
-Opens the connection for a given socket. If `port` and `host` are given,
-then the socket will be opened as a TCP socket, if `host` is omitted,
-`localhost` will be assumed. If a `path` is given, the socket will be
-opened as a unix socket to that path.
-
-Normally this method is not needed, as `net.createConnection` opens the
-socket. Use this only if you are implementing a custom Socket or if a
-Socket is closed and you want to reuse it to connect to another server.
-
-This function is asynchronous. When the ['connect'](#event_connect_) event is
-emitted the socket is established. If there is a problem connecting, the
-`'connect'` event will not be emitted, the `'error'` event will be emitted with
-the exception.
-
-The `connectListener` parameter will be added as an listener for the
-['connect'](#event_connect_) event.
+* `fd` allows you to specify the existing file descriptor of socket. 
+* `type` specifies the underlying protocol. It can be `'tcp4'`, `'tcp6'`, or `'unix'`.
+* `allowHalfOpen` is a boolean indicating how the socket should end. For more information, see the [[net.createServer `createServer()`]] method and the [[net.Socket@end `'end'`]] event.
 
 
-### socket.bufferSize
+### net.Socket.connect(port [, host=localhost] [, connectionListener()])
+- port {Number}  The port to connect to
+- host {String}  The name of the host to connect to; it's entirely optional, as you can just use `(port, connectListener)` if you wish
+- connectionListener {Function}  Automatically set as a listener for the [[net.Server@connection `'connection'`]] event
 
-`net.Socket` has the property that `socket.write()` always works. This is to
-help users get up and running quickly. The computer cannot always keep up
-with the amount of data that is written to a socket - the network connection
-simply might be too slow. Node will internally queue up the data written to a
-socket and send it out over the wire when it is possible. (Internally it is
-polling on the socket's file descriptor for being writable).
+Opens the connection for a given socket. If `port` and `host` are given, then the socket is opened as a TCP socket. If a `path` is given, the socket is opened as a Unix socket to that path.
 
-The consequence of this internal buffering is that memory may grow. This
-property shows the number of characters currently buffered to be written.
-(Number of characters is approximately equal to the number of bytes to be
-written, but the buffer may contain strings, and the strings are lazily
-encoded, so the exact number of bytes is not known.)
+Normally this method isn't needed, as `net.createConnection()` opens the socket. Use this only if you are implementing a custom Socket or if a Socket is closed and you want to reuse it to connect to another server.
 
-Users who experience large or growing `bufferSize` should attempt to
-"throttle" the data flows in their program with `pause()` and `resume()`.
+This function is asynchronous. When the `'connect'` event is emitted the socket is established. If there is a problem connecting, the `'connect'` event  isn't emitted,  and the `'error'` event is emitted with the exception.
 
 
-### socket.setEncoding([encoding])
+### net.Socket.bufferSize, Number
 
-Sets the encoding (either `'ascii'`, `'utf8'`, or `'base64'`) for data that is
-received. Defaults to `null`.
+`net.Socket` has the property that `socket.write()` always works. This is to help users get up and running quickly. The computer can't always keep up with the amount of data that is written to a socket—the network connection simply might be too slow. Node.js will internally queue up the data written to a socket and send it out over the wire whenever it's possible. (Internally, it's polling on the socket's file descriptor for being writable.)
 
-### socket.write(data, [encoding], [callback])
+The consequence of this internal buffering is that memory may grow. This property shows the number of characters currently buffered to be written.  The number of characters is approximately equal to the number of bytes to be written, but the buffer may contain strings, and the strings are lazily encoded, so the _exact_ number of bytes is not known.
 
-Sends data on the socket. The second parameter specifies the encoding in the
-case of a string--it defaults to UTF8 encoding.
+Note: Users who experience a large or growing `bufferSize` should attempt to "throttle" the data flows in their program with `pause()` and `resume()`.
 
-Returns `true` if the entire data was flushed successfully to the kernel
-buffer. Returns `false` if all or part of the data was queued in user memory.
-`'drain'` will be emitted when the buffer is again free.
 
-The optional `callback` parameter will be executed when the data is finally
-written out - this may not be immediately.
+### net.Socket.setEncoding([encoding=null])
+- encoding {String}  The encoding to use (either `'ascii'`, `'utf8'`, or `'base64'`)
 
-### socket.end([data], [encoding])
+Sets the encoding for data that is received.
 
-Half-closes the socket. i.e., it sends a FIN packet. It is possible the
-server will still send some data.
+### net.Socket.setSecure()
+(deprecated: 0.3.0)
 
-If `data` is specified, it is equivalent to calling
-`socket.write(data, encoding)` followed by `socket.end()`.
+This function was used to upgrade the connection to SSL/TLS. See the [[tls TLS]] section for the new API.
 
-### socket.destroy()
 
-Ensures that no more I/O activity happens on this socket. Only necessary in
-case of errors (parse error or so).
+### net.Socket.write(data [, encoding='utf8'] [, callback()]), Boolean
+- data {String}  The data to write
+- enocding {String}  The encoding to use
+- callback {Function}  The callback to execute once the write is finished
 
-### socket.pause()
+Sends data on the socket. The second parameter specifies the encoding in the case of a string—it defaults to UTF8 encoding.
 
-Pauses the reading of data. That is, `'data'` events will not be emitted.
-Useful to throttle back an upload.
+Returns `true` if the entire data was flushed successfully to the kernel buffer. Returns `false` if all or part of the data was queued in user memory. `'drain'` is emitted when the buffer is again free.
 
-### socket.resume()
+### net.Socket.end([data] [, encoding])
+- data {String}  The data to write first
+- encoding {String}   The encoding to use
+
+Half-closes the socket, _i.e._, it sends a FIN packet. It is possible the server can still send some data.
+
+If `data` is specified, it's equivalent to calling `socket.write(data, encoding)` followed by `socket.end()`.
+
+### net.Socket.destroy()
+
+Ensures that no more I/O activity happens on this socket. Only necessary in case of errors (like with a parse error).
+
+### net.Socket.pause()
+
+Pauses the reading of data. That is, `'data'` events are no longer emitted. Useful to throttle back an upload.
+
+
+### net.Socket.resume()
 
 Resumes reading after a call to `pause()`.
 
-### socket.setTimeout(timeout, [callback])
+### net.Socket.setTimeout(timeout, [callback()])
+- timeout {Number}  The timeout length (in milliseconds)
+- callback {Function}   The function to execute as a one time listener for the `'timeout'` event.
 
-Sets the socket to timeout after `timeout` milliseconds of inactivity on
-the socket. By default `net.Socket` do not have a timeout.
+Sets the socket to timeout after `timeout` milliseconds of inactivity on the socket. By default `net.Socket` don't have a timeout.
 
-When an idle timeout is triggered the socket will receive a `'timeout'`
-event but the connection will not be severed. The user must manually `end()`
-or `destroy()` the socket.
+When an idle timeout is triggered the socket will receive a `'timeout'` event but the connection will not be severed. The user must manually `end()` or `destroy()` the socket.
 
 If `timeout` is 0, then the existing idle timeout is disabled.
 
-The optional `callback` parameter will be added as a one time listener for the
-`'timeout'` event.
+### net.Socket.setNoDelay([noDelay=true])
+- noDelay {Boolean}  If `true`, immediately fires off data each time `socket.write()` is called.
 
-### socket.setNoDelay([noDelay])
+Disables [the Nagle algorithm](http://en.wikipedia.org/wiki/Nagle's_algorithm). By default TCP connections use the Nagle algorithm, they buffer data before sending it off. 
 
-Disables the Nagle algorithm. By default TCP connections use the Nagle
-algorithm, they buffer data before sending it off. Setting `true` for
-`noDelay` will immediately fire off data each time `socket.write()` is called.
-`noDelay` defaults to `true`.
+### net.Socket.setKeepAlive([enable=false] [, initialDelay=0])
+- enable {Boolean}  Enables or disables whether to stay alive
+- initialDelay {Number}   The delay (in milliseconds) between the last data packet received and the first keepalive probe
 
-### socket.setKeepAlive([enable], [initialDelay])
+Enable and disable keep-alive functionality, and optionally set the initial delay before the first keepalive probe is sent on an idle socket.
 
-Enable/disable keep-alive functionality, and optionally set the initial
-delay before the first keepalive probe is sent on an idle socket.
-`enable` defaults to `false`.
+Setting `initialDelay` to 0 for leaves the value unchanged from the default (or previous) setting.
 
-Set `initialDelay` (in milliseconds) to set the delay between the last
-data packet received and the first keepalive probe. Setting 0 for
-initialDelay will leave the value unchanged from the default
-(or previous) setting. Defaults to `0`.
 
-### socket.address()
+#### Example
 
-Returns the bound address, the address family name and port of the
-socket as reported by the operating system. Returns an object with
-three properties, e.g.
-`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/net/net.server.address.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-### socket.remoteAddress
 
-The string representation of the remote IP address. For example,
-`'74.125.127.100'` or `'2001:4860:a005::68'`.
+### net.Socket.address(), Object
 
-### socket.remotePort
+Returns the bound address and port of the socket as reported by the operating system. Returns an object with two properties that looks like this:
 
-The numeric representation of the remote port. For example,
-`80` or `21`.
+		{"address":"192.168.57.1", "port":62053}
 
-### socket.bytesRead
+### net.Socket.remoteAddress, String
+
+
+The string representation of the remote IP address. For example, `'74.125.127.100'` or `'2001:4860:a005::68'`.
+
+### net.Socket.remotePort, Number
+
+
+The numeric representation of the remote port. For example, `80` or `21`.
+
+### net.Socket.bytesRead, Number
+
 
 The amount of received bytes.
 
-### socket.bytesWritten
+### net.Socket.bytesWritten, Number
+
 
 The amount of bytes sent.
 
+### net.Socket@connect()
 
-`net.Socket` instances are EventEmitters with the following events:
 
-### Event: 'connect'
+Emitted when a socket connection is successfully established. For more information, see [[net.Socket.connect `connect()`]].
 
-Emitted when a socket connection is successfully established.
-See `connect()`.
+### net.Socket@data(data)
+- data {Buffer | String}  A `Buffer` or `String`, depending on what it is
 
-### Event: 'data'
+Emitted when data is received. The encoding of `data` is set by `socket.setEncoding()`.
 
-* {Buffer object}
+For more information, see the [[streams.ReadableStream ReadableStream]] section.
 
-Emitted when data is received.  The argument `data` will be a `Buffer` or
-`String`.  Encoding of data is set by `socket.setEncoding()`.
-(See the [Readable Stream](stream.html#readable_stream) section for more
-information.)
+### net.Socket@end()
 
-Note that the __data will be lost__ if there is no listener when a `Socket`
-emits a `'data'` event.
-
-### Event: 'end'
+By default (when `allowHalfOpen == false`), the socket destroys its file descriptor once it has written out its pending write queue. However, by setting `allowHalfOpen == true` the socket won't automatically `end()` its side, allowing the user to write arbitrary amounts of data, with the caveat that the user is required to `end()` their side now.
 
 Emitted when the other end of the socket sends a FIN packet.
 
-By default (`allowHalfOpen == false`) the socket will destroy its file
-descriptor  once it has written out its pending write queue.  However, by
-setting `allowHalfOpen == true` the socket will not automatically `end()`
-its side allowing the user to write arbitrary amounts of data, with the
-caveat that the user is required to `end()` their side now.
+### net.Socket.timeout()
+(related to: net.Socket.setTimeout)
+
+Emitted if the socket times out from inactivity. This is only to notify that the socket has been idle. The user must manually close the connection.
 
 
-### Event: 'timeout'
-
-Emitted if the socket times out from inactivity. This is only to notify that
-the socket has been idle. The user must manually close the connection.
-
-See also: `socket.setTimeout()`
-
-
-### Event: 'drain'
+### net.Socket.drain()
+(related to: net.Socket.write)
 
 Emitted when the write buffer becomes empty. Can be used to throttle uploads.
 
-See also: the return values of `socket.write()`
 
-### Event: 'error'
+### net.Socket.error(exception)
+- exception {Error}  Any exceptions encountered
 
-* {Error object}
+Emitted when an error occurs.  The `'close'` event is called directly following this event.
 
-Emitted when an error occurs.  The `'close'` event will be called directly
-following this event.
+### net.Socket.close(had_error)
+- had_error {Boolean}  A `true` boolean if the socket was closed due to a transmission error
 
-### Event: 'close'
-
-* `had_error` {Boolean} true if the socket had a transmission error
-
-Emitted once the socket is fully closed. The argument `had_error` is a boolean
-which says if the socket was closed due to a transmission error.
-
-## net.isIP(input)
-
-Tests if input is an IP address. Returns 0 for invalid strings,
-returns 4 for IP version 4 addresses, and returns 6 for IP version 6 addresses.
-
-
-## net.isIPv4(input)
-
-Returns true if input is a version 4 IP address, otherwise returns false.
-
-
-## net.isIPv6(input)
-
-Returns true if input is a version 6 IP address, otherwise returns false.
-
+Emitted once the socket is fully closed.

--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -1,50 +1,25 @@
-# os
+## os
 
     Stability: 4 - API Frozen
 
-Provides a few basic operating-system related utility functions.
+This provides a way to retrieve various information about the underlaying operating system. Add `require('os')` in your code to access this module.
 
-Use `require('os')` to access this module.
+#### Example
 
-## os.hostname()
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/os/os.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Returns the hostname of the operating system.
 
-## os.type()
-
-Returns the operating system name.
-
-## os.platform()
-
-Returns the operating system platform.
-
-## os.arch()
+  
+### os.arch(), String
 
 Returns the operating system CPU architecture.
 
-## os.release()
 
-Returns the operating system release.
+### os.cpus(), [Object]
 
-## os.uptime()
+Returns an array of objects containing information about each CPU/core installed: the model, speed (in MHz), and times (an object containing the number of CPU ticks spent in: user, nice, sys, idle, and irq).
 
-Returns the system uptime in seconds.
-
-## os.loadavg()
-
-Returns an array containing the 1, 5, and 15 minute load averages.
-
-## os.totalmem()
-
-Returns the total amount of system memory in bytes.
-
-## os.freemem()
-
-Returns the amount of free system memory in bytes.
-
-## os.cpus()
-
-Returns an array of objects containing information about each CPU/core installed: model, speed (in MHz), and times (an object containing the number of CPU ticks spent in: user, nice, sys, idle, and irq).
+#### Example
 
 Example inspection of os.cpus:
 
@@ -66,56 +41,77 @@ Example inspection of os.cpus:
            irq: 0 } },
       { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
         speed: 2926,
-        times:
-         { user: 248450,
-           nice: 0,
-           sys: 21750,
-           idle: 1070919370,
-           irq: 0 } },
-      { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
-        speed: 2926,
-        times:
-         { user: 256880,
-           nice: 0,
-           sys: 19430,
-           idle: 1070905480,
-           irq: 20 } },
-      { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
-        speed: 2926,
-        times:
-         { user: 511580,
-           nice: 20,
-           sys: 40900,
-           idle: 1070842510,
-           irq: 0 } },
-      { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
-        speed: 2926,
-        times:
-         { user: 291660,
-           nice: 0,
-           sys: 34360,
-           idle: 1070888000,
-           irq: 10 } },
-      { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
-        speed: 2926,
-        times:
-         { user: 308260,
-           nice: 0,
-           sys: 55410,
-           idle: 1071129970,
-           irq: 880 } },
-      { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
-        speed: 2926,
-        times:
-         { user: 266450,
-           nice: 1480,
-           sys: 34920,
-           idle: 1072572010,
-           irq: 30 } } ]
+       times:
+       { user: 248450,
+        nice: 0,
+         sys: 21750,
+         idle: 1070919370,
+         irq: 0 } },
+    { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
+      speed: 2926,
+      times:
+       { user: 256880,
+         nice: 0,
+         sys: 19430,
+         idle: 1070905480,
+         irq: 20 } },
+    { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
+      speed: 2926,
+      times:
+       { user: 511580,
+         nice: 20,
+         sys: 40900,
+         idle: 1070842510,
+         irq: 0 } },
+    { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
+      speed: 2926,
+      times:
+       { user: 291660,
+         nice: 0,
+         sys: 34360,
+         idle: 1070888000,
+         irq: 10 } },
+    { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
+      speed: 2926,
+      times:
+       { user: 308260,
+         nice: 0,
+         sys: 55410,
+         idle: 1071129970,
+         irq: 880 } },
+    { model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
+      speed: 2926,
+      times:
+       { user: 266450,
+         nice: 1480,
+         sys: 34920,
+         idle: 1072572010,
+         irq: 30 } } ]
 
-## os.networkInterfaces()
 
-Get a list of network interfaces:
+           
+### os.freemem(), Number
+
+
+Returns the amount of free system memory in bytes.
+
+ 
+
+
+### os.hostname(), String
+
+
+Returns the hostname of the operating system.
+
+ 
+
+
+### os.networkInterfaces(), Object
+
+
+Returns a list of network interfaces.
+
+#### Example
 
     { lo0: 
        [ { address: '::1', family: 'IPv6', internal: true },
@@ -129,6 +125,51 @@ Get a list of network interfaces:
       vmnet8: [ { address: '10.88.88.1', family: 'IPv4', internal: false } ],
       ppp0: [ { address: '10.2.0.231', family: 'IPv4', internal: false } ] }
 
-## os.EOL
 
-A constant defining the appropriate End-of-line marker for the operating system.
+ 
+
+
+### os.loadavg(), [Number]
+
+
+Returns an array containing the 1, 5, and 15 minute load averages.
+
+ 
+
+
+### os.platform(), String
+
+ 
+Returns the operating system platform.
+
+ 
+
+
+### os.release(), String
+
+ 
+Returns the operating system release.
+
+ 
+
+
+### os.totalmem(), Number
+
+Returns the total amount of system memory in bytes.
+
+ 
+
+
+### os.type(), String
+
+Returns the operating system name.
+
+ 
+
+
+### os.uptime(), Number
+
+
+Returns the system uptime in seconds.
+ 
+

--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -1,57 +1,59 @@
-# Path
+## path
 
     Stability: 3 - Stable
+    
+This module contains utilities for handling and transforming file paths. Add `require('path')` to your code to use this module.
 
-This module contains utilities for handling and transforming file
-paths.  Almost all these methods perform only string transformations.
-The file system is not consulted to check whether paths are valid.
+Almost all these methods perform only string transformations. **The file system is not consulted to check whether paths are valid.** `path.exists` and `path.existsSync` are the exceptions, and should logically be found in the fs module as they do access the file system.
 
-Use `require('path')` to use this module.  The following methods are provided:
 
-## path.normalize(p)
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+### path.normalize(p), String
+- p {String}   The path to normalize
 
 Normalize a string path, taking care of `'..'` and `'.'` parts.
 
-When multiple slashes are found, they're replaced by a single one;
-when the path contains a trailing slash, it is preserved.
-On windows backslashes are used. 
+When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used. 
 
-Example:
+#### Example
 
-    path.normalize('/foo/bar//baz/asdf/quux/..')
-    // returns
-    '/foo/bar/baz/asdf'
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.normalize.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## path.join([path1], [path2], [...])
 
-Join all arguments together and normalize the resulting path.
-Non-string arguments are ignored.
 
-Example:
 
-    path.join('/foo', 'bar', 'baz/asdf', 'quux', '..')
-    // returns
-    '/foo/bar/baz/asdf'
+### path.join(path1, path2 [, paths...]), String
+- path1 {String}  The first path to join
+- path2 {String}  The second path to join
+- paths {String}  Additional paths to join
 
-    path.join('foo', {}, 'bar')
-    // returns
-    'foo/bar'
+Join all arguments together and normalize the resulting path. Non-string arguments are ignored.
 
-## path.resolve([from ...], to)
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.join.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+
+### path.resolve([from ...], to) , String
+- from {String}  Paths to prepend (and append) to `to`
+- to {String}   The path to resolve
 
 Resolves `to` to an absolute path.
 
-If `to` isn't already absolute `from` arguments are prepended in right to left
-order, until an absolute path is found. If after using all `from` paths still
-no absolute path is found, the current working directory is used as well. The
-resulting path is normalized, and trailing slashes are removed unless the path 
-gets resolved to the root directory. Non-string arguments are ignored.
+If `to` isn't already absolute, the `from` arguments are prepended in right to left order, until an absolute path is found. If, after using all the `from` paths still no absolute path is found, the current working directory is used as well. The resulting path is normalized, and trailing slashes are removed unless the path gets resolved to the root directory. Non-string arguments are ignored.
 
-Another way to think of it is as a sequence of `cd` commands in a shell.
+Another way to think of it is as a sequence of `cd` commands in a shell. The following call:
 
     path.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile')
 
-Is similar to:
+is similar to:
 
     cd foo/bar
     cd /tmp/file/
@@ -59,82 +61,89 @@ Is similar to:
     cd a/../subfile
     pwd
 
-The difference is that the different paths don't need to exist and may also be
-files.
+The difference is that the different paths don't need to exist and may also be files.
 
-Examples:
+#### Examples
 
-    path.resolve('/foo/bar', './baz')
-    // returns
-    '/foo/bar/baz'
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.resolve.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    path.resolve('/foo/bar', '/tmp/file/')
-    // returns
-    '/tmp/file'
 
-    path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
-    // if currently in /home/myself/node, it returns
-    '/home/myself/node/wwwroot/static_files/gif/image.gif'
 
-## path.relative(from, to)
+
+### path.relative(from, to), String
+- from {String}   The starting path
+- to {String}   To final path
 
 Solve the relative path from `from` to `to`.
 
-At times we have two absolute paths, and we need to derive the relative
-path from one to the other.  This is actually the reverse transform of
-`path.resolve`, which means we see that:
+At times, you have two absolute paths, and you need to derive the relative path from one to the other. This is actually the reverse transform of [[path.resolve `path.resolve()`]], which means you'll see that:
+   
+   path.resolve(from, path.relative(from, to)) == path.resolve(to)
 
-    path.resolve(from, path.relative(from, to)) == path.resolve(to)
+#### Example
 
-Examples:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.relative.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    path.relative('C:\\orandea\\test\\aaa', 'C:\\orandea\\impl\\bbb')
-    // returns
-    '..\\..\\impl\\bbb'
 
-    path.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb')
-    // returns
-    '../../impl/bbb'
 
-## path.dirname(p)
 
-Return the directory name of a path.  Similar to the Unix `dirname` command.
+### path.dirname(p), String
+- p {String}   A path
 
-Example:
+Return the directory name of a path.  Similar to the Unix [`dirname`](http://www.kernel.org/doc/man-pages/online/pages/man3/basename.3.html) command.
 
-    path.dirname('/foo/bar/baz/asdf/quux')
-    // returns
-    '/foo/bar/baz/asdf'
+#### Example
 
-## path.basename(p, [ext])
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.dirname.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-Return the last portion of a path.  Similar to the Unix `basename` command.
 
-Example:
 
-    path.basename('/foo/bar/baz/asdf/quux.html')
-    // returns
-    'quux.html'
 
-    path.basename('/foo/bar/baz/asdf/quux.html', '.html')
-    // returns
-    'quux'
+### path.basename(p, [ext]), String
+- p {String}   A path
+- ext {String}  If provided, the extension to omit
 
-## path.extname(p)
+Return the last portion of a path.  Similar to the Unix [`basename`](http://www.kernel.org/doc/man-pages/online/pages/man3/basename.3.html) command.
 
-Return the extension of the path, from the last '.' to end of string
-in the last portion of the path.  If there is no '.' in the last portion
-of the path or the first character of it is '.', then it returns
-an empty string.  Examples:
+#### Example
 
-    path.extname('index.html')
-    // returns
-    '.html'
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.basename.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    path.extname('index.')
-    // returns
-    '.'
 
-    path.extname('index')
-    // returns
-    ''
+
+
+### path.extname(p), String
+- p {String}   A path
+
+Return the extension of the path, from the last '.' to end of string in the last portion of the path.  If there is no '.' in the last portion of the path or the first character of it is '.', then the method returns an empty string.  
+
+#### Examples
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.extname.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+
+### path.exists(p [, callback(exists)]), String
+- p {String}   A path to check
+- callback {Function}  A callback to execute once the method completes
+- exists {Boolean}   This is `true` if the path actually exists
+
+Tests whether or not the given path exists by checking with the file system.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/path/path.exists.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+
+###  path.existsSync(p), Boolean
+- p {String}   A path to check
+
+The synchronous version of `path.exists`. Tests whether or not the given path exists by checking with the file system
+
+#### Returns
+`true` if the path exists, `false` otherwise.
+
+

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -1,308 +1,125 @@
-# process
+## process
 
-<!-- type=global -->
-
-The `process` object is a global object and can be accessed from anywhere.
-It is an instance of `EventEmitter`.
+The `process` object is a global object, and can be accessed from anywhere. It is an instance of [[eventemitter `EventEmitter`]].
 
 
-## Event: 'exit'
+#### Example: Handling Signal Events
 
-Emitted when the process is about to exit.  This is a good hook to perform
-constant time checks of the module's state (like for unit tests).  The main
-event loop will no longer be run after the 'exit' callback finishes, so
-timers may not be scheduled.
+Signal events are emitted when processes receive a signal. See [sigaction(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/sigaction.2.html) for a list of standard POSIX signal names such as SIGINT, SIGUSR1, etc.
 
-Example of listening for `exit`:
+#### Example: Listening for `SIGINT`:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+### process@exit()
+
+Emitted when the process is about to exit.  This is a good hook to perform constant time checks of the module's state (like for unit tests).  The main event loop will no longer be run after the `exit` callback finishes, so timers may not be scheduled.
+
+#### Example: Listening for an `'exit'` event:
 
     process.on('exit', function () {
-      process.nextTick(function () {
-       console.log('This will not run');
-      });
-      console.log('About to exit.');
+        process.nextTick(function () {
+            console.log('This will not run');
+        });
+        console.log('About to exit.');
     });
 
-## Event: 'uncaughtException'
-
-Emitted when an exception bubbles all the way back to the event loop. If a
-listener is added for this exception, the default action (which is to print
-a stack trace and exit) will not occur.
-
-Example of listening for `uncaughtException`:
-
-    process.on('uncaughtException', function (err) {
-      console.log('Caught exception: ' + err);
-    });
-
-    setTimeout(function () {
-      console.log('This will still run.');
-    }, 500);
-
-    // Intentionally cause an exception, but don't catch it.
-    nonexistentFunc();
-    console.log('This will not run.');
-
-Note that `uncaughtException` is a very crude mechanism for exception
-handling.  Using try / catch in your program will give you more control over
-your program's flow.  Especially for server programs that are designed to
-stay running forever, `uncaughtException` can be a useful safety mechanism.
+ 
 
 
-## Signal Events
+### process@uncaughtException(err)
+- err {Error}  The standard Error Object
 
-<!--type=event-->
-<!--name=SIGINT, SIGUSR1, etc.-->
+Emitted when an exception bubbles all the way back to the event loop. If a listener is added for this exception, the default action (which is to print a stack trace and exit) won't occur.
 
-Emitted when the processes receives a signal. See sigaction(2) for a list of
-standard POSIX signal names such as SIGINT, SIGUSR1, etc.
+#### Example: Listening for an `'uncaughtException'`:
 
-Example of listening for `SIGINT`:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.uncaughtException.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    // Start reading from stdin so we don't exit.
-    process.stdin.resume();
-
-    process.on('SIGINT', function () {
-      console.log('Got SIGINT.  Press Control-D to exit.');
-    });
-
-An easy way to send the `SIGINT` signal is with `Control-C` in most terminal
-programs.
+Note: An `uncaughtException` is a very crude mechanism for exception handling. Using `try / catch` in your program gives you more control over your program's flow.  Especially for server programs that are designed to stay running forever, `uncaughtException` can be a useful safety mechanism.
 
 
-## process.stdout
-
-A `Writable Stream` to `stdout`.
-
-Example: the definition of `console.log`
-
-    console.log = function (d) {
-      process.stdout.write(d + '\n');
-    };
-
-`process.stderr` and `process.stdout` are unlike other streams in Node in
-that writes to them are usually blocking.  They are blocking in the case
-that they refer to regular files or TTY file descriptors. In the case they
-refer to pipes, they are non-blocking like other streams.
+ 
 
 
-## process.stderr
-
-A writable stream to stderr.
-
-`process.stderr` and `process.stdout` are unlike other streams in Node in
-that writes to them are usually blocking.  They are blocking in the case
-that they refer to regular files or TTY file descriptors. In the case they
-refer to pipes, they are non-blocking like other streams.
-
-
-## process.stdin
-
-A `Readable Stream` for stdin. The stdin stream is paused by default, so one
-must call `process.stdin.resume()` to read from it.
-
-Example of opening standard input and listening for both events:
-
-    process.stdin.resume();
-    process.stdin.setEncoding('utf8');
-
-    process.stdin.on('data', function (chunk) {
-      process.stdout.write('data: ' + chunk);
-    });
-
-    process.stdin.on('end', function () {
-      process.stdout.write('end');
-    });
-
-
-## process.argv
-
-An array containing the command line arguments.  The first element will be
-'node', the second element will be the name of the JavaScript file.  The
-next elements will be any additional command line arguments.
-
-    // print process.argv
-    process.argv.forEach(function (val, index, array) {
-      console.log(index + ': ' + val);
-    });
-
-This will generate:
-
-    $ node process-2.js one two=three four
-    0: node
-    1: /Users/mjr/work/node/process-2.js
-    2: one
-    3: two=three
-    4: four
-
-
-## process.execPath
-
-This is the absolute pathname of the executable that started the process.
-
-Example:
-
-    /usr/local/bin/node
-
-
-## process.abort()
-
-This causes node to emit an abort. This will cause node to exit and
-generate a core file.
-
-## process.chdir(directory)
+### process.chdir(directory)
+- directory {String}   The directory name to change to
 
 Changes the current working directory of the process or throws an exception if that fails.
 
-    console.log('Starting directory: ' + process.cwd());
+#### Example
+
+    console.log('Starting at directory: ' + process.cwd());
     try {
       process.chdir('/tmp');
       console.log('New directory: ' + process.cwd());
     }
     catch (err) {
-      console.log('chdir: ' + err);
+      console.log('chdir failed: ' + err);
     }
 
+ 
 
 
-## process.cwd()
+### process.cwd(), String
 
-Returns the current working directory of the process.
+Returns the current working directory of the process. For example:
 
-    console.log('Current directory: ' + process.cwd());
-
-
-## process.env
-
-An object containing the user environment. See environ(7).
+  console.log('Current directory: ' + process.cwd());
 
 
-## process.exit([code])
 
-Ends the process with the specified `code`.  If omitted, exit uses the
-'success' code `0`.
 
-To exit with a 'failure' code:
+
+### process.exit(code=0)
+- code {Number}  The code to end with
+
+Ends the process with the specified `code`.
+
+#### Example: Exiting with a 'failure' code:
 
     process.exit(1);
 
-The shell that executed node should see the exit code as 1.
+The shell that executed this should see the exit code as `1`.
+
+ 
 
 
-## process.getgid()
+### process.getgid(), Number
 
-Gets the group identity of the process. (See getgid(2).)
-This is the numerical group id, not the group name.
+Gets the group identity of the process. This is the numerical group id, not the group name. For more information, see [getgid(2)](http://kernel.org/doc/man-pages/online/pages/man2/getgid.2.html).
 
-    console.log('Current gid: ' + process.getgid());
+#### Example
 
-
-## process.setgid(id)
-
-Sets the group identity of the process. (See setgid(2).)  This accepts either
-a numerical ID or a groupname string. If a groupname is specified, this method
-blocks while resolving it to a numerical ID.
-
-    console.log('Current gid: ' + process.getgid());
-    try {
-      process.setgid(501);
-      console.log('New gid: ' + process.getgid());
-    }
-    catch (err) {
-      console.log('Failed to set gid: ' + err);
-    }
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.getgid.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
 
-## process.getuid()
-
-Gets the user identity of the process. (See getuid(2).)
-This is the numerical userid, not the username.
-
-    console.log('Current uid: ' + process.getuid());
 
 
-## process.setuid(id)
 
-Sets the user identity of the process. (See setuid(2).)  This accepts either
-a numerical ID or a username string.  If a username is specified, this method
-blocks while resolving it to a numerical ID.
-
-    console.log('Current uid: ' + process.getuid());
-    try {
-      process.setuid(501);
-      console.log('New uid: ' + process.getuid());
-    }
-    catch (err) {
-      console.log('Failed to set uid: ' + err);
-    }
+### process.getuid(), Number
 
 
-## process.version
+Gets the user identity of the process. Note that this is the numerical userid, not the username. For more information, see [getuid(2)](http://kernel.org/doc/man-pages/online/pages/man2/getuid.2.html).
 
-A compiled-in property that exposes `NODE_VERSION`.
+#### Example
 
-    console.log('Version: ' + process.version);
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.getuid.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## process.versions
-
-A property exposing version strings of node and its dependencies.
-
-    console.log(process.versions);
-
-Will output:
-
-    { node: '0.4.12',
-      v8: '3.1.8.26',
-      ares: '1.7.4',
-      ev: '4.4',
-      openssl: '1.0.0e-fips' }
-
-## process.config
-
-An Object containing the JavaScript representation of the configure options
-that were used to compile the current node executable. This is the same as
-the "config.gypi" file that was produced when running the `./configure` script.
-
-An example of the possible output looks like:
-
-    { target_defaults:
-       { cflags: [],
-         default_configuration: 'Release',
-         defines: [],
-         include_dirs: [],
-         libraries: [] },
-      variables:
-       { host_arch: 'x64',
-         node_install_npm: 'true',
-         node_install_waf: 'true',
-         node_prefix: '',
-         node_shared_v8: 'false',
-         node_shared_zlib: 'false',
-         node_use_dtrace: 'false',
-         node_use_openssl: 'true',
-         node_use_system_openssl: 'false',
-         strict_aliasing: 'true',
-         target_arch: 'x64',
-         v8_use_snapshot: 'true' } }
-
-## process.installPrefix
-
-A compiled-in property that exposes `NODE_PREFIX`.
-
-    console.log('Prefix: ' + process.installPrefix);
+ 
 
 
-## process.kill(pid, [signal])
+### process.kill(pid, signal='SIGTERM')
+- pid {Number}   The process id to kill
+- signal {String}  A string describing the signal to send; the default is `SIGTERM`.
 
-Send a signal to a process. `pid` is the process id and `signal` is the
-string describing the signal to send.  Signal names are strings like
-'SIGINT' or 'SIGUSR1'.  If omitted, the signal will be 'SIGTERM'.
-See kill(2) for more information.
+Send a signal to a process. The `signal` names are strings like 'SIGINT' or 'SIGUSR1'. For more information, see [kill(2)](http://www.kernel.org/doc/man-pages/online/pages/man2/kill.2.html).
 
-Note that just because the name of this function is `process.kill`, it is
-really just a signal sender, like the `kill` system call.  The signal sent
-may do something other than kill the target process.
+Note: Just because the name of this function is `process.kill`, it is really just a signal sender, like the `kill` system call.  The signal sent may do something other than kill the target process.
 
-Example of sending a signal to yourself:
+#### Example: Sending a signal to yourself
 
     process.on('SIGHUP', function () {
       console.log('Got SIGHUP signal.');
@@ -315,96 +132,241 @@ Example of sending a signal to yourself:
 
     process.kill(process.pid, 'SIGHUP');
 
-
-## process.pid
-
-The PID of the process.
-
-    console.log('This process is pid ' + process.pid);
-
-## process.title
-
-Getter/setter to set what is displayed in 'ps'.
+ 
 
 
-## process.arch
+### process.memoryUsage(), Object
 
-What processor architecture you're running on: `'arm'`, `'ia32'`, or `'x64'`.
+Returns an object describing the memory usage of the Node.js process measured in bytes.
 
-    console.log('This processor architecture is ' + process.arch);
+#### Example
 
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.memoryusage.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## process.platform
+This generates:
 
-What platform you're running on. `'linux2'`, `'darwin'`, etc.
+  { rss: 4935680,
+    heapTotal: 1826816,
+    heapUsed: 650472 }
 
-    console.log('This platform is ' + process.platform);
-
-
-## process.memoryUsage()
-
-Returns an object describing the memory usage of the Node process
-measured in bytes.
-
-    var util = require('util');
-
-    console.log(util.inspect(process.memoryUsage()));
-
-This will generate:
-
-    { rss: 4935680,
-      heapTotal: 1826816,
-      heapUsed: 650472 }
-
-`heapTotal` and `heapUsed` refer to V8's memory usage.
+In this object, `heapTotal` and `heapUsed` refer to V8's memory usage.
 
 
-## process.nextTick(callback)
-
-On the next loop around the event loop call this callback.
-This is *not* a simple alias to `setTimeout(fn, 0)`, it's much more
-efficient.
-
-    process.nextTick(function () {
-      console.log('nextTick callback');
-    });
 
 
-## process.umask([mask])
+### process.nextTick(callback())
+- callback {Function}   The callback function to execute on the next tick
 
-Sets or reads the process's file mode creation mask. Child processes inherit
-the mask from the parent process. Returns the old mask if `mask` argument is
-given, otherwise returns the current mask.
+On the next loop around the event loop call this callback. This is **not** a simple alias to `setTimeout(fn, 0)`; it's much more efficient.
 
-    var oldmask, newmask = 0644;
+#### Example
 
-    oldmask = process.umask(newmask);
-    console.log('Changed umask from: ' + oldmask.toString(8) +
-                ' to ' + newmask.toString(8));
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.nexttick.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-
-## process.uptime()
-
-Number of seconds Node has been running.
+ 
 
 
-## process.hrtime()
+### process.setgid(id)
+- id {Number}  The new identity for the group process
 
-Returns the current high-resolution real time in a `[seconds, nanoseconds]`
-tuple Array. It is relative to an arbitrary time in the past. It is not
-related to the time of day and therefore not subject to clock drift. The
-primary use is for measuring performance between intervals.
+Sets the group identity of the process. This accepts either a numerical ID or a groupname string. If a groupname is specified, this method blocks while resolving it to a numerical ID. For more information, see [setgid(2)](http://kernel.org/doc/man-pages/online/pages/man2/setgid.2.html).
 
-You may pass in the result of a previous call to `process.hrtime()` to get
-a diff reading, useful for benchmarks and measuring intervals:
+#### Example
 
-    var t = process.hrtime();
-    // [ 1800216, 927643717 ]
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.setgid.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
+ 
 
-    setTimeout(function () {
-      t = process.hrtime(t);
-      // [ 1, 6962306 ]
 
-      console.log('benchmark took %d seconds and %d nanoseconds', t[0], t[1]);
-      // benchmark took 1 seconds and 6962306 nanoseconds
-    }, 1000);
+### process.setuid(id)
+- id {Number}   The new identity for the user process
+
+Sets the user identity of the process. This accepts either a numerical ID or a username string.  If a username is specified, this method blocks while resolving it to a numerical ID. For more information, see [setuid(2)](http://kernel.org/doc/man-pages/online/pages/man2/setuid.2.html).
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.setuid.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+ 
+
+
+### process.umask([mask])
+- mask {Number}  The mode creation mask to get or set
+
+Sets or reads the process's file mode creation mask. Child processes inherit the mask from the parent process. Returns the old mask if `mask` argument is given, otherwise returns the current mask.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.umask.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+ 
+
+
+### process.uptime(), Number
+
+Returns the number of seconds Node.js has been running.
+
+
+
+
+### process.arch, String
+
+Identifies which processor architecture you're running on: `'arm'`, `'ia32'`, or `'x64'`.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.arch.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+ 
+
+
+### process.argv, Array
+
+An array containing the command line arguments.  The first element is 'node', and the second element is the name of the Javascript file.  The next elements will be any additional command line arguments.
+
+#### Example
+
+First, create a file called process.argv.js:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.argv.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+Then, using the Node.js REPL, type the following command:
+
+  $ node process-2.js one two=three four
+
+You should see the following results:
+
+  0: node
+  1: <directoryPath>/process.js
+  2: one
+  3: two=three
+  4: four
+
+
+
+ 
+### process.execPath, String
+
+This is the absolute pathname of the executable that started the process.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.execpath.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+    
+ 
+
+
+### process.pid, Number
+
+Returns the PID of the process.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.pid.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+    
+ 
+
+   
+### process.platform, String
+
+Identifies the platform you're running on, like `'linux2'`, `'darwin'`, etc.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.platform.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+ 
+
+
+### process.title, String
+
+A getter and setter to set what is displayed in `ps`.
+
+ 
+
+### process.version, String
+
+A compiled-in property that exposes the `NODE_VERSION`.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.version.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+ 
+
+
+### process.versions, Object
+
+A property exposing version strings of Node.js and its dependencies.
+
+#### Example
+
+The following code:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.versions.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+outputs something similar to:
+
+   { node: '0.4.12',
+    v8: '3.1.8.26',
+    ares: '1.7.4',
+    ev: '4.4',
+    openssl: '1.0.0e-fips' }
+ 
+
+
+### process.installPrefix, String
+
+A compiled-in property that exposes the `NODE_PREFIX`.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.installprefix.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+ 
+
+
+### process.stderr, fs.WriteStream
+
+A writable stream to stderr.
+
+`process.stderr` and `process.stdout` are unlike other streams in Node.js in that writes to them are usually blocking.  They are blocking in the case that they refer to regular files or TTY file descriptors. In the case they refer to pipes, they are non-blocking like other streams.
+
+
+
+
+### process.env, Object
+
+An object containing the user environment. For more information, see [environ(7)](http://kernel.org/doc/man-pages/online/pages/man7/environ.7.html).
+
+ 
+
+
+### process.stdin, fs.ReadStream
+
+A `Readable Stream` for stdin. The stdin stream is paused by default, so one must call `process.stdin.resume()` to read from it.
+
+#### Example
+
+Here's an example of opening standard input and listening for both events:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/process/process.stdin.js?linestart=3&lineend=0&showlines=true' defer='defer'></script>
+
+
+
+
+### process.stdout, fs.WriteStream
+
+
+A writable stream to `stdout`.
+
+`process.stderr` and `process.stdout` are unlike other streams in Node.js in that writes to them are usually blocking.  They are blocking in the case that they refer to regular files or TTY file descriptors. In the case they refer to pipes, they are non-blocking like other streams.
+
+As an aside, here's what the innards of `console.log()` look like:
+
+    console.log (d) {
+      process.stdout.write(d + '\n');
+    };
+
+ 
+

--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -1,49 +1,53 @@
-# Query String
+## querystring
 
     Stability: 3 - Stable
+    
+This module provides utilities for dealing with query strings in URLs. To include this module, add `require('querystring')` to your code.
 
-<!--name=querystring-->
+#### Example
 
-This module provides utilities for dealing with query strings.
-It provides the following methods:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/querystring/querystring.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## querystring.stringify(obj, [sep], [eq])
 
-Serialize an object to a query string.
-Optionally override the default separator (`'&'`) and assignment (`'='`)
-characters.
 
-Example:
+### querystring.escape(), String
 
-    querystring.stringify({ foo: 'bar', baz: ['qux', 'quux'], corge: '' })
-    // returns
-    'foo=bar&baz=qux&baz=quux&corge='
+The escape function used by `querystring.stringify()`, provided so that it can be overridden, if necessary.
 
-    querystring.stringify({foo: 'bar', baz: 'qux'}, ';', ':')
-    // returns
-    'foo:bar;baz:qux'
+ 
 
-## querystring.parse(str, [sep], [eq], [options])
 
-Deserialize a query string to an object.
-Optionally override the default separator (`'&'`) and assignment (`'='`)
-characters.
+### querystring.parse(str [, sep='&'] [, eq='=']), Object
+- str {String}  The query string to parse
+- sep {String}  The separator character
+- eq {String}  The equivalency character
 
-Options object may contain `maxKeys` property (equal to 1000 by default), it'll
-be used to limit processed keys. Set it to 0 to remove key count limitation.
+Deserialize a query string to an object and returns it. You can choose to override the default separator and assignment characters.
 
-Example:
+#### Example
 
-    querystring.parse('foo=bar&baz=qux&baz=quux&corge')
-    // returns
-    { foo: 'bar', baz: ['qux', 'quux'], corge: '' }
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/querystring/querystring.parse.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+  
+ 
 
-## querystring.escape
 
-The escape function used by `querystring.stringify`,
-provided so that it could be overridden if necessary.
+### querystring.stringify(obj [, sep='&'] [, eq='=']), String
+- obj {Object}   The JSON object to serialize
+- sep {String}  The separator character
+- eq {String}  The equivalency character
 
-## querystring.unescape
+Serialize an object to a query string and returns it. You can choose to override the default separator and assignment characters.
 
-The unescape function used by `querystring.parse`,
-provided so that it could be overridden if necessary.
+#### Examples
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/querystring/querystring.stringify.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
+
+
+### querystring.unescape() , String
+
+The `unescape()` function, used by `querystring.parse()`, is provided so that it can be overridden if necessary.
+
+
+
+

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -1,283 +1,129 @@
-# Readline
+## readline
 
-    Stability: 2 - Unstable
+    Stability: 3 - Stable
+    
+Readline allows you to read of a stream (such as STDIN) on a line-by-line basis. To use this module, add `require('readline')` to your code.
 
-To use this module, do `require('readline')`. Readline allows reading of a
-stream (such as `process.stdin`) on a line-by-line basis.
+Note: Once you've invoked this module, your Node.js program won't terminate until you've closed the interface, and the STDIN stream. Here's how to allow your program to gracefully terminate:
 
-Note that once you've invoked this module, your node program will not
-terminate until you've closed the interface. Here's how to allow your
-program to gracefully exit:
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/readline/readline.escaping.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-    var rl = require('readline');
 
-    var i = rl.createInterface({
-      input: process.stdin,
-      output: process.stdout
-    });
 
-    i.question("What do you think of node.js? ", function(answer) {
-      // TODO: Log the answer in a database
-      console.log("Thank you for your valuable feedback:", answer);
+#### Example: Crafting a tiny command line interface:
 
-      i.close();
-    });
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/readline/readline.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-## rl.createInterface(options)
+For more real-life use cases, take a look at this slightly more complicated [example](https://gist.github.com/901104), as well as the [http-console](https://github.com/cloudhead/http-console) module.
 
-Creates a readline `Interface` instance. Accepts an "options" Object that takes
-the following values:
 
- - `input` - the readable stream to listen to (Required).
+### readline.createInterface(input[, output], completer()), readline.interface
+- input {streams.ReadableStream}   The readable stream
+- output {streams.WritableStream}   The writeable stream
+- completer {Function}   A function to use for autocompletion
 
- - `output` - the writable stream to write readline data to (Required).
+Takes two streams and creates a readline interface. 
 
- - `completer` - an optional function that is used for Tab autocompletion. See
-   below for an example of using this.
+When passed a substring, `completer()` returns `[[substr1, substr2, ...], originalsubstring]`.
 
- - `terminal` - pass `true` if the `input` and `output` streams should be
-   treated like a TTY, and have ANSI/VT100 escape codes written to it.
-   Defaults to checking `isTTY` on the `output` stream upon instantiation.
-
-The `completer` function is given a the current line entered by the user, and
-is supposed to return an Array with 2 entries:
-
- 1. An Array with matching entries for the completion.
-
- 2. The substring that was used for the matching.
-
-Which ends up looking something like:
-`[[substr1, substr2, ...], originalsubstring]`.
-
-Example:
-
-    function completer(line) {
-      var completions = '.help .error .exit .quit .q'.split(' ')
-      var hits = completions.filter(function(c) { return c.indexOf(line) == 0 })
-      // show all completions if none found
-      return [hits.length ? hits : completions, line]
-    }
-
-Also `completer` can be run in async mode if it accepts two arguments:
+`completer()` runs in an asynchronous manner if it accepts just two arguments:
 
     function completer(linePartial, callback) {
-      callback(null, [['123'], linePartial]);
+        callback(null, [['123'], linePartial]);
     }
 
-`createInterface` is commonly used with `process.stdin` and
-`process.stdout` in order to accept user input:
+#### Example
+
+`createInterface()` is commonly used with `process.stdin` and `process.stdout` in order to accept user input:
 
     var readline = require('readline');
-    var rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout
-    });
 
-Once you have a readline instance, you most commonly listen for the
-`"line"` event.
+    var myTerminal = readline.createInterface(process.stdin, process.stdout);
+  
 
-If `terminal` is `true` for this instance then the `output` stream will get
-the best compatability if it defines an `output.columns` property, and fires
-a `"resize"` event on the `output` if/when the columns ever change
-(`process.stdout` does this automatically when it is a TTY).
+ 
+## readline.interface
 
-## Class: Interface
+The class that represents a readline interface with a stdin and stdout stream.
 
-The class that represents a readline interface with an input and output
-stream.
 
-### rl.setPrompt(prompt, length)
+### readline.interface.pause()
 
-Sets the prompt, for example when you run `node` on the command line, you see
-`> `, which is node's prompt.
+Pauses the `tty`.
 
-### rl.prompt([preserveCursor])
 
-Readies readline for input from the user, putting the current `setPrompt`
-options on a new line, giving the user a new spot to write. Set `preserveCursor`
-to `true` to prevent the cursor placement being reset to `0`.
 
-This will also resume the `input` stream used with `createInterface` if it has
-been paused.
+### readline.interface.close(line)
 
-### rl.question(query, callback)
+Closes the `tty`. Without this call, your program will run indefinitely.
 
-Prepends the prompt with `query` and invokes `callback` with the user's
-response. Displays the query to the user, and then invokes `callback`
-with the user's response after it has been typed.
 
-This will also resume the `input` stream used with `createInterface` if
-it has been paused.
+  
+### readline.interface.prompt()
 
-Example usage:
+Readies the readline for input from the user, putting the current `setPrompt` options on a new line, giving the user a new spot to write.
 
-    interface.question('What is your favorite food?', function(answer) {
+ 
+
+
+### readline.interface.question(query, callback())
+- query {String}  A string to display the user
+- callback {Function}  The function to execute once the method completes
+
+Prepends the prompt with `query` and invokes `callback` with the user's respons after it has been entered.
+
+#### Example
+
+    readline.interface.question('What is your favorite food?', function(answer) {
       console.log('Oh, so your favorite food is ' + answer);
     });
+  
 
-### rl.pause()
-
-Pauses the readline `input` stream, allowing it to be resumed later if needed.
-
-### rl.resume()
-
-Resumes the readline `input` stream.
-
-### rl.close()
-
-Closes the `Interface` instance, relinquishing control on the `input` and
-`output` streams. The "close" event will also be emitted.
-
-### rl.write(data, [key])
-
-Writes `data` to `output` stream. `key` is an object literal to represent a key
-sequence; available if the terminal is a TTY.
-
-This will also resume the `input` stream if it has been paused.
-
-Example:
-
-    rl.write('Delete me!');
-    // Simulate ctrl+u to delete the line written previously
-    rl.write(null, {ctrl: true, name: 'u'});
-
-## Events
-
-### Event: 'line'
-
-`function (line) {}`
-
-Emitted whenever the `input` stream receives a `\n`, usually received when the
-user hits enter, or return. This is a good hook to listen for user input.
-
-Example of listening for `line`:
-
-    rl.on('line', function (cmd) {
-      console.log('You just typed: '+cmd);
-    });
-
-### Event: 'pause'
-
-`function () {}`
-
-Emitted whenever the `input` stream is paused.
-
-Also emitted whenever the `input` stream is not paused and receives the
-`SIGCONT` event. (See events `SIGTSTP` and `SIGCONT`)
-
-Example of listening for `pause`:
-
-    rl.on('pause', function() {
-      console.log('Readline paused.');
-    });
-
-### Event: 'resume'
-
-`function () {}`
-
-Emitted whenever the `input` stream is resumed.
-
-Example of listening for `resume`:
-
-    rl.on('resume', function() {
-      console.log('Readline resumed.');
-    });
-
-### Event: 'close'
-
-`function () {}`
-
-Emitted when `close()` is called.
-
-Also emitted when the `input` stream receives its "end" event. The `Interface`
-instance should be considered "finished" once this is emitted. For example, when
-the `input` stream receives `^D`, respectively known as `EOT`.
-
-This event is also called if there is no `SIGINT` event listener present when
-the `input` stream receives a `^C`, respectively known as `SIGINT`.
-
-### Event: 'SIGINT'
-
-`function () {}`
-
-Emitted whenever the `input` stream receives a `^C`, respectively known as
-`SIGINT`. If there is no `SIGINT` event listener present when the `input`
-stream receives a `SIGINT`, `pause` will be triggered.
-
-Example of listening for `SIGINT`:
-
-    rl.on('SIGINT', function() {
-      rl.question('Are you sure you want to exit?', function(answer) {
-        if (answer.match(/^y(es)?$/i)) rl.pause();
-      });
-    });
-
-### Event: 'SIGTSTP'
-
-`function () {}`
-
-**This does not work on Windows.**
-
-Emitted whenever the `input` stream receives a `^Z`, respectively known as
-`SIGTSTP`. If there is no `SIGTSTP` event listener present when the `input`
-stream receives a `SIGTSTP`, the program will be sent to the background.
-
-When the program is resumed with `fg`, the `pause` and `SIGCONT` events will be
-emitted. You can use either to resume the stream.
-
-The `pause` and `SIGCONT` events will not be triggered if the stream was paused
-before the program was sent to the background.
-
-Example of listening for `SIGTSTP`:
-
-    rl.on('SIGTSTP', function() {
-      // This will override SIGTSTP and prevent the program from going to the
-      // background.
-      console.log('Caught SIGTSTP.');
-    });
-
-### Event: 'SIGCONT'
-
-`function () {}`
-
-**This does not work on Windows.**
-
-Emitted whenever the `input` stream is sent to the background with `^Z`,
-respectively known as `SIGTSTP`, and then continued with `fg(1)`. This event
-only emits if the stream was not paused before sending the program to the
-background.
-
-Example of listening for `SIGCONT`:
-
-    rl.on('SIGCONT', function() {
-      // `prompt` will automatically resume the stream
-      rl.prompt();
-    });
+ 
 
 
-## Example: Tiny CLI
+### readline.interface.resume()
 
-Here's an example of how to use all these together to craft a tiny command
-line interface:
+Resumes `tty`.
 
-    var readline = require('readline'),
-        rl = readline.createInterface(process.stdin, process.stdout);
 
-    rl.setPrompt('OHAI> ');
-    rl.prompt();
 
-    rl.on('line', function(line) {
-      switch(line.trim()) {
-        case 'hello':
-          console.log('world!');
-          break;
-        default:
-          console.log('Say what? I might have heard `' + line.trim() + '`');
-          break;
-      }
-      rl.prompt();
-    }).on('close', function() {
-      console.log('Have a great day!');
-      process.exit(0);
-    });
 
+### readline.interface.setPrompt(prompt, length)
+- prompt {String}   The prompting character; this can also be a phrase
+- length {String}   The length before line wrapping
+
+Sets the prompt character. For example, when you run `node` on the command line, you'll see `> `, which is Node's prompt.
+
+ 
+
+
+### readline.interface.write()
+
+Writes to the `tty`.
+
+
+
+### readline.interface@close()
+
+
+
+Emitted whenever the `in` stream receives a `^C` (`SIGINT`) or `^D` (`EOT`). This is a good way to know the user is finished using your program.
+
+#### Example
+
+Example of listening for `close`, and exiting the program afterward:
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/readline/readline.close.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+    
+ 
+
+### readline.interface@line(line)
+- line {String}  The line that prompted the event
+
+
+Emitted whenever the `in` stream receives a `\n`, usually received when the user hits Enter, or Return. This is a good hook to listen for user input.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/readline/readline.line.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -1,12 +1,8 @@
-# REPL
+## repl
 
-A Read-Eval-Print-Loop (REPL) is available both as a standalone program and
-easily includable in other programs. The REPL provides a way to interactively
-run JavaScript and see the results.  It can be used for debugging, testing, or
-just trying things out.
+A Read-Eval-Print-Loop (REPL) is available both as a standalone program and easily includable in other programs.  REPL provides a way to interactively run Javascript and see the results.  It can be used for debugging, testing, or just trying things out.
 
-By executing `node` without any arguments from the command-line you will be
-dropped into the REPL. It has simplistic emacs line-editing.
+By executing `node` without any arguments from the command line, you'll be dropped into the REPL. It has a simplistic emacs line-editing:
 
     mjr:~$ node
     Type '.help' for options.
@@ -19,130 +15,17 @@ dropped into the REPL. It has simplistic emacs line-editing.
     2
     3
 
-For advanced line-editors, start node with the environmental variable
-`NODE_NO_READLINE=1`. This will start the main and debugger REPL in canonical
-terminal settings which will allow you to use with `rlwrap`.
+For advanced line-editors, start `node` with the environmental variable `NODE_NO_READLINE=1`. This starts the REPL in canonical terminal settings which allow you to use with `rlwrap`.
 
-For example, you could add this to your bashrc file:
+For a quicker configuration, you could add this to your `.bashrc` file:
 
     alias node="env NODE_NO_READLINE=1 rlwrap node"
 
+#### REPL Features
 
-## repl.start(options)
+Inside the REPL, multi-line expressions can be input, and tab completion is supported for both global and local variables.
 
-Returns and starts a `REPLServer` instance. Accepts an "options" Object that
-takes the following values:
-
- - `prompt` - the prompt and `stream` for all I/O. Defaults to `> `.
-
- - `input` - the readable stream to listen to. Defaults to `process.stdin`.
-
- - `output` - the writable stream to write readline data to. Defaults to
-   `process.stdout`.
-
- - `terminal` - pass `true` if the `stream` should be treated like a TTY, and
-   have ANSI/VT100 escape codes written to it. Defaults to checking `isTTY`
-   on the `output` stream upon instantiation.
-
- - `eval` - function that will be used to eval each given line. Defaults to
-   an async wrapper for `eval()`. See below for an example of a custom `eval`.
-
- - `useColors` - a boolean which specifies whether or not the `writer` function
-   should output colors. If a different `writer` function is set then this does
-   nothing. Defaults to the repl's `terminal` value.
-
- - `useGlobal` - if set to `true`, then the repl will use the `global` object,
-   instead of running scripts in a separate context. Defaults to `false`.
-
- - `ignoreUndefined` - if set to `true`, then the repl will not output the
-   return value of command if it's `undefined`. Defaults to `false`.
-
- - `writer` - the function to invoke for each command that gets evaluated which
-   returns the formatting (including coloring) to display. Defaults to
-   `util.inspect`.
-
-You can use your own `eval` function if it has following signature:
-
-    function eval(cmd, context, filename, callback) {
-      callback(null, result);
-    }
-
-Multiple REPLs may be started against the same running instance of node.  Each
-will share the same global object but will have unique I/O.
-
-Here is an example that starts a REPL on stdin, a Unix socket, and a TCP socket:
-
-    var net = require("net"),
-        repl = require("repl");
-
-    connections = 0;
-
-    repl.start({
-      prompt: "node via stdin> ",
-      input: process.stdin,
-      output: process.stdout
-    });
-
-    net.createServer(function (socket) {
-      connections += 1;
-      repl.start({
-        prompt: "node via Unix socket> ",
-        input: socket,
-        output: socket
-      }).on('exit', function() {
-        socket.end();
-      })
-    }).listen("/tmp/node-repl-sock");
-
-    net.createServer(function (socket) {
-      connections += 1;
-      repl.start({
-        prompt: "node via TCP socket> ",
-        input: socket,
-        output: socket
-      }).on('exit', function() {
-        socket.end();
-      });
-    }).listen(5001);
-
-Running this program from the command line will start a REPL on stdin.  Other
-REPL clients may connect through the Unix socket or TCP socket. `telnet` is useful
-for connecting to TCP sockets, and `socat` can be used to connect to both Unix and
-TCP sockets.
-
-By starting a REPL from a Unix socket-based server instead of stdin, you can
-connect to a long-running node process without restarting it.
-
-For an example of running a "full-featured" (`terminal`) REPL over
-a `net.Server` and `net.Socket` instance, see: https://gist.github.com/2209310
-
-For an example of running a REPL instance over `curl(1)`,
-see: https://gist.github.com/2053342
-
-### Event: 'exit'
-
-`function () {}`
-
-Emitted when the user exits the REPL in any of the defined ways. Namely, typing
-`.exit` at the repl, pressing Ctrl+C twice to signal SIGINT, or pressing Ctrl+D
-to signal "end" on the `input` stream.
-
-Example of listening for `exit`:
-
-    r.on('exit', function () {
-      console.log('Got "exit" event from repl!');
-      process.exit();
-    });
-
-
-## REPL Features
-
-<!-- type=misc -->
-
-Inside the REPL, Control+D will exit.  Multi-line expressions can be input.
-Tab completion is supported for both global and local variables.
-
-The special variable `_` (underscore) contains the result of the last expression.
+The special variable `_` contains the result of the last expression, like so:
 
     > [ "a", "b", "c" ]
     [ 'a', 'b', 'c' ]
@@ -151,9 +34,7 @@ The special variable `_` (underscore) contains the result of the last expression
     > _ += 1
     4
 
-The REPL provides access to any variables in the global scope. You can expose
-a variable to the REPL explicitly by assigning it to the `context` object
-associated with each `REPLServer`.  For example:
+The REPL provides access to any variables in the global scope. You can expose a variable to the REPL explicitly by assigning it to the `context` object associated with each `REPLServer`.  For example:
 
     // repl_test.js
     var repl = require("repl"),
@@ -167,22 +48,60 @@ Things in the `context` object appear as local within the REPL:
     > m
     'message'
 
+#### Special Commands
+
 There are a few special REPL commands:
 
-  - `.break` - While inputting a multi-line expression, sometimes you get lost
-    or just don't care about completing it. `.break` will start over.
-  - `.clear` - Resets the `context` object to an empty object and clears any
-    multi-line expression.
-  - `.exit` - Close the I/O stream, which will cause the REPL to exit.
-  - `.help` - Show this list of special commands.
-  - `.save` - Save the current REPL session to a file
-    >.save ./file/to/save.js
-  - `.load` - Load a file into the current REPL session.
-    >.load ./file/to/load.js
+  - `.break`: while inputting a multi-line expression, sometimes you get lost or just don't care about completing it; this wipes it out so you can start over
+  - `.clear`: resets the `context` object to an empty object and clears any multi-line expression.
+  - `.exit`: closes the I/O stream, which causes the REPL to exit.
+  - `.help`: shows this list of special commands
+  - `.save`: save the current REPL session to a file, like so: `>.save ./file/to/save.js`
+  - `.load`: loads a file into the current REPL session, like so: `>.load ./file/to/load.js`
 
-The following key combinations in the REPL have these special effects:
+#### Key Combinations
 
-  - `<ctrl>C` - Similar to the `.break` keyword.  Terminates the current
-    command.  Press twice on a blank line to forcibly exit.
-  - `<ctrl>D` - Similar to the `.exit` keyword.
+The following key combinations in the REPL have special effects:
+
+  - `<ctrl>C` - Similar to the `.break` keyword, this terminates the current command.  Press twice on a blank line to forcibly exit the REPL.
+  - `<ctrl>D` - Similar to the `.exit` keyword, it closes to stream and exits the REPL
+        
+
+### repl.start([prompt='&gt; '] [, stream=process.stdin] [, eval=eval] [, useGlobal=false] [, ignoreUndefined=false])
+ - prompt {String}  The starting prompt
+ - stream {String}  The stream to read from
+ - eval {String}  An asynchronous wrapper function that executes after each line
+ - useGlobal {String}   If `true`, then the REPL uses the global objectm instead of scripts in a separate context
+ - ignoreUndefined {String}  If `true`, the REPL won't output return valyes of a command if it's `undefined`
+
+ Starts a REPL with `prompt` as the prompt and `stream` for all I/O. 
+ 
+ You can use your own `eval` function if it has the following signature:
+  
+     function eval(cmd, callback) {
+       callback(null, result);
+     }
+ 
+ Multiple REPLs can be started against the same running instance of node.  Each share the same global object but will have unique I/O.
+ 
+ #### Example
+ 
+ Here's an example that starts a REPL on stdin, a Unix socket, and a TCP socket:
+ 
+     var net = require("net"),
+         repl = require("repl");
+ 
+     connections = 0;
+ 
+     repl.start("node via stdin> ");
+ 
+     net.createServer(function (socket) {
+       connections += 1;
+       repl.start("node via Unix socket> ", socket);
+     }).listen("/tmp/node-repl-sock");
+ 
+    net.createServer(function (socket) {
+       connections += 1;
+       repl.start("node via TCP socket> ", socket);
+     }).listen(5001);
 

--- a/doc/api/stdio.markdown
+++ b/doc/api/stdio.markdown
@@ -1,60 +1,92 @@
-# console
+## console
 
-    Stability: 4 - API Frozen
+    Stability: 3 - Stable
+    
+These methods are useful for printing to stdout and stderr. They are similar to the `console` object functions provided by most web browsers. The `console` object is global, so you don't need to `require` anything.
 
-* {Object}
-
-<!--type=global-->
-
-For printing to stdout and stderr.  Similar to the console object functions
-provided by most web browsers, here the output is sent to stdout or stderr.
+It's important to note that printing to stdout and stderr is synchronous, and therefore, blocking.
 
 
-## console.log()
+console.assert()
+(alias of: assert.ok)
 
-Prints to stdout with newline. This function can take multiple arguments in a
-`printf()`-like way. Example:
-
-    console.log('count: %d', count);
-
-If formatting elements are not found in the first string then `util.inspect`
-is used on each argument.
-See [util.format()](util.html#util.format) for more information.
-
-## console.info()
-
-Same as `console.log`.
-
-## console.warn()
-## console.error()
-
-Same as `console.log` but prints to stderr.
-
-## console.dir(obj)
-
-Uses `util.inspect` on `obj` and prints resulting string to stdout.
-
-## console.time(label)
-
-Mark a time.
+An alias to `assert.ok()`.
 
 
-## console.timeEnd(label)
 
-Finish timer, record output. Example
+console.dir(obj)
+- obj {Object}  An object to inspect
+(alias of: util.inspect)
 
-    console.time('100-elements');
-    for (var i = 0; i < 100; i++) {
-      ;
-    }
-    console.timeEnd('100-elements');
+Uses [[util.inspect `util.inspect()`]] on `obj` and prints the resulting string to stderr.
 
 
-## console.trace()
+console.warn([arg...])
+- warn {String}  A message to send
+(related to: console.log)
 
-Print a stack trace to stderr of the current position.
+This performs the same role as `console.log()`, but prints to stderr instead.
 
-## console.assert()
 
-Same as `assert.ok()`.
+console.error([arg...])
+- obj {Object}  An object to inspect
+(related to: console.log)
+
+This performs the same role as `console.log()`, but prints to stderr instead.
+
+
+
+console.info()
+(alias of: console.log)
+
+This is just an alias to `console.log()`.
+
+
+console.log([arg...])
+- arg {String}   The string to print, and any additional formatting arguments
+(alias of: util.format)
+
+Prints to stdout with a newline. This function can take multiple arguments in [a `printf()`-like](http://en.wikipedia.org/wiki/Printf_format_string#Format_placeholders) way.
+     
+Each placeholder is replaced with the converted value from its corresponding argument. Supported placeholders are:
+
+* `%s` - String.
+* `%d` - Number (both integer and float).
+* `%j` - JSON.
+* `%%` - single percent sign (`'%'`). This does not consume an argument.
+
+If formatting elements are not found in the first string then [[util.inspect `util.inspect()`]] is used on each argument. 
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/console/console.log.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+console.time(label)
+- label {String}  An identifying string
+(related to: console.timeEnd)
+
+Marks a time by printing it out to the console. This is used in conjunction with `console.timeEnd()`.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/console/console.time.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+
+console.timeEnd(label)
+- label {String}  An identifying string
+(related to: console.time)
+
+Finish the previous timer and prints output.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/console/console.time.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+console.trace()
+
+Prints a stack trace to stderr of the current position.
+
 

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1,102 +1,95 @@
-# Stream
+## streams
 
     Stability: 2 - Unstable
 
-A stream is an abstract interface implemented by various objects in Node.
-For example a request to an HTTP server is a stream, as is stdout. Streams
-are readable, writable, or both. All streams are instances of `EventEmitter`.
+A stream is an abstract interface implemented by various objects in Node.js. For example, a request to an HTTP server is a stream, as is stdout. Streams can be readable, writable, or both. All streams are instances of [[eventemitter `EventEmitter`]].
 
-You can load up the Stream base class by doing `require('stream')`.
+For more information, see [this article on understanding streams](../nodejs_dev_guide/understanding_streams.html).
 
-## Readable Stream
+#### Example: Printing to the console
+	
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/streams/streams.1.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-<!--type=class-->
+#### Example: Reading from the console
 
-A `Readable Stream` has the following methods, members, and events.
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/streams/streams.2.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-### Event: 'data'
+## streams.ReadableStream
 
-`function (data) { }`
 
-The `'data'` event emits either a `Buffer` (by default) or a string if
-`setEncoding()` was used.
 
-Note that the __data will be lost__ if there is no listener when a
-`Readable Stream` emits a `'data'` event.
+### streams.ReadableStream@close()
 
-### Event: 'end'
+Emitted when the underlying file descriptor has been closed. Not all streams emit this.  For example, an incoming HTTP request don't emit `close`.
 
-`function () { }`
+ 
 
-Emitted when the stream has received an EOF (FIN in TCP terminology).
-Indicates that no more `'data'` events will happen. If the stream is also
-writable, it may be possible to continue writing.
 
-### Event: 'error'
+### streams.ReadableStream@data(data)
+- data {Buffer | String}   The data being emitted
 
-`function (exception) { }`
+The `data` event emits either a `Buffer` (by default) or a string if `setEncoding()` was previously used on the stream.
+
+ 
+
+
+### streams.ReadableStream@end()
+
+Emitted when the stream has received an EOF (FIN in TCP terminology). Indicates that no more `data` events will happen. If the stream is also writable, it may be possible to continue writing.
+
+ 
+
+
+### streams.ReadableStream@error()
 
 Emitted if there was an error receiving data.
-
-### Event: 'close'
-
-`function () { }`
-
-Emitted when the underlying file descriptor has been closed. Not all streams
-will emit this.  (For example, an incoming HTTP request will not emit
-`'close'`.)
-
-### stream.readable
-
-A boolean that is `true` by default, but turns `false` after an `'error'`
-occurred, the stream came to an `'end'`, or `destroy()` was called.
-
-### stream.setEncoding(encoding)
-Makes the data event emit a string instead of a `Buffer`. `encoding` can be
-`'utf8'`, `'ascii'`, or `'base64'`.
-
-### stream.pause()
-
-Issues an advisory signal to the underlying communication layer, requesting
-that no further data be sent until `resume()` is called.
-
-Note that, due to the advisory nature, certain streams will not be paused
-immediately, and so `'data'` events may be emitted for some indeterminate
-period of time even after `pause()` is called. You may wish to buffer such
-`'data'` events.
-
-### stream.resume()
-
-Resumes the incoming `'data'` events after a `pause()`.
-
-### stream.destroy()
-
-Closes the underlying file descriptor. Stream will not emit any more events.
+ 
 
 
-### stream.destroySoon()
+### streams.ReadableStream@pipe(src)
+- src {streams.ReadableStream}  The readable stream
+
+Emitted when the stream is passed to a readable stream's pipe method.
+
+ 
+
+
+### streams.ReadableStream.destroy()
+
+Closes the underlying file descriptor. The stream will not emit any more events.
+ 
+
+
+### streams.ReadableStream.destroySoon()
 
 After the write queue is drained, close the file descriptor.
 
-### stream.pipe(destination, [options])
+ 
 
-This is a `Stream.prototype` method available on all `Stream`s.
 
-Connects this read stream to `destination` WriteStream. Incoming
-data on this stream gets written to `destination`. The destination and source
-streams are kept in sync by pausing and resuming as necessary.
+### streams.ReadableStream.pause()
+
+Pause any incoming `'data'` events.
+
+
+
+
+### streams.ReadableStream.pipe(destination [, options]), streams
+- destination {streams.WritableStream}   The WriteStream to connect to
+- options {Object}   Any optional commands to send
+
+This is the `Stream.prototype()` method available on all `Stream` objects. It connects this read stream to a `destination`. Incoming data on this stream is then written to `destination`. The destination and source streams are kept in sync by Node.js pausing and resuming as necessary.
 
 This function returns the `destination` stream.
 
+By default, `end()` is called on the destination when the source stream emits `end`, so that `destination` is no longer writable. Pass `{ end: false }` into `options` to keep the destination stream open.
+
+#### Example 
+
 Emulating the Unix `cat` command:
 
-    process.stdin.resume();
-    process.stdin.pipe(process.stdout);
-
-
-By default `end()` is called on the destination when the source stream emits
-`end`, so that `destination` is no longer writable. Pass `{ end: false }` as
-`options` to keep the destination stream open.
+    process.stdin.resume(); // process.stdin is paused by default, so we need to start it up
+    process.stdin.pipe(process.stdout); // type something into the console & watch it repeat
 
 This keeps `process.stdout` open so that "Goodbye" can be written at the end.
 
@@ -108,82 +101,99 @@ This keeps `process.stdout` open so that "Goodbye" can be written at the end.
       process.stdout.write("Goodbye\n");
     });
 
+ 
+ 
 
-## Writable Stream
+/** related to: streams.ReadableStream.data
+streams.ReadableStream.setEncoding(encoding)
+- encoding {String}  The encoding to use; this can be `'utf8'`, `'ascii'`, or `'base64'`.
 
-<!--type=class-->
+Makes the `data` event emit a string instead of a `Buffer`.
 
-A `Writable Stream` has the following methods, members, and events.
+ 
 
-### Event: 'drain'
 
-`function () { }`
+### streams.ReadableStream.resume()
 
-After a `write()` method returned `false`, this event is emitted to
-indicate that it is safe to write again.
+Resumes the incoming `'data'` events after a `pause()`. 
 
-### Event: 'error'
+ 
 
-`function (exception) { }`
+## streams.WritableStream
 
-Emitted on error with the exception `exception`.
+ 
 
-### Event: 'close'
+### streams.WritableStream.writable, Boolean
 
-`function () { }`
+A boolean that is `true` by default, but turns `false` after an `error` event occurs, the stream comes to an `'end'`, or if `destroy()` was called.
+
+
+
+### streams.WritableStream@close()
+
 
 Emitted when the underlying file descriptor has been closed.
 
-### Event: 'pipe'
+ 
 
-`function (src) { }`
 
-Emitted when the stream is passed to a readable stream's pipe method.
 
-### stream.writable
+### streams.WritableStream@drain()
 
-A boolean that is `true` by default, but turns `false` after an `'error'`
-occurred or `end()` / `destroy()` was called.
+After a `write()` method returns `false`, this event is emitted to indicate that it is safe to write again.
 
-### stream.write(string, [encoding], [fd])
+ 
 
-Writes `string` with the given `encoding` to the stream.  Returns `true` if
-the string has been flushed to the kernel buffer.  Returns `false` to
-indicate that the kernel buffer is full, and the data will be sent out in
-the future. The `'drain'` event will indicate when the kernel buffer is
-empty again. The `encoding` defaults to `'utf8'`.
 
-If the optional `fd` parameter is specified, it is interpreted as an integral
-file descriptor to be sent over the stream. This is only supported for UNIX
-streams, and is silently ignored otherwise. When writing a file descriptor in
-this manner, closing the descriptor before the stream drains risks sending an
-invalid (closed) FD.
+### streams.WritableStream@error(exception)
+- exception {Error}  The exception that was received
 
-### stream.write(buffer)
+Emitted when there's an error with the exception `exception`.
 
-Same as the above except with a raw buffer.
+ 
 
-### stream.end()
 
-Terminates the stream with EOF or FIN.
-This call will allow queued write data to be sent before closing the stream.
+### streams.WritableStream.destroy()
 
-### stream.end(string, encoding)
+Closes the underlying file descriptor. The stream doesn't emit any more events. Any queued write data is not sent.
 
-Sends `string` with the given `encoding` and terminates the stream with EOF
-or FIN. This is useful to reduce the number of packets sent.
 
-### stream.end(buffer)
 
-Same as above but with a `buffer`.
 
-### stream.destroy()
+### streams.WritableStream.destroySoon()
 
-Closes the underlying file descriptor. Stream will not emit any more events.
-Any queued write data will not be sent.
+After the write queue is drained, this closes the file descriptor. `destroySoon()` can still destroy straight away, as long as there is no data left in the queue for writes.
 
-### stream.destroySoon()
 
-After the write queue is drained, close the file descriptor. `destroySoon()`
-can still destroy straight away, as long as there is no data left in the queue
-for writes.
+ 
+
+### streams.WritableStream.end()
+### streams.WritableStream.end(string, encoding)
+### streams.WritableStream.end(Buffer)
+- string {String}  The message to send
+- encoding {String}  The encoding to use
+- buffer {Buffer}   The buffer to send
+
+Terminates the stream with EOF or FIN. This call send queued write data before closing the stream.
+
+For `streams.WritableStream.end(string, encoding)`, a `string` with the given `encoding` is sent. This is useful to reduce the number of packets sent.
+
+For `streams.WritableStream.end(Buffer)`, a `buffer` is sent.
+
+
+
+
+### streams.WritableStream.write(string, encoding='utf8' [, fd])
+### streams.WritableStream.write(Buffer)
+- string {String}   The string to write
+- encoding {String}   The encoding to use; defaults to `utf8`
+- fd {Number}   An optional file descriptor to pass
+- buffer {Buffer}  The buffer to write to
+
+Writes `string` with the given `encoding` to the stream, or write `buffer`.  Returns `true` if the string has been flushed to the kernel buffer.  Returns `false` to indicate that the kernel buffer is full, and the data will be sent out in the future. The `drain` event indicates when the kernel buffer is empty again.
+
+If `fd` is specified, it's interpreted as an integral file descriptor to be sent over the stream. This is only supported for UNIX streams, and is ignored otherwise. When writing a file descriptor in this manner, closing the descripton before the stream drains risks sending an invalid (closed) FD.
+
+ 
+
+

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -1,31 +1,88 @@
-# Timers
+## timer
 
     Stability: 5 - Locked
 
-All of the timer functions are globals.  You do not need to `require()`
-this module in order to use them.
+The timer functions are useful for scheduling functions to run after a defined amount of time. All of the objects in this class are global; the method calls don't need to be prepended with an object name.
 
-## setTimeout(callback, delay, [arg], [...])
+It's important to note that your callback probably *won't* be called in exactly `delay` milliseconds. Node.js makes no guarantees about the exact timing of when the callback is fired, nor of the ordering things will fire in. The callback is called as close as possible to the time specified.
 
-To schedule execution of a one-time `callback` after `delay` milliseconds. Returns a
-`timeoutId` for possible use with `clearTimeout()`. Optionally you can
-also pass arguments to the callback.
+The difference between ``setInterval()` and `setTimeout()` is simple: `setTimeout()` executes a function after a certain period of time, while `setInterval()` executes a function, then after a set period of time, executes the function again, then waits again, and executes again. This continues until `clearInterval()` is called.
 
-It is important to note that your callback will probably not be called in exactly
-`delay` milliseconds - Node.js makes no guarantees about the exact timing of when
-the callback will fire, nor of the ordering things will fire in. The callback will
-be called as close as possible to the time specified.
 
-## clearTimeout(timeoutId)
+#### Example: The Wrong Way to use Timers
+
+		for (var i = 0; i < 5; i++) {
+		   setTimeout(function () {
+		     console.log(i);
+		   }, i);
+		 }
+
+The code above prints the number `5` five times. This happens because the loop fills up before the first `setTimeout()` is called.
+
+#### Example: The Right Way to use Timers
+
+The solution to the above problem is to create a [closure](http://stackoverflow.com/questions/1801957/what-exactly-does-closure-refer-to-in-javascript) so that the current value of `i` is stored:
+
+     for (var i = 0; i < 5; i++) {
+       (
+           function(i) {
+               setTimeout(function () {
+                   console.log(i);
+                }, i);
+            }
+        )(i)};
+
+
+
+
+
+### timer.clearInterval(intervalId)
+- intervalId {Number}   The id of the interval
+
+Stops a interval from triggering. 
+
+
+ 
+
+
+### timer.clearTimeout(timeoutId)
+- timeoutId {Number}   The id of the timeout
 
 Prevents a timeout from triggering.
 
-## setInterval(callback, delay, [arg], [...])
+ 
 
-To schedule the repeated execution of `callback` every `delay` milliseconds.
-Returns a `intervalId` for possible use with `clearInterval()`. Optionally
-you can also pass arguments to the callback.
 
-## clearInterval(intervalId)
+### timer.setInterval(callback(), delay [, arg...])
+- callback {Function}   The callback function to execute
+- delay {Number}   The delay (in milliseconds) before executing the callback
+- arg {Object}  Any optional arguments to pass the to callback
 
-Stops a interval from triggering.
+This schedules the repeated execution of a callback function after a defined delay. It returns an `intervalId` for possible use with `clearInterval()`. Optionally, you can also pass arguments to the callback.
+
+
+#### Example
+		var interval_count = 0;
+
+		// Set an interval for one second, twice;
+		// on the third second, break out
+		setInterval(function(param) {
+		  ++interval_count;
+
+		  if (interval_count == 3)
+		    clearInterval(this);
+		}, 1000, 'test param');
+
+ 
+
+
+/**
+ timer.setTimeout(callback(), delay [, arg...])
+- callback {Function}   The callback function to execute
+- delay {Number}   The delay (in milliseconds) before executing the callback
+- arg {Object}  Any optional arguments to pass the to callback
+
+This function schedules the execution of a one-time callback function after a defined delay, It returns a `timeoutId`, which can be used later with `clearTimeout()`. Optionally, you can also pass arguments to the callback. 
+
+
+ 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -1,211 +1,75 @@
-# TLS (SSL)
+## tls
 
     Stability: 3 - Stable
+    
+The `tls` module uses OpenSSL to provide both the Transport Layer Security and the Secure Socket Layer; in other words, it provides encrypted stream communications. To access this module, add `require('tls')` in your code. 
 
-Use `require('tls')` to access this module.
-
-The `tls` module uses OpenSSL to provide Transport Layer Security and/or
-Secure Socket Layer: encrypted stream communication.
-
-TLS/SSL is a public/private key infrastructure. Each client and each
-server must have a private key. A private key is created like this
+TLS/SSL is a public/private key infrastructure. Each client and each server must have a private key. A private key is created in your terminal like this:
 
     openssl genrsa -out ryans-key.pem 1024
 
-All severs and some clients need to have a certificate. Certificates are public
-keys signed by a Certificate Authority or self-signed. The first step to
-getting a certificate is to create a "Certificate Signing Request" (CSR)
-file. This is done with:
+where `ryans-key.pm` is the name of your file. All servers (and some clients) need to have a certificate. Certificates are public keys signed by a Certificate Authority— or, they are self-signed. The first step to getting a certificate is to create a "Certificate Signing Request" (CSR) file. This is done using:
 
     openssl req -new -key ryans-key.pem -out ryans-csr.pem
 
-To create a self-signed certificate with the CSR, do this:
+To create a self-signed certificate with the CSR, enter this:
 
     openssl x509 -req -in ryans-csr.pem -signkey ryans-key.pem -out ryans-cert.pem
 
-Alternatively you can send the CSR to a Certificate Authority for signing.
+Alternatively, you can send the CSR to a Certificate Authority for signing.
 
-(TODO: docs on creating a CA, for now interested users should just look at
-`test/fixtures/keys/Makefile` in the Node source code)
-
-## Client-initiated renegotiation attack mitigation
-
-<!-- type=misc -->
-
-The TLS protocol lets the client renegotiate certain aspects of the TLS session.
-Unfortunately, session renegotiation requires a disproportional amount of
-server-side resources, which makes it a potential vector for denial-of-service
-attacks.
-
-To mitigate this, renegotiations are limited to three times every 10 minutes. An
-error is emitted on the [CleartextStream](#tls.CleartextStream) instance when
-the threshold is exceeded. The limits are configurable:
-
-  - `tls.CLIENT_RENEG_LIMIT`: renegotiation limit, default is 3.
-
-  - `tls.CLIENT_RENEG_WINDOW`: renegotiation window in seconds, default is
-                               10 minutes.
-
-Don't change the defaults unless you know what you are doing.
-
-To test your server, connect to it with `openssl s_client -connect address:port`
-and tap `R<CR>` (that's the letter `R` followed by a carriage return) a few
-times.
+(Documentation on creating a CA are pending; for now, interested users should just look at [`test/fixtures/keys/Makefile`](https://github.com/joyent/node/blob/master/test/fixtures/keys/Makefile) in the Node.js source code.)
 
 
-## NPN and SNI
+#### Using NPN and SNI
 
-<!-- type=misc -->
+NPN (Next Protocol Negotiation) and SNI (Server Name Indication) are TLS handshake extensions provided with this module.
 
-NPN (Next Protocol Negotiation) and SNI (Server Name Indication) are TLS
-handshake extensions allowing you:
-
-  * NPN - to use one TLS server for multiple protocols (HTTP, SPDY)
-  * SNI - to use one TLS server for multiple hostnames with different SSL
-    certificates.
+NPN is to use one TLS server for multiple protocols (HTTP, SPDY).
+SNI is to use one TLS server for multiple hostnames with different SSL certificates.
 
 
-## tls.createServer(options, [secureConnectionListener])
 
-Creates a new [tls.Server](#tls.Server).
-The `connectionListener` argument is automatically set as a listener for the
-[secureConnection](#event_secureConnection_) event.
-The `options` object has these possibilities:
+### tls@secureConnection(cleartextStream)
+- cleartextStream {tls.CleartextStream}  A object containing the NPN and SNI string protocols
 
-  - `key`: A string or `Buffer` containing the private key of the server in
-    PEM format. (Required)
+This event is emitted after a new connection has been successfully handshaked. The argument is a instance of [[tls.CleartextStream CleartextStream]]. It has all the common stream methods and events.
 
-  - `passphrase`: A string of passphrase for the private key.
+If [[tls.CleartextStream.authorized `tls.CleartextStream.authorized`]] is `false`, then [[tls.CleartextStream.authorizationError `tls.Cleartext.authorizationError`]] is set to describe how the authorization failed. Depending on the settings of the TLS server, your unauthorized connections may still be accepted.
 
-  - `cert`: A string or `Buffer` containing the certificate key of the server in
-    PEM format. (Required)
+`cleartextStream.npnProtocol` is a string containing the selected NPN protocol. `cleartextStream.servername` is a string containing the servername requested with SNI.
 
-  - `ca`: An array of strings or `Buffer`s of trusted certificates. If this is
-    omitted several well known "root" CAs will be used, like VeriSign.
-    These are used to authorize connections.
-
-  - `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate
-    Revocation List)
-
-  - `ciphers`: A string describing the ciphers to use or exclude. Consult
-    <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for
-    details on the format.
-    To mitigate [BEAST attacks]
-    (http://blog.ivanristic.com/2011/10/mitigating-the-beast-attack-on-tls.html),
-    it is recommended that you use this option in conjunction with the
-    `honorCipherOrder` option described below to prioritize the RC4 algorithm,
-    since it is a non-CBC cipher. A recommended cipher list follows:
-    `ECDHE-RSA-AES256-SHA:AES256-SHA:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM`
-
-  - `honorCipherOrder` :
-	When choosing a cipher, use the server's preferences instead of the client
-	preferences.
-	Note that if SSLv2 is used, the server will send its list of preferences
-	to the client, and the client chooses the cipher.
-	Although, this option is disabled by default, it is *recommended* that you
-	use this option in conjunction with the `ciphers` option to mitigate
-	BEAST attacks.
-
-  - `requestCert`: If `true` the server will request a certificate from
-    clients that connect and attempt to verify that certificate. Default:
-    `false`.
-
-  - `rejectUnauthorized`: If `true` the server will reject any connection
-    which is not authorized with the list of supplied CAs. This option only
-    has an effect if `requestCert` is `true`. Default: `false`.
-
-  - `NPNProtocols`: An array or `Buffer` of possible NPN protocols. (Protocols
-    should be ordered by their priority).
-
-  - `SNICallback`: A function that will be called if client supports SNI TLS
-    extension. Only one argument will be passed to it: `servername`. And
-    `SNICallback` should return SecureContext instance.
-    (You can use `crypto.createCredentials(...).context` to get proper
-    SecureContext). If `SNICallback` wasn't provided - default callback with
-    high-level API will be used (see below).
-
-  - `sessionIdContext`: A string containing a opaque identifier for session
-    resumption. If `requestCert` is `true`, the default is MD5 hash value
-    generated from command-line. Otherwise, the default is not provided.
-
-Here is a simple example echo server:
-
-    var tls = require('tls');
-    var fs = require('fs');
-
-    var options = {
-      key: fs.readFileSync('server-key.pem'),
-      cert: fs.readFileSync('server-cert.pem'),
-
-      // This is necessary only if using the client certificate authentication.
-      requestCert: true,
-
-      // This is necessary only if the client uses the self-signed certificate.
-      ca: [ fs.readFileSync('client-cert.pem') ]
-    };
-
-    var server = tls.createServer(options, function(cleartextStream) {
-      console.log('server connected',
-                  cleartextStream.authorized ? 'authorized' : 'unauthorized');
-      cleartextStream.write("welcome!\n");
-      cleartextStream.setEncoding('utf8');
-      cleartextStream.pipe(cleartextStream);
-    });
-    server.listen(8000, function() {
-      console.log('server bound');
-    });
+ 
 
 
-You can test this server by connecting to it with `openssl s_client`:
+### tls.connect(port [, host=localhost] [, options] [, secureConnectListener]), tls.CleartextStream
+- port {Number}   The port to connect to
+- host {String}   An optional hostname to connect to`
+- options {Object}   Any options you want to pass to the server
+- secureConnectionListener {Function}   An optional listener
+
+Creates a new client connection to the given `port` and `host`. This function returns a [[tls.CleartextStream `tls.CleartextStream`]] object.
+
+`options` should be an object that specifies the following values:
+
+  - `key`: A string or `Buffer` containing the private key of the client in aPEM format. The default is `null`.
+
+  - `passphrase`: A string of a passphrase for the private key. The default is `null`.
+
+  - `cert`: A string or `Buffer` containing the certificate key of the client in a PEM format; in other words, the public x509 certificate to use. The default is `null`.
+
+  - `ca`: An array of strings or `Buffer`s of trusted certificates. These are used to authorize connections. If this is omitted, several "well-known root" CAs will be used, like VeriSign. 
+
+  - `NPNProtocols`: An array of strings or a  `Buffer` containing supported NPN protocols. 
+        `Buffer` should have the following format: `0x05hello0x05world`, where the preceding byte indicates the following protocol name's length. Passing an array is usually much simpler: `['hello', 'world']`. 
+        Protocols should be ordered by their priority.
+
+  - `servername`: The server name for the SNI (Server Name Indication) TLS extension.
+
+`secureConnectionListener` automatically sets a listener for the [`secureConnection`](#tls.event.secureConnection) event.
 
 
-    openssl s_client -connect 127.0.0.1:8000
-
-
-## tls.connect(options, [secureConnectListener])
-## tls.connect(port, [host], [options], [secureConnectListener])
-
-Creates a new client connection to the given `port` and `host` (old API) or
-`options.port` and `options.host`. (If `host` is omitted, it defaults to
-`localhost`.) `options` should be an object which specifies:
-
-  - `host`: Host the client should connect to
-
-  - `port`: Port the client should connect to
-
-  - `socket`: Establish secure connection on a given socket rather than
-    creating a new socket. If this option is specified, `host` and `port`
-    are ignored.
-
-  - `key`: A string or `Buffer` containing the private key of the client in
-    PEM format.
-
-  - `passphrase`: A string of passphrase for the private key.
-
-  - `cert`: A string or `Buffer` containing the certificate key of the client in
-    PEM format.
-
-  - `ca`: An array of strings or `Buffer`s of trusted certificates. If this is
-    omitted several well known "root" CAs will be used, like VeriSign.
-    These are used to authorize connections.
-
-  - `rejectUnauthorized`: If `true`, the server certificate is verified against
-    the list of supplied CAs. An `'error'` event is emitted if verification
-    fails. Default: `false`.
-
-  - `NPNProtocols`: An array of string or `Buffer` containing supported NPN
-    protocols. `Buffer` should have following format: `0x05hello0x05world`,
-    where first byte is next protocol name's length. (Passing array should
-    usually be much simpler: `['hello', 'world']`.)
-
-  - `servername`: Servername for SNI (Server Name Indication) TLS extension.
-
-The `secureConnectListener` parameter will be added as a listener for the
-['secureConnect'](#event_secureConnect_) event.
-
-`tls.connect()` returns a [CleartextStream](#tls.CleartextStream) object.
-
-Here is an example of a client of echo server as described previously:
+#### Example: Connecting to an echo server on port 8000:
 
     var tls = require('tls');
     var fs = require('fs');
@@ -232,153 +96,193 @@ Here is an example of a client of echo server as described previously:
     cleartextStream.on('end', function() {
       server.close();
     });
+    
+ 
 
 
-## tls.createSecurePair([credentials], [isServer], [requestCert], [rejectUnauthorized])
+### tls.createSecurePair([credentials] [, isServer] [, requestCert] [, rejectUnauthorized]), tls.SecurePair
+- credentials {Object}   An optional credentials object from [[crypto.createCredentials `crypto.createCredentials()`]]
+- isServer {Boolean}   An optional boolean indicating whether this TLS connection should be opened as a server (`true`) or a client (`false`)
+- requestCert {Boolean}  A boolean indicating whether a server should request a certificate from a connecting client; only applies to server connections
+- rejectUnauthorized {Boolean}   A boolean indicating whether a server should automatically reject clients with invalid certificates; only applies to servers with `requestCert` enabled
 
-Creates a new secure pair object with two streams, one of which reads/writes
-encrypted data, and one reads/writes cleartext data.
-Generally the encrypted one is piped to/from an incoming encrypted data stream,
-and the cleartext one is used as a replacement for the initial encrypted stream.
+Creates a new secure `pair` object with two streams, one of which reads/writes encrypted data, and one reads/writes cleartext data. This function returns a SecurePair object with [[tls.CleartextStream `tls.CleartextStream`]] and `encrypted` stream properties.
 
- - `credentials`: A credentials object from crypto.createCredentials( ... )
+Generally, the encrypted strean is piped to/from an incoming encrypted data stream, and the cleartext one is used as a replacement for the initial encrypted stream.
 
- - `isServer`: A boolean indicating whether this tls connection should be
-   opened as a server or a client.
-
- - `requestCert`: A boolean indicating whether a server should request a
-   certificate from a connecting client. Only applies to server connections.
-
- - `rejectUnauthorized`: A boolean indicating whether a server should
-   automatically reject clients with invalid certificates. Only applies to
-   servers with `requestCert` enabled.
-
-`tls.createSecurePair()` returns a SecurePair object with
-[cleartext](#tls.CleartextStream) and `encrypted` stream properties.
-
-## Class: SecurePair
-
-Returned by tls.createSecurePair.
-
-### Event: 'secure'
-
-The event is emitted from the SecurePair once the pair has successfully
-established a secure connection.
-
-Similarly to the checking for the server 'secureConnection' event,
-pair.cleartext.authorized should be checked to confirm whether the certificate
-used properly authorized.
-
-## Class: tls.Server
-
-This class is a subclass of `net.Server` and has the same methods on it.
-Instead of accepting just raw TCP connections, this accepts encrypted
-connections using TLS or SSL.
-
-### Event: 'secureConnection'
-
-`function (cleartextStream) {}`
-
-This event is emitted after a new connection has been successfully
-handshaked. The argument is a instance of
-[CleartextStream](#tls.CleartextStream). It has all the common stream methods
-and events.
-
-`cleartextStream.authorized` is a boolean value which indicates if the
-client has verified by one of the supplied certificate authorities for the
-server. If `cleartextStream.authorized` is false, then
-`cleartextStream.authorizationError` is set to describe how authorization
-failed. Implied but worth mentioning: depending on the settings of the TLS
-server, you unauthorized connections may be accepted.
-`cleartextStream.npnProtocol` is a string containing selected NPN protocol.
-`cleartextStream.servername` is a string containing servername requested with
-SNI.
+ 
 
 
-### Event: 'clientError'
+### tls.createServer(options [, secureConnectionListener])
+- options {Object}   Any options you want to pass to the server
+- secureConnectionListener {Function}  An optional listener
 
-`function (exception) { }`
+Creates a new [[tls.Server `tls.Server`]].
 
-When a client connection emits an 'error' event before secure connection is
-established - it will be forwarded here.
+The `options` object has the following mix of required values:
+
+  - `key`: A string or `Buffer` containing the private key of the server in a PEM format. (Required)
+  - `cert`: A string or `Buffer` containing the certificate key of the server in a PEM format. (Required)
+
+`options` also has the following option values:
+
+  - `ca`: An array of strings or `Buffer`s of trusted certificates. These are used to authorize connections. If this is omitted, several "well-known root" CAs will be used, like VeriSign. 
+
+  - `NPNProtocols`: An array of strings or a  `Buffer` containing supported NPN protocols. 
+        `Buffer` should have the following format: `0x05hello0x05world`, where the preceding byte indicates the following protocol name's length. Passing an array is usually much simplier: `['hello', 'world']`. 
+        Protocols should be ordered by their priority.
+
+  - `passphrase`: A string of a passphrase for the private key.
+
+  - `rejectUnauthorized`: If `true` the server rejects any connection that is not authorized with the list of supplied CAs. This option only has an effect if `requestCert` is `true`. This defaults to `false`.
+
+  - `requestCert`: If `true` the server requests a certificate from clients that connect and attempt to verify that certificate. This defaults to `false`.
+
+  - `sessionIdContext`: A string containing an opaque identifier for session resumption. If `requestCert` is `true`, the default is an MD5 hash value generated from the command line. Otherwise, the default is not provided.
+
+  - `SNICallback`: A function that is called if the client supports the SNI TLS extension. Only one argument will be passed to it: `servername`. `SNICallback` should return a SecureContext instance. You can use `crypto.createCredentials(...).context` to get a proper SecureContext. If `SNICallback` wasn't provided, a default callback within the high-level API is used (for more information, see below).
+
+`secureConnectionListener` automatically sets a listener for the [`secureConnection`](#tls.event.secureConnection) event.
+
+#### Example
+
+Here's a simple "echo" server:
+
+    var tls = require('tls');
+    var fs = require('fs');
+
+    var options = {
+      key: fs.readFileSync('server-key.pem'),
+      cert: fs.readFileSync('server-cert.pem'),
+
+      // This is necessary only if using the client certificate authentication.
+      requestCert: true,
+
+      // This is necessary only if the client uses the self-signed certificate.
+      ca: [ fs.readFileSync('client-cert.pem') ]
+    };
+
+    var server = tls.createServer(options, function(cleartextStream) {
+      console.log('server connected',
+                  cleartextStream.authorized ? 'authorized' : 'unauthorized');
+      cleartextStream.write("welcome!\n");
+      cleartextStream.setEncoding('utf8');
+      cleartextStream.pipe(cleartextStream);
+    });
+    server.listen(8000, function() {
+      console.log('server bound');
+    });
+
+You can test this server by connecting to it with `openssl s_client`:
+
+    openssl s_client -connect 127.0.0.1:8000
+
+## tls.Server
+
+This class is a subclass of [[net.Server `net.Server`]] and has the same methods as it. However, instead of accepting just raw TCP connections, it also accepts encrypted connections using TLS or SSL.
+
+### tls.Server.addContext(hostname, credentials)
+- hostname {String}   The hostname to match
+- credentials {Object}   The credentials to use
+
+Add secure context that will be used if client request's SNI hostname is matching passed `hostname` (wildcards can be used). `credentials` can contain `key`, `cert`, and `ca`.
+
+#### Example
+    var serverResults = [];
+
+    var server = tls.createServer(serverOptions, function(c) {
+      serverResults.push(c.servername);
+    });
+
+    server.addContext('a.example.com', SNIContexts['a.example.com']);
+    server.addContext('*.test.com', SNIContexts['asterisk.test.com']);
+
+    server.listen(1337);
+
+### tls.Server.address(), String
+
+Returns the bound address and port of the server as reported by the operating system. 
+
+For more information, see [[net.Server.address `net.Server.address()`]].
+
+### tls.Server.close()
 
 
-### server.listen(port, [host], [callback])
+Stops the server from accepting new connections. This function is asynchronous, and the server is finally closed when it emits a `'close'` event.
 
-Begin accepting connections on the specified `port` and `host`.  If the
-`host` is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`).
+### tls.Server.listen(port, [host], [callback()])
+- port {Number}  The specific port to listen to
+- host {String}   An optional host to listen to
+- callback {Function}   An optional callback to execute when the server has been bound
 
-This function is asynchronous. The last parameter `callback` will be called
-when the server has been bound.
+Begin accepting connections on the specified `port` and `host`.  If the `host` is omitted, the server will accept connections directed to any IPv4 address (`INADDR_ANY`).
 
-See `net.Server` for more information.
+For more information, see [[net.Server `net.Server`]].
 
+### tls.Server.pause(msecs=1000)
+- msecs {Number}  The number of milliseconds to pause for
 
-### server.close()
+Stop accepting connections for the given number of milliseconds. This could be useful for throttling new connections against DoS attacks or other oversubscriptions.
 
-Stops the server from accepting new connections. This function is
-asynchronous, the server is finally closed when the server emits a `'close'`
-event.
-
-### server.address()
-
-Returns the bound address, the address family name and port of the
-server as reported by the operating system.
-See [net.Server.address()](net.html#server.address) for more information.
-
-### server.addContext(hostname, credentials)
-
-Add secure context that will be used if client request's SNI hostname is
-matching passed `hostname` (wildcards can be used). `credentials` can contain
-`key`, `cert` and `ca`.
-
-### server.maxConnections
-
-Set this property to reject connections when the server's connection count
-gets high.
-
-### server.connections
+### tls.Server.connections, Number
 
 The number of concurrent connections on the server.
 
 
-## Class: tls.CleartextStream
+### tls.Server.maxConnections, Number
 
-This is a stream on top of the *Encrypted* stream that makes it possible to
-read/write an encrypted data as a cleartext data.
+Set this property to reject connections when the server's connection count gets high.
 
-This instance implements a duplex [Stream](stream.html) interfaces.
-It has all the common stream methods and events.
+## tls.SecurePair
 
-A ClearTextStream is the `clear` member of a SecurePair object.
+Returned by [[tls.createSecurePair `tls.createSecurePair()`]].
 
-### Event: 'secureConnect'
+### tls.SecurePair@secure()
 
-This event is emitted after a new connection has been successfully handshaked. 
-The listener will be called no matter if the server's certificate was
-authorized or not. It is up to the user to test `cleartextStream.authorized`
-to see if the server certificate was signed by one of the specified CAs.
-If `cleartextStream.authorized === false` then the error can be found in
-`cleartextStream.authorizationError`. Also if NPN was used - you can check
-`cleartextStream.npnProtocol` for negotiated protocol.
+The event is emitted from the SecurePair once the pair has successfully established a secure connection.
 
-### cleartextStream.authorized
+Similar to the checking for the server `'secureConnection'` event, [[tls.CleartextStream.authorized `tls.CleartextStream.authorized`]] should be checked to confirm whether the certificate used properly authorized.
 
-A boolean that is `true` if the peer certificate was signed by one of the
-specified CAs, otherwise `false`
 
-### cleartextStream.authorizationError
+## tls.CleartextStream
 
-The reason why the peer's certificate has not been verified. This property
-becomes available only when `cleartextStream.authorized === false`.
+This is a stream on top of the encrypted stream that makes it possible to read/write an encrypted data as a cleartext data.
 
-### cleartextStream.getPeerCertificate()
+This instance implements the duplex [[streams `Stream`]] interfaces. It has all the common stream methods and events.
 
-Returns an object representing the peer's certificate. The returned object has
-some properties corresponding to the field of the certificate.
+### tls.CleartextStream@secureConnect()
 
-Example:
+This event is emitted after a new connection has been successfully handshaked. The listener will be called no matter if the server's certificate was authorized or not. 
+
+It is up to the user to test `cleartextStream.authorized` to see if the server certificate was signed by one of the specified CAs. If `cleartextStream.authorized === false`, then the error can be found in `cleartextStream.authorizationError`. Also if NPN was used, you can check `cleartextStream.npnProtocol` for the negotiated protocol.
+  
+
+### tls.CleartextStream@clientError(exception)
+- exception {Error}  The standard Error object
+
+If a client connection emits an 'error' event before a secure connection is established, this event is triggered, and the error is passed along.
+
+ 
+### tls.CleartextStream.authorized, Boolean
+
+If `true`, the peer certificate was signed by one of the specified CAs; otherwise, `false`.
+
+### tls.CleartextStream.authorizationError, Error
+
+
+The reason why the peer's certificate has not been verified. This property becomes available only when `cleartextStream.authorized === false`.
+
+
+
+
+### tls.CleartextStream.getPeerCertificate(), Object
+
+
+Returns an object representing the peer's certificate. The returned object has some properties corresponding to the field of the certificate.
+
+If the peer does not provide a certificate, it returns `null` or an empty object.
+
+#### Example
 
     { subject: 
        { C: 'UK',
@@ -394,36 +298,30 @@ Example:
          O: 'node.js',
          OU: 'Test TLS Certificate',
          CN: 'localhost' },
-      valid_from: 'Nov 11 09:52:22 2009 GMT',
-      valid_to: 'Nov  6 09:52:22 2029 GMT',
-      fingerprint: '2A:7A:C2:DD:E5:F9:CC:53:72:35:99:7A:02:5A:71:38:52:EC:8A:DF' }
+         valid_from: 'Nov 11 09:52:22 2009 GMT',
+         valid_to: 'Nov  6 09:52:22 2029 GMT',
+        fingerprint: '2A:7A:C2:DD:E5:F9:CC:53:72:35:99:7A:02:5A:71:38:52:EC:8A:DF' }
+ 
 
-If the peer does not provide a certificate, it returns `null` or an empty
-object.
 
-### cleartextStream.getCipher()
-Returns an object representing the cipher name and the SSL/TLS
-protocol version of the current connection.
+### tls.CleartextStream.connections(), Object
 
-Example:
-{ name: 'AES256-SHA', version: 'TLSv1/SSLv3' }
+Returns the bound address and port of the underlying socket as reported by the operating system. The object has two properties, _e.g._ `{"address":"192.168.57.1", "port":62053}`
 
-See SSL_CIPHER_get_name() and SSL_CIPHER_get_version() in
-http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_CIPHERS for more
-information.
 
-### cleartextStream.address()
 
-Returns the bound address, the address family name and port of the
-underlying socket as reported by the operating system. Returns an
-object with three properties, e.g.
-`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`
+### tls.CleartextStream.remoteAddress, String
 
-### cleartextStream.remoteAddress
+The string representation of the remote IP address. For example, `'74.125.127.100'` or `'2001:4860:a005::68'`.
 
-The string representation of the remote IP address. For example,
-`'74.125.127.100'` or `'2001:4860:a005::68'`.
+ 
 
-### cleartextStream.remotePort
+
+### tls.CleartextStream.remotePort, Number
 
 The numeric representation of the remote port. For example, `443`.
+
+ 
+
+
+

--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -1,75 +1,34 @@
-# TTY
+## tty
 
-    Stability: 2 - Unstable
+    Stability: 3 - Stable
+    
+This module controls printing to the terminal output. Use `require('tty')` to access this module.
 
-The `tty` module houses the `tty.ReadStream` and `tty.WriteStream` classes. In
-most cases, you will not need to use this module directly.
+#### Example
 
-When node detects that it is being run inside a TTY context, then `process.stdin`
-will be a `tty.ReadStream` instance and `process.stdout` will be
-a `tty.WriteStream` instance. The preferred way to check if node is being run in
-a TTY context is to check `process.stdout.isTTY`:
-
-    $ node -p -e "Boolean(process.stdout.isTTY)"
-    true
-    $ node -p -e "Boolean(process.stdout.isTTY)" | cat
-    false
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/tty/tty.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
 
-## tty.isatty(fd)
+### tty.getWindowSize(fd), Array
+- fd {Number}   The file descriptor to check
+(deprecated: 0.6.0)
 
-Returns `true` or `false` depending on if the `fd` is associated with a
-terminal.
+This function no longer exists. Use [[process.stdout `process.stdout.getWindowSize()`]] instead.
 
+### tty.isatty(fd), Boolean
+- fd {Number}   The file descriptor to check
 
-## tty.setRawMode(mode)
+Returns `true` or `false` depending on if the file descriptor is associated with a terminal.
 
-Deprecated. Use `tty.ReadStream#setRawMode()`
-(i.e. `process.stdin.setRawMode()`) instead.
+### tty.setRawMode(mode)
+- mode {Boolean}  A boolean value indicating how to set the rawness
 
+This sets the properties of the current process's stdin file descriptor to act either as a raw device (`true`) or default (`false`).
 
-## Class: ReadStream
+### tty.setWindowSize(fd, row, col)
+- fd {Number}  The file descriptor to use
+- row {Number}  The number of rows
+- col {Number}  The number of columns
+(deprecated: 0.6.0)
 
-A `net.Socket` subclass that represents the readable portion of a tty. In normal
-circumstances, `process.stdin` will be the only `tty.ReadStream` instance in any
-node program (only when `isatty(0)` is true).
-
-### rs.isRaw
-
-A `Boolean` that is initialized to `false`. It represents the current "raw" state
-of the `tty.ReadStream` instance.
-
-### rs.setRawMode(mode)
-
-`mode` should be `true` or `false`. This sets the properties of the
-`tty.ReadStream` to act either as a raw device or default. `isRaw` will be set
-to the resulting mode.
-
-
-## Class WriteStream
-
-A `net.Socket` subclass that represents the writable portion of a tty. In normal
-circumstances, `process.stdout` will be the only `tty.WriteStream` instance
-ever created (and only when `isatty(1)` is true).
-
-### ws.columns
-
-A `Number` that gives the number of columns the TTY currently has. This property
-gets updated on "resize" events.
-
-### ws.rows
-
-A `Number` that gives the number of rows the TTY currently has. This property
-gets updated on "resize" events.
-
-### Event: 'resize'
-
-`function () {}`
-
-Emitted by `refreshSize()` when either of the `columns` or `rows` properties
-has changed.
-
-    process.stdout.on('resize', function() {
-      console.log('screen size has changed!');
-      console.log(process.stdout.columns + 'x' + process.stdout.rows);
-    });
+This function no longer exists.

--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -1,82 +1,100 @@
-# URL
+## url
 
     Stability: 3 - Stable
+    
+This module has utilities for URL resolution and parsing. To use it, add `require('url')` to your code.
 
-This module has utilities for URL resolution and parsing.
-Call `require('url')` to use it.
+Parsed URL objects have some or all of the following fields, depending on whether or not they exist in the URL string. Any parts that are not in the URL string are not in the parsed object. All the examples shown use the following URL:
 
-Parsed URL objects have some or all of the following fields, depending on
-whether or not they exist in the URL string. Any parts that are not in the URL
-string will not be in the parsed object. Examples are shown for the URL
+`'http://user:pass@HOST.com:8080/p/a/t/h?query=string#hash'`
 
-`'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'`
+* `href`: the full URL that was originally parsed. Both the protocol and host are in lowercase.
 
-* `href`: The full URL that was originally parsed. Both the protocol and host are lowercased.
+  For the URL above, this is: `'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'`
+  
+* `protocol`: the request protocol, in lowercase.
 
-  Example: `'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'`
-* `protocol`: The request protocol, lowercased.
+  For the URL above, this is: `'http:'`
+  
+* `host`: the full lowercased host portion of the URL, including port and authentication information.
 
-  Example: `'http:'`
-* `host`: The full lowercased host portion of the URL, including the port.
+  For the URL above, this is: `'user:pass@host.com:8080'`
+  
+* `auth`: The authentication information from the URL.
 
-  Example: `'host.com:8080'`
-* `auth`: The authentication information portion of a URL.
+  For the URL above, this is: `'user:pass'`
+  
+* `hostname`: the lowercased hostname portion of the URL.
 
-  Example: `'user:pass'`
-* `hostname`: Just the lowercased hostname portion of the host.
+  For the URL above, this is: `'host.com'`
+  
+* `port`: The port number of the URL.
 
-  Example: `'host.com'`
-* `port`: The port number portion of the host.
+  For the URL above, this is: `'8080'`
+  
+* `pathname`: the path section of the URL, that comes after the host and before the query, including the initial slash (if present).
 
-  Example: `'8080'`
-* `pathname`: The path section of the URL, that comes after the host and before the query, including the initial slash if present.
+  For the URL above, this is: `'/p/a/t/h'`
+  
+* `search`: the 'query string' portion of the URL, including the leading question mark.
 
-  Example: `'/p/a/t/h'`
-* `search`: The 'query string' portion of the URL, including the leading question mark.
+  For the URL above, this is: `'?query=string'`
+  
+* `path`: a concatenation of `pathname` and `search`.
 
-  Example: `'?query=string'`
-* `path`: Concatenation of `pathname` and `search`.
+  For the URL above, this is: `'/p/a/t/h?query=string'`
+  
+* `query`: either the 'params' portion of the query string, or a querystring-parsed object.
 
-  Example: `'/p/a/t/h?query=string'`
-* `query`: Either the 'params' portion of the query string, or a querystring-parsed object.
+  For the URL above, this is: `'query=string'` or `{'query':'string'}`
+  
+* `hash`: the 'fragment' portion of the URL including the pound-sign.
 
-  Example: `'query=string'` or `{'query':'string'}`
-* `hash`: The 'fragment' portion of the URL including the pound-sign.
+  For the URL above, this is: `'#hash'`
 
-  Example: `'#hash'`
 
-The following methods are provided by the URL module:
 
-## url.parse(urlStr, [parseQueryString], [slashesDenoteHost])
 
-Take a URL string, and return an object.
+### url.parse(urlStr [, parseQueryString=false] [, slashesDenoteHost=false]), Object
+- urlStr {String}  The URL string
+- parseQueryString {Boolean}  If `true`, the method parses the URL using the [[querystring `querystring`]] module
+- slashesDenoteHost {Boolean}  If `true`, `//foo/bar` acts like `{ host : 'foo', pathname  '/bar' }`, instead of `{ pathname : '//foo/bar' }`
 
-Pass `true` as the second argument to also parse
-the query string using the `querystring` module.
-Defaults to `false`.
+Takes a URL string, and return it as an object.
 
-Pass `true` as the third argument to treat `//foo/bar` as
-`{ host: 'foo', pathname: '/bar' }` rather than
-`{ pathname: '//foo/bar' }`. Defaults to `false`.
+ 
 
-## url.format(urlObj)
 
-Take a parsed URL object, and return a formatted URL string.
+### url.format(urlObj), String
+ - urlObj {String}  The object to tranform into a URL
 
-* `href` will be ignored.
-* `protocol`is treated the same with or without the trailing `:` (colon).
-  * The protocols `http`, `https`, `ftp`, `gopher`, `file` will be postfixed with `://` (colon-slash-slash).
-  * All other protocols `mailto`, `xmpp`, `aim`, `sftp`, `foo`, etc will be postfixed with `:` (colon)
-* `auth` will only be used if `host` is absent.
-* `hostname` will only be used if `host` is absent.
-* `port` will only be used if `host` is absent.
-* `host` will be used in place of `hostname` and `port`
+Take a parsed URL object, and return a formatted URL string that contains these properties:
+
+* `href` is ignored.
+* `protocol` is treated the same with or without the trailing `:` (colon). Note that:
+  -- The protocols `http`, `https`, `ftp`, `gopher`, and `file` are postfixed with `://`
+  -- All other protocols (like `mailto`, `xmpp`, `aim`, `sftp`, `foo`, etc) are postfixed with `:`
+* `auth` is only used if `host` is absent
+* `hostname` is only used if `host` is absent
+* `port` is only used if `host` is absent
+* `host` is only used in place of `auth`, `hostname`, and `port`
 * `pathname` is treated the same with or without the leading `/` (slash)
-* `search` will be used in place of `query`
-* `query` (object; see `querystring`) will only be used if `search` is absent.
-* `search` is treated the same with or without the leading `?` (question mark)
-* `hash` is treated the same with or without the leading `#` (pound sign, anchor)
+* `search` is used in place of `query`
+* `query`, a [querystring](querystring.html) object, is only used if `search` is absent
+* `search` is treated the same with or without the leading `?` 
+* `hash` is treated the same with or without the leading `#` 
 
-## url.resolve(from, to)
+ 
 
-Take a base URL, and a href URL, and resolve them as a browser would for an anchor tag.
+
+### url.resolve(from, to), String
+- from {String}  The base URL
+- to  (String): The href URL
+
+Takes a base URL, and a href URL, and resolve them as a browser would for an anchor tag.
+
+#### Example
+	
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/url/url.resolve.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
+

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -1,176 +1,143 @@
-# util
+## util
 
     Stability: 5 - Locked
 
-These functions are in the module `'util'`. Use `require('util')` to access
-them.
+
+The `util` module provides varies utilities that you can use in your Node.js programs, fmostly around verifying the type of an object. To access these methods, add `require('util')` to your code.
+
+A major difference between these methods and the ones found in the [[console `console`]] module is that these don't print to the console.
 
 
-## util.format()
 
-Returns a formatted string using the first argument as a `printf`-like format.
+### util.debug(str), String
+- str {String}   The string to print
 
-The first argument is a string that contains zero or more *placeholders*.
-Each placeholder is replaced with the converted value from its corresponding
-argument. Supported placeholders are:
+A synchronous output function. This block the process and outputs `string` immediately to `stderr`.
+
+
+ 
+
+
+### util.format([arg...]), String
+- arg {String}   The string to print, and any additional formatting arguments
+
+Returns a formatted string using the first argument in [a `printf()`-like](http://en.wikipedia.org/wiki/Printf_format_string#Format_placeholders) way.
+
+The first argument is a string that contains zero or more placeholders. Each placeholder is replaced with the converted value from its corresponding argument. Supported placeholders are:
 
 * `%s` - String.
 * `%d` - Number (both integer and float).
 * `%j` - JSON.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
 
-If the placeholder does not have a corresponding argument, the placeholder is
-not replaced.
 
-    util.format('%s:%s', 'foo'); // 'foo:%s'
+#### Example
 
-If there are more arguments than placeholders, the extra arguments are
-converted to strings with `util.inspect()` and these strings are concatenated,
-delimited by a space.
-
-    util.format('%s:%s', 'foo', 'bar', 'baz'); // 'foo:bar baz'
-
-If the first argument is not a format string then `util.format()` returns
-a string that is the concatenation of all its arguments separated by spaces.
-Each argument is converted to a string with `util.inspect()`.
-
-    util.format(1, 2, 3); // '1 2 3'
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.format.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+ 
 
 
-## util.debug(string)
+### util.inspect(object, showHidden=false, depth=2), String
+- object {Object}   The object to be represented
+- showHidden {Boolean}  Identifies whether the non-enumerable properties are also shown
+- depth {Number}  Indicates how many times to recurse while formatting the object
 
-A synchronous output function. Will block the process and
-output `string` immediately to `stderr`.
+Returns a string representation of `object`, which is useful for debugging.
 
-    require('util').debug('message on stderr');
+To make the function recurse an object indefinitely, pass in `null` for `depth`.
 
+If `colors` is `true`, the output is styled with ANSI color codes.
 
-## util.log(string)
+#### Example
 
-Output with timestamp on `stdout`.
+Here's an example inspecting all the properties of the `util` object:
 
-    require('util').log('Timestamped message.');
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.inspect.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
 
-
-## util.inspect(object, [showHidden], [depth], [colors])
-
-Return a string representation of `object`, which is useful for debugging.
-
-If `showHidden` is `true`, then the object's non-enumerable properties will be
-shown too. Defaults to `false`.
-
-If `depth` is provided, it tells `inspect` how many times to recurse while
-formatting the object. This is useful for inspecting large complicated objects.
-
-The default is to only recurse twice.  To make it recurse indefinitely, pass
-in `null` for `depth`.
-
-If `colors` is `true`, the output will be styled with ANSI color codes.
-Defaults to `false`.
-
-Example of inspecting all properties of the `util` object:
-
-    var util = require('util');
-
-    console.log(util.inspect(util, true, null));
+ 
 
 
-## util.isArray(object)
+### util.isArray(object), Boolean
+- object {Object}   The object to be identified
 
-Returns `true` if the given "object" is an `Array`. `false` otherwise.
+Returns `true` if the given object is an `Array`.
 
-    var util = require('util');
+#### Example
 
-    util.isArray([])
-      // true
-    util.isArray(new Array)
-      // true
-    util.isArray({})
-      // false
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.isArray.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+ 
 
 
-## util.isRegExp(object)
+### util.isDate(object), Boolean
+- object {Object}   The object to be identified
 
-Returns `true` if the given "object" is a `RegExp`. `false` otherwise.
+Returns `true` if the given object is a `Date`.
 
-    var util = require('util');
+#### Example
 
-    util.isRegExp(/some regexp/)
-      // true
-    util.isRegExp(new RegExp('another regexp'))
-      // true
-    util.isRegExp({})
-      // false
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.isDate.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+ 
 
 
-## util.isDate(object)
+### util.isError(object), Boolean
+- object {Object}   The object to be identified
 
-Returns `true` if the given "object" is a `Date`. `false` otherwise.
+Returns `true` if the given object is an `Error`.
 
-    var util = require('util');
+#### Example
 
-    util.isDate(new Date())
-      // true
-    util.isDate(Date())
-      // false (without 'new' returns a String)
-    util.isDate({})
-      // false
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.isError.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+ 
 
 
-## util.isError(object)
+### util.isRegExp(object), Boolean
+- object {Object}   The object to be identified
 
-Returns `true` if the given "object" is an `Error`. `false` otherwise.
+Returns `true` if the given "object" is a `RegExp`.
 
-    var util = require('util');
+#### Example
 
-    util.isError(new Error())
-      // true
-    util.isError(new TypeError())
-      // true
-    util.isError({ name: 'Error', message: 'an error occurred' })
-      // false
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.isRegExp.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+    
 
-
-## util.pump(readableStream, writableStream, [callback])
-
-Experimental
-
-Read the data from `readableStream` and send it to the `writableStream`.
-When `writableStream.write(data)` returns `false` `readableStream` will be
-paused until the `drain` event occurs on the `writableStream`. `callback` gets
-an error as its only argument and is called when `writableStream` is closed or
-when an error occurs.
+ 
 
 
-## util.inherits(constructor, superConstructor)
+### util.log(str)
+- str {String}  The string to print
 
-Inherit the prototype methods from one
-[constructor](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor)
-into another.  The prototype of `constructor` will be set to a new
-object created from `superConstructor`.
+Outputs to `stdout`...but with a timestamp!
 
-As an additional convenience, `superConstructor` will be accessible
-through the `constructor.super_` property.
+ 
 
-    var util = require("util");
-    var events = require("events");
 
-    function MyStream() {
-        events.EventEmitter.call(this);
-    }
+### util.pump(readableStream, writableStream, [callback()])
+- readableStream {streams.ReadableStream}  The stream to read from
+- writableStream {streams.WritableStream}  The stream to write to
+- callback {Function}   An optional callback function once the pump is through
 
-    util.inherits(MyStream, events.EventEmitter);
+Reads the data from `readableStream` and sends it to the `writableStream`.
 
-    MyStream.prototype.write = function(data) {
-        this.emit("data", data);
-    }
+When `writableStream.write(data)` returns `false`, `readableStream` is paused until the `drain` event occurs on the `writableStream`. `callback` gets an error as its only argument and is called when `writableStream` is closed or when an error occurs.
 
-    var stream = new MyStream();
+ 
+### util.inherits(constructor, superConstructor)
+- constructor {Function}  The prototype methods to inherit
+- superConstructor {Object}  The new object's type
 
-    console.log(stream instanceof events.EventEmitter); // true
-    console.log(MyStream.super_ === events.EventEmitter); // true
+Inherit the prototype methods from one constructor into another. The prototype of `constructor` is set to a new object created from `superConstructor`.
 
-    stream.on("data", function(data) {
-        console.log('Received data: "' + data + '"');
-    })
-    stream.write("It works!"); // Received data: "It works!"
+As an additional convenience, `superConstructor` is accessible through the `constructor.super_` property.
+
+For more information, see the MDN [`constructor`](https://developer.mozilla.org/en/Javascript/Reference/Global_Objects/Object/constructor) documentation.
+
+#### Example
+
+<script src='http://snippets.c9.io/github.com/c9/nodemanual.org-examples/nodejs_ref_guide/util/util.inherits.js?linestart=3&lineend=0&showlines=false' defer='defer'></script>
+
+
+ 
+


### PR DESCRIPTION
@isaacs @piscisaureus

First, terribly sorry for the delay on this. I get blocked by a lot of work at work.

This PR represents the rewritten, reformatted documentation fork, hosted on NodeManual, up to latest, 0.6.15.

Off the top of my heads, syntactically, things that have changed everywhere are:
1. Consistency between using `{` `}` everywhere
2. Consistency in headings (`##` is always class; `###` is always members)
3. Dropped the use of `->` as a return signifier, in exchange for a simple `,`
4. Stopped using a return type of `Void`, as Bert rightly pointed out, the concept doesn't exist. 

Probably there's more. Point something out in a diff and I'll be able to explain it.

I tested this by using my API doc generation tool, [panino](https://github.com/gjtorikian/panino-docs). It uses a strict grammar for validating things, and doesn't take any bullshit.

The files are full of C9 snippets, which are just gists that are executable in [Cloud9 IDE](http://ww.c9.io). Even if I wasn't working there, I still feel strongly that having _live, executable code_ would be infinitely superior than static text, to novices and experts alike.

Beyond that, though, the effort at NodeManual to provide a consistent and helpful design towards accessing the API documentation is also something that should be strongly considered. Grouping reference material with tutorials just makes sense, and providing an easy navigation (beyond just straight Markdown to HTML conversion) is beneficial to everyone using, reading, and writing the docs.

If there are questions, ask away.
