### PR TITLE
fs: fix fs.readFile and fs.readFileSync in size=0 stat case

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -167,7 +167,7 @@ fs.readFile = function(path, encoding_) {
     fs.close(fd, function(er) {
       if (size === 0) {
         // collected the data into the buffers list.
-        buffer = Buffer.concat(buffer.length, pos);
+        buffer = Buffer.concat(buffers, pos);
       }
 
       if (encoding) buffer = buffer.toString(encoding);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -223,7 +223,7 @@ fs.readFileSync = function(path, encoding) {
     if (size !== 0) {
       done = pos >= size;
     } else {
-      done = bytesRead > 0;
+      done = bytesRead >= 0;
     }
   }
 


### PR DESCRIPTION
6ce013dd4bbe660c12ce11c338b788163305cd2b has two bugs. 
One is a typo in arguments of Buffer.concat() in fs.readFile() which caused the test failure of test-fs-readfile-zero-byte-liar.js and the other is the one which caused  an infinite loop  in reading a real empty size file so that test-fs-readfile-empty.js was timeout.

```
> ./node ./test/simple/test-fs-readfile-zero-byte-liar.js

buffer.js:474
    throw new Error('Usage: Buffer.concat(list, [length])');
          ^
Error: Usage: Buffer.concat(list, [length])
    at Function.concat (buffer.js:474:11)
    at fs.js:170:25
    at Object.oncomplete (fs.js:298:15)
>
> ./node test/simple/test-fs-readfile-empty.js
(this goes infinity loop)
```

After this patch, the tow tests were passed as

```
>./node ./test/simple/test-fs-readfile-zero-byte-liar.js
ok
> ./node ./test/simple/test-fs-readfile-empty.js
>
```
