### PR TITLE
Fixes #3497

### DIFF
--- a/test/simple/test-os.js
+++ b/test/simple/test-os.js
@@ -74,23 +74,18 @@ if (process.platform != 'sunos') {
   assert.ok(os.totalmem() > 0);
 }
 
-
+// Check for an IPv4 loopback 
 var interfaces = os.networkInterfaces();
 console.error(interfaces);
-switch (platform) {
-  case 'linux':
-    var filter = function(e) { return e.address == '127.0.0.1'; };
-    var actual = interfaces.lo.filter(filter);
-    var expected = [{ address: '127.0.0.1', family: 'IPv4', internal: true }];
-    assert.deepEqual(actual, expected);
-    break;
-  case 'win32':
-    var filter = function(e) { return e.address == '127.0.0.1'; };
-    var actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
-    var expected = [{ address: '127.0.0.1', family: 'IPv4', internal: true }];
-    assert.deepEqual(actual, expected);
-    break;
+var filter = function(e) { return e.address == '127.0.0.1'; };
+var expected = { address: '127.0.0.1', family: 'IPv4', internal: true };
+var address = function(a) { assert.deepEqual(a, expected); return true; };
+var count = 0;
+for (var i in interfaces) {
+  var addr=interfaces[i].filter(filter).filter(address);
+  count += addr.length;
 }
+assert(count > 0);
 
 var EOL = os.EOL;
 assert.ok(EOL.length > 0);

--- a/test/simple/test-os.js
+++ b/test/simple/test-os.js
@@ -30,7 +30,7 @@ var os = require('os');
 process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
-var t = ( process.platform === 'win32' ? 'c:\\windows\\temp' : '/tmp' );
+var t = (process.platform === 'win32' ? 'c:\\windows\\temp' : '/tmp');
 assert.equal(os.tmpDir(), '/tmpdir');
 process.env.TMPDIR = '';
 assert.equal(os.tmpDir(), '/tmp');
@@ -74,23 +74,24 @@ if (process.platform != 'sunos') {
   assert.ok(os.totalmem() > 0);
 }
 
-
+// Check at least 1 IPv4 loopback exists & all have correct details
 var interfaces = os.networkInterfaces();
 console.error(interfaces);
-switch (platform) {
-  case 'linux':
-    var filter = function(e) { return e.address == '127.0.0.1'; };
-    var actual = interfaces.lo.filter(filter);
-    var expected = [{ address: '127.0.0.1', family: 'IPv4', internal: true }];
-    assert.deepEqual(actual, expected);
-    break;
-  case 'win32':
-    var filter = function(e) { return e.address == '127.0.0.1'; };
-    var actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
-    var expected = [{ address: '127.0.0.1', family: 'IPv4', internal: true }];
-    assert.deepEqual(actual, expected);
-    break;
+
+var expected = { address: '127.0.0.1', family: 'IPv4', internal: true };
+var found = false;
+for (var iname in interfaces) {
+  var inter = interfaces[iname];
+
+  var addrs = inter.length;
+  for (var a = 0; a < addrs; a++) {
+    if (inter[a].address == '127.0.0.1') {
+      assert.deepEqual(inter[a], expected);
+      found = true;
+    }
+  }
 }
+assert(found);
 
 var EOL = os.EOL;
 assert.ok(EOL.length > 0);

--- a/test/simple/test-os.js
+++ b/test/simple/test-os.js
@@ -30,7 +30,7 @@ var os = require('os');
 process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
-var t = ( process.platform === 'win32' ? 'c:\\windows\\temp' : '/tmp' );
+var t = (process.platform === 'win32' ? 'c:\\windows\\temp' : '/tmp');
 assert.equal(os.tmpDir(), '/tmpdir');
 process.env.TMPDIR = '';
 assert.equal(os.tmpDir(), '/tmp');
@@ -74,18 +74,26 @@ if (process.platform != 'sunos') {
   assert.ok(os.totalmem() > 0);
 }
 
-// Check for an IPv4 loopback 
+// Check at least 1 IPv4 loopback exists & all have correct details
 var interfaces = os.networkInterfaces();
 console.error(interfaces);
+
 var filter = function(e) { return e.address == '127.0.0.1'; };
 var expected = { address: '127.0.0.1', family: 'IPv4', internal: true };
-var address = function(a) { assert.deepEqual(a, expected); return true; };
-var count = 0;
-for (var i in interfaces) {
-  var addr=interfaces[i].filter(filter).filter(address);
-  count += addr.length;
+
+var found = false;
+for (var iname in interfaces) {
+  var inter = interfaces[iname];
+
+  var addrs = inter.length;
+  for (var a = 0; a < addrs; a++) {
+    if (inter[a].address == '127.0.0.1') {
+      assert.deepEqual(inter[a], expected);
+      found = true;
+    }
+  }
 }
-assert(count > 0);
+assert(found);
 
 var EOL = os.EOL;
 assert.ok(EOL.length > 0);

--- a/test/simple/test-os.js
+++ b/test/simple/test-os.js
@@ -78,9 +78,7 @@ if (process.platform != 'sunos') {
 var interfaces = os.networkInterfaces();
 console.error(interfaces);
 
-var filter = function(e) { return e.address == '127.0.0.1'; };
 var expected = { address: '127.0.0.1', family: 'IPv4', internal: true };
-
 var found = false;
 for (var iname in interfaces) {
   var inter = interfaces[iname];


### PR DESCRIPTION
This iterates all interfaces to locate an IPv4 loopback rather than assuming fixed interface names.
Tested on OS X 10.6.8, CentOS 6.2 (64-bit) & Win XP SP2 (64-bit). 
