### PR TITLE
Windows: Loading from the global folders

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -494,6 +494,11 @@ Module._initPaths = function() {
     paths.unshift(path.resolve(process.env['HOME'], '.node_libraries'));
     paths.unshift(path.resolve(process.env['HOME'], '.node_modules'));
   }
+  
+  if (process.env['USERPROFILE']) {
+    paths.unshift(path.resolve(process.env['USERPROFILE'], '.node_libraries'));
+    paths.unshift(path.resolve(process.env['USERPROFILE'], '.node_modules'));
+  }
 
   if (process.env['NODE_PATH']) {
     var splitter = process.platform === 'win32' ? ';' : ':';


### PR DESCRIPTION
Fix #3461
Windows do not have HOME environment variable, so that node will not search $HOME/.node_modules and $HOME/.node_libraries.On Windows, a similar environment variable is called USERPROFILE.
