### PR TITLE
fs.watch should not require a listener arguments

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -477,7 +477,7 @@ you need to compare `curr.mtime` and `prev.mtime`.
 
 Stop watching for changes on `filename`.
 
-## fs.watch(filename, [options], listener)
+## fs.watch(filename, [options], [listener])
 
     Stability: 2 - Unstable.  Not available on all platforms.
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -773,16 +773,15 @@ fs.watch = function(filename) {
     listener = arguments[1];
   }
 
-  if (!listener) {
-    throw new Error('watch requires a listener function');
-  }
-
   if (options.persistent === undefined) options.persistent = true;
 
   watcher = new FSWatcher();
   watcher.start(filename, options.persistent);
 
-  watcher.addListener('change', listener);
+  if (listener) {
+    watcher.addListener('change', listener);
+  }
+
   return watcher;
 };
 

--- a/test/simple/test-fs-watch.js
+++ b/test/simple/test-fs-watch.js
@@ -58,15 +58,6 @@ try { fs.rmdirSync(testsubdir); } catch (e) { }
 
 fs.writeFileSync(filepathOne, 'hello');
 
-assert.throws(
-    function() {
-      fs.watch(filepathOne);
-    },
-    function(e) {
-      return e.message === 'watch requires a listener function';
-    }
-);
-
 assert.doesNotThrow(
     function() {
       var watcher = fs.watch(filepathOne, function(event, filename) {
@@ -90,15 +81,6 @@ setTimeout(function() {
 process.chdir(testDir);
 
 fs.writeFileSync(filepathTwoAbs, 'howdy');
-
-assert.throws(
-    function() {
-      fs.watch(filepathTwo);
-    },
-    function(e) {
-      return e.message === 'watch requires a listener function';
-    }
-);
 
 assert.doesNotThrow(
     function() {


### PR DESCRIPTION
Since `fs.watch` returns an event emitter where the `change` event is exactly the same as the `listener` callback, the argument should be required.
