### PR TITLE
Maybe we need to call process.parent.emit('evt', 'some data');

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -391,6 +391,8 @@ function maybeClose(subprocess) {
 function ChildProcess() {
   var self = this;
 
+  this.parent = process;
+
   this._closesNeeded = 1;
   this._closesGot = 0;
 


### PR DESCRIPTION
I think if we use message event to do many things, we will need to route it. But if we use process.parent like window.parent in browser to do something, we can just call process.parent.emit('evt', 'something');
