### PR TITLE
HTTP client mem leak when socket hang up?

### DIFF
--- a/lib/freelist.js
+++ b/lib/freelist.js
@@ -38,6 +38,7 @@ exports.FreeList.prototype.alloc = function() {
 exports.FreeList.prototype.free = function(obj) {
   //debug("free " + this.name + " " + this.list.length);
   if (this.list.length < this.max) {
+    obj.socket._httpMessage.removeAllListeners();
     this.list.push(obj);
   }
 };


### PR DESCRIPTION
Hi, 

In production we have a serious memory leak. I tried to figure it out using the module `weak`.
When I remove HTTP clients in my code, I don't have mem leaks. So I thought there was something strange in the HTTP client.

I started with #3179, and found something else when the socket hang up (socket hang up happens in our production code).

When executing this [gist](https://gist.github.com/2560161), weak tell us that some of our objects are not GC.

```
# node --expose-gc leak.js
webkit-devtools-agent started on 127.0.0.1:1337
We should do 18 requests
3MB used
Done: 0/18, not yet GC: 0
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up 
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
90MB used
Done: 18/18, not yet GC: 7
all requests done, memory should be collected by now ?
39MB used
Done: 18/18, not yet GC: 7
all requests done, memory should be collected by now ?
```

Using [webkit-devtools-agent](https://github.com/c4milo/node-webkit-agent), I found that the leak is retained by an HTTPParser. So i tried this : 

```
exports.FreeList.prototype.free = function(obj) {
  //debug("free " + this.name + " " + this.list.length);
  if (this.list.length < this.max) {
-    this.list.push(obj);
+    // this.list.push(obj);
  }
};
```

And the leak in the gist disappear.

```
$ node --expose-gc gistfile1.js 
We should do 18 requests
2MB used
Done: 0/18, not yet GC: 0
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
89MB used
Done: 18/18, not yet GC: 0
all requests done, memory should be collected by now ?
2MB used
Done: 18/18, not yet GC: 0
all requests done, memory should be collected by now ?
2MB used
Done: 18/18, not yet GC: 0
all requests done, memory should be collected by now ?
2MB used
Done: 18/18, not yet GC: 0
all requests done, memory should be collected by now ?
```

I tried to do something smarter in this pull request. The http tests still works. I hope this pull-request will help.

Thanks for node. It rocks !
