### PR TITLE
cluster2: fix random port assignment

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -117,7 +117,7 @@ where the 'listening' event is emitted.
 
 The event handler is executed with two arguments, the `worker` contains the worker
 object and the `address` object contains the following connection properties:
-`address`, `port` and `addressType`. This is very useful if the worker is listening
+`address`, `port` and `family`. This is very useful if the worker is listening
 on more than one address.
 
     cluster.on('listening', function(worker, address) {
@@ -143,7 +143,7 @@ connections.
 ## Event: 'exit'
 
 * `worker` {Worker object}
-* `code` {Number} the exit code, if it exited normally. 
+* `code` {Number} the exit code, if it exited normally.
 * `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
   the process to be killed.
 
@@ -435,12 +435,12 @@ on the specified worker.
 
 ### Event: 'exit'
 
-* `code` {Number} the exit code, if it exited normally. 
+* `code` {Number} the exit code, if it exited normally.
 * `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
   the process to be killed.
 
 Emitted by the individual worker instance, when the underlying child process
-is terminated.  See [child_process event: 'exit'](child_process.html#child_process_event_exit). 
+is terminated.  See [child_process event: 'exit'](child_process.html#child_process_event_exit).
 
     var worker = cluster.fork();
     worker.on('exit', function(code, signal) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -51,7 +51,7 @@ var ids = 0;
 var serverHandlers = {};
 
 // Used in the worker:
-var serverListeners = {};
+var serverListeners = [];
 var queryIds = 0;
 var queryCallbacks = {};
 
@@ -193,7 +193,7 @@ if (cluster.isMaster) {
 
     // This sequence of information is unique to the connection
     // but not to the worker
-    var args = [message.address, message.port, message.addressType];
+    var args = [message.address, message.port, message.family];
     var key = args.join(':');
     var handler;
 
@@ -216,12 +216,12 @@ if (cluster.isMaster) {
     worker.emit('listening', {
       address: message.address,
       port: message.port,
-      addressType: message.addressType
+      family: message.family
     });
     cluster.emit('listening', worker, {
       address: message.address,
       port: message.port,
-      addressType: message.addressType
+      family: message.family
     });
   };
 
@@ -415,7 +415,7 @@ if (cluster.isMaster) {
     this.suicide = true;
 
     // keep track of open servers
-    var servers = Object.keys(serverListeners).length;
+    var servers = serverListeners.length;
     var progress = new ProgressTracker(servers, function() {
       // There are no more servers open so we will close the IPC channel.
       // Closing the IPC channel will emit a disconnect event
@@ -432,9 +432,10 @@ if (cluster.isMaster) {
       progress.check();
 
       // closing all servers gracefully
-      var server;
-      for (var key in serverListeners) {
-        server = serverListeners[key];
+      var server, i = serverListeners.length;
+
+      while (i--) {
+        server = serverListeners[i];
 
         // in case the server is closed we won't close it again
         if (server._handle === null) {
@@ -512,20 +513,24 @@ cluster._getServer = function(tcpSelf, address, port, addressType, cb) {
   // This can only be called from a worker.
   assert(cluster.isWorker);
 
+  var isRandom = port === null || port === 0;
+
   // Store tcp instance for later use
-  var key = [address, port, addressType].join(':');
-  serverListeners[key] = tcpSelf;
+  serverListeners.push(tcpSelf);
 
   // Send a listening message to the master
   tcpSelf.once('listening', function() {
+    var message = tcpSelf.address();
+    message.cmd = 'listening';
+
     cluster.worker.state = 'listening';
-    sendInternalMessage(cluster.worker, {
-      cmd: 'listening',
-      address: address,
-      port: port,
-      addressType: addressType
-    });
+    sendInternalMessage(cluster.worker, message);
   });
+
+  // in case that port is null or 0, don't request a server from the master
+  if (isRandom) {
+    return cb();
+  }
 
   // Request the fd handler from the master process
   var message = {

--- a/test/simple/test-cluster-basic.js
+++ b/test/simple/test-cluster-basic.js
@@ -135,7 +135,7 @@ else if (cluster.isMaster) {
           assert.equal(arguments.length, 1);
           var expect = { address: '127.0.0.1',
                          port: common.PORT,
-                         addressType: 4 };
+                         family: 'IPv4' };
           assert.deepEqual(arguments[0], expect);
           break;
 

--- a/test/simple/test-cluster-random-port-1.js
+++ b/test/simple/test-cluster-random-port-1.js
@@ -1,0 +1,35 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  var worker = cluster.fork();
+
+  worker.on('listening', function () {
+    worker.disconnect();
+  });
+} else {
+  net.createServer().listen();
+}

--- a/test/simple/test-cluster-random-port-2.js
+++ b/test/simple/test-cluster-random-port-2.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  var worker = cluster.fork();
+
+  var oldPort;
+
+  worker.on('listening', function (address) {
+    if (oldPort === undefined) {
+      return oldPort = address.port;
+    }
+
+    assert.notEqual(oldPort, address.port);
+    cluster.disconnect();
+  });
+} else {
+
+  var listen = function () {
+    var server = net.createServer();
+    server.listen(0, function () {
+      process.send(server.address());
+    });
+  };
+
+  listen();
+  listen();
+}


### PR DESCRIPTION
This patch will fix issue #3324 and #3325 by simply handle random port servers as any ordinary non-cluster server.

It also renames the addressType property in cluster listening event argument to family (I believe this is more consistent). 
