### PR TITLE
Some speed improvements to querystring

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -45,57 +45,48 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
   var n, m, hexchar;
 
   for (var inIndex = 0, outIndex = 0; inIndex <= s.length; inIndex++) {
-    var c = s.charCodeAt(inIndex);
-    switch (state) {
-      case 'CHAR':
-        switch (c) {
-          case charCode('%'):
-            n = 0;
-            m = 0;
-            state = 'HEX0';
-            break;
-          case charCode('+'):
-            if (decodeSpaces) c = charCode(' ');
-            // pass thru
-          default:
-            out[outIndex++] = c;
-            break;
-        }
-        break;
-
-      case 'HEX0':
-        state = 'HEX1';
-        hexchar = c;
-        if (charCode('0') <= c && c <= charCode('9')) {
-          n = c - charCode('0');
-        } else if (charCode('a') <= c && c <= charCode('f')) {
-          n = c - charCode('a') + 10;
-        } else if (charCode('A') <= c && c <= charCode('F')) {
-          n = c - charCode('A') + 10;
-        } else {
-          out[outIndex++] = charCode('%');
-          out[outIndex++] = c;
-          state = 'CHAR';
-          break;
-        }
-        break;
-
-      case 'HEX1':
+    var c = s.charCodeAt(inIndex), cc = s.charAt(inIndex);
+    if (state === 'CHAR') {
+      if (cc === '%') {
+          n = 0;
+          m = 0;
+          state = 'HEX0';
+      }
+      else if (decodeSpaces && cc === '+') {
+        out[outIndex++] = charCode(' ');
+      }
+      else out[outIndex++] = c;
+    }
+    else if (state === 'HEX0') {
+      state = 'HEX1';
+      hexchar = c;
+      if ('0' <= cc && cc <= '9') {
+        n = c - charCode('0');
+      } else if ('a' <= cc && cc <= 'f') {
+        n = c - charCode('a') + 10;
+      } else if ('A' <= cc && cc <= 'F') {
+        n = c - charCode('A') + 10;
+      } else {
+        out[outIndex++] = charCode('%');
+        out[outIndex++] = c;
         state = 'CHAR';
-        if (charCode('0') <= c && c <= charCode('9')) {
+      }
+    }
+    else if(state === 'HEX1'){
+        state = 'CHAR';
+        if ('0' <= cc && cc <= '9') {
           m = c - charCode('0');
-        } else if (charCode('a') <= c && c <= charCode('f')) {
+        } else if ('a' <= cc && cc <= 'f') {
           m = c - charCode('a') + 10;
-        } else if (charCode('A') <= c && c <= charCode('F')) {
+        } else if ('A' <= cc && cc <= 'F') {
           m = c - charCode('A') + 10;
         } else {
           out[outIndex++] = charCode('%');
           out[outIndex++] = hexchar;
           out[outIndex++] = c;
-          break;
+          continue;
         }
         out[outIndex++] = 16 * n + m;
-        break;
     }
   }
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -22,7 +22,7 @@
 // Query String Utilities
 
 var QueryString = exports;
-var urlDecode = process.binding('http_parser').urlDecode;
+//var urlDecode = process.binding('http_parser').urlDecode;
 
 
 // If obj.hasOwnProperty has been overridden, then calling

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -125,15 +125,13 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
 
   if (typeof obj === 'object'){
     return Object.keys(obj).map(function(k) {
-      var ks = QueryString.escape(stringifyPrimitive(k));
+      var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
       if (Array.isArray(obj[k])) {
         return obj[k].map(function(v) {
-          return ks + eq +
-                 QueryString.escape(stringifyPrimitive(v));
+          return ks + QueryString.escape(stringifyPrimitive(v));
         }).join(sep);
       } else {
-        return ks + eq +
-               QueryString.escape(stringifyPrimitive(obj[k]));
+        return ks + QueryString.escape(stringifyPrimitive(obj[k]));
       }
     }).join(sep);
   }

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -32,6 +32,12 @@ function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
+
+function charCode(c) {
+  return c.charCodeAt(0);
+}
+
+
 // a safe fast alternative to decodeURIComponent
 QueryString.unescapeBuffer = function(s, decodeSpaces) {
   var out = new Buffer(s.length);
@@ -40,47 +46,56 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
 
   for (var inIndex = 0, outIndex = 0; inIndex <= s.length; inIndex++) {
     var c = s.charCodeAt(inIndex);
-    if (state === 'CHAR') {
-      if (c === 37 /* '%' */ ) {
-          n = 0;
-          m = 0;
-          state = 'HEX0';
-      }
-      else if (decodeSpaces && c === 43 /* '+' */ ) {
-        out[outIndex++] = 32 /* ' ' */ ;
-      }
-      else out[outIndex++] = c;
-    }
-    else if (state === 'HEX0') {
-      state = 'HEX1';
-      hexchar = c;
-      if (48 /* '0' */  <= c && c <= 57 /* '9' */ ) {
-        n = c - 48 /* '0' */ ;
-      } else if (97 /* 'a' */  <= c && c <= 102 /* 'f' */ ) {
-        n = c - 97 /* 'a' */  + 10;
-      } else if (65 /* 'A' */  <= c && c <= 70 /* 'F' */ ) {
-        n = c - 65 /* 'A' */  + 10;
-      } else {
-        out[outIndex++] = 37 /* '%' */ ;
-        out[outIndex++] = c;
-        state = 'CHAR';
-      }
-    }
-    else if (state === 'HEX1') {
-        state = 'CHAR';
-        if (48 /* '0' */  <= c && c <= 57 /* '9' */ ) {
-          m = c - 48 /* '0' */ ;
-        } else if (97 /* 'a' */  <= c && c <= 102 /* 'f' */ ) {
-          m = c - 97 /* 'a' */  + 10;
-        } else if (65 /* 'A' */  <= c && c <= 70 /* 'F' */ ) {
-          m = c - 65 /* 'A' */  + 10;
+    switch (state) {
+      case 'CHAR':
+        switch (c) {
+          case charCode('%'):
+            n = 0;
+            m = 0;
+            state = 'HEX0';
+            break;
+          case charCode('+'):
+            if (decodeSpaces) c = charCode(' ');
+            // pass thru
+          default:
+            out[outIndex++] = c;
+            break;
+        }
+        break;
+
+      case 'HEX0':
+        state = 'HEX1';
+        hexchar = c;
+        if (charCode('0') <= c && c <= charCode('9')) {
+          n = c - charCode('0');
+        } else if (charCode('a') <= c && c <= charCode('f')) {
+          n = c - charCode('a') + 10;
+        } else if (charCode('A') <= c && c <= charCode('F')) {
+          n = c - charCode('A') + 10;
         } else {
-          out[outIndex++] = 37 /* '%' */ ;
+          out[outIndex++] = charCode('%');
+          out[outIndex++] = c;
+          state = 'CHAR';
+          break;
+        }
+        break;
+
+      case 'HEX1':
+        state = 'CHAR';
+        if (charCode('0') <= c && c <= charCode('9')) {
+          m = c - charCode('0');
+        } else if (charCode('a') <= c && c <= charCode('f')) {
+          m = c - charCode('a') + 10;
+        } else if (charCode('A') <= c && c <= charCode('F')) {
+          m = c - charCode('A') + 10;
+        } else {
+          out[outIndex++] = charCode('%');
           out[outIndex++] = hexchar;
           out[outIndex++] = c;
-          continue;
+          break;
         }
         out[outIndex++] = 16 * n + m;
+        break;
     }
   }
 
@@ -100,24 +115,26 @@ QueryString.escape = function(str) {
 };
 
 var stringifyPrimitive = function(v) {
-  if (typeof v === 'string') return v;
-  if (typeof v === 'boolean'){
-    if(v) return 'true';
-    return 'false';
+  switch (typeof v) {
+    case 'string':  return v;
+    case 'boolean': return v ? 'true' : 'false';
+    case 'number':
+      if (isFinite(v)){
+        return v;
+      }
+    default: return '';
   }
-  if (typeof v === 'number' && isFinite(v)) {
-    return v;
-  }
-  return '';
 };
 
 
 QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
   if (!sep) sep = '&';
   if (!eq) eq = '=';
-  if (obj === null) obj = undefined;
+  if (obj === null) {
+    obj = undefined;
+  }
 
-  if (typeof obj === 'object'){
+  if (typeof obj === 'object') {
     return Object.keys(obj).map(function(k) {
       var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
       if (Array.isArray(obj[k])) {

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -72,7 +72,7 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
         state = 'CHAR';
       }
     }
-    else if(state === 'HEX1'){
+    else if (state === 'HEX1') {
         state = 'CHAR';
         if ('0' <= cc && cc <= '9') {
           m = c - charCode('0');
@@ -106,19 +106,15 @@ QueryString.escape = function(str) {
 };
 
 var stringifyPrimitive = function(v) {
-  switch (typeof v) {
-    case 'string':
-      return v;
-
-    case 'boolean':
-      return v ? 'true' : 'false';
-
-    case 'number':
-      return isFinite(v) ? v : '';
-
-    default:
-      return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'boolean'){
+    if(v) return 'true';
+    return 'false';
   }
+  if (typeof v === 'number' && isFinite(v)) {
+    return v;
+  }
+  return '';
 };
 
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -119,31 +119,29 @@ var stringifyPrimitive = function(v) {
 
 
 QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
-  sep = sep || '&';
-  eq = eq || '=';
-  obj = (obj === null) ? undefined : obj;
+  if (!sep) sep = '&';
+  if (!eq) eq = '=';
+  if (obj === null) obj = undefined;
 
-  switch (typeof obj) {
-    case 'object':
-      return Object.keys(obj).map(function(k) {
-        if (Array.isArray(obj[k])) {
-          return obj[k].map(function(v) {
-            return QueryString.escape(stringifyPrimitive(k)) +
-                   eq +
-                   QueryString.escape(stringifyPrimitive(v));
-          }).join(sep);
-        } else {
-          return QueryString.escape(stringifyPrimitive(k)) +
-                 eq +
-                 QueryString.escape(stringifyPrimitive(obj[k]));
-        }
-      }).join(sep);
-
-    default:
-      if (!name) return '';
-      return QueryString.escape(stringifyPrimitive(name)) + eq +
-             QueryString.escape(stringifyPrimitive(obj));
+  if (typeof obj === 'object'){
+    return Object.keys(obj).map(function(k) {
+      var ks = QueryString.escape(stringifyPrimitive(k));
+      if (Array.isArray(obj[k])) {
+        return obj[k].map(function(v) {
+          return ks + eq +
+                 QueryString.escape(stringifyPrimitive(v));
+        }).join(sep);
+      } else {
+        return ks + eq +
+               QueryString.escape(stringifyPrimitive(obj[k]));
+      }
+    }).join(sep);
   }
+
+  if(!name) return '';
+
+  return QueryString.escape(stringifyPrimitive(name)) + eq +
+         QueryString.escape(stringifyPrimitive(obj));
 };
 
 // Parse a key=val string.

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -146,33 +146,34 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
 
 // Parse a key=val string.
 QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
-  sep = sep || '&';
-  eq = eq || '=';
+  if (!sep) sep = '&';
+  if (!eq) eq = '=';
+
   var obj = {},
       maxKeys = 1000;
+
+  if (typeof qs !== 'string' || qs.length === 0) {
+    return obj;
+  }
 
   // Handle maxKeys = 0 case
   if (options && typeof options.maxKeys === 'number') {
     maxKeys = options.maxKeys;
   }
 
-  if (typeof qs !== 'string' || qs.length === 0) {
-    return obj;
-  }
-
   var regexp = /\+/g;
   qs = qs.split(sep);
 
   // maxKeys <= 0 means that we should not limit keys count
-  if (maxKeys > 0) {
+  if (maxKeys > 0 && qs.length > maxKeys) {
     qs = qs.slice(0, maxKeys);
   }
 
   for (var i = 0, len = qs.length; i < len; ++i) {
     var x = qs[i].replace(regexp, '%20'),
         idx = x.indexOf(eq),
-        kstr = x.substring(0, idx),
-        vstr = x.substring(idx + 1), k, v;
+        kstr = x.substr(0, idx),
+        vstr = x.substr(idx + 1), k, v;
 
     if (kstr === '' && vstr !== '') {
       kstr = vstr;
@@ -189,10 +190,10 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;
-    } else if (!Array.isArray(obj[k])) {
-      obj[k] = [obj[k], v];
-    } else {
+    } else if (Array.isArray(obj[k])) {
       obj[k].push(v);
+    } else {
+      obj[k] = [obj[k], v];
     }
   }
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -32,12 +32,6 @@ function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-
-function charCode(c) {
-  return c.charCodeAt(0);
-}
-
-
 // a safe fast alternative to decodeURIComponent
 QueryString.unescapeBuffer = function(s, decodeSpaces) {
   var out = new Buffer(s.length);
@@ -45,43 +39,43 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
   var n, m, hexchar;
 
   for (var inIndex = 0, outIndex = 0; inIndex <= s.length; inIndex++) {
-    var c = s.charCodeAt(inIndex), cc = s.charAt(inIndex);
+    var c = s.charCodeAt(inIndex);
     if (state === 'CHAR') {
-      if (cc === '%') {
+      if (c === 37 /* '%' */ ) {
           n = 0;
           m = 0;
           state = 'HEX0';
       }
-      else if (decodeSpaces && cc === '+') {
-        out[outIndex++] = charCode(' ');
+      else if (decodeSpaces && c === 43 /* '+' */ ) {
+        out[outIndex++] = 32 /* ' ' */ ;
       }
       else out[outIndex++] = c;
     }
     else if (state === 'HEX0') {
       state = 'HEX1';
       hexchar = c;
-      if ('0' <= cc && cc <= '9') {
-        n = c - charCode('0');
-      } else if ('a' <= cc && cc <= 'f') {
-        n = c - charCode('a') + 10;
-      } else if ('A' <= cc && cc <= 'F') {
-        n = c - charCode('A') + 10;
+      if (48 /* '0' */  <= c && c <= 57 /* '9' */ ) {
+        n = c - 48 /* '0' */ ;
+      } else if (97 /* 'a' */  <= c && c <= 102 /* 'f' */ ) {
+        n = c - 97 /* 'a' */  + 10;
+      } else if (65 /* 'A' */  <= c && c <= 70 /* 'F' */ ) {
+        n = c - 65 /* 'A' */  + 10;
       } else {
-        out[outIndex++] = charCode('%');
+        out[outIndex++] = 37 /* '%' */ ;
         out[outIndex++] = c;
         state = 'CHAR';
       }
     }
     else if (state === 'HEX1') {
         state = 'CHAR';
-        if ('0' <= cc && cc <= '9') {
-          m = c - charCode('0');
-        } else if ('a' <= cc && cc <= 'f') {
-          m = c - charCode('a') + 10;
-        } else if ('A' <= cc && cc <= 'F') {
-          m = c - charCode('A') + 10;
+        if (48 /* '0' */  <= c && c <= 57 /* '9' */ ) {
+          m = c - 48 /* '0' */ ;
+        } else if (97 /* 'a' */  <= c && c <= 102 /* 'f' */ ) {
+          m = c - 97 /* 'a' */  + 10;
+        } else if (65 /* 'A' */  <= c && c <= 70 /* 'F' */ ) {
+          m = c - 65 /* 'A' */  + 10;
         } else {
-          out[outIndex++] = charCode('%');
+          out[outIndex++] = 37 /* '%' */ ;
           out[outIndex++] = hexchar;
           out[outIndex++] = c;
           continue;


### PR DESCRIPTION
I couldn't really understand [this commit message](https://github.com/joyent/node/commit/5e3ca981556c305830553d006b76d5dcaaf49276) _(Make QueryString.parse() even faster)_, as there was some crappy code in the module. So I tried to make it a true statement (not just for that function, but for the whole module), optimizing at different places.

Some of the things that were optimized:
- **Avoid switch statements**: At one place, there was a switch statement that just checked for a single condition. Extremely wasteful. Besides, if-else constructs are much more readable.
- **Don't cache typeof**: A couple of days ago, I found [this test](http://jsperf.com/cached-typeof/) at jsPerf, which is pretty interesting. It looks like V8 optimizes `typeof x === 'type'` calls, so caching the call is actually bad. I created a [fork](http://jsperf.com/cached-typeof/2) including the switch statement, have a look at your own (a hint: Only half of the iterations with switch). This isn't critical, but it's also only a small change.
- **Escape from the `charCode()` hell**: I don't know why there were so many (unnecessary) calls of `charCode`, but string comparison is faster by several magnitudes, so let's use that. Besides, all the calls could be replaced with hardcoded numbers (which, of course, would hurt readability, so I didn't do that).
- **Don't assign things to themselves**: `foo = foo || 'bar'` is a pretty common pattern, but an `if` is the better choice in performance sensitive code. (I used an `if` that's directly followed by the assignment, I hope that fits nodes style.)
- **Don't create an exact copy of an Array that's thrown away afterwards**: In `QueryString.parse()`, `Array#slice` was called for any array. A check of the arrays length property avoids the garbage.

I guess I need to sign something before gettings this merged, so point me at it and I'll do it. And when there's anything else to do before getting this merged, tell me.
