### PR TITLE
domain: use camelCase for properties

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -55,7 +55,7 @@ function uncaughtHandler(er) {
   if (exports.active && !exports.active._disposed) {
     decorate(er, {
       domain: exports.active,
-      domain_thrown: true
+      domainThrown: true
     });
     exports.active.emit('error', er);
   } else if (process.listeners('uncaughtException').length === 1) {
@@ -159,8 +159,8 @@ Domain.prototype.bind = function(cb, interceptError) {
         (arguments[0] instanceof Error)) {
       var er = arguments[0];
       decorate(er, {
-        domain_bound: cb,
-        domain_thrown: false,
+        domainBound: cb,
+        domainThrown: false,
         domain: self
       });
       self.emit('error', er);

--- a/lib/events.js
+++ b/lib/events.js
@@ -54,9 +54,9 @@ EventEmitter.prototype.emit = function() {
     {
       if (this.domain) {
         var er = arguments[1];
-        er.domain_emitter = this;
+        er.domainEmitter = this;
         er.domain = this.domain;
-        er.domain_thrown = false;
+        er.domainThrown = false;
         this.domain.emit('error', er);
         return false;
       }

--- a/test/simple/test-domain-implicit-fs.js
+++ b/test/simple/test-domain-implicit-fs.js
@@ -37,8 +37,8 @@ d.on('error', function(er) {
   switch (er.message) {
     case "ENOENT, open 'this file does not exist'":
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, true);
-      assert.ok(!er.domain_emitter);
+      assert.equal(er.domainThrown, true);
+      assert.ok(!er.domainEmitter);
       assert.equal(er.code, 'ENOENT');
       assert.equal(er.path, 'this file does not exist');
       assert.equal(typeof er.errno, 'number');

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -37,28 +37,28 @@ d.on('error', function(er) {
   switch (er.message) {
     case 'emitted':
       assert.equal(er.domain, d);
-      assert.equal(er.domain_emitter, e);
-      assert.equal(er.domain_thrown, false);
+      assert.equal(er.domainEmitter, e);
+      assert.equal(er.domainThrown, false);
       break;
 
     case 'bound':
-      assert.ok(!er.domain_emitter);
+      assert.ok(!er.domainEmitter);
       assert.equal(er.domain, d);
-      assert.equal(er.domain_bound, fn);
-      assert.equal(er.domain_thrown, false);
+      assert.equal(er.domainBound, fn);
+      assert.equal(er.domainThrown, false);
       break;
 
     case 'thrown':
-      assert.ok(!er.domain_emitter);
+      assert.ok(!er.domainEmitter);
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, true);
+      assert.equal(er.domainThrown, true);
       break;
 
     case "ENOENT, open 'this file does not exist'":
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, false);
-      assert.equal(typeof er.domain_bound, 'function');
-      assert.ok(!er.domain_emitter);
+      assert.equal(er.domainThrown, false);
+      assert.equal(typeof er.domainBound, 'function');
+      assert.ok(!er.domainEmitter);
       assert.equal(er.code, 'ENOENT');
       assert.equal(er.path, 'this file does not exist');
       assert.equal(typeof er.errno, 'number');
@@ -69,29 +69,29 @@ d.on('error', function(er) {
       assert.equal(er.code, 'ENOENT');
       assert.equal(er.path, 'stream for nonexistent file');
       assert.equal(er.domain, d);
-      assert.equal(er.domain_emitter, fst);
-      assert.ok(!er.domain_bound);
-      assert.equal(er.domain_thrown, false);
+      assert.equal(er.domainEmitter, fst);
+      assert.ok(!er.domainBound);
+      assert.equal(er.domainThrown, false);
       break;
 
     case 'implicit':
-      assert.equal(er.domain_emitter, implicit);
+      assert.equal(er.domainEmitter, implicit);
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, false);
-      assert.ok(!er.domain_bound);
+      assert.equal(er.domainThrown, false);
+      assert.ok(!er.domainBound);
       break;
 
     case 'implicit timer':
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, true);
-      assert.ok(!er.domain_emitter);
-      assert.ok(!er.domain_bound);
+      assert.equal(er.domainThrown, true);
+      assert.ok(!er.domainEmitter);
+      assert.ok(!er.domainBound);
       break;
 
     case 'Cannot call method \'isDirectory\' of undefined':
       assert.equal(er.domain, d);
-      assert.ok(!er.domain_emitter);
-      assert.ok(!er.domain_bound);
+      assert.ok(!er.domainEmitter);
+      assert.ok(!er.domainBound);
       break;
 
     default:


### PR DESCRIPTION
Make `domain` module follow camelCase convention (as rest of the core
code does).
