### PR TITLE
libuv recognizes and emits ENODEV

### DIFF
--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -126,7 +126,8 @@ extern "C" {
   XX( 53, ENOTEMPTY, "directory not empty") \
   XX( 54, ENOSPC, "no space left on device") \
   XX( 55, EIO, "i/o error") \
-  XX( 56, EROFS, "read-only file system" )
+  XX( 56, EROFS, "read-only file system" ) \
+  XX( 57, ENODEV, "no such device" )
 
 
 #define UV_ERRNO_GEN(val, name, s) UV_##name = val,

--- a/deps/uv/src/unix/error.c
+++ b/deps/uv/src/unix/error.c
@@ -86,6 +86,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case EADDRNOTAVAIL: return UV_EADDRNOTAVAIL;
     case ENOTDIR: return UV_ENOTDIR;
     case EISDIR: return UV_EISDIR;
+    case ENODEV: return UV_ENODEV;
     case ENOTCONN: return UV_ENOTCONN;
     case EEXIST: return UV_EEXIST;
     case EHOSTUNREACH: return UV_EHOSTUNREACH;


### PR DESCRIPTION
produces better error message from test-dgram-multicast-multi-process
when run w/o network.

before:

=== release test-dgram-multicast-multi-process ===
Path: simple/test-dgram-multicast-multi-process
dgram.js:287
    throw new errnoException(errno, 'addMembership');
          ^
Error: addMembership Unknown system errno 19
    at new errnoException (dgram.js:356:11)
    at Socket.addMembership (dgram.js:287:11)
    at Object.<anonymous> (/home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js:224:16)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:487:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
[PARENT] Worker 9223 died. 1 dead of 3

dgram.js:287
    throw new errnoException(errno, 'addMembership');
          ^
Error: addMembership Unknown system errno 19
    at new errnoException (dgram.js:356:11)
    at Socket.addMembership (dgram.js:287:11)
    at Object.<anonymous> (/home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js:224:16)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:487:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)

[PARENT] sent 'First message to send' to 224.0.0.114:12346
dgram.js:287
[PARENT] sent 'Second message to send' to 224.0.0.114:12346
    throw new errnoException(errno, 'addMembership');
[PARENT] sent 'Third message to send' to 224.0.0.114:12346
          ^
[PARENT] sendSocket closed
[PARENT] Worker 9224 died. 2 dead of 3
Error: addMembership Unknown system errno 19
    at new errnoException (dgram.js:356:11)
    at Socket.addMembership (dgram.js:287:11)
    at Object.<anonymous> (/home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js:224:16)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:487:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
[PARENT] Worker 9225 died. 3 dead of 3
[PARENT] All workers have died.
[PARENT] Fail
Command: out/Release/node /home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js

after:

=== release test-dgram-multicast-multi-process ===
Path: simple/test-dgram-multicast-multi-process
dgram.js:287
    throw new errnoException(errno, 'addMembership');
          ^
Error: addMembership ENODEV
    at new errnoException (dgram.js:356:11)
    at Socket.addMembership (dgram.js:287:11)
    at Object.<anonymous> (/home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js:224:16)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:487:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
[PARENT] Worker 13141 died. 1 dead of 3

dgram.js:287
    throw new errnoException(errno, 'addMembership');
          ^
[PARENT] sent 'First message to send' to 224.0.0.114:12346
[PARENT] sent 'Second message to send' to 224.0.0.114:12346
[PARENT] sent 'Third message to send' to 224.0.0.114:12346
[PARENT] sent 'Fourth message to send' to 224.0.0.114:12346
[PARENT] sendSocket closed

dgram.js:287
    throw new errnoException(errno, 'addMembership');
          ^
Error: addMembership ENODEV
    at new errnoException (dgram.js:356:11)
    at Socket.addMembership (dgram.js:287:11)
    at Object.<anonymous> (/home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js:224:16)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:487:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
[PARENT] Worker 13142 died. 2 dead of 3
Error: addMembership ENODEV
    at new errnoException (dgram.js:356:11)
    at Socket.addMembership (dgram.js:287:11)
    at Object.<anonymous> (/home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js:224:16)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:487:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
[PARENT] Worker 13143 died. 3 dead of 3
[PARENT] All workers have died.
[PARENT] Fail
Command: out/Release/node /home/roman/wc/node/test/simple/test-dgram-multicast-multi-process.js
