### PR TITLE
./configure: be compatible with CC containing multiple words

### DIFF
--- a/configure
+++ b/configure
@@ -241,7 +241,7 @@ def target_arch():
 
 def compiler_version():
   try:
-    proc = subprocess.Popen([CC, '-v'], stderr=subprocess.PIPE)
+    proc = subprocess.Popen(CC.split() + ['-v'], stderr=subprocess.PIPE)
   except OSError:
     return None
   lines = proc.communicate()[1].split('\n')


### PR DESCRIPTION
For example:

```
CC='ccache gcc' ./configure
```

The bug was introduced in 5062741bd7a8ac6b7713defde62c0b8d3ab23fc8;
a similar bug was fixed in 5abcdc967173a8019d6b0f76c1ddfa5d6e90e4a6.
