### PR TITLE
Aliasing EventEmitter.prototype.removeListener as EventEmitter.prototype.off

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -48,6 +48,7 @@ it is removed.
     });
 
 ### emitter.removeListener(event, listener)
+### emitter.off(event, listener)
 
 Remove a listener from the listener array for the specified event.
 **Caution**: changes array indices in the listener array behind the listener.

--- a/lib/events.js
+++ b/lib/events.js
@@ -222,6 +222,8 @@ EventEmitter.prototype.removeListener = function(type, listener) {
   return this;
 };
 
+EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+
 EventEmitter.prototype.removeAllListeners = function(type) {
   if (arguments.length === 0) {
     this._events = {};

--- a/test/simple/test-event-emitter-remove-listeners.js
+++ b/test/simple/test-event-emitter-remove-listeners.js
@@ -23,6 +23,10 @@ var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 
+var e = new events.EventEmitter();
+
+// sanity check
+assert.equal(e.removeListener, e.off);
 
 var count = 0;
 


### PR DESCRIPTION
I understand the API of `events` is frozen but `EventEmitter`s should have `removeListener` aliased as `off` just as they have `addListener` aliased as `on`
