### PR TITLE
cluster: remove NODE_UNIQUE_ID from env on startup

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -33,7 +33,7 @@ var debug;
 if (process.env.NODE_DEBUG && /cluster/.test(process.env.NODE_DEBUG)) {
   debug = function(x) {
     var prefix = process.pid + ',' +
-        (process.env.NODE_WORKER_ID ? 'Worker' : 'Master');
+        (process.env.NODE_UNIQUE_ID ? 'Worker' : 'Master');
     console.error(prefix, x);
   };
 } else {

--- a/lib/net.js
+++ b/lib/net.js
@@ -24,6 +24,7 @@ var stream = require('stream');
 var timers = require('timers');
 var util = require('util');
 var assert = require('assert');
+var cluster;
 
 function noop() {}
 
@@ -907,8 +908,9 @@ Server.prototype._listen2 = function(address, port, addressType, backlog) {
 
 
 function listen(self, address, port, addressType, backlog) {
-  if (process.env.NODE_UNIQUE_ID) {
-    var cluster = require('cluster');
+  if (!cluster) cluster = require('cluster');
+
+  if (cluster.isWorker) {
     cluster._getServer(self, address, port, addressType, function(handle) {
       self._handle = handle;
       self._listen2(address, port, addressType, backlog);

--- a/src/node.js
+++ b/src/node.js
@@ -78,6 +78,9 @@
       if (process.env.NODE_UNIQUE_ID) {
         var cluster = NativeModule.require('cluster');
         cluster._setupWorker();
+
+        // Make sure it's not accidentally inherited by child processes.
+        delete process.env.NODE_UNIQUE_ID;
       }
 
       var Module = NativeModule.require('module');

--- a/test/simple/test-cluster-basic.js
+++ b/test/simple/test-cluster-basic.js
@@ -24,6 +24,9 @@ var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 
+assert.equal('NODE_UNIQUE_ID' in process.env, false,
+      'NODE_UNIQUE_ID should be removed on startup');
+
 function forEach(obj, fn) {
   Object.keys(obj).forEach(function(name, index) {
     fn(obj[name], name, index);
@@ -39,9 +42,6 @@ if (cluster.isWorker) {
 }
 
 else if (cluster.isMaster) {
-
-  assert.equal('NODE_UNIQUE_ID' in process.env, false,
-      'cluster.isMaster should not be true when NODE_UNIQUE_ID is set');
 
   var checks = {
     cluster: {


### PR DESCRIPTION
In case a worker would spawn a new subprocess with process.env, NODE_UNIQUE_ID would have been a part
of the env. Making the new subprocess belive it is a worker, this would result in some confusion if
the subprocess where to listen to a port, since the server handle request would then be relayed to
the worker.

This patch removes the NODE_UNIQUE_ID flag fron process.env on startup so any subprocess spawned by
a worker is a normal process with no cluster stuff, what so ever.
