### PR TITLE
buffer: make SlowBuffer inherit from Buffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -24,25 +24,14 @@ var assert = require('assert');
 
 exports.INSPECT_MAX_BYTES = 50;
 
+// Make SlowBuffer inherit from Buffer
+SlowBuffer.prototype.__proto__ = Buffer.prototype;
+
 
 function toHex(n) {
   if (n < 16) return '0' + n.toString(16);
   return n.toString(16);
 }
-
-
-SlowBuffer.prototype.inspect = function() {
-  var out = [],
-      len = this.length;
-  for (var i = 0; i < len; i++) {
-    out[i] = toHex(this[i]);
-    if (i == exports.INSPECT_MAX_BYTES) {
-      out[i + 1] = '...';
-      break;
-    }
-  }
-  return '<SlowBuffer ' + out.join(' ') + '>';
-};
 
 
 SlowBuffer.prototype.hexSlice = function(start, end) {
@@ -291,24 +280,25 @@ function allocPool() {
 
 // Static methods
 Buffer.isBuffer = function isBuffer(b) {
-  return b instanceof Buffer || b instanceof SlowBuffer;
+  return b instanceof Buffer;
 };
 
 
 // Inspect
 Buffer.prototype.inspect = function inspect() {
   var out = [],
-      len = this.length;
+      len = this.length,
+      name = this.constructor.name;
 
   for (var i = 0; i < len; i++) {
-    out[i] = toHex(this.parent[i + this.offset]);
+    out[i] = toHex(this[i]);
     if (i == exports.INSPECT_MAX_BYTES) {
       out[i + 1] = '...';
       break;
     }
   }
 
-  return '<Buffer ' + out.join(' ') + '>';
+  return '<' + name  + ' ' + out.join(' ') + '>';
 };
 
 
@@ -1128,32 +1118,3 @@ Buffer.prototype.writeDoubleLE = function(value, offset, noAssert) {
 Buffer.prototype.writeDoubleBE = function(value, offset, noAssert) {
   writeDouble(this, value, offset, true, noAssert);
 };
-
-SlowBuffer.prototype.readUInt8 = Buffer.prototype.readUInt8;
-SlowBuffer.prototype.readUInt16LE = Buffer.prototype.readUInt16LE;
-SlowBuffer.prototype.readUInt16BE = Buffer.prototype.readUInt16BE;
-SlowBuffer.prototype.readUInt32LE = Buffer.prototype.readUInt32LE;
-SlowBuffer.prototype.readUInt32BE = Buffer.prototype.readUInt32BE;
-SlowBuffer.prototype.readInt8 = Buffer.prototype.readInt8;
-SlowBuffer.prototype.readInt16LE = Buffer.prototype.readInt16LE;
-SlowBuffer.prototype.readInt16BE = Buffer.prototype.readInt16BE;
-SlowBuffer.prototype.readInt32LE = Buffer.prototype.readInt32LE;
-SlowBuffer.prototype.readInt32BE = Buffer.prototype.readInt32BE;
-SlowBuffer.prototype.readFloatLE = Buffer.prototype.readFloatLE;
-SlowBuffer.prototype.readFloatBE = Buffer.prototype.readFloatBE;
-SlowBuffer.prototype.readDoubleLE = Buffer.prototype.readDoubleLE;
-SlowBuffer.prototype.readDoubleBE = Buffer.prototype.readDoubleBE;
-SlowBuffer.prototype.writeUInt8 = Buffer.prototype.writeUInt8;
-SlowBuffer.prototype.writeUInt16LE = Buffer.prototype.writeUInt16LE;
-SlowBuffer.prototype.writeUInt16BE = Buffer.prototype.writeUInt16BE;
-SlowBuffer.prototype.writeUInt32LE = Buffer.prototype.writeUInt32LE;
-SlowBuffer.prototype.writeUInt32BE = Buffer.prototype.writeUInt32BE;
-SlowBuffer.prototype.writeInt8 = Buffer.prototype.writeInt8;
-SlowBuffer.prototype.writeInt16LE = Buffer.prototype.writeInt16LE;
-SlowBuffer.prototype.writeInt16BE = Buffer.prototype.writeInt16BE;
-SlowBuffer.prototype.writeInt32LE = Buffer.prototype.writeInt32LE;
-SlowBuffer.prototype.writeInt32BE = Buffer.prototype.writeInt32BE;
-SlowBuffer.prototype.writeFloatLE = Buffer.prototype.writeFloatLE;
-SlowBuffer.prototype.writeFloatBE = Buffer.prototype.writeFloatBE;
-SlowBuffer.prototype.writeDoubleLE = Buffer.prototype.writeDoubleLE;
-SlowBuffer.prototype.writeDoubleBE = Buffer.prototype.writeDoubleBE;


### PR DESCRIPTION
I wanted people to comment on this one because it's somewhat controversial. To anyone who doesn't like the `__proto__` usage, the justification is that we do the same thing to the `process` object to make it be an EventEmtter.

But basically this frees us from manually having to copy over functions to SlowBuffer's prototype (which has bitten us multiple times in the past). It's also nice for modules like `buffertools` or my new `ref` which extend Buffer's prototype, and therefore wouldn't [have to do so for SlowBuffer as well](https://github.com/TooTallNate/ref/blob/15b272bcb352d0af4ebec8b96e03b8c5a93bdfa5/lib/ref.js#L427-439).

As an added bonus, the `inspect()` function is now shared between Buffer and SlowBuffer, removing some duplicate code. There's probably more functions that we could share, but I figured there's probably speed optimizations that should be left in place.

Thoughts?

/cc @isaacs @bnoordhuis @piscisaureus
