### PR TITLE
Automatically `.toString()` functions in REPL.

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -67,7 +67,14 @@ module.paths = require('module')._nodeModulePaths(module.filename);
 
 // Can overridden with custom print functions, such as `probe` or `eyes.js`.
 // This is the default "writer" value if none is passed in the REPL options.
-exports.writer = util.inspect;
+exports.writer = function(obj) {
+  if (typeof obj === 'function') {
+    return obj.toString();
+  }
+  else {
+    return util.inspect.apply(null, arguments);
+  }
+};
 
 exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
   'crypto', 'dgram', 'dns', 'events', 'fs', 'http', 'https', 'net',
@@ -167,10 +174,10 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
   }
   self.useColors = !!options.useColors;
 
-  if (self.useColors && self.writer === util.inspect) {
+  if (self.useColors && self.writer === exports.writer) {
     // Turn on ANSI coloring.
     self.writer = function(obj, showHidden, depth) {
-      return util.inspect(obj, showHidden, depth, true);
+      return exports.writer(obj, showHidden, depth, true);
     };
   }
 

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -131,6 +131,9 @@ function error_test() {
       expect: prompt_unix },
     { client: client_unix, send: 'blah()',
       expect: '1\n' + prompt_unix },
+    // Functions should return function.toString() when not called. (#3509)
+    { client: client_unix, send: 'blah',
+      expect: /^function blah()/ },
     // Functions should not evaluate twice (#2773)
     { client: client_unix, send: 'var I = [1,2,3,function() {}]; I.pop()',
       expect: '[Function]' },


### PR DESCRIPTION
Fixes #3509
