### PR TITLE
Improve Exception reporting

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -304,11 +304,16 @@ Module._load = function(request, parent, isMain) {
   }
 
   Module._cache[filename] = module;
+
+  var hadException = true;
+
   try {
     module.load(filename);
-  } catch (err) {
-    delete Module._cache[filename];
-    throw err;
+    hadException = false;
+  } finally {
+    if (hadException) {
+      delete Module._cache[filename];
+    }
   }
 
   return module.exports;

--- a/src/node.js
+++ b/src/node.js
@@ -180,26 +180,18 @@
 
   startup.processNextTick = function() {
     var nextTickQueue = [];
+    var nextTickIndex = 0;
 
     process._tickCallback = function() {
-      var l = nextTickQueue.length;
-      if (l === 0) return;
+      var nextTickLength = nextTickQueue.length;
+      if (nextTickLength === 0) return;
 
-      var q = nextTickQueue;
-      nextTickQueue = [];
+      while (nextTickIndex < nextTickLength) {
+        nextTickQueue[nextTickIndex++]();
+      }
 
-      try {
-        for (var i = 0; i < l; i++) q[i]();
-      }
-      catch (e) {
-        if (i + 1 < l) {
-          nextTickQueue = q.slice(i + 1).concat(nextTickQueue);
-        }
-        if (nextTickQueue.length) {
-          process._needTickCallback();
-        }
-        throw e; // process.nextTick error, or 'error' event on first tick
-      }
+      nextTickQueue.splice(0, nextTickIndex);
+      nextTickIndex = 0;
     };
 
     process.nextTick = function(callback) {

--- a/test/message/stack_overflow.out
+++ b/test/message/stack_overflow.out
@@ -1,6 +1,6 @@
 before
 
-module.js:311
-    throw err;
-          ^
+*test*message*stack_overflow.js:31
+function stackOverflow() {
+                      ^
 RangeError: Maximum call stack size exceeded

--- a/test/message/stack_overflow.out
+++ b/test/message/stack_overflow.out
@@ -1,6 +1,6 @@
 before
 
-node.js:*
-        throw e; // process.nextTick error, or 'error' event on first tick
-              ^
+module.js:311
+    throw err;
+          ^
 RangeError: Maximum call stack size exceeded

--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,6 +1,6 @@
 before
 
-node.js:*
-        throw e; // process.nextTick error, or 'error' event on first tick
-              ^
+module.js:311
+    throw err;
+          ^
 MyCustomError: This is a custom message

--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,6 +1,6 @@
 before
 
-module.js:311
-    throw err;
-          ^
+*test*message*throw_custom_error.js:31
+throw { name: 'MyCustomError', message: 'This is a custom message' };
+^
 MyCustomError: This is a custom message

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,6 +1,6 @@
 before
 
-module.js:311
-    throw err;
-          ^
+*/test/message/throw_non_error.js:31
+throw { foo: 'bar' };
+^
 [object Object]

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,6 +1,6 @@
 before
 
-node.js:*
-        throw e; // process.nextTick error, or 'error' event on first tick
-              ^
+module.js:311
+    throw err;
+          ^
 [object Object]

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -1,8 +1,8 @@
 before
 
-node.js:*
-        throw e; // process.nextTick error, or 'error' event on first tick
-              ^
+module.js:311
+    throw err;
+          ^
 ReferenceError: foo is not defined
     at evalmachine.<anonymous>:*
     at Object.<anonymous> (*test*message*undefined_reference_in_new_context.js:*)

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -1,8 +1,8 @@
 before
 
-module.js:311
-    throw err;
-          ^
+*test*message*undefined_reference_in_new_context.js:34
+script.runInNewContext();
+       ^
 ReferenceError: foo is not defined
     at evalmachine.<anonymous>:*
     at Object.<anonymous> (*test*message*undefined_reference_in_new_context.js:*)


### PR DESCRIPTION
2 patches that improve / fix the output of the `throw` call sites for errors triggered inside `process.nextTick` callbacks as well as during module loading.
