### PR TITLE
doc: util: add args to format and methods error, puts, print

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -6,7 +6,7 @@ These functions are in the module `'util'`. Use `require('util')` to access
 them.
 
 
-## util.format()
+## util.format(format, [...])
 
 Returns a formatted string using the first argument as a `printf`-like format.
 
@@ -44,6 +44,20 @@ output `string` immediately to `stderr`.
 
     require('util').debug('message on stderr');
 
+## util.error([...])
+
+Same as `util.debug()` except this will output all arguments immediately to
+`stderr`.
+
+## util.puts([...])
+
+A synchronous output function. Will block the process and output all arguments
+to `stdout` with newlines after each argument.
+
+## util.print([...])
+
+A synchronous output function. Will block the process, cast each argument to a
+string then output to `stdout`. Does not place newlines after each argument.
 
 ## util.log(string)
 


### PR DESCRIPTION
Related to #1613 with the mention of `sys.puts` missing.
