### PR TITLE
Mem leak timeout

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1128,6 +1128,8 @@ ClientRequest.prototype.onSocket = function(socket) {
     var freeParser = function() {
       if (parser) {
         parsers.free(parser);
+        parser.socket.removeAllListeners();
+        parser.socket._httpMessage.removeAllListeners();
         parser.socket.onend = null;
         parser.socket.ondata = null;
         parser.socket = null;

--- a/lib/net.js
+++ b/lib/net.js
@@ -293,7 +293,6 @@ Socket.prototype._connectQueueCleanUp = function(exception) {
 
 Socket.prototype._destroy = function(exception, cb) {
   var self = this;
-  this.removeAllListeners('timeout');
 
   function fireErrorCallbacks() {
     if (cb) cb(exception);
@@ -334,6 +333,7 @@ Socket.prototype._destroy = function(exception, cb) {
 
   process.nextTick(function() {
     self.emit('close', exception ? true : false);
+    self.removeAllListeners();
   });
 
   this.destroyed = true;

--- a/lib/net.js
+++ b/lib/net.js
@@ -293,6 +293,7 @@ Socket.prototype._connectQueueCleanUp = function(exception) {
 
 Socket.prototype._destroy = function(exception, cb) {
   var self = this;
+  this.removeAllListeners('timeout');
 
   function fireErrorCallbacks() {
     if (cb) cb(exception);


### PR DESCRIPTION
Hi, 

As discussed in #3179

For me the branch [http-memleak](https://github.com/joyent/node/tree/http-memleak) works well, but I still have a memory leak when I use setTimeout

```
http.get({
  hostname: 'localhost',
  pathname: '/index.html?' + Math.random(),
  port: 3000,
  protocol: 'http:'
}, cb).on('error', function(e) {
  cb(e);
}).setTimeout(10, function(){
  console.log('nothing here')
})
```

https://gist.github.com/2577565

This pull request fix the gist issue:

```
node --expose-gc maxired.js
webkit-devtools-agent started on 0.0.0.0:1337
We should do 18 requests
3MB used
Done: 0/18, not yet GC: 0
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
Got error: socket hang up
90MB used
Done: 18/18, not yet GC: 0
all requests done, memory should be collected by now ?
3MB used
Done: 18/18, not yet GC: 0
all requests done, memory should be collected by now ?
```

Big up @Maxired
