### PR TITLE
don't require password when generating ca2-crl.pem

### DIFF
--- a/test/fixtures/keys/Makefile
+++ b/test/fixtures/keys/Makefile
@@ -120,13 +120,15 @@ ca2-crl.pem: ca2-key.pem ca2-cert.pem ca2.cnf
 	openssl ca -revoke agent4-cert.pem \
 		-keyfile ca2-key.pem \
 		-cert ca2-cert.pem \
-		-config ca2.cnf
+		-config ca2.cnf \
+		-passin 'pass:password'
 	openssl ca \
 		-keyfile ca2-key.pem \
 		-cert ca2-cert.pem \
 		-config ca2.cnf \
 		-gencrl \
-		-out ca2-crl.pem
+		-out ca2-crl.pem \
+		-passin 'pass:password'
 
 clean:
 	rm -f *.pem *.srl ca2-database.txt ca2-serial


### PR DESCRIPTION
patching 0.6.x with https://github.com/joyent/node/pull/2991 to fix simple/test-tls-server-verify requires rebuilding the files in test/fixtures/keys, which currently requires user interaction, this change fixes that.
