### PR TITLE
msi: cleanup wix project files

### DIFF
--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
@@ -7,7 +7,7 @@
     <ProductVersion>3.5</ProductVersion>
     <ProjectGuid>{1d808ff0-b5a9-4be9-859d-b334b6f48be2}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>node</OutputName>
+    <OutputName>node-v$(NodeVersion)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
@@ -43,25 +43,9 @@
       <Name>WixUIExtension</Name>
     </WixExtension>
   </ItemGroup>
-  <UsingTask TaskName="GenerateProductId" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-    <ParameterGroup>
-      <ProductId ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-          this.ProductId = System.Guid.NewGuid().ToString().ToUpper();
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
   <Import Project="$(WixTargetsPath)" />
     <Target Name="BeforeBuild">
-      <GenerateProductId>
-        <Output PropertyName="NodeProductId" TaskParameter="ProductId"/>
-      </GenerateProductId>
-      <CreateProperty Value="$(DefineConstants);ProductId=$(NodeProductId)">
-        <Output TaskParameter="Value" PropertyName="DefineConstants" />
-      </CreateProperty>
+      <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\deps\npm" PreprocessorVariable="var.NPMSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="NPMFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\npm.wxs">
+      </HeatDirectory>
     </Target>
 </Project>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -4,7 +4,7 @@
   <?define repoDir="$(var.ProjectDir)..\..\..\" ?>
   <?define sourcedir="$(var.repoDir)\$(var.Configuration)\" ?>
 
-  <Product Id="$(var.ProductId)"
+  <Product Id="*"
            Name="node.js"
            Language="1033"
            Version="$(var.ProductVersion)"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -116,12 +116,11 @@ if not defined msi goto run
 python "%~dp0tools\getnodeversion.py" > "%temp%\node_version.txt"
 if not errorlevel 0 echo Cannot determine current version of node.js & goto exit
 for /F "tokens=*" %%i in (%temp%\node_version.txt) do set NODE_VERSION=%%i
-heat dir deps\npm -var var.NPMSourceDir -dr NodeModulesFolder -cg NPMFiles -gg -template fragment -nologo -out npm.wxs
 msbuild "%~dp0tools\msvs\msi\nodemsi.sln" /m /t:Clean,Build /p:Configuration=%config% /p:Platform=%msiplatform% /p:NodeVersion=%NODE_VERSION% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 
 if defined nosign goto run
-signtool sign /a Release\node.msi
+signtool sign /a Release\node-v%NODE_VERSION%-%msiplatform%.msi
 
 :run
 @rem Run tests if requested.


### PR DESCRIPTION
The current wix project files do some manual processing and generation which
wix supports doing out of the box. This patch will use the HeatDirectory task
to generate the npm.wxs file and use the auto GUID generation. I also changed
the msi filename generation to include the version number to match the
currently used name for released msi files.

Note: I did not test the msi signing part
