### PR TITLE
add NODE_EXTERN to node::Start

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -85,7 +85,7 @@
 
 namespace node {
 
-int Start(int argc, char *argv[]);
+NODE_EXTERN int Start(int argc, char *argv[]);
 
 char** Init(int argc, char *argv[]);
 v8::Handle<v8::Object> SetupProcessObject(int argc, char *argv[]);


### PR DESCRIPTION
@bnoordhuis
(same as #3376 but with different destination branch)

I'm building node as a DLL on Windows (which works awesome by the way) for embedding inside another application.

`node::Start` isn't currently exported. It's a useful function.

Thanks!
