### PR TITLE
Patch to improve the functionality of fs.watch() by enhancing both Node and libuv

### DIFF
--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -1498,8 +1498,9 @@ UV_EXTERN int uv_fs_fchown(uv_loop_t* loop, uv_fs_t* req, uv_file file,
 
 
 enum uv_fs_event {
-  UV_RENAME = 1,
-  UV_CHANGE = 2
+  UV_RENAME = 1 << 0,
+  UV_CHANGE = 1 << 1,
+  UV_REVOKE = 1 << 2
 };
 
 

--- a/deps/uv/src/unix/kqueue.c
+++ b/deps/uv/src/unix/kqueue.c
@@ -110,7 +110,7 @@ int uv_fs_event_init(uv_loop_t* loop,
   assert(!flags);
 
   /* TODO open asynchronously - but how do we report back errors? */
-  if ((fd = open(filename, O_RDONLY)) == -1) {
+  if ((fd = open(filename, O_EVTONLY)) == -1) {
     uv__set_sys_error(loop, errno);
     return -1;
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -30,6 +30,7 @@ var pathModule = require('path');
 
 var binding = process.binding('fs');
 var constants = process.binding('constants');
+var FSEvent = process.binding('fs_event_wrap').FSEvent;
 var fs = exports;
 var Stream = require('stream').Stream;
 var EventEmitter = require('events').EventEmitter;
@@ -803,7 +804,6 @@ function errnoException(errorno, syscall) {
 
 function FSWatcher() {
   var self = this;
-  var FSEvent = process.binding('fs_event_wrap').FSEvent;
   this._handle = new FSEvent();
   this._handle.owner = this;
 

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -138,6 +138,9 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
     SetErrno(uv_last_error(uv_default_loop()));
     eventStr = String::Empty();
   }
+  else if (events & UV_REVOKE) {
+    eventStr = String::New("revoke");
+  }
   else if (events & UV_RENAME) {
     eventStr = String::New("rename");
   }


### PR DESCRIPTION
I wanted to submit this directly to libuv, but since it requires changes in Node too, I thought I should put it here first.

Changes in libuv:
- `uv_fs_event` enum is defined with bit-shifts, which make the intent obvious
- Adds new `uv_fs_event` type, UV_REVOKE, for files that are deleted or unmounted
- Filenames are loaded and passed to the callback with kqueue just like they are on other platforms (Windows, etc.)

Changes in Node:
- Support for UV_REVOKE (passed to fs.watch() callbacks as "revoke")
- No change related to filenames, since it is already supported for some platforms

Issues:
- Probably breaks the libuv build on non-OS X platforms that use Kqueue (FreeBSD?), because it uses F_FULLFSYNC in order to get the latest filename after a rename operation (see the comment in the path about this)
- Furthermore, may not always return the latest filename on platforms without F_FULLFSYNC support
- No UV_REVOKE support is added to any of the other libuv platforms (I don't have access to them)

I know this patch causes as many problems as it solves, but I hope it can serve as a starting point to improve file event support.

Thanks,
Ben
