### PR TITLE
fs: no end emit after createReadStream.pause()

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1068,7 +1068,9 @@ var ReadStream = fs.ReadStream = function(path, options) {
   }
 
   if (this.fd !== null) {
-    this._read();
+    process.nextTick(function () {
+      self._read();
+    });
     return;
   }
 

--- a/test/simple/test-fs-empty-readStream.js
+++ b/test/simple/test-fs-empty-readStream.js
@@ -1,0 +1,66 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var fs = require('fs');
+
+var emptyFile = path.join(common.fixturesDir, 'empty.txt');
+
+fs.open(emptyFile, 'r', function (error, fd) {
+  assert.ifError(error);
+
+  var read = fs.createReadStream(emptyFile, { 'fd': fd });
+
+  read.once('data', function () {
+    throw new Error("data event should not emit");
+  });
+
+  var readEmit = false;
+  read.once('end', function () {
+    readEmit = true;
+  });
+
+  setTimeout(function () {
+      assert.equal(readEmit, true);
+  }, 50);
+});
+
+fs.open(emptyFile, 'r', function (error, fd) {
+  assert.ifError(error);
+
+  var read = fs.createReadStream(emptyFile, { 'fd': fd });
+  read.pause();
+
+  read.once('data', function () {
+    throw new Error("data event should not emit");
+  });
+
+  var readEmit = false;
+  read.once('end', function () {
+    readEmit = true;
+  });
+
+  setTimeout(function () {
+      assert.equal(readEmit, false);
+  }, 50);
+});


### PR DESCRIPTION
In case a fd option is given to fs.createReadStream a read will instantly
happen. But in the edge case where fd point to an empty file and .pause()
was executed instantly, the end event would emit since no async wait was
between fs.createReadStream and the file read there emits end.
