### PR TITLE
Some small speed improvements (path.js)

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -33,7 +33,7 @@ function normalizeArray(parts, allowAboveRoot) {
   var up = 0;
   for (var i = parts.length - 1; i >= 0; i--) {
     var last = parts[i];
-    if (last == '.') {
+    if (last === '.') {
       parts.splice(i, 1);
     } else if (last === '..') {
       parts.splice(i, 1);
@@ -101,7 +101,7 @@ if (isWindows) {
         path = process.env['=' + resolvedDevice];
         // Verify that a drive-local cwd was found and that it actually points
         // to our drive. If not, default to the drive's root.
-        if (!path || path.slice(0, 3).toLowerCase() !==
+        if (!path || path.substr(0, 3).toLowerCase() !==
             resolvedDevice.toLowerCase() + '\\') {
           path = resolvedDevice + '\\';
         }
@@ -191,14 +191,14 @@ if (isWindows) {
       return p && typeof p === 'string';
     }
 
-    var paths = Array.prototype.slice.call(arguments, 0).filter(f);
+    var paths = Array.prototype.filter.call(arguments, f);
     var joined = paths.join('\\');
 
     // Make sure that the joined path doesn't start with two slashes
     // - it will be mistaken for an unc path by normalize() -
     // unless the paths[0] also starts with two slashes
     if (/^[\\\/]{2}/.test(joined) && !/^[\\\/]{2}/.test(paths[0])) {
-      joined = joined.slice(1);
+      joined = joined.substr(1);
     }
 
     return exports.normalize(joined);
@@ -307,7 +307,7 @@ if (isWindows) {
   // posix version
   exports.normalize = function(path) {
     var isAbsolute = path.charAt(0) === '/',
-        trailingSlash = path.slice(-1) === '/';
+        trailingSlash = path.substr(-1) === '/';
 
     // Normalize the path
     path = normalizeArray(path.split('/').filter(function(p) {
@@ -393,7 +393,7 @@ exports.dirname = function(path) {
 
   if (dir) {
     // It has a dirname, strip trailing slash
-    dir = dir.substring(0, dir.length - 1);
+    dir = dir.substr(0, dir.length - 1);
   }
 
   return root + dir;
@@ -436,11 +436,11 @@ if (isWindows) {
 
     var resolvedPath = exports.resolve(path);
 
-    if (resolvedPath.match(/^[a-zA-Z]\:\\/)) {
+    if (/^[a-zA-Z]\:\\/.test(resolvedPath)) {
       // path is local filesystem path, which needs to be converted
       // to long UNC path.
       return '\\\\?\\' + resolvedPath;
-    } else if (resolvedPath.match(/^\\\\[^?.]/)) {
+    } else if (/^\\\\[^?.]/.test(resolvedPath)) {
       // path is network UNC path, which needs to be converted
       // to long UNC path.
       return '\\\\?\\UNC\\' + resolvedPath.substring(2);


### PR DESCRIPTION
- Use always `String#substr` as it's the [fastest of all substring methods](https://gist.github.com/320e6a4558e969048e7a#file_str_slice_vs_str_substr_vs_str_substring.js)
- Use `Array#filter` directly, don't call `Array#slice` before that (as it creates garbage & isn't required) ([benchmark](https://gist.github.com/320e6a4558e969048e7a#file_arr_slice_filter_vs_arr_filter.js))
- Use `RegExp#test` instead of `String#match` for getting booleans as it's [faster](https://gist.github.com/320e6a4558e969048e7a#file_re_test_vs_str_match.js) (& doesn't create an unused array)

And I added a tripple-equal instead of a double-equal, which is simply more consistent.
