### PR TITLE
cluster: s/uniqueID/id/g

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -128,13 +128,13 @@ This can be used to log worker activity, and create you own timeout.
     }
 
     cluster.on('fork', function(worker) {
-      timeouts[worker.uniqueID] = setTimeout(errorMsg, 2000);
+      timeouts[worker.id] = setTimeout(errorMsg, 2000);
     });
     cluster.on('listening', function(worker, address) {
-      clearTimeout(timeouts[worker.uniqueID]);
+      clearTimeout(timeouts[worker.id]);
     });
     cluster.on('exit', function(worker, code, signal) {
-      clearTimeout(timeouts[worker.uniqueID]);
+      clearTimeout(timeouts[worker.id]);
       errorMsg();
     });
 
@@ -183,7 +183,7 @@ the process is stuck in a cleanup or if there are long-living
 connections.
 
     cluster.on('disconnect', function(worker) {
-      console.log('The worker #' + worker.uniqueID + ' has disconnected');
+      console.log('The worker #' + worker.id + ' has disconnected');
     });
 
 ## Event: 'exit'
@@ -265,13 +265,13 @@ The method takes an optional callback argument which will be called when finishe
 
 * {Object}
 
-In the cluster all living worker objects are stored in this object by there
-`uniqueID` as the key. This makes it easy to loop through all living workers.
+In the cluster all living worker objects are stored in this object by their
+`id` as the key. This makes it easy to loop through all living workers.
 
     // Go through all workers
     function eachWorker(callback) {
-      for (var uniqueID in cluster.workers) {
-        callback(cluster.workers[uniqueID]);
+      for (var id in cluster.workers) {
+        callback(cluster.workers[id]);
       }
     }
     eachWorker(function(worker) {
@@ -279,10 +279,10 @@ In the cluster all living worker objects are stored in this object by there
     });
 
 Should you wish to reference a worker over a communication channel, using
-the worker's uniqueID is the easiest way to find the worker.
+the worker's id is the easiest way to find the worker.
 
-    socket.on('data', function(uniqueID) {
-      var worker = cluster.workers[uniqueID];
+    socket.on('data', function(id) {
+      var worker = cluster.workers[id];
     });
 
 ## Class: Worker
@@ -291,12 +291,12 @@ A Worker object contains all public information and method about a worker.
 In the master it can be obtained using `cluster.workers`. In a worker
 it can be obtained using `cluster.worker`.
 
-### worker.uniqueID
+### worker.id
 
 * {String}
 
 Each new worker is given its own unique id, this id is stored in the
-`uniqueID`.
+`id`.
 
 While a worker is alive, this is the key that indexes it in
 cluster.workers
@@ -434,8 +434,8 @@ in the master process using the message system:
 
       // Start workers and listen for messages containing notifyRequest
       cluster.autoFork();
-      Object.keys(cluster.workers).forEach(function(uniqueID) {
-        cluster.workers[uniqueID].on('message', messageHandler);
+      Object.keys(cluster.workers).forEach(function(id) {
+        cluster.workers[id].on('message', messageHandler);
       });
 
     } else {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -258,8 +258,11 @@ function Worker(customEnv) {
   var self = this;
   var env = process.env;
 
-  // Assign uniqueID, default null
-  this.uniqueID = cluster.isMaster ? ++ids : toDecInt(env.NODE_UNIQUE_ID);
+  // Assign id, default null
+  this.id = cluster.isMaster ? ++ids : toDecInt(env.NODE_UNIQUE_ID);
+
+  // XXX: legacy.  Remove in v0.9
+  this.uniqueID = this.workerID = this.id
 
   // Assign state
   this.state = 'none';
@@ -268,9 +271,9 @@ function Worker(customEnv) {
   if (cluster.isMaster) {
 
     // Create env object
-    // first: copy and add uniqueID
+    // first: copy and add id
     var envCopy = util._extend({}, env);
-    envCopy['NODE_UNIQUE_ID'] = this.uniqueID;
+    envCopy['NODE_UNIQUE_ID'] = this.id;
     // second: extend envCopy with the env argument
     if (isObject(customEnv)) {
       envCopy = util._extend(envCopy, customEnv);
@@ -288,7 +291,7 @@ function Worker(customEnv) {
 
   if (cluster.isMaster) {
     // Save worker in the cluster.workers array
-    cluster.workers[this.uniqueID] = this;
+    cluster.workers[this.id] = this;
 
     // Emit a fork event, on next tick
     // There is no worker.fork event since this has no real purpose
@@ -328,7 +331,7 @@ function prepareExit(worker, state) {
 
   // Remove from workers in the master
   if (cluster.isMaster) {
-    delete cluster.workers[worker.uniqueID];
+    delete cluster.workers[worker.id];
   }
 }
 
@@ -350,7 +353,7 @@ function sendInternalMessage(worker, message/*, handler, callback*/) {
 
   // Store callback for later
   if (callback) {
-    message._requestEcho = worker.uniqueID + ':' + (++queryIds);
+    message._requestEcho = worker.id + ':' + (++queryIds);
     queryCallbacks[message._requestEcho] = callback;
   }
 


### PR DESCRIPTION
Calling it an 'id' implies that it is an identification, and thus unique.  There is no need for the longer name.
