### PR TITLE
Improvement to Readline: Re-use the last history item if exactly the same as the entered line

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -188,12 +188,14 @@ Interface.prototype._onLine = function(line) {
 Interface.prototype._addHistory = function() {
   if (this.line.length === 0) return '';
 
-  this.history.unshift(this.line);
+  if (this.history.length === 0 || this.history[0] !== this.line) {
+    this.history.unshift(this.line);
+
+    // Only store so many
+    if (this.history.length > kHistorySize) this.history.pop();
+  }
+
   this.historyIndex = -1;
-
-  // Only store so many
-  if (this.history.length > kHistorySize) this.history.pop();
-
   return this.history[0];
 };
 


### PR DESCRIPTION
This is a small convenience improvement to the history mechanism of Readline: When the newly entered line is exactly the same as the last item stored in the history. Adding it once again is not very useful in practice, from my perspective (and from day-to-day experience with the node command prompt).

Indeed, if the user enters the same line several times in a row -- not an unusual thing when experimenting or debugging -- and then wants to find and re-use an earlier line from the history. Then scrolling through all the lastly repeated "dupes" of the very same command line does not add any convenience to the user experience and it makes it a little bit longer to find what is needed.
