### PR TITLE
Add test for regression in 0.7.9 on handling bad unicode sequences

### DIFF
--- a/test/simple/test-bad-unicode.js
+++ b/test/simple/test-bad-unicode.js
@@ -1,0 +1,26 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+var assert = require('assert');
+var bad_unicode = '\uc/ef';
+
+console.log(bad_unicode);
+
+assert.equal(bad_unicode, "uc/ef");


### PR DESCRIPTION
This was a regression in 0.7.9.
## 0.6.x

```
$ node test/simple/test-bad-unicode.js 
uc/ef
```
## 0.7.9

```
$ node test/simple/test-bad-unicode.js 

/Users/dscape/Desktop/node/test/simple/test-bad-unicode.js:22
var bad_unicode = '\uc/ef';
                  ^^^

module.js:437
  var compiledWrapper = runInThisContext(wrapper, filename, true);
                        ^
SyntaxError: Unexpected token ILLEGAL
    at Module._compile (module.js:437:25)
    at Object..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function._load (module.js:312:12)
    at module.js:487:10
    at EventEmitter._tickCallback (node.js:238:9)
```
## Master

This has been fixed in master, `make test` worked.
