### PR TITLE
Fix #3425: removeAllListeners should delete array

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -228,15 +228,8 @@ EventEmitter.prototype.removeAllListeners = function(type) {
     return this;
   }
 
-  var events = this._events && this._events[type];
-  if (!events) return this;
-
-  if (isArray(events)) {
-    events.splice(0);
-  } else {
-    this._events[type] = null;
-  }
-
+  // does not use listeners(), so no side effect of creating _events[type]
+  if (type && this._events && this._events[type]) this._events[type] = null;
   return this;
 };
 

--- a/test/simple/test-event-emitter-remove-all-listeners.js
+++ b/test/simple/test-event-emitter-remove-all-listeners.js
@@ -39,10 +39,15 @@ e1.removeAllListeners('baz');
 assert.deepEqual(e1.listeners('foo'), [listener]);
 assert.deepEqual(e1.listeners('bar'), []);
 assert.deepEqual(e1.listeners('baz'), []);
-// identity check, the array should not change
-assert.equal(e1.listeners('foo'), fooListeners);
-assert.equal(e1.listeners('bar'), barListeners);
-assert.equal(e1.listeners('baz'), bazListeners);
+// after calling removeAllListeners,
+// the old listeners array should stay unchanged
+assert.deepEqual(fooListeners, [listener]);
+assert.deepEqual(barListeners, [listener]);
+assert.deepEqual(bazListeners, [listener, listener]);
+// after calling removeAllListeners,
+// new listeners arrays are different from the old
+assert.notEqual(e1.listeners('bar'), barListeners);
+assert.notEqual(e1.listeners('baz'), bazListeners);
 
 var e2 = new events.EventEmitter();
 e2.on('foo', listener);


### PR DESCRIPTION
When removeAllListeners is called, the listeners array is deleted to maintain compatibility with v0.6.

This request fixes issue #3425 by reverting 78dc13fbf97e2e3003e6f3baacdd5ff60e8de3f7. In addition to the revert, I've updated the tests to match the reverted behavior.
