### PR TITLE
doc: updated JavaScript casing where relevant

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -27,7 +27,7 @@ libraries.
 ## Hello world
 
 To get started let's make a small Addon which is the C++ equivalent of
-the following Javascript code:
+the following JavaScript code:
 
     exports.hello = function() { return 'world'; };
 

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -2,7 +2,7 @@
 
     Stability: 3 - Stable
 
-Pure Javascript is Unicode friendly but not nice to binary data.  When
+Pure JavaScript is Unicode friendly but not nice to binary data.  When
 dealing with TCP streams or the file system, it's necessary to handle octet
 streams. Node has several strategies for manipulating, creating, and
 consuming octet streams.


### PR DESCRIPTION
While reviewing part of the node documentation, I noticed JavaScript is not always cased the same way.
This patch should fix the JavaScript casing where relevant.
