### PR TITLE
add a child domain explicitly.

### DIFF
--- a/test/simple/test-domain-multi.js
+++ b/test/simple/test-domain-multi.js
@@ -43,10 +43,9 @@ a.on('error', function(er) {
 
 var http = require('http');
 var server = http.createServer(function (req, res) {
-  // child domain.
-  // implicitly added to a, because we're in a when
-  // it is created.
+  // child domain of a.
   var b = domain.create();
+  a.add(b);
 
   // treat these EE objects as if they are a part of the b domain
   // so, an 'error' event on them propagates to the domain, rather


### PR DESCRIPTION
domain isn't added to other domain implicitly.

http://nodejs.org/docs/v0.7.8/api/domain.html#domain_implicit_binding
"If you want to nest Domain objects as children of a parent Domain,
then you must explicitly add them, and then dispose of them later. "
