### PR TITLE
docs: Switch to the asynchronous Google Analytics snippet

### DIFF
--- a/doc/about/index.html
+++ b/doc/about/index.html
@@ -130,7 +130,7 @@ console.log('Server running at http://127.0.0.1:1337/');</pre>
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright 2012 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
+        <p>Copyright 2012 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
     </div>
 
 
@@ -139,15 +139,13 @@ console.log('Server running at http://127.0.0.1:1337/');</pre>
     <script>highlight(undefined, undefined, 'pre');</script>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script>
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
   </body>
 </html>

--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -42,17 +42,17 @@
                 <p class="twitter"><a href="http://twitter.com/nodejs">@nodejs</a></p>
 
             </div>
-        
+
             <div id="column1" class="interior">
                 <p>Node's most valuable feature is the friendly and <a href="http://blip.tv/jsconf/nodeconf-2011-marak-squires-5729610">colorful community</a> of developers. There are many places where this group congregates on the internet. This page attempts to highlight the best forums.</p>
-        
+
               <div class="row clearfix">
                   <div class="block">
                       <h2 class="documentation">Documentation</h2>
 
                           <p><a href="http://nodejs.org/docs/latest/api">Official API docs</a> detail the node API.</p>
                           <p><a href="http://docs.nodejitsu.com/">docs.nodejitsu.com</a> answers many of the common problems people come across.</p>
-                          <p><a href="http://howtonode.org/">How To Node</a> has a growing number of useful tutorials.</p> 
+                          <p><a href="http://howtonode.org/">How To Node</a> has a growing number of useful tutorials.</p>
                           <p><a href="http://stackoverflow.com/questions/tagged/node.js">Stack Overflow node.js tag</a> collects new information every day.</p>
                       </div>
 
@@ -75,7 +75,7 @@
                       </div>
                   </div>
 
-        
+
               <div class="row clearfix">
                   <div class="block">
                       <h2 class="mailing">Mailing Lists</h2>
@@ -134,7 +134,7 @@
                           <br>
                           <a href="http://nodejs.ir">nodejs.ir</a> Iran group in Persian
                           <br>
-                          <a href="http://nodejs.jp/">nodejs.jp</a> Japan user group 
+                          <a href="http://nodejs.jp/">nodejs.jp</a> Japan user group
                           <br>
                           <a href="http://cnodejs.org">CNodeJS.org</a> Chinese community
                           <br>
@@ -161,7 +161,7 @@
                               channel</a> for those who miss a day.</p>
                   </div>
               </div>
-        
+
                   <p><a href="http://notinventedhe.re/on/2011-7-26"><img
                   src="http://nodejs.org/images/not-invented-here.png" width="100%"></a></p>
         </div>
@@ -180,19 +180,17 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright 2012 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
+        <p>Copyright 2012 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
     </div>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script>
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
 </body>
 </html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -31,7 +31,7 @@
 
         <a href="#download" class="button" id="downloadbutton">Download</a>
         <a href="http://nodejs.org/docs/latest/api/index.html" class="button" id="docsbutton">Docs</a>
-        <p class="version">v0.7.5</p> 
+        <p class="version">v0.7.5</p>
     </div>
     <div id="quotes" class="clearfix">
         <h2>Node.js in the Industry</h2>
@@ -211,7 +211,7 @@ server.listen(1337, '127.0.0.1');</pre>
             <!-- <li><a hrfe="http://twitter.com/nodejs" class="twitter">@nodejs</a></li> -->
         </ul>
 
-        <p>Copyright 2012 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
+        <p>Copyright 2012 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
     </div>
 
 
@@ -220,15 +220,13 @@ server.listen(1337, '127.0.0.1');</pre>
     <script>highlight(undefined, undefined, 'pre');</script>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script>
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
   </body>
 </html>

--- a/doc/logos/index.html
+++ b/doc/logos/index.html
@@ -40,7 +40,7 @@
                 <p class="twitter"><a href="http://twitter.com/nodejs">@nodejs</a></p>
 
             </div>
-        
+
             <div id="column1" class="interior">
           <h2>Logo Downloads</h2>
           <table border="0" cellspacing="0" cellpadding="10">
@@ -82,19 +82,17 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>., Node.js is a <a href="/trademark-policy.pdf">trademark of Joyent, Inc</a>., <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">View License</a></p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>., Node.js is a <a href="/trademark-policy.pdf">trademark of Joyent, Inc</a>., <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">View License</a></p>
     </div>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script type="text/javascript">
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
 </body>
 </html>

--- a/doc/template.html
+++ b/doc/template.html
@@ -56,21 +56,20 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright 2012 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
+        <p>Copyright 2012 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.5/LICENSE">license</a>.</p>
     </div>
-    
+
   <script src="assets/sh_main.js"></script>
   <script src="assets/sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>
   <script>
-    var gaJsHost = (("https:" == document.location.protocol) ?
-    "https://ssl." : "http://www.");
-    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+    window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+    (function(d, t) {
+      var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+      g.src = '//www.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g, s);
+    }(document, 'script'));
   </script>
-  <script>
-    try {
-      var pageTracker = _gat._getTracker("UA-10874194-2");
-      pageTracker._trackPageview();
-      } catch(err) {}</script>
 </body>
 </html>


### PR DESCRIPTION
The old snippet needlessly uses `document.write`. As nodejs.org doesn’t work over HTTPS/SSL, the protocol check was not needed either. Let’s use the optimized version of the most recent, asynchronous GA snippet, as per http://mathiasbynens.be/notes/async-analytics-snippet.
