### PR TITLE
node: change the constructor name of process from EventEmitter to process

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2162,8 +2162,9 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
   Local<FunctionTemplate> process_template = FunctionTemplate::New();
 
-  process = Persistent<Object>::New(process_template->GetFunction()->NewInstance());
+  process_template->SetClassName(String::NewSymbol("process"));
 
+  process = Persistent<Object>::New(process_template->GetFunction()->NewInstance());
 
   process->SetAccessor(String::New("title"),
                        ProcessTitleGetter,

--- a/src/node.js
+++ b/src/node.js
@@ -29,7 +29,13 @@
 
   function startup() {
     var EventEmitter = NativeModule.require('events').EventEmitter;
-    process.__proto__ = EventEmitter.prototype;
+
+    process.__proto__ = Object.create(EventEmitter.prototype, {
+      constructor: {
+        value: process.constructor
+      }
+    });
+
     process.EventEmitter = EventEmitter; // process.EventEmitter is deprecated
 
     startup.globalVariables();


### PR DESCRIPTION
Before this commit `process.foo();` would result in the following error message:

```
TypeError: Object #<EventEmitter> has no method 'foo'
```

however with this commit the developer will get a more useful and correct error message:

```
TypeError: Object #<process> has no method 'foo'
```
