### PR TITLE
test: fix test-dgram-broadcast-multi-process

### DIFF
--- a/test/simple/test-dgram-broadcast-multi-process.js
+++ b/test/simple/test-dgram-broadcast-multi-process.js
@@ -23,7 +23,7 @@ var common = require('../common'),
     assert = require('assert'),
     dgram = require('dgram'),
     util = require('util'),
-    assert = require('assert'),
+    networkInterfaces= require('os').networkInterfaces(),
     Buffer = require('buffer').Buffer,
     fork = require('child_process').fork,
     LOCAL_BROADCAST_HOST = '255.255.255.255',
@@ -34,6 +34,19 @@ var common = require('../common'),
       new Buffer('Third message to send'),
       new Buffer('Fourth message to send')
     ];
+
+// take the first non-internal interface as the address for binding
+get_bindAddress: for (var name in networkInterfaces) {
+  var interfaces = networkInterfaces[name];
+  for(var i = 0; i < interfaces.length; i++) {
+    var localInterface = interfaces[i];
+    if (!localInterface.internal && localInterface.family === 'IPv4') {
+      var bindAddress = localInterface.address;
+      break get_bindAddress;
+    }
+  }
+}
+assert.ok(bindAddress);
 
 if (process.argv[2] !== 'child') {
   var workers = {},
@@ -146,7 +159,9 @@ if (process.argv[2] !== 'child') {
 
   var sendSocket = dgram.createSocket('udp4');
 
-  sendSocket.bind(common.PORT);
+  // bind the address explicitly for sending
+  // INADDR_BROADCAST to only one interface
+  sendSocket.bind(common.PORT, bindAddress);
   sendSocket.setBroadcast(true);
 
   sendSocket.on('close', function() {
@@ -187,6 +202,9 @@ if (process.argv[2] === 'child') {
   var listenSocket = dgram.createSocket('udp4');
 
   listenSocket.on('message', function(buf, rinfo) {
+    // receive udp messages only sent from parent
+    if (rinfo.address !== bindAddress) return;
+    
     console.error('[CHILD] %s received %s from %j',
                   process.pid,
                   util.inspect(buf.toString()),


### PR DESCRIPTION
The test was failed when a router replies IPADDR_BROADCAST as

```
> ./node test/simple/test-dgram-broadcast-multi-process.js
[CHILD] 5715 received 'First message to send' from {"address":"10.0.2.15","family":"IPv4","port":12346,"size":21}
[CHILD] 5715 received 'First message to send' from {"address":"192.168.56.1","family":"IPv4","port":61611,"size":21}
[PARENT] sent 'First message to send' to 255.255.255.255:12346
[CHILD] 5715 received 'Second message to send' from 
(snip)
[CHILD] 5713 received 'Second message to send' from {"address":"192.168.56.1","family":"IPv4","port":61611,"size":22}
[PARENT] 5713 received 4 messages total.
[PARENT] All workers have received the required number of messages. Will now compare.
[PARENT] 5713 received 4 matching messges.
[PARENT] 5714 received 8 matching messges.

assert.js:104
  throw new assert.AssertionError({
        ^
AssertionError: A worker received an invalid multicast message
    at /home/ohtsu/tmp/github/node/test/simple/test-dgram-broadcast-multi-process.js:134:22
    at Array.forEach (native)
    at ChildProcess.<anonymous> (/home/ohtsu/tmp/github/node/test/simple/test-dgram-broadcast-multi-process.js:116:34)
    at ChildProcess.EventEmitter.emit (events.js:91:17)
    at handleMessage (child_process.js:273:12)
    at Pipe.channel.onread (child_process.js:293:9)
```

Fixed it by binding a socket to the only one address of a non-internal interface firstly appeared.
