### PR TITLE
Rearranged urlFormat

### DIFF
--- a/benchmark/url.js
+++ b/benchmark/url.js
@@ -1,0 +1,22 @@
+var url = require('url'),
+    urls = [
+      'http://nodejs.org/docs/latest/api/url.html#url_url_format_urlobj',
+      'http://blog.nodejs.org/',
+      'https://encrypted.google.com/search?q=url&q=site:npmjs.org&hl=en',
+      'javascript:alert("node is awesome");',
+      'some.ran/dom/url.thing?oh=yes#whoo'
+    ],
+    paths = [
+      '../foo/bar?baz=boom',
+      'foo/bar',
+      'http://nodejs.org',
+      './foo/bar?baz'
+    ];
+
+urls.forEach(url.parse);
+urls.forEach(url.format);
+urls.forEach(function(u){
+  paths.forEach(function(p){
+    url.resolve(u, p);
+  });
+});

--- a/lib/url.js
+++ b/lib/url.js
@@ -317,55 +317,77 @@ function urlFormat(obj) {
   // If it's an obj, this is a no-op.
   // this way, you can call url_format() on strings
   // to clean up potentially wonky urls.
-  if (typeof(obj) === 'string') obj = urlParse(obj);
+  if (typeof obj === 'string') obj = urlParse(obj);
 
-  var auth = obj.auth || '';
-  if (auth) {
-    auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ':');
-    auth += '@';
-  }
+  var url = '';
 
-  var protocol = obj.protocol || '',
-      pathname = obj.pathname || '',
-      hash = obj.hash || '',
-      host = false,
-      query = '';
-
-  if (obj.host !== undefined) {
-    host = auth + obj.host;
-  } else if (obj.hostname !== undefined) {
-    host = auth + (obj.hostname.indexOf(':') === -1 ?
-        obj.hostname :
-        '[' + obj.hostname + ']');
-    if (obj.port) {
-      host += ':' + obj.port;
+  if (obj.protocol) {
+    url += obj.protocol;
+    if (obj.protocol.substr(-1) !== ':') {
+      url += ':';
     }
   }
 
-  if (obj.query && typeof obj.query === 'object' &&
-      Object.keys(obj.query).length) {
-    query = querystring.stringify(obj.query);
-  }
-
-  var search = obj.search || (query && ('?' + query)) || '';
-
-  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
-
+  var hasHost = obj.host !== undefined || obj.hostname !== undefined;
+  var addSlashes = obj.slashes ||
+      (!obj.protocol || obj.slashedProtocol[obj.protocol]) && hasHost;
+  
   // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
   // unless they had them to begin with.
-  if (obj.slashes ||
-      (!protocol || slashedProtocol[protocol]) && host !== false) {
-    host = '//' + (host || '');
-    if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
-  } else if (!host) {
-    host = '';
+  if (addSlashes) {
+    url += '//';
   }
 
-  if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
-  if (search && search.charAt(0) !== '?') search = '?' + search;
+  if (hasHost) {
+    if (obj.auth) {
+      url += encodeURIComponent(obj.auth).replace(/%3A/i, ':');
+      url += '@';
+    }
+    if (obj.host !== undefined) {
+      url += obj.host;
+    }
+    else { //obj.hostname !== undefined
+      if (obj.hostname.indexOf(':') >= 0) {
+        url += '[' + obj.hostname + ']';
+      }
+      else {
+        url += obj.hostname;
+      }
+      if (obj.port) {
+        url += ':' + obj.port;
+      }
+    }
+  }
 
-  return protocol + host + pathname + search + hash;
+  if (obj.pathname) {
+    if (addSlashes && obj.pathname.charAt(0) !== '/') {
+      url += '/';
+    }
+    url += obj.pathname;
+  }
+
+  if (obj.search) {
+    if (obj.search.charAt(0) !== '?') {
+      url += '?';
+    }
+    url += obj.search;
+  } else if (obj.query && typeof obj.query === 'object') {
+    for (var key in obj.query) {
+      if (Object.prototype.hasOwnProperty.call(obj.query, key)) {
+        url += '?' + querystring.stringify(obj.query);
+        break;
+      }
+    }
+  }
+
+  if (obj.hash) {
+    if (obj.hash.charAt(0) !== '#') {
+      url += '#';
+    }
+    url += obj.hash;
+  }
+
+  return url;
 }
 
 function urlResolve(source, relative) {


### PR DESCRIPTION
After spending five minutes figuring out what the `urlFormat` function does, I decided to open another pull request with a rearranged version (I don't want to write _rewritten_, as that would be too much). This time, the parts are processed in order and directly appended to the result string.

A quick [benchmark](https://gist.github.com/320e6a4558e969048e7a#file_new_url_format.js) showed the following results:

```
{ node: '0.6.17',
  v8: '3.6.6.25',
  ares: '1.7.5-DEV',
  uv: '0.6',
  openssl: '0.9.8r' }
Scores: (bigger is better)

new_format
Raw:
 > 25.94810379241517
 > 26.06177606177606
 > 26.418786692759294
 > 26.29016553067186
 > 26.162790697674417
Average (mean) 26.17632455505936

old_format
Raw:
 > 19.53125
 > 20.937188434695912
 > 20.833333333333332
 > 20.854021847070506
 > 20.792079207920793
Average (mean) 20.58957456460411

Winner: new_format
Compared with next highest (old_format), it's:
21.34% faster
1.27 times as fast
0.1 order(s) of magnitude faster
```
