### PR TITLE
events: cache `domain` module locally

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -20,11 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var isArray = Array.isArray;
+var domain;
 
 function EventEmitter() {
   if (exports.usingDomains) {
     // if there is an active domain, then attach to it.
-    var domain = require('domain');
+    domain = domain || require('domain');
     if (domain.active && !(this instanceof domain.Domain)) {
       this.domain = domain.active;
     }


### PR DESCRIPTION
It's faster than calling `require` every time we create an
`EventEmitter`.
