### PR TITLE
http: fix duplicated variable declaration

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1284,7 +1284,6 @@ function socketCloseListener() {
   var parser = socket.parser;
   var req = socket._httpMessage;
   debug('HTTP socket close');
-  var req = socket._httpMessage;
   req.emit('close');
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.


### PR DESCRIPTION
The line was  improperly merged in faa4d9ff5f7ff676db06240e09140f9780e2638c
