### PR TITLE
Fast readfile

### DIFF
--- a/benchmark/fs-readfile.js
+++ b/benchmark/fs-readfile.js
@@ -1,0 +1,72 @@
+// Call fs.readFile over and over again really fast.
+// Then see how many times it got called.
+// Yes, this is a silly benchmark.  Most benchmarks are silly.
+
+var path = require('path');
+var filename = path.resolve(__dirname, 'http.sh');
+var fs = require('fs');
+var count = 0;
+var go = true;
+var len = -1;
+var assert = require('assert');
+
+var concurrency = 1;
+var encoding = null;
+var time = 10;
+
+for (var i = 2; i < process.argv.length; i++) {
+  var arg = process.argv[i];
+  if (arg.match(/^-e$/)) {
+    encoding = process.argv[++i] || null;
+  } else if (arg.match(/^-c$/)) {
+    concurrency = ~~process.argv[++i];
+    if (concurrency < 1) concurrency = 1;
+  } else if (arg === '-t') {
+    time = ~~process.argv[++i];
+    if (time < 1) time = 1;
+  }
+}
+
+
+setTimeout(function() {
+  go = false;
+}, time * 1000);
+
+function round(n) {
+  return Math.floor(n * 100) / 100;
+}
+
+var start = process.hrtime();
+while (concurrency--) readFile();
+
+function readFile() {
+  if (!go) {
+    process.stdout.write('\n');
+    console.log('read the file %d times (higher is better)', count);
+    var end = process.hrtime();
+    var elapsed = [end[0] - start[0], end[1] - start[1]];
+    var ns = elapsed[0] * 1E9 + elapsed[1];
+    var nsper = round(ns / count);
+    console.log('%d ns per read (lower is better)', nsper);
+    var readsper = round(count / (ns / 1E9));
+    console.log('%d reads per sec (higher is better)', readsper);
+    process.exit(0);
+    return;
+  }
+
+  if (!(count % 1000)) {
+    process.stdout.write('.');
+  }
+
+  if (encoding) fs.readFile(filename, encoding, then);
+  else fs.readFile(filename, then);
+
+  function then(er, data) {
+    assert.ifError(er);
+    count++;
+    // basic sanity test: we should get the same number of bytes each time.
+    if (count === 1) len = data.length;
+    else assert(len === data.length);
+    readFile();
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -103,92 +103,87 @@ fs.readFile = function(path, encoding_) {
   var encoding = typeof(encoding_) === 'string' ? encoding_ : null;
   var callback = arguments[arguments.length - 1];
   if (typeof(callback) !== 'function') callback = noop;
-  var readStream = fs.createReadStream(path);
-  var buffers = [];
-  var nread = 0;
-  var error;
 
-  readStream.on('data', function(chunk) {
-    buffers.push(chunk);
-    nread += chunk.length;
-  });
+  // first, stat the file, so we know the size.
+  var size;
+  var buffer;
+  var pos = 0;
+  var fd;
 
-  readStream.on('error', function(er) {
-    error = er;
-    readStream.destroy();
-    if (!readStream.fd) {
-      readStream.emit('close');
-    }
-  });
+  fs.open(path, constants.O_RDONLY, 438 /*=0666*/, function(er, fd_) {
+    if (er) return callback(er);
+    fd = fd_;
 
-  readStream.on('close', function() {
-    if (error) {
-      return callback(error);
-    }
-
-    // copy all the buffers into one
-    var buffer;
-    switch (buffers.length) {
-      case 0: buffer = new Buffer(0); break;
-      case 1: buffer = buffers[0]; break;
-      default: // concat together
-        buffer = new Buffer(nread);
-        var n = 0;
-        buffers.forEach(function(b) {
-          var l = b.length;
-          b.copy(buffer, n, 0, l);
-          n += l;
-        });
-        break;
-    }
-    if (encoding) {
-      try {
-        buffer = buffer.toString(encoding);
-      } catch (er) {
-        return callback(er);
+    fs.fstat(fd, function(er, st) {
+      if (er) return callback(er);
+      size = st.size;
+      if (size === 0) {
+        buffer = new Buffer(0);
+        return afterRead(null, 0);
       }
-    }
-    callback(null, buffer);
+
+      buffer = new Buffer(size);
+      read();
+    });
   });
+
+  function read() {
+    fs.read(fd, buffer, pos, size - pos, pos, afterRead);
+  }
+
+  function afterRead(er, bytesRead) {
+    if (er) {
+      return fs.close(fd, function(er2) {
+        return callback(er);
+      });
+    }
+
+    pos += bytesRead;
+    if (pos === size) close();
+    else read();
+  }
+
+  function close() {
+    fs.close(fd, function(er) {
+      if (encoding) buffer = buffer.toString(encoding);
+      return callback(er, buffer);
+    });
+  }
 };
 
 fs.readFileSync = function(path, encoding) {
   var fd = fs.openSync(path, constants.O_RDONLY, 438 /*=0666*/);
-  var buffer = new Buffer(4048);
-  var buffers = [];
-  var nread = 0;
-  var lastRead = 0;
 
+  var size;
+  var threw = true;
   try {
-    do {
-      if (lastRead) {
-        buffer._bytesRead = lastRead;
-        nread += lastRead;
-        buffers.push(buffer);
-      }
-      var buffer = new Buffer(4048);
-      lastRead = fs.readSync(fd, buffer, 0, buffer.length, null);
-    } while (lastRead > 0);
+    size = fs.fstatSync(fd).size;
+    threw = false;
   } finally {
-    fs.closeSync(fd);
+    if (threw) fs.closeSync(fd);
   }
 
-  if (buffers.length > 1) {
-    var offset = 0;
-    var i;
-    buffer = new Buffer(nread);
-    buffers.forEach(function(i) {
-      if (!i._bytesRead) return;
-      i.copy(buffer, offset, 0, i._bytesRead);
-      offset += i._bytesRead;
-    });
-  } else if (buffers.length) {
-    // buffers has exactly 1 (possibly zero length) buffer, so this should
-    // be a shortcut
-    buffer = buffers[0].slice(0, buffers[0]._bytesRead);
-  } else {
-    buffer = new Buffer(0);
+  if (size === 0) {
+    fs.closeSync(fd);
+    return encoding ? '' : new Buffer(0);
   }
+
+  var buffer = new Buffer(size);
+  var pos = 0;
+
+  while (pos < size) {
+    var threw = true;
+    try {
+      var bytesRead = fs.readSync(fd, buffer, pos, size - pos, pos);
+      threw = false;
+    } finally {
+      if (threw) fs.closeSync(fd);
+    }
+
+    pos += bytesRead;
+  }
+
+  fs.closeSync(fd);
 
   if (encoding) buffer = buffer.toString(encoding);
   return buffer;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -99,10 +99,19 @@ fs.existsSync = function(path) {
   }
 };
 
+var readFileReqs = {};
 fs.readFile = function(path, encoding_) {
   var encoding = typeof(encoding_) === 'string' ? encoding_ : null;
   var callback = arguments[arguments.length - 1];
   if (typeof(callback) !== 'function') callback = noop;
+
+  var k = path + '\n' + encoding;
+  if (readFileReqs[k]) {
+    readFileReqs[k].push(callback);
+    return;
+  }
+
+  readFileReqs[k] = [callback];
 
   // first, stat the file, so we know the size.
   var size;
@@ -111,11 +120,11 @@ fs.readFile = function(path, encoding_) {
   var fd;
 
   fs.open(path, constants.O_RDONLY, 438 /*=0666*/, function(er, fd_) {
-    if (er) return callback(er);
+    if (er) return done(er);
     fd = fd_;
 
     fs.fstat(fd, function(er, st) {
-      if (er) return callback(er);
+      if (er) return done(er);
       size = st.size;
       if (size === 0) {
         buffer = new Buffer(0);
@@ -134,7 +143,7 @@ fs.readFile = function(path, encoding_) {
   function afterRead(er, bytesRead) {
     if (er) {
       return fs.close(fd, function(er2) {
-        return callback(er);
+        return done(er);
       });
     }
 
@@ -146,7 +155,15 @@ fs.readFile = function(path, encoding_) {
   function close() {
     fs.close(fd, function(er) {
       if (encoding) buffer = buffer.toString(encoding);
-      return callback(er, buffer);
+      return done(er, buffer);
+    });
+  }
+
+  function done(er, buffer) {
+    var callbacks = readFileReqs[k];
+    readFileReqs[k] = null;
+    callbacks.forEach(function(callback) {
+      callback(er, buffer);
     });
   }
 };

--- a/test/simple/test-fs-sync-fd-leak.js
+++ b/test/simple/test-fs-sync-fd-leak.js
@@ -38,6 +38,10 @@ fs.writeSync = function() {
   throw new Error('BAM');
 };
 
+fs.fstatSync = function() {
+  throw new Error('BAM');
+};
+
 ensureThrows(function() {
   fs.readFileSync('dummy');
 });


### PR DESCRIPTION
In joyent/node#3268, @brendangregg pointed out that fs.readFile is not as optimized as it could be.

The first commit adds a benchmark.  The second makes it go a bit faster.

The third completely destroys the benchmark on the high-concurrency use-case, but does so in a rather dubious manner.  (See the commit message for details.)
