### PR TITLE
Fix hardfloat detection in Linux

### DIFF
--- a/deps/v8/src/platform-linux.cc
+++ b/deps/v8/src/platform-linux.cc
@@ -167,7 +167,7 @@ bool OS::ArmCpuHasFeature(CpuFeature feature) {
 // calling this will return 1.0 and otherwise 0.0.
 static void ArmUsingHardFloatHelper() {
   asm("mov r0, #0":::"r0");
-#if defined(__VFP_FP__) && !defined(__SOFTFP__)
+#if defined(__ARM_PCS_VFP) && !defined(__SOFTFP__)
   // Load 0x3ff00000 into r1 using instructions available in both ARM
   // and Thumb mode.
   asm("mov r1, #3":::"r1");


### PR DESCRIPTION
gcc has a builtin define to denote hard abi when in use, e.g. when
using -mfloat-abi=hard it will define **ARM_PCS_VFP to 1 and therefore
we should check that to determine which calling convention is in use
and not __VFP_FP** which merely indicates presence of VFP unit

The fix has been provided by Khem Raj raj.khem@gmail.com
