### PR TITLE
Surface localAddress bind failure in connect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -565,21 +565,26 @@ function connect(self, address, port, addressType, localAddress) {
 
   assert.ok(self._connecting);
 
+  if (localAddress) {
+    var r;
+    if (addressType == 6) {
+      r = self._handle.bind6(localAddress);
+    } else {
+      r = self._handle.bind(localAddress);
+    }
+
+    if (r) {
+      self._destroy(errnoException(errno, 'bind'));
+      return;
+    }
+  }
+
   var connectReq;
   if (addressType == 6) {
-    if (localAddress) {
-      self._handle.bind6(localAddress);
-    }
     connectReq = self._handle.connect6(address, port);
   } else if (addressType == 4) {
-    if (localAddress) {
-      self._handle.bind(localAddress);
-    }
     connectReq = self._handle.connect(address, port);
   } else {
-    if (localAddress) {
-      self._handle.bind(localAddress);
-    }
     connectReq = self._handle.connect(address, afterConnect);
   }
 

--- a/test/simple/test-http-localaddress-bind-error.js
+++ b/test/simple/test-http-localaddress-bind-error.js
@@ -1,0 +1,61 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var http = require('http'),
+    assert = require('assert');
+
+var invalidLocalAddress = '1.2.3.4';
+var gotError = false;
+
+var server = http.createServer(function (req, res) {
+  console.log("Connect from: " + req.connection.remoteAddress);
+
+  req.on('end', function() {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('You are from: ' + req.connection.remoteAddress);
+  });
+});
+
+server.listen(common.PORT, "127.0.0.1", function() {
+  var req = http.request({
+    host: 'localhost',
+    port: common.PORT,
+    path: '/',
+    method: 'GET',
+    localAddress: invalidLocalAddress
+  }, function(res) {
+    console.log('unexpectedly got response from server');
+
+    server.close();
+    process.exit(1);
+  }).on('error', function(e) {
+    console.log('client got error: ' + e.message);
+    gotError = true;
+
+    server.close();
+    process.exit();
+  }).end();
+});
+
+process.on('exit', function() {
+  assert.ok(gotError);
+});

--- a/test/simple/test-http-localaddress-bind-error.js
+++ b/test/simple/test-http-localaddress-bind-error.js
@@ -52,7 +52,6 @@ server.listen(common.PORT, "127.0.0.1", function() {
     gotError = true;
 
     server.close();
-    process.exit();
   }).end();
 });
 

--- a/test/simple/test-https-localaddress-bind-error.js
+++ b/test/simple/test-https-localaddress-bind-error.js
@@ -1,0 +1,67 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var https = require('https'),
+    fs = require('fs'),
+    assert = require('assert');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var invalidLocalAddress = '1.2.3.4';
+var gotError = false;
+
+var server = https.createServer(options, function (req, res) {
+  console.log("Connect from: " + req.connection.remoteAddress);
+
+  req.on('end', function() {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('You are from: ' + req.connection.remoteAddress);
+  });
+});
+
+server.listen(common.PORT, "127.0.0.1", function() {
+  var req = https.request({
+    host: 'localhost',
+    port: common.PORT,
+    path: '/',
+    method: 'GET',
+    localAddress: invalidLocalAddress
+  }, function(res) {
+    console.log('unexpectedly got response from server');
+
+    server.close();
+    process.exit(1);
+  }).on('error', function(e) {
+    console.log('client got error: ' + e.message);
+    gotError = true;
+
+    server.close();
+    process.exit();
+  }).end();
+});
+
+process.on('exit', function() {
+  assert.ok(gotError);
+});

--- a/test/simple/test-https-localaddress-bind-error.js
+++ b/test/simple/test-https-localaddress-bind-error.js
@@ -58,7 +58,6 @@ server.listen(common.PORT, "127.0.0.1", function() {
     gotError = true;
 
     server.close();
-    process.exit();
   }).end();
 });
 


### PR DESCRIPTION
Currently when `connect` is passed an invalid `localAddress` and the call to `bind` fails, the error is ignored. As a result, outbound requests are sent from a different address than the user expects.

This change handles failure to `bind` in the same manner as failure to `connect`.
