### PR TITLE
doc: fix setEncoding()

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -258,9 +258,9 @@ Also `request.httpVersionMajor` is the first integer and
 
 ### request.setEncoding([encoding])
 
-Set the encoding for the request body. Either `'utf8'` or `'binary'`. Defaults
-to `null`, which means that the `'data'` event will emit a `Buffer` object..
-
+Set the encoding for the request body. See
+[stream.setEncoding()](stream.html#stream_stream_setencoding_encoding)
+for more information.
 
 ### request.pause()
 
@@ -873,9 +873,9 @@ The response trailers object. Only populated after the 'end' event.
 
 ### response.setEncoding([encoding])
 
-Set the encoding for the response body. Either `'utf8'`, `'ascii'`, or
-`'base64'`. Defaults to `null`, which means that the `'data'` event will emit
-a `Buffer` object.
+Set the encoding for the response body. See
+[stream.setEncoding()](stream.html#stream_stream_setencoding_encoding)
+for more information.
 
 ### response.pause()
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -292,8 +292,9 @@ Users who experience large or growing `bufferSize` should attempt to
 
 ### socket.setEncoding([encoding])
 
-Sets the encoding (either `'ascii'`, `'utf8'`, or `'base64'`) for data that is
-received. Defaults to `null`.
+Set the encoding for the socket as a Readable Stream. See
+[stream.setEncoding()](stream.html#stream_stream_setencoding_encoding)
+for more information.
 
 ### socket.write(data, [encoding], [callback])
 

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -51,9 +51,10 @@ will emit this.  (For example, an incoming HTTP request will not emit
 A boolean that is `true` by default, but turns `false` after an `'error'`
 occurred, the stream came to an `'end'`, or `destroy()` was called.
 
-### stream.setEncoding(encoding)
-Makes the data event emit a string instead of a `Buffer`. `encoding` can be
-`'utf8'`, `'ascii'`, or `'base64'`.
+### stream.setEncoding([encoding])
+
+Makes the `'data'` event emit a string instead of a `Buffer`. `encoding` can be
+`'utf8'`, `'utf16le'` (`'ucs2'`), `'ascii'`, or `'hex'`. Defaults to `'utf8'`.
 
 ### stream.pause()
 


### PR DESCRIPTION
Descriptions of `setEncoding()` are wrong and inconsistent. This patch corrects them. 
