### PR TITLE
Fix #3242 Actually deprecate 'binary' buffer encoding

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -33,12 +33,13 @@ encoding method.  Here are the different string encodings.
 
 * `'base64'` - Base64 string encoding.
 
-* `'binary'` - A way of encoding raw binary data into strings by using only
-  the first 8 bits of each character. This encoding method is deprecated and
-  should be avoided in favor of `Buffer` objects where possible. This encoding
-  will be removed in future versions of Node.
-
 * `'hex'` - Encode each byte as two hexadecimal characters.
+
+If you need direct access to the bytes, then the best way is to use a
+Buffer object directly, rather than any string encoding.  In the past,
+there were options for `'binary'`, `'raw'`, and others, but these all
+involve unnecessary copying.  Just use Buffers directly if you need
+access to the actual bytes.
 
 ## Class: Buffer
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -22,6 +22,15 @@
 var SlowBuffer = process.binding('buffer').SlowBuffer;
 var assert = require('assert');
 
+// Deprecate the 'binary' encoding.
+// TODO: Remove it entirely in v0.9.
+var binaryWarned = false;
+function binaryWarn() {
+  if (binaryWarned) return;
+  binaryWarned = true;
+  console.error('The binary buffer encoding is deprecated.');
+}
+
 exports.INSPECT_MAX_BYTES = 50;
 
 
@@ -82,6 +91,7 @@ SlowBuffer.prototype.toString = function(encoding, start, end) {
       return this.asciiSlice(start, end);
 
     case 'binary':
+      binaryWarn();
       return this.binarySlice(start, end);
 
     case 'base64':
@@ -168,6 +178,7 @@ SlowBuffer.prototype.write = function(string, offset, length, encoding) {
       return this.asciiWrite(string, offset, length);
 
     case 'binary':
+      binaryWarn();
       return this.binaryWrite(string, offset, length);
 
     case 'base64':
@@ -368,6 +379,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       break;
 
     case 'binary':
+      binaryWarn();
       ret = this.parent.binaryWrite(string, this.offset + offset, length);
       break;
 
@@ -424,6 +436,7 @@ Buffer.prototype.toString = function(encoding, start, end) {
       return this.parent.asciiSlice(start, end);
 
     case 'binary':
+      binaryWarn();
       return this.parent.binarySlice(start, end);
 
     case 'base64':
@@ -536,6 +549,7 @@ Buffer.prototype.utf8Slice = function(start, end) {
 };
 
 Buffer.prototype.binarySlice = function(start, end) {
+  binaryWarn();
   return this.toString('binary', start, end);
 };
 
@@ -548,6 +562,7 @@ Buffer.prototype.utf8Write = function(string, offset) {
 };
 
 Buffer.prototype.binaryWrite = function(string, offset) {
+  binaryWarn();
   return this.write(string, offset, 'binary');
 };
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1104,16 +1104,18 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
   } else if (strcasecmp(*encoding, "ucs-2") == 0) {
     return UCS2;
   } else if (strcasecmp(*encoding, "binary") == 0) {
+    fprintf(stderr, "The 'binary' buffer encoding is deprecated. "
+                    "Use a Buffer object directly.\n");
     return BINARY;
   } else if (strcasecmp(*encoding, "hex") == 0) {
     return HEX;
   } else if (strcasecmp(*encoding, "raw") == 0) {
     fprintf(stderr, "'raw' (array of integers) has been removed. "
-                    "Use 'binary'.\n");
+                    "Use a Buffer object directly.\n");
     return BINARY;
   } else if (strcasecmp(*encoding, "raws") == 0) {
-    fprintf(stderr, "'raws' encoding has been renamed to 'binary'. "
-                    "Please update your code.\n");
+    fprintf(stderr, "'raws' (array of integers) has been removed. "
+                    "Use a Buffer object directly.\n");
     return BINARY;
   } else {
     return _default;
@@ -1147,8 +1149,8 @@ ssize_t DecodeBytes(v8::Handle<v8::Value> val, enum encoding encoding) {
   HandleScope scope;
 
   if (val->IsArray()) {
-    fprintf(stderr, "'raw' encoding (array of integers) has been removed. "
-                    "Use 'binary'.\n");
+    fprintf(stderr, "'raw' (array of integers) has been removed. "
+                    "Use a Buffer object directly.\n");
     assert(0);
     return -1;
   }
@@ -1184,8 +1186,8 @@ ssize_t DecodeWrite(char *buf,
   // http://groups.google.com/group/v8-users/browse_thread/thread/1f83b0ba1f0a611
 
   if (val->IsArray()) {
-    fprintf(stderr, "'raw' encoding (array of integers) has been removed. "
-                    "Use 'binary'.\n");
+    fprintf(stderr, "'raw' (array of integers) has been removed. "
+                    "Use a Buffer object directly.\n");
     assert(0);
     return -1;
   }


### PR DESCRIPTION
Prints warnings whenever the 'binary' encoding is used.

We can remove it entirely in master once we fork 0.8 off.
