### PR TITLE
windows/msi: fix adding node to PATH

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -51,7 +51,7 @@
                          Name="PATH" 
                          Part="last" 
                          System="yes" 
-                         Value="[NodeRoot]" />
+                         Value="[APPLICATIONROOTDIRECTORY]" />
           </Component>
           <Component Id="npmcmd" Guid="31e9986d-74cd-44e1-878c-194d3e997d32">
             <File Id="filenpmcmd" KeyPath="yes" Source="$(var.NPMSourceDir)\bin\npm.cmd" />


### PR DESCRIPTION
With joyent/node@943448772e988eba86173e9d53746137070420f4 I broke adding nodejs to PATH, this pull request fixes that.
