### PR TITLE
Included example on how to use fs.read()

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -341,6 +341,36 @@ If `position` is `null`, data will be read from the current file position.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.
 
+    var fs = require('fs');
+    var fileName = __dirname + '/test.txt';
+
+    // Create the test file (this is sync on purpose)
+    fs.writeFileSync(fileName, 'five guys named moe', 'utf8');
+
+    // Read async
+    fs.open(fileName, 'r', function(err, fd) {
+        var content = new Buffer("123456789", "utf8");
+        if(err) {
+            console.log("Error opening file: ", err);		
+        } else {
+            console.log("Open returned fd: ", fd);
+            fs.read(fd, content, 0, 9, 0, function(err, bytesRead, buffer) {
+                if(err) {
+                    console.log("Error reading: ", err);
+                } else {
+                    console.log("# of bytes read: ", bytesRead);
+                    console.log("bytes: ", buffer);
+                    console.log("string: [" + buffer.toString() + "]");
+                    fs.close(fd, function() {
+                        console.log("fd %d has been closed", fd);
+                    });
+                }
+            });
+        }
+    });
+
+
+
 ## fs.readSync(fd, buffer, offset, length, position)
 
 Synchronous version of buffer-based `fs.read`. Returns the number of


### PR DESCRIPTION
This example shows to how to use fs.read() with a buffer. 

It also shows how to use fs.open() and fs.close()
