### PR TITLE
Fix #3521 Use an object as the process.env proto

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1959,8 +1959,8 @@ static Handle<Value> EnvGetter(Local<String> property,
     return scope.Close(String::New(reinterpret_cast<uint16_t*>(buffer), result));
   }
 #endif
-  // Not found
-  return Undefined();
+  // Not found.  Fetch from prototype.
+  return info.Data().As<Object>()->Get(property);
 }
 
 
@@ -2210,7 +2210,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
                                        EnvQuery,
                                        EnvDeleter,
                                        EnvEnumerator,
-                                       Undefined());
+                                       Object::New());
   Local<Object> env = envTemplate->NewInstance();
   process->Set(String::NewSymbol("env"), env);
 

--- a/test/simple/test-process-env.js
+++ b/test/simple/test-process-env.js
@@ -47,8 +47,18 @@ if (process.argv[2] == 'you-are-the-child') {
   // failed assertion results in process exiting with status code 1
   assert.equal(false, 'NODE_PROCESS_ENV_DELETED' in process.env);
   assert.equal(42, process.env.NODE_PROCESS_ENV);
+  assert.equal('asdf', process.env.hasOwnProperty);
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var has = hasOwnProperty.call(process.env, 'hasOwnProperty');
+  assert.equal(true, has);
   process.exit(0);
 } else {
+  assert.equal(Object.prototype.hasOwnProperty, process.env.hasOwnProperty);
+  var has = process.env.hasOwnProperty('hasOwnProperty');
+  assert.equal(false, has);
+
+  process.env.hasOwnProperty = 'asdf';
+
   process.env.NODE_PROCESS_ENV = 42;
   assert.equal(42, process.env.NODE_PROCESS_ENV);
 


### PR DESCRIPTION
For some reason, though, it looks like EnvGetter is not called for the
key `__proto__`, so I can't make the info->Data() accessible.  However,
putting the Object.prototype keys there, in such a way that they are not
OwnProperties, and are supersceded by environs, makes process.env much
less weird.

Re: #3521
