### PR TITLE
ReadableStream does not have a destroySoon method

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -67,11 +67,6 @@ Resumes the incoming `'data'` events after a `pause()`.
 
 Closes the underlying file descriptor. Stream will not emit any more events.
 
-
-### stream.destroySoon()
-
-After the write queue is drained, close the file descriptor.
-
 ### stream.pipe(destination, [options])
 
 This is a `Stream.prototype` method available on all `Stream`s.


### PR DESCRIPTION
ReadableStream does not have a destroySoon method, however the docs list a destroySoon method under ReadableStream.  The docs appear to have been copy/pasted from WritableStream.  This patch removes the destroySoon documentation from the Readable Stream section.
