### PR TITLE
bug with user-supplied inspect() function returns non-string

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -158,7 +158,7 @@ function formatValue(ctx, value, recurseTimes) {
       value.inspect !== exports.inspect &&
       // Also filter out any prototype objects using the circular check.
       !(value.constructor && value.constructor.prototype === value)) {
-    return value.inspect(recurseTimes);
+    return String(value.inspect(recurseTimes));
   }
 
   // Primitive types cannot have properties

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -97,6 +97,13 @@ assert.doesNotThrow(function() {
   util.inspect(r);
 });
 
+// bug with user-supplied inspect function returns non-string
+assert.doesNotThrow(function() {
+  util.inspect([{
+    inspect: function(){return 123}
+  }])
+});
+
 // GH-2225
 var x = { inspect: util.inspect };
 assert.ok(util.inspect(x).indexOf('inspect') != -1);


### PR DESCRIPTION
``` javascript
> require('util').inspect([{inspect: function(){return 123}}])
TypeError: Object 123 has no method 'indexOf'
    at formatProperty (util.js:322:15)
```
