### PR TITLE
buffer: add UTF-16LE encoding name

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -23,10 +23,13 @@ encoding method.  Here are the different string encodings.
   `0x20` (character code of a space). If you want to convert a null character
   into `0x00`, you should use `'utf8'`.
 
-* `'utf8'` - Multi byte encoded Unicode characters.  Many web pages and other document formats use UTF-8.
+* `'utf8'` - Multibyte encoded Unicode characters. Many web pages and other
+  document formats use UTF-8.
 
-* `'ucs2'` - 2-bytes, little endian encoded Unicode characters. It can encode
-  only BMP(Basic Multilingual Plane, U+0000 - U+FFFF).
+* `'utf16le'` - 2 or 4 bytes, little endian encoded Unicode characters.
+  Surrogate pairs (U+10000 to U+10FFFF) are supported.
+
+* `'ucs2'` - Alias to `'utf16le'`.
 
 * `'base64'` - Base64 string encoding.
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -89,6 +89,8 @@ SlowBuffer.prototype.toString = function(encoding, start, end) {
 
     case 'ucs2':
     case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
       return this.ucs2Slice(start, end);
 
     default:
@@ -173,6 +175,8 @@ SlowBuffer.prototype.write = function(string, offset, length, encoding) {
 
     case 'ucs2':
     case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
       return this.ucs2Write(string, offset, length);
 
     default:
@@ -374,6 +378,8 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
 
     case 'ucs2':
     case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
       ret = this.parent.ucs2Write(string, this.offset + offset, length);
       break;
 
@@ -425,6 +431,8 @@ Buffer.prototype.toString = function(encoding, start, end) {
 
     case 'ucs2':
     case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
       return this.parent.ucs2Slice(start, end);
 
     default:

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -266,6 +266,10 @@ assert.equal(size, 4);
 assert.equal(charsWritten, 2);
 assert.deepEqual(f, new Buffer([0x42, 0x30, 0x44, 0x30, 0x00]));
 
+var f = new Buffer('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
+assert.equal(f.length, 4);
+assert.deepEqual(f, new Buffer('3DD84DDC', 'hex'));
+
 
 var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
 var g = new Buffer(arrayIsh);


### PR DESCRIPTION
Now, V8 supports a surrogate pair,  let's call UTF-16LE (`'utf16le'` or `'utf-16le'`) rather than UCS-2 (`'ucs2'` or `'ucs-2'`).
