### PR TITLE
Make UNWRAP macro generic, move to node_internals.h, abort on wrong unwrap

### DIFF
--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -30,18 +30,6 @@ namespace node {
 
 static Persistent<String> onchange_sym;
 
-#define UNWRAP                                                              \
-  assert(!args.Holder().IsEmpty());                                         \
-  assert(args.Holder()->InternalFieldCount() > 0);                          \
-  FSEventWrap* wrap =                                                       \
-      static_cast<FSEventWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) {                                                              \
-    uv_err_t err;                                                           \
-    err.code = UV_EBADF;                                                    \
-    SetErrno(err);                                                          \
-    return scope.Close(Integer::New(-1));                                   \
-  }
-
 class FSEventWrap: public HandleWrap {
 public:
   static void Initialize(Handle<Object> target);
@@ -103,7 +91,7 @@ Handle<Value> FSEventWrap::New(const Arguments& args) {
 Handle<Value> FSEventWrap::Start(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(FSEventWrap)
 
   if (args.Length() < 1 || !args[0]->IsString()) {
     return ThrowException(Exception::TypeError(String::New("Bad arguments")));
@@ -178,7 +166,7 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
 Handle<Value> FSEventWrap::Close(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(FSEventWrap)
 
   if (!wrap->initialized_)
     return Undefined();

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -41,19 +41,6 @@ using v8::Arguments;
 using v8::Integer;
 
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  HandleWrap* wrap =  \
-      static_cast<HandleWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
-
 // defined in node.cc
 extern ngx_queue_t handle_wrap_queue;
 
@@ -68,7 +55,7 @@ void HandleWrap::Initialize(Handle<Object> target) {
 Handle<Value> HandleWrap::Unref(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(HandleWrap)
 
   // Calling unnecessarily is a no-op
   if (wrap->unref) {
@@ -86,7 +73,7 @@ Handle<Value> HandleWrap::Unref(const Arguments& args) {
 Handle<Value> HandleWrap::Ref(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(HandleWrap)
 
   // Calling multiple times is a no-op
   if (!wrap->unref) {
@@ -103,17 +90,19 @@ Handle<Value> HandleWrap::Ref(const Arguments& args) {
 Handle<Value> HandleWrap::Close(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  HandleWrap *wrap = static_cast<HandleWrap*>(args.Holder()->GetPointerFromInternalField(0));
 
-  // guard against uninitialized handle or double close
-  if (wrap->handle__ == NULL) return v8::Null();
-  assert(!wrap->object_.IsEmpty());
-  uv_close(wrap->handle__, OnClose);
-  wrap->handle__ = NULL;
+  if (wrap) {
+    // guard against uninitialized handle or double close
+    if (wrap->handle__ == NULL) return v8::Null();
+    assert(!wrap->object_.IsEmpty());
+    uv_close(wrap->handle__, OnClose);
+    wrap->handle__ = NULL;
 
-  HandleWrap::Ref(args);
+    HandleWrap::Ref(args);
 
-  wrap->StateChange();
+    wrap->StateChange();
+  }
 
   return v8::Null();
 }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -22,6 +22,8 @@
 #ifndef SRC_NODE_INTERNALS_H_
 #define SRC_NODE_INTERNALS_H_
 
+#include <stdlib.h>
+
 #include "v8.h"
 
 namespace node {
@@ -80,6 +82,17 @@ inline static v8::Handle<v8::Value> ThrowTypeError(const char* errmsg) {
 inline static v8::Handle<v8::Value> ThrowRangeError(const char* errmsg) {
   THROW_ERROR(v8::Exception::RangeError);
 }
+
+#define UNWRAP(type)                                                        \
+  assert(!args.Holder().IsEmpty());                                         \
+  assert(args.Holder()->InternalFieldCount() > 0);                          \
+  type* wrap =                                                              \
+      static_cast<type*>(args.Holder()->GetPointerFromInternalField(0));    \
+  if (!wrap) {                                                              \
+    fprintf(stderr, #type ": Aborting due to unwrap failure at %s:%d\n",    \
+            __FILE__, __LINE__);                                            \
+    abort();                                                                \
+  }
 
 } // namespace node
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -26,18 +26,6 @@
 #include "stream_wrap.h"
 #include "pipe_wrap.h"
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  PipeWrap* wrap =  \
-      static_cast<PipeWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Object;
@@ -149,7 +137,7 @@ PipeWrap::PipeWrap(Handle<Object> object, bool ipc)
 Handle<Value> PipeWrap::Bind(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap)
 
   String::AsciiValue name(args[0]);
 
@@ -166,7 +154,7 @@ Handle<Value> PipeWrap::Bind(const Arguments& args) {
 Handle<Value> PipeWrap::SetPendingInstances(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap)
 
   int instances = args[0]->Int32Value();
 
@@ -180,7 +168,7 @@ Handle<Value> PipeWrap::SetPendingInstances(const Arguments& args) {
 Handle<Value> PipeWrap::Listen(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap)
 
   int backlog = args[0]->Int32Value();
 
@@ -269,7 +257,7 @@ void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
 Handle<Value> PipeWrap::Open(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap)
 
   int fd = args[0]->IntegerValue();
 
@@ -282,7 +270,7 @@ Handle<Value> PipeWrap::Open(const Arguments& args) {
 Handle<Value> PipeWrap::Connect(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(PipeWrap)
 
   String::AsciiValue name(args[0]);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -25,18 +25,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  ProcessWrap* wrap =  \
-      static_cast<ProcessWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Object;
@@ -97,7 +85,7 @@ class ProcessWrap : public HandleWrap {
   static Handle<Value> Spawn(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(ProcessWrap)
 
     Local<Object> js_options = args[0]->ToObject();
 
@@ -238,7 +226,7 @@ class ProcessWrap : public HandleWrap {
   static Handle<Value> Kill(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(ProcessWrap)
 
     int signal = args[0]->Int32Value();
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -53,19 +53,6 @@ using v8::Number;
 using v8::Exception;
 
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  StreamWrap* wrap =  \
-      static_cast<StreamWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
-
 typedef class ReqWrap<uv_shutdown_t> ShutdownWrap;
 
 class WriteWrap: public ReqWrap<uv_write_t> {
@@ -134,7 +121,7 @@ void StreamWrap::UpdateWriteQueueSize() {
 Handle<Value> StreamWrap::ReadStart(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap)
 
   bool ipc_pipe = wrap->stream_->type == UV_NAMED_PIPE &&
                   ((uv_pipe_t*)wrap->stream_)->ipc;
@@ -155,7 +142,7 @@ Handle<Value> StreamWrap::ReadStart(const Arguments& args) {
 Handle<Value> StreamWrap::ReadStop(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap)
 
   int r = uv_read_stop(wrap->stream_);
 
@@ -248,7 +235,7 @@ void StreamWrap::OnRead2(uv_pipe_t* handle, ssize_t nread, uv_buf_t buf,
 Handle<Value> StreamWrap::WriteBuffer(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap)
 
   // The first argument is a buffer.
   assert(args.Length() >= 1 && Buffer::HasInstance(args[0]));
@@ -299,7 +286,7 @@ Handle<Value> StreamWrap::WriteStringImpl(const Arguments& args) {
   HandleScope scope;
   int r;
 
-  UNWRAP
+  UNWRAP(StreamWrap)
 
   if (args.Length() < 1)
     return ThrowTypeError("Not enough arguments");
@@ -474,7 +461,7 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
 Handle<Value> StreamWrap::Shutdown(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(StreamWrap)
 
   ShutdownWrap* req_wrap = new ShutdownWrap();
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -43,18 +43,6 @@
 # define uv_inet_ntop inet_ntop
 #endif
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  TCPWrap* wrap =  \
-      static_cast<TCPWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Arguments;
@@ -172,7 +160,7 @@ Handle<Value> TCPWrap::GetSockName(const Arguments& args) {
   HandleScope scope;
   struct sockaddr_storage address;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   int addrlen = sizeof(address);
   int r = uv_tcp_getsockname(&wrap->handle_,
@@ -193,7 +181,7 @@ Handle<Value> TCPWrap::GetPeerName(const Arguments& args) {
   HandleScope scope;
   struct sockaddr_storage address;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   int addrlen = sizeof(address);
   int r = uv_tcp_getpeername(&wrap->handle_,
@@ -213,7 +201,7 @@ Handle<Value> TCPWrap::GetPeerName(const Arguments& args) {
 Handle<Value> TCPWrap::SetNoDelay(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   int enable = static_cast<int>(args[0]->BooleanValue());
   int r = uv_tcp_nodelay(&wrap->handle_, enable);
@@ -227,7 +215,7 @@ Handle<Value> TCPWrap::SetNoDelay(const Arguments& args) {
 Handle<Value> TCPWrap::SetKeepAlive(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   int enable = args[0]->Int32Value();
   unsigned int delay = args[1]->Uint32Value();
@@ -244,7 +232,7 @@ Handle<Value> TCPWrap::SetKeepAlive(const Arguments& args) {
 Handle<Value> TCPWrap::SetSimultaneousAccepts(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   bool enable = args[0]->BooleanValue();
 
@@ -260,7 +248,7 @@ Handle<Value> TCPWrap::SetSimultaneousAccepts(const Arguments& args) {
 Handle<Value> TCPWrap::Bind(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
@@ -278,7 +266,7 @@ Handle<Value> TCPWrap::Bind(const Arguments& args) {
 Handle<Value> TCPWrap::Bind6(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   String::AsciiValue ip6_address(args[0]);
   int port = args[1]->Int32Value();
@@ -296,7 +284,7 @@ Handle<Value> TCPWrap::Bind6(const Arguments& args) {
 Handle<Value> TCPWrap::Listen(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   int backlog = args[0]->Int32Value();
 
@@ -374,7 +362,7 @@ void TCPWrap::AfterConnect(uv_connect_t* req, int status) {
 Handle<Value> TCPWrap::Connect(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();
@@ -404,7 +392,7 @@ Handle<Value> TCPWrap::Connect(const Arguments& args) {
 Handle<Value> TCPWrap::Connect6(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(TCPWrap)
 
   String::AsciiValue ip_address(args[0]);
   int port = args[1]->Int32Value();

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -22,18 +22,6 @@
 #include "node.h"
 #include "handle_wrap.h"
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  TimerWrap* wrap =  \
-      static_cast<TimerWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
 namespace node {
 
 using v8::Object;
@@ -127,7 +115,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Start(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap)
 
     int64_t timeout = args[0]->IntegerValue();
     int64_t repeat = args[1]->IntegerValue();
@@ -145,7 +133,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Stop(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap)
 
     int r = uv_timer_stop(&wrap->handle_);
 
@@ -159,7 +147,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Again(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap)
 
     int r = uv_timer_again(&wrap->handle_);
 
@@ -173,7 +161,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> SetRepeat(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap)
 
     int64_t repeat = args[0]->IntegerValue();
 
@@ -185,7 +173,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> GetRepeat(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TimerWrap)
 
     int64_t repeat = uv_timer_get_repeat(&wrap->handle_);
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -42,19 +42,6 @@ using v8::Arguments;
 using v8::Integer;
 using v8::Undefined;
 
-#define UNWRAP \
-  assert(!args.Holder().IsEmpty()); \
-  assert(args.Holder()->InternalFieldCount() > 0); \
-  TTYWrap* wrap =  \
-      static_cast<TTYWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) { \
-    uv_err_t err; \
-    err.code = UV_EBADF; \
-    SetErrno(err); \
-    return scope.Close(Integer::New(-1)); \
-  }
-
-
 class TTYWrap : StreamWrap {
  public:
   static void Initialize(Handle<Object> target) {
@@ -122,7 +109,7 @@ class TTYWrap : StreamWrap {
   static Handle<Value> GetWindowSize(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TTYWrap)
 
     int width, height;
     int r = uv_tty_get_winsize(&wrap->handle_, &width, &height);
@@ -142,7 +129,7 @@ class TTYWrap : StreamWrap {
   static Handle<Value> SetRawMode(const Arguments& args) {
     HandleScope scope;
 
-    UNWRAP
+    UNWRAP(TTYWrap)
 
     int r = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -49,18 +49,6 @@ using namespace v8;
 
 namespace node {
 
-#define UNWRAP                                                              \
-  assert(!args.Holder().IsEmpty());                                         \
-  assert(args.Holder()->InternalFieldCount() > 0);                          \
-  UDPWrap* wrap =                                                           \
-      static_cast<UDPWrap*>(args.Holder()->GetPointerFromInternalField(0)); \
-  if (!wrap) {                                                              \
-    uv_err_t err;                                                           \
-    err.code = UV_EBADF;                                                    \
-    SetErrno(err);                                                          \
-    return scope.Close(Integer::New(-1));                                   \
-  }
-
 typedef ReqWrap<uv_udp_send_t> SendWrap;
 
 // see tcp_wrap.cc
@@ -169,7 +157,7 @@ Handle<Value> UDPWrap::DoBind(const Arguments& args, int family) {
   HandleScope scope;
   int r;
 
-  UNWRAP
+  UNWRAP(UDPWrap)
 
   // bind(ip, port, flags)
   assert(args.Length() == 3);
@@ -210,7 +198,7 @@ Handle<Value> UDPWrap::Bind6(const Arguments& args) {
 #define X(name, fn)                                                           \
   Handle<Value> UDPWrap::name(const Arguments& args) {                        \
     HandleScope scope;                                                        \
-    UNWRAP                                                                    \
+    UNWRAP(UDPWrap)                                                                    \
     assert(args.Length() == 1);                                               \
     int flag = args[0]->Int32Value();                                         \
     int r = fn(&wrap->handle_, flag);                                         \
@@ -229,7 +217,7 @@ X(SetMulticastLoopback, uv_udp_set_multicast_loop)
 Handle<Value> UDPWrap::SetMembership(const Arguments& args,
                                      uv_membership membership) {
   HandleScope scope;
-  UNWRAP
+  UNWRAP(UDPWrap)
 
   assert(args.Length() == 2);
 
@@ -268,7 +256,7 @@ Handle<Value> UDPWrap::DoSend(const Arguments& args, int family) {
   // send(buffer, offset, length, port, address)
   assert(args.Length() == 5);
 
-  UNWRAP
+  UNWRAP(UDPWrap)
 
   assert(Buffer::HasInstance(args[0]));
   Local<Object> buffer_obj = args[0]->ToObject();
@@ -327,7 +315,7 @@ Handle<Value> UDPWrap::Send6(const Arguments& args) {
 Handle<Value> UDPWrap::RecvStart(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(UDPWrap)
 
   // UV_EALREADY means that the socket is already bound but that's okay
   int r = uv_udp_recv_start(&wrap->handle_, OnAlloc, OnRecv);
@@ -343,7 +331,7 @@ Handle<Value> UDPWrap::RecvStart(const Arguments& args) {
 Handle<Value> UDPWrap::RecvStop(const Arguments& args) {
   HandleScope scope;
 
-  UNWRAP
+  UNWRAP(UDPWrap)
 
   int r = uv_udp_recv_stop(&wrap->handle_);
 
@@ -355,7 +343,7 @@ Handle<Value> UDPWrap::GetSockName(const Arguments& args) {
   HandleScope scope;
   struct sockaddr_storage address;
 
-  UNWRAP
+  UNWRAP(UDPWrap)
 
   int addrlen = sizeof(address);
   int r = uv_udp_getsockname(&wrap->handle_,


### PR DESCRIPTION
Rebase of #3048.

// cc: @ssuda @bnoordhuis
