### PR TITLE
cluster: fix random port assignment

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -780,7 +780,7 @@ Server.prototype._listen2 = function(address, port, addressType) {
 
 
 function listen(self, address, port, addressType) {
-  if (process.env.NODE_WORKER_ID) {
+  if (process.env.NODE_WORKER_ID && port) {
     require('cluster')._getServer(address, port, addressType, function(handle) {
       self._handle = handle;
       self._listen2(address, port, addressType);

--- a/test/simple/test-cluster-random-port-1.js
+++ b/test/simple/test-cluster-random-port-1.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  cluster.fork();
+} else {
+  net.createServer().listen(function () {
+    process.exit();
+  });
+}

--- a/test/simple/test-cluster-random-port-2.js
+++ b/test/simple/test-cluster-random-port-2.js
@@ -1,0 +1,54 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  var worker = cluster.fork();
+
+  var oldPort;
+
+  worker.on('message', function (address) {
+    if (address.cmd) return;
+
+    if (oldPort === undefined) {
+      return oldPort = address.port;
+    }
+
+    assert.notEqual(oldPort, address.port);
+    worker.kill(0);
+  });
+} else {
+
+  var listen = function () {
+    console.log('foo');
+    var server = net.createServer();
+    server.listen(0, function () {
+      process.send(server.address());
+    });
+  };
+
+  listen();
+  listen();
+}


### PR DESCRIPTION
This patch will fix issue #3324 and #3325 by simply handle random port servers as any ordinary non-cluster server.

This patch should land in v0.6, in case of 0.8 some more code is properly required in order to support the listening event.
