### PR TITLE
net: Prevent property access throws during close

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -439,7 +439,7 @@ Socket.prototype._getpeername = function() {
     this._peername = this._handle.getpeername();
     // getpeername() returns null on error
     if (this._peername === null) {
-        return {};
+      return {};
     }
   }
   return this._peername;

--- a/lib/net.js
+++ b/lib/net.js
@@ -437,6 +437,10 @@ Socket.prototype._getpeername = function() {
   }
   if (!this._peername) {
     this._peername = this._handle.getpeername();
+    // getpeername() returns null on error
+    if (this._peername === null) {
+        return {};
+    }
   }
   return this._peername;
 };

--- a/test/simple/test-net-during-close.js
+++ b/test/simple/test-net-during-close.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var accessedProperties = false;
+
+var server = net.createServer(function(socket) {
+  socket.end();
+});
+
+server.listen(common.PORT, function() {
+  var client = net.createConnection(common.PORT);
+  server.close();
+  // server connection event has not yet fired
+  // client is still attempting to connect
+  assert.doesNotThrow(function() {
+    client.remoteAddress;
+    client.remotePort;
+  });
+  accessedProperties = true;
+  // exit now, do not wait for the client error event
+  process.exit(0);
+});
+
+process.on('exit', function() {
+  assert(accessedProperties);
+});


### PR DESCRIPTION
Fix #3455.

The remoteAddress and remotePort properties are dynamically retrieved from _getpeername().

While _getpeername() checks if the _handle is null, it is also possible for the tcp_wrapped _handle.getpeername() to return null on error.

Such a condition happens when the remote closes and one of these properties is accessed before _handle is set to null.
