### PR TITLE
repl: Don't search for `npm` in `cmd` if `cmd` isn't a string.

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -281,7 +281,8 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
       // If error was SyntaxError and not JSON.parse error
       if (isSyntaxError(e)) {
-        if (cmd.trim().match(/^npm /) && !self.bufferedCommand) {
+        if (typeof cmd === 'string' && cmd.trim().match(/^npm /) &&
+            !self.bufferedCommand) {
           self.outputStream.write('npm should be run outside of the ' +
                                   'node repl, in your normal shell.\n' +
                                   '(Press Control-D to exit.)\n');

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -150,7 +150,14 @@ function error_test() {
       expect: '1' },
     // npm prompt error message
     { client: client_unix, send: 'npm install foobar',
-      expect: expect_npm }
+      expect: expect_npm },
+    // function(){} shouldn't throw an error. (#3515)
+    { client: client_unix, send: 'function(){}',
+      expect: prompt_multiline },
+    { client: client_unix, send: '\n',
+      expect: prompt_multiline },
+    { client: client_unix, send: '.break',
+      expect: prompt_unix }
   ]);
 }
 


### PR DESCRIPTION
Fixes #3515
