### PR TITLE
Don't lowercase http req header until inside _addHeaderLine method

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -87,7 +87,7 @@ function parserOnHeadersComplete(info) {
   for (var i = 0; i < n; i += 2) {
     var k = headers[i];
     var v = headers[i + 1];
-    parser.incoming._addHeaderLine(k.toLowerCase(), v);
+    parser.incoming._addHeaderLine(k, v);
   }
 
 
@@ -134,7 +134,7 @@ function parserOnMessageComplete() {
     for (var i = 0, n = headers.length; i < n; i += 2) {
       var k = headers[i];
       var v = headers[i + 1];
-      parser.incoming._addHeaderLine(k.toLowerCase(), v);
+      parser.incoming._addHeaderLine(k, v);
     }
     parser._headers = [];
     parser._url = '';
@@ -380,6 +380,7 @@ IncomingMessage.prototype._emitEnd = function() {
 IncomingMessage.prototype._addHeaderLine = function(field, value) {
   var dest = this.complete ? this.trailers : this.headers;
 
+  field = field.toLowerCase();
   switch (field) {
     // Array headers:
     case 'set-cookie':


### PR DESCRIPTION
If we normalize the case of the header name _before_ calling _addHeaderLine, then there's no way to get the original header even if we monkey-patch _addHeaderLine.
