### PR TITLE
Implement setsid support

### DIFF
--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -1227,7 +1227,15 @@ enum uv_process_flags {
    * converting the argument list into a command line string. This option is
    * only meaningful on Windows systems. On unix it is silently ignored.
    */
-  UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS = (1 << 2)
+  UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS = (1 << 2),
+  /*
+   * On UNIX-like systems, the child process will become a new session leader.
+   * The session ID will be equal to the child process PID.
+   * See man setsid for more information.
+   *
+   * To kill the process group, call uv_kill with a negative PID.
+   */
+  UV_PROCESS_SETSID = (1 << 3)
 };
 
 /*

--- a/deps/uv/src/unix/process.c
+++ b/deps/uv/src/unix/process.c
@@ -176,7 +176,8 @@ int uv_spawn(uv_loop_t* loop, uv_process_t* process,
   assert(options.file != NULL);
   assert(!(options.flags & ~(UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
                              UV_PROCESS_SETGID |
-                             UV_PROCESS_SETUID)));
+                             UV_PROCESS_SETUID |
+                             UV_PROCESS_SETSID)));
 
 
   uv__handle_init(loop, (uv_handle_t*)process, UV_PROCESS);
@@ -279,6 +280,12 @@ int uv_spawn(uv_loop_t* loop, uv_process_t* process,
       _exit(127);
     }
 
+    pid_t sid = -1;
+    if ((options.flags & UV_PROCESS_SETSID) && -1 == (sid = setsid())) {
+      perror("setsid()");
+      _exit(127);
+    }
+
     environ = options.env;
 
     execvp(options.file, options.args);
@@ -373,7 +380,7 @@ int uv_process_kill(uv_process_t* process, int signum) {
 
 
 uv_err_t uv_kill(int pid, int signum) {
-  int r = kill(pid, signum);
+  int r = (pid >= 0) ? kill(pid, signum) : killpg(-pid, signum);
 
   if (r) {
     return uv__new_sys_error(errno);

--- a/deps/uv/test/test-list.h
+++ b/deps/uv/test/test-list.h
@@ -172,6 +172,8 @@ TEST_DECLARE   (listen_no_simultaneous_accepts)
 TEST_DECLARE   (fs_stat_root)
 #else
 TEST_DECLARE   (spawn_setuid_setgid)
+TEST_DECLARE   (spawn_setsid)
+TEST_DECLARE   (spawn_setsid_killpg)
 #endif
 HELPER_DECLARE (tcp4_echo_server)
 HELPER_DECLARE (tcp6_echo_server)
@@ -341,6 +343,8 @@ TASK_LIST_START
   TEST_ENTRY  (fs_stat_root)
 #else
   TEST_ENTRY  (spawn_setuid_setgid)
+  TEST_ENTRY  (spawn_setsid)
+  TEST_ENTRY  (spawn_setsid_killpg)
 #endif
 
   TEST_ENTRY  (fs_file_noent)

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -356,9 +356,9 @@ of the child only, with no effect on the grandchildren.
 
 Example of using `setsid`:
 
-  var spawn = require('child_process').spawn,
-      child = spawn('sh', ['-c', 'sleep 30 &'], {setsid: true};
-  process.kill(-child.pid);  // On UNIX this will also kill "sleep 30"
+    var spawn = require('child_process').spawn,
+        child = spawn('sh', ['-c', 'sleep 30 &'], {setsid: true});
+    process.kill(-child.pid);  // On UNIX will also kill the "sleep 30" process
 
 
 See also: `child_process.exec()` and `child_process.fork()`

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -347,6 +347,20 @@ There are several internal options. In particular `stdinStream`,
 `stdoutStream`, `stderrStream`. They are for INTERNAL USE ONLY. As with all
 undocumented APIs in Node, they should not be used.
 
+`setsid` allows to make the child process a new session leader on UNIX-like
+systems and has no effect on Windows. The session ID (SID) will be equal to the
+leader's PID. You can then kill, or send a signal to, all processes in the
+session by calling `process.kill` with the negated PID of the leader -- the
+process that you spawned here. On Windows it would still do a regular `kill`
+of the child only, with no effect on the grandchildren.
+
+Example of using `setsid`:
+
+  var spawn = require('child_process').spawn,
+      child = spawn('sh', ['-c', 'sleep 30 &'], {setsid: true};
+  process.kill(-child.pid);  // On UNIX this will also kill "sleep 30"
+
+
 See also: `child_process.exec()` and `child_process.fork()`
 
 ## child_process.exec(command, [options], callback)

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -331,6 +331,12 @@ Example of sending a signal to yourself:
 
     process.kill(process.pid, 'SIGHUP');
 
+If you spawn a session leader via child_process API with an option
+`setsid: true`, you can kill, or send a signal to, the entire process group
+by calling `kill` with the negative PID of the session leader -- on UNIX-like
+systems it will invoke the `killpg` system function with that ID.
+On Windows it will still do a regular `kill` for that PID, so no need to write
+platform conditions, although it would not affect the grandchildren on Windows.
 
 ## process.pid
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -601,7 +601,8 @@ var spawn = exports.spawn = function(file, args, options) {
     customFds: options ? options.customFds : null,
     stdinStream: options ? options.stdinStream : null,
     uid: options ? options.uid : null,
-    gid: options ? options.gid : null
+    gid: options ? options.gid : null,
+    setsid: options ? options.setsid : null
   });
 
   return child;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -485,7 +485,8 @@ exports.execFile = function(file /* args, options, callback */) {
     maxBuffer: 200 * 1024,
     killSignal: 'SIGTERM',
     cwd: null,
-    env: null
+    env: null,
+    setsid: null
   };
 
   // Parse the parameters.
@@ -505,6 +506,7 @@ exports.execFile = function(file /* args, options, callback */) {
   var child = spawn(file, args, {
     cwd: options.cwd,
     env: options.env,
+    setsid: options.setsid,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 

--- a/src/node.js
+++ b/src/node.js
@@ -415,6 +415,15 @@
     process.kill = function(pid, sig) {
       var r;
 
+      // On UNIX, a kill with a negative PID means killpg().
+      // On Windows there is no exact equivalent for killpg().
+      // Allow to write code without platform checks and to pass a negative
+      // PID to kill() even on Windows, translate it into a straight kill().
+      var isWindows = process.platform === 'win32';
+      if (isWindows && pid < 0) {
+        pid = -pid;
+      }
+
       // preserve null signal
       if (0 === sig) {
         r = process._kill(pid, 0);

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -199,6 +199,11 @@ class ProcessWrap : public HandleWrap {
       options.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
     }
 
+    // options.setsid
+    if (js_options->Get(String::NewSymbol("setsid"))->IsTrue()) {
+      options.flags |= UV_PROCESS_SETSID;
+    }
+
     int r = uv_spawn(uv_default_loop(), &wrap->process_, options);
 
     if (r) {

--- a/test/simple/test-child-process-setsid-killpg.js
+++ b/test/simple/test-child-process-setsid-killpg.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+var spawn = require('child_process').spawn;
+
+var is_windows = process.platform === 'win32';
+
+var exitCode;
+var termSignal;
+var gotStdoutEOF = false;
+var gotStderrEOF = false;
+
+var cat = spawn('cat', [], {setsid: true});
+
+
+cat.stdout.on('data', function(chunk) {
+  assert.ok(false);
+});
+
+cat.stdout.on('end', function() {
+  gotStdoutEOF = true;
+});
+
+cat.stderr.on('data', function(chunk) {
+  assert.ok(false);
+});
+
+cat.stderr.on('end', function() {
+  gotStderrEOF = true;
+});
+
+cat.on('exit', function(code, signal) {
+  exitCode = code;
+  termSignal = signal;
+});
+
+assert.equal(cat.killed, false);
+process.kill(-cat.pid);  // killpg(cat.pid)
+assert.equal(cat.killed, false);  // We only implicitly kill the process
+
+process.on('exit', function() {
+  assert.strictEqual(exitCode, null);
+  assert.strictEqual(termSignal, 'SIGTERM');
+  assert.ok(gotStdoutEOF);
+  assert.ok(gotStderrEOF);
+});

--- a/test/simple/test-child-process-setsid-killpg.js
+++ b/test/simple/test-child-process-setsid-killpg.js
@@ -34,7 +34,7 @@ var termSignal;
 var gotStdoutEOF = false;
 var gotStderrEOF = false;
 
-var cat = spawn('cat', [], {setsid: true});
+var cat = spawn(is_windows ? 'cmd' : 'cat', [], {setsid: true});
 
 
 cat.stdout.on('data', function(chunk) {
@@ -59,8 +59,8 @@ cat.on('exit', function(code, signal) {
 });
 
 assert.equal(cat.killed, false);
-process.kill(-cat.pid);  // killpg(cat.pid)
-assert.equal(cat.killed, false);  // We only implicitly kill the process
+process.kill(is_windows? cat.pid : -cat.pid);  // negative -> killpg(cat.pid)
+assert.equal(cat.killed, is_windows);  // On UNIX we kill implicitly
 
 process.on('exit', function() {
   assert.strictEqual(exitCode, null);

--- a/test/simple/test-child-process-setsid-killpg.js
+++ b/test/simple/test-child-process-setsid-killpg.js
@@ -59,8 +59,8 @@ cat.on('exit', function(code, signal) {
 });
 
 assert.equal(cat.killed, false);
-process.kill(is_windows? cat.pid : -cat.pid);  // negative -> killpg(cat.pid)
-assert.equal(cat.killed, is_windows);  // On UNIX we kill implicitly
+process.kill(-cat.pid);  // UNIX: killpg(cat.pid); Windows: kill(cat.pid)
+assert.equal(cat.killed, false);  // Built-in exit handlers do not set .killed
 
 process.on('exit', function() {
   assert.strictEqual(exitCode, null);


### PR DESCRIPTION
Implement, and document better, the setsid option in the child_process API.
Teach process.kill() to kill a UNIX session via killpg() when passing a negative SID, where the SID is equal to the session leader's PID.
