### PR TITLE
Warn the user about the lack of an acceptable C compiler on the system

### DIFF
--- a/configure
+++ b/configure
@@ -154,10 +154,20 @@ def pkg_config(pkg):
 def host_arch_cc():
   """Host architecture check using the CC command."""
 
-  p = subprocess.Popen(CC.split() + ['-dM', '-E', '-'],
-                       stdin=subprocess.PIPE,
-                       stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE)
+  try:
+    p = subprocess.Popen(CC.split() + ['-dM', '-E', '-'],
+                         stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+  except OSError:
+    print '''Node.js configure error: No acceptable C compiler found!
+
+        Please make sure you have a C compiler installed on your system and/or
+        consider adjusting the CC environment variable if you installed
+        it in a non-standard prefix.
+        '''
+    sys.exit()
+
   p.stdin.write('\n')
   out = p.communicate()[0]
 


### PR DESCRIPTION
Hi!

I'm running under linux and I went into this error when trying to run the configure script:

Traceback (most recent call last):
  File "./configure", line 327, in <module>
    configure_node(output)
  File "./configure", line 235, in configure_node
    o['variables']['host_arch'] = host_arch()
  File "./configure", line 210, in host_arch
    arch = host_arch_cc()
  File "./configure", line 160, in host_arch_cc
    stderr=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 679, in **init**
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1228, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

My problem was that I didn't had the gcc compiler installed on my system. After getting this error, I thought that this error should be properly shown to the user in a more human-friendly way. Don't you think?

So I catched the expection, added this warning and a sys.exit(). I don't know if you'll like this way, so I'm willing to accept suggestions for changes.

Best regards!
