### PR TITLE
Add NODE_EXTERN to node::Start

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -101,7 +101,7 @@
 
 namespace node {
 
-int Start(int argc, char *argv[]);
+NODE_EXTERN int Start(int argc, char *argv[]);
 
 char** Init(int argc, char *argv[]);
 v8::Handle<v8::Object> SetupProcessObject(int argc, char *argv[]);


### PR DESCRIPTION
I'm building node as a DLL on Windows (which works awesome by the way) for embedding inside another application.

`node::Start` isn't currently exported. It's a useful function.

Any chance we can add this to both v0.6 and master? Thanks!
