### PR TITLE
skip test-http-full-response if we get errors from ab

### DIFF
--- a/test/simple/test-http-full-response.js
+++ b/test/simple/test-http-full-response.js
@@ -49,8 +49,8 @@ function runAb(opts, callback) {
   var command = 'ab ' + opts + ' http://127.0.0.1:' + common.PORT + '/';
   exec(command, function(err, stdout, stderr) {
     if (err) {
-      if (stderr.indexOf('ab') >= 0) {
-        console.log('ab not installed? skipping test.\n' + stderr);
+      if (/ab|apr/mi.test(stderr)) {
+        console.log('problem spawning ab - skipping test.\n' + stderr);
         process.reallyExit(0);
       }
       process.exit();


### PR DESCRIPTION
`ab` can be present, but broken; we shouldn't fail a node test because of an error in a third-party tool.
