### PR TITLE
child_process.fork: allow execPath to be specified.

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -203,7 +203,10 @@ exports.fork = function(modulePath /*, args, options*/) {
   // stdin is the IPC channel.
   options.stdinStream = createPipe(true);
 
-  var child = spawn(process.execPath, args, options);
+  // default to process.execPath if options.execPath is not provided
+  options.execPath = options.execPath || process.execPath;
+
+  var child = spawn(options.execPath, args, options);
 
   setupChannel(child, options.stdinStream);
 


### PR DESCRIPTION
When running coffee-script files with dev tools like node-dev or testing tools like mocha, execPath is always "node" as these tools are plain js.

To be able to fork a coffee-script child process, I have to modify process.execPath to the path of "coffee":
   [process.oldExecPath, process.execPath] = [process.execPath,'/usr/local/bin/coffee']
   child = fork modulePath, [], options
   process.execPath = process.oldExecPath if process.oldExecPath

This pull request provides child_process.fork with an optional execPath option.
