### PR TITLE
EventEmitter.onAny

### DIFF
--- a/benchmark/event_emitter.js
+++ b/benchmark/event_emitter.js
@@ -1,0 +1,138 @@
+var EventEmitter = require('events').EventEmitter,
+    assert       = require('assert');
+
+
+function noListeners(max) {
+  var ee = new EventEmitter();
+
+  for (var i = 0 ; i < max ; i ++) {
+    ee.emit('myevent');
+  }
+}
+
+function oneEventOneListener(max) {
+  var ee = new EventEmitter();
+  var eventCount = 0;
+
+  ee.on('myevent', function() {
+    eventCount ++;
+  });
+
+  for (var i = 0 ; i < max ; i ++) {
+    ee.emit('myevent');
+  }
+
+  assert.equal(eventCount, max);
+}
+
+function oneEventFourListeners(max) {
+  var ee = new EventEmitter();
+  var eventCount = 0;
+
+  for ( var l = 0 ; l < 4 ; l ++) {
+    ee.on('myevent', function() {
+      eventCount ++;
+    });
+  }
+
+  for (var i = 0 ; i < max ; i ++) {
+    ee.emit('myevent');
+  }
+
+  assert.equal(eventCount, max * 4);
+}
+
+function twoEventsTwoListeners(max) {
+  var ee = new EventEmitter();
+  max = max / 2;
+  var eventCount = 0;
+
+  for ( var l = 0 ; l < 2 ; l ++) {
+    ee.on('myevent' + l, function() {
+      eventCount ++;
+    });
+  }
+
+  for ( var j = 0 ; j < 2 ; j ++) {
+    for (var i = 0 ; i < max ; i ++) {
+      ee.emit('myevent' + j);
+    }
+  }
+
+  assert.equal(eventCount, max * 2);
+}
+
+function twoEventsFourListeners(max) {
+  var ee = new EventEmitter();
+  max = max / 2;
+  var eventCount = 0;
+
+  for ( var l = 0 ; l < 2 ; l ++) {
+    for ( var m = 0 ; m < 2 ; m ++) {
+      ee.on('myevent' + l, function() {
+        eventCount ++;
+      });
+    }
+  }
+
+  for ( var j = 0 ; j < 2 ; j ++) {
+    for (var i = 0 ; i < max ; i ++) {
+      ee.emit('myevent' + j);
+    }
+  }
+
+  assert.equal(eventCount, max * 4);
+}
+
+//
+// Test definitions
+//
+var tests = [
+  { name: 'no listeners'
+  , loop: 1e8
+  , fn: noListeners }
+, { name: '1 event, 1 listener'
+  , loop: 1e8
+  , fn: oneEventOneListener }
+, { name: '1 event, 4 listeners'
+  , loop: 1e8
+  , fn: oneEventFourListeners }
+, { name: '2 events, 2 listeners'
+  , loop: 1e8
+  , fn: twoEventsTwoListeners }
+, { name: '2 events, 4 listeners'
+  , loop: 1e8
+  , fn: twoEventsFourListeners }
+];
+
+function run(i) {
+
+  if (i >= tests.length) {
+    console.log('All done.');
+    return;
+  }
+
+  var test = tests[i];
+  var testFunc = test.fn;
+  var loop = test.loop;
+
+  var start = Date.now();
+
+  testFunc(loop);
+  var end = Date.now();
+  var diff = end - start;
+  var seconds = diff / 1000;
+  var rate = Math.round(loop / seconds);
+  console.log(test.name + ': Ellapsed: '  + seconds + 's. Rate: ' + rate + ' emits/sec.');
+  process.nextTick(function() {
+    run(i + 1);
+  });
+}
+
+if (process.argv[2]) {
+  tests = tests.filter(function(test) {
+    return test.name === process.argv[2];
+  });
+}
+
+run(0);

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -47,6 +47,20 @@ it is removed.
       console.log('Ah, we have our first user!');
     });
 
+### emitter.onAny(listener)
+
+Adds a listener for the "*" event type. This event type will be emitted on every event.
+
+    server.onAny(function (eventType, arg1, arg2) {
+      console.log('server emitter event type ', eventType);
+    });
+
+This is equivalent to:
+
+    server.on("*", function (eventType, arg1, arg2) {
+      console.log('server emitter event type ', eventType);
+    });
+
 ### emitter.removeListener(event, listener)
 
 Remove a listener from the listener array for the specified event.
@@ -64,6 +78,21 @@ Remove a listener from the listener array for the specified event.
 
 Removes all listeners, or those of the specified event.
 
+### emitter.removeAnyListener(listener)
+
+Removes a listener of the "*" event.
+
+    var callback = function(eventType, arg1, arg2) {
+      console.log('server emitter event type ', eventType);
+    };
+
+    server.onAny(callback);
+
+    server.removeAnyListener(callback);
+
+This last line is equivalent to:
+
+    server.removeListener("*", callback);
 
 ### emitter.setMaxListeners(n)
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -21,6 +21,8 @@
 
 var isArray = Array.isArray;
 
+var eventTypeAny = '*';
+
 function EventEmitter() {
   if (exports.usingDomains) {
     // if there is an active domain, then attach to it.
@@ -45,7 +47,7 @@ EventEmitter.prototype.setMaxListeners = function(n) {
 };
 
 
-EventEmitter.prototype.emit = function() {
+function emit() {
   var type = arguments[0];
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
@@ -123,12 +125,28 @@ EventEmitter.prototype.emit = function() {
   }
 };
 
+EventEmitter.prototype.emit = emit;
+
+function emitAll() {
+  var hasHandlers = emit.apply(this, arguments);
+  var args = Array.prototype.slice.call(arguments);
+  var eventType = args.shift();
+
+  emit.call(this, eventTypeAny, eventType, args);
+
+  return hasHandlers;
+}
+
 EventEmitter.prototype.addListener = function(type, listener) {
   if ('function' !== typeof listener) {
     throw new Error('addListener only takes instances of Function');
   }
 
   if (!this._events) this._events = {};
+
+  if (type === eventTypeAny && this.emit !== emitAll) {
+    this.emit = emitAll;
+  }
 
   // To avoid recursion in the case that type == "newListeners"! Before
   // adding it to the listeners, first emit "newListeners".
@@ -219,6 +237,10 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     delete this._events[type];
   }
 
+  if (type === eventTypeAny && this.listeners(type).length === 0) {
+    delete this.emit;
+  }
+
   return this;
 };
 
@@ -237,8 +259,24 @@ EventEmitter.prototype.removeAllListeners = function(type) {
     this._events[type] = null;
   }
 
+  if (type === eventTypeAny) {
+    delete this.emit;
+  }
+
   return this;
 };
+
+EventEmitter.prototype.onAny = function(callback) {
+  this.on(eventTypeAny, callback);
+
+  return this;
+};
+
+EventEmitter.prototype.removeAnyListener = function(callback) {
+  this.removeListener(eventTypeAny, callback);
+
+  return this;
+}
 
 EventEmitter.prototype.listeners = function(type) {
   if (!this._events) this._events = {};

--- a/test/simple/test-event-emitter-on-any.js
+++ b/test/simple/test-event-emitter-on-any.js
@@ -1,0 +1,56 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var e = new events.EventEmitter();
+
+var events_new_listener_emited = [];
+var listeners_new_listener_emited = [];
+var times_hello_emited = 0;
+
+e.on('newListener', function(event, listener) {
+  events_new_listener_emited.push(event);
+  listeners_new_listener_emited.push(listener);
+});
+
+function hello(eventType, args) {
+  console.log('hello');
+  times_hello_emited += 1;
+  assert.equal('hello', eventType);
+  assert.deepEqual(['a', 'b'], args);
+}
+e.onAny(hello);
+
+console.log('start');
+
+e.emit('hello', 'a', 'b');
+
+
+process.on('exit', function() {
+  assert.deepEqual(['*'], events_new_listener_emited);
+  assert.deepEqual([hello], listeners_new_listener_emited);
+  assert.equal(1, times_hello_emited);
+});
+
+

--- a/test/simple/test-event-emitter-remove-any-listener.js
+++ b/test/simple/test-event-emitter-remove-any-listener.js
@@ -1,0 +1,75 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+
+var count = 0;
+
+function listener1() {
+  console.log('listener1');
+  count++;
+}
+
+function listener2() {
+  console.log('listener2');
+  count++;
+}
+
+function listener3() {
+  console.log('listener3');
+  count++;
+}
+
+var e1 = new events.EventEmitter();
+var e1listeners = e1.listeners('*');
+e1.onAny(listener1);
+assert.equal(e1listeners.length, 1);
+e1.removeAnyListener(listener1);
+assert.deepEqual([], e1.listeners('*'));
+e1.emit('a');
+assert.equal(0, count);
+e1.onAny(listener1);
+e1.emit('a');
+assert.equal(1, count);
+
+// identity check, listeners array should be the same
+assert.equal(e1listeners, e1.listeners('*'));
+
+var e2 = new events.EventEmitter();
+e2.onAny(listener1);
+e2.removeAnyListener(listener2);
+assert.deepEqual([listener1], e2.listeners('*'));
+
+var e3 = new events.EventEmitter();
+e3.onAny(listener1);
+e3.onAny(listener2);
+var e3listeners = e3.listeners('*');
+assert.equal(e3listeners.length, 2)
+e3.removeAnyListener(listener1);
+assert.equal(e3listeners.length, 1)
+assert.deepEqual([listener2], e3.listeners('*'));
+
+assert.equal(e3listeners, e3.listeners('*'));
+
+


### PR DESCRIPTION
This patch allows to listen to all events emitted by an event emitter using:

``` javascript
emitter.onAny(function(eventType, args) {
  console.log('emitter emitted event type "%s" with args %j', eventType, args);
});
```

or, alternatively:

``` javascript
emitter.on('*', function(eventType, args) {
  console.log('emitter emitted event type "%s" with args %j', eventType, args);
});
```

I have benchmarked EventEmitter, and came to the conclusion that it is impossible to introduce a change like this in `EventEmitter.prototype.emit` without any serious performance regression.

This solution, however, does not introduce any performance penalty if the user is not listening to all events. This is done by wrapping `emitter.emit` on demand.

Also, I am unwrapping if the user removes all the event listeners for event type "*".
