### PR TITLE
Added a new parameter staticlib in configure. Using this parameter node ...

### DIFF
--- a/configure
+++ b/configure
@@ -126,6 +126,11 @@ parser.add_option("--dest-cpu",
     dest="dest_cpu",
     help="CPU architecture to build for. Valid values are: arm, ia32, x64")
 
+parser.add_option("--staticlib",
+    action="store_true",
+    dest="staticlib",
+    help="Enable this option to build Node as a static library")
+
 (options, args) = parser.parse_args()
 
 
@@ -232,6 +237,13 @@ def configure_node(o):
   o['variables']['node_prefix'] = options.prefix if options.prefix else ''
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['node_install_waf'] = b(not options.without_waf)
+  o['variables']['node_staticlib']   = b(options.staticlib)
+
+  if os.path.exists('lib/_third_party_main.js'):
+    o['variables']['node_thirdparty'] = 'lib/_third_party_main.js'
+  else:
+    o['variables']['node_thirdparty'] = ''
+
   o['variables']['host_arch'] = host_arch()
   o['variables']['target_arch'] = options.dest_cpu or target_arch()
   o['default_configuration'] = 'Debug' if options.debug else 'Release'

--- a/node.gyp
+++ b/node.gyp
@@ -47,8 +47,7 @@
       'lib/url.js',
       'lib/util.js',
       'lib/vm.js',
-      'lib/zlib.js',
-      '<@(node_thirdparty)'
+      'lib/zlib.js'
     ],
   },
 

--- a/node.gyp
+++ b/node.gyp
@@ -177,14 +177,14 @@
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
         }],
-    
-       [ 'node_staticlib=="true"', {
+
+        [ 'node_staticlib=="true"', {
           'type': '<(library)',
          }, {
           'sources': ['src/node_main.cc'],
         }],
 
-       [ 'OS=="win"', {
+        [ 'OS=="win"', {
           'sources': [
             'tools/msvs/res/node.rc',
           ],

--- a/node.gyp
+++ b/node.gyp
@@ -9,6 +9,7 @@
     'node_shared_zlib%': 'false',
     'node_use_openssl%': 'true',
     'node_use_system_openssl%': 'false',
+    'node_staticlib%': 'true',
     'library_files': [
       'src/node.js',
       'lib/_debugger.js',
@@ -47,6 +48,7 @@
       'lib/util.js',
       'lib/vm.js',
       'lib/zlib.js',
+      '<@(node_thirdparty)'
     ],
   },
 
@@ -78,7 +80,6 @@
         'src/node_file.cc',
         'src/node_http_parser.cc',
         'src/node_javascript.cc',
-        'src/node_main.cc',
         'src/node_os.cc',
         'src/node_script.cc',
         'src/node_string.cc',
@@ -176,8 +177,14 @@
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
         }],
+    
+       [ 'node_staticlib=="true"', {
+          'type': '<(library)',
+         }, {
+          'sources': ['src/node_main.cc'],
+        }],
 
-        [ 'OS=="win"', {
+       [ 'OS=="win"', {
           'sources': [
             'tools/msvs/res/node.rc',
           ],


### PR DESCRIPTION
...will be compiled as a library. Also added to include _third_party_main.js if present.

Support for staticlib in node.gyp, if staticlib is set it sets target as library and excludes node_main.cc. Also added node_thirdparty variable to include third party main if present in library folder during compilation.

Fix for issue#3143
