### PR TITLE
test-tls-set-ciphers wants NULL-MD5, falls back to MD5

### DIFF
--- a/test/simple/test-tls-set-ciphers.js
+++ b/test/simple/test-tls-set-ciphers.js
@@ -33,7 +33,7 @@ if (process.platform === 'win32') {
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
-  ciphers: 'NULL-MD5' // it's ultra-fast!
+  ciphers: 'NULL-MD5:MD5' // prefer fast NULL-MD5, with fallback
 };
 
 var reply = 'I AM THE WALRUS'; // something recognizable
@@ -51,8 +51,9 @@ var server = tls.createServer(options, function(conn) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var cmd = 'openssl s_client -cipher NULL-MD5 -connect 127.0.0.1:' +
-            common.PORT;
+  var cmd = 'openssl s_client' +
+            ' -cipher ' + options.ciphers +
+            ' -connect 127.0.0.1:' + common.PORT;
 
   exec(cmd, function(err, stdout, stderr) {
     if (err) throw err;


### PR DESCRIPTION
this fixes the test on openSUSE 12.1, which excludes NULL-MD5
support from its openssl packages.
