### PR TITLE
docs: Switch to the asynchronous Google Analytics snippet

### DIFF
--- a/doc/about/index.html
+++ b/doc/about/index.html
@@ -130,7 +130,7 @@ console.log('Server running at http://127.0.0.1:1337/');</pre>
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
     </div>
 
 
@@ -139,15 +139,14 @@ console.log('Server running at http://127.0.0.1:1337/');</pre>
     <script>highlight(undefined, undefined, 'pre');</script>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
-    <script>
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
-    </script>
+
   </body>
 </html>

--- a/doc/blog.html
+++ b/doc/blog.html
@@ -103,7 +103,7 @@
           <%- post.content %>
 
           <p class="respond">Please post feedback and comments on
-            <a href="https://groups.google.com/group/nodejs">the Node.JS 
+            <a href="https://groups.google.com/group/nodejs">the Node.JS
               user mailing list</a>.</p>
 
           <%
@@ -197,21 +197,20 @@
           <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
       </ul>
 
-      <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/master/LICENSE">license</a>.</p>
+      <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/master/LICENSE">license</a>.</p>
     </div>
 
   <script src="../sh_main.js"></script>
   <script src="../sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>
   <script>
-    var gaJsHost = (("https:" == document.location.protocol) ?
-    "https://ssl." : "http://www.");
-    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+    window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+    (function(d, t) {
+      var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+      g.src = '//www.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g, s);
+    }(document, 'script'));
   </script>
-  <script>
-    try {
-      var pageTracker = _gat._getTracker("UA-10874194-2");
-      pageTracker._trackPageview();
-      } catch(err) {}</script>
 </body>
 </html>

--- a/doc/changelog-foot.html
+++ b/doc/changelog-foot.html
@@ -15,22 +15,21 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
     </div>
 
   <script src="sh_main.js"></script>
   <script src="sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>
   <script>
-    var gaJsHost = (("https:" == document.location.protocol) ?
-    "https://ssl." : "http://www.");
-    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+    window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+    (function(d, t) {
+      var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+      g.src = '//www.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g, s);
+    }(document, 'script'));
   </script>
-  <script>
-    try {
-      var pageTracker = _gat._getTracker("UA-10874194-2");
-      pageTracker._trackPageview();
-      } catch(err) {}</script>
 </body>
 </html>
 

--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -42,10 +42,10 @@
                 <p class="twitter"><a href="http://twitter.com/nodejs">@nodejs</a></p>
 
             </div>
-        
+
             <div id="column1" class="interior">
                 <p>Node's most valuable feature is the friendly and <a href="http://blip.tv/jsconf/nodeconf-2011-marak-squires-5729610">colorful community</a> of developers. There are many places where this group congregates on the internet. This page attempts to highlight the best forums.</p>
-        
+
               <div class="row clearfix">
                   <div class="block">
                       <h2 class="documentation">Documentation</h2>
@@ -54,7 +54,7 @@
                           <p><a href="http://www.nodemanual.org">Node Manual</a> offers stylized API docs, as well as tutorials and live code samples</p>
                           <p><a href="http://www.nodebits.org">Node Bits</a> provides sample Node.js projects</p>
                           <p><a href="http://docs.nodejitsu.com/">docs.nodejitsu.com</a> answers many of the common problems people come across.</p>
-                          <p><a href="http://howtonode.org/">How To Node</a> has a growing number of useful tutorials.</p> 
+                          <p><a href="http://howtonode.org/">How To Node</a> has a growing number of useful tutorials.</p>
                           <p><a href="http://stackoverflow.com/questions/tagged/node.js">Stack Overflow node.js tag</a> collects new information every day.</p>
                       </div>
 
@@ -77,7 +77,7 @@
                       </div>
                   </div>
 
-        
+
               <div class="row clearfix">
                   <div class="block">
                       <h2 class="mailing">Mailing Lists</h2>
@@ -169,7 +169,7 @@
                               channel</a> for those who miss a day.</p>
                   </div>
               </div>
-        
+
                   <p><a href="http://notinventedhe.re/on/2011-7-26"><img
                   src="http://nodejs.org/images/not-invented-here.png" width="100%"></a></p>
         </div>
@@ -188,19 +188,17 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
     </div>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script>
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
 </body>
 </html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -31,7 +31,7 @@
 
         <a href="#download" class="button" id="downloadbutton">Download</a>
         <a href="api/" class="button" id="docsbutton">Docs</a>
-        <p class="version">__VERSION__</p> 
+        <p class="version">__VERSION__</p>
 
         <a href="http://github.com/joyent/node"><img class="forkme" src="https://a248.e.akamai.net/camo.github.com/abad93f42020b733148435e2cd92ce15c542d320/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub"></a>
     </div>
@@ -214,7 +214,7 @@ server.listen(1337, '127.0.0.1');</pre>
             <!-- <li><a hrfe="http://twitter.com/nodejs" class="twitter">@nodejs</a></li> -->
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
     </div>
 
 
@@ -223,15 +223,13 @@ server.listen(1337, '127.0.0.1');</pre>
     <script>highlight(undefined, undefined, 'pre');</script>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script>
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
   </body>
 </html>

--- a/doc/logos/index.html
+++ b/doc/logos/index.html
@@ -40,7 +40,7 @@
                 <p class="twitter"><a href="http://twitter.com/nodejs">@nodejs</a></p>
 
             </div>
-        
+
             <div id="column1" class="interior">
           <h2>Logo Downloads</h2>
           <table border="0" cellspacing="0" cellpadding="10">
@@ -82,19 +82,17 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>., Node.js is a <a href="/trademark-policy.pdf">trademark of Joyent, Inc</a>., <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View License</a></p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>., Node.js is a <a href="/trademark-policy.pdf">trademark of Joyent, Inc</a>., <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View License</a></p>
     </div>
 
     <script>
-      var gaJsHost = (("https:" == document.location.protocol) ?
-      "https://ssl." : "http://www.");
-      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-    </script>
-    <script type="text/javascript">
-      try {
-        var pageTracker = _gat._getTracker("UA-10874194-2");
-        pageTracker._trackPageview();
-      } catch(err) {}
+      window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
     </script>
 </body>
 </html>

--- a/doc/template.html
+++ b/doc/template.html
@@ -66,21 +66,20 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
     </div>
 
   <script src="../sh_main.js"></script>
   <script src="../sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>
   <script>
-    var gaJsHost = (("https:" == document.location.protocol) ?
-    "https://ssl." : "http://www.");
-    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+    window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+    (function(d, t) {
+      var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+      g.src = '//www.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g, s);
+    }(document, 'script'));
   </script>
-  <script>
-    try {
-      var pageTracker = _gat._getTracker("UA-10874194-2");
-      pageTracker._trackPageview();
-      } catch(err) {}</script>
 </body>
 </html>


### PR DESCRIPTION
The old snippet needlessly uses `document.write`. As nodejs.org doesn’t work over HTTPS/SSL, the protocol check was not needed either. Let’s use the optimized version of the most recent, asynchronous GA snippet, as per http://mathiasbynens.be/notes/async-analytics-snippet.

Rebased against v0.8 branch as requested by @isaacs in #3298.
