### PR TITLE
Fix building with a shared zlib: ensure link with '-lz'

### DIFF
--- a/wscript
+++ b/wscript
@@ -296,7 +296,7 @@ def configure(conf):
   conf.env["USE_GDBJIT"] = o.use_gdbjit
   conf.env['USE_NPM'] = not o.without_npm
 
-  if not conf.env["USE_SHARED_ZLIB"] and not sys.platform.startswith("win32"):
+  if not sys.platform.startswith("win32"):
     conf.env.append_value("LINKFLAGS", "-lz")
 
   conf.check(lib='dl', uselib_store='DL')


### PR DESCRIPTION
Configuring for a shared zlib:

```
LDFLAGS="-L/opt/local/lib -R/opt/local/lib" \
    ./configure --shared-zlib \
    --shared-zlib-includes=/opt/local/include \
    --shared-zlib-libpath=/opt/local/lib
```

and building would fail on SmartOS because the link would not include '-lz'.
This doesn't fail on Mac (at least in my setup) because you get lucky with the
openssl libs reported from the Homebrew pkg-config:

```
$ pkg-config --libs openssl
-lssl -lcrypto -lz
```

On SmartOS, the pkgsrc libs for openssl are:

```
$ pkg-config --libs openssl
-Wl,-R/opt/local/lib -L/opt/local/lib -lssl -lcrypto -lsocket -lnsl -ldl
```

The patch has no adverse effect on the Mac build (my control case).
