### PR TITLE
Fixes issue #3428 - Net module bug under clustering - server.listen(0); port == 0; assigns the same port to each worker

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -900,7 +900,8 @@ Server.prototype._listen2 = function(address, port, addressType, backlog) {
 function listen(self, address, port, addressType, backlog) {
   if (!cluster) cluster = require('cluster');
 
-  if (cluster.isWorker) {
+  // share the server if we're clustered and specifying port to use
+  if (cluster.isWorker && port !== 0) {
     cluster._getServer(self, address, port, addressType, function(handle) {
       self._handle = handle;
       self._listen2(address, port, addressType, backlog);


### PR DESCRIPTION
Single-line fix. If we are connecting on port 0 as a worker in a cluster environment, we need to create a new connection using a randomly allocated port for each worker and not share the "port 0" connection.

The core of the problem lies in the fact that the cluster module caches the connections using

``` javascript
// cluster.js - cluster._getServer - line 516
var key = [address, port, addressType].join(':');
```

So, if we try to get a port 0 connection from the cluster (we're trying to get a randomly allocated port), the cluster module detects that we have already opened a "port 0" connection and returns that descriptor. Ideally, this method should be fixed to store the actual port that is opened when the connection is created. That way we don't falsely claim that we are storing a connection listening on port 0, which causes future requests for a random port to share this connection.

However, workers have no need to be sharing their connection when they open up a socket using port 0. If I intend to share a port among workers, I would specify the port.

Given that assumption, we can bypass changing the cluster.js module's code and simply only call the cluster module if we are operating as a worker in a cluster environment AND we are specifying the exact port to connect to. This is what my patch does.
