### PR TITLE
Domains dispose problem

### DIFF
--- a/benchmark/http_simple.js
+++ b/benchmark/http_simple.js
@@ -13,15 +13,8 @@ var fixed = makeString(20 * 1024, 'C'),
 
 var useDomains = process.env.NODE_USE_DOMAINS;
 
-// set up one global domain.
 if (useDomains) {
   var domain = require('domain');
-  var gdom = domain.create();
-  gdom.on('error', function(er) {
-    console.log('Error on global domain', er);
-    throw er;
-  });
-  gdom.enter();
 }
 
 var server = http.createServer(function (req, res) {
@@ -29,6 +22,7 @@ var server = http.createServer(function (req, res) {
     var dom = domain.create();
     dom.add(req);
     dom.add(res);
+    dom.enter();
   }
 
   var commands = req.url.split('/');

--- a/lib/events.js
+++ b/lib/events.js
@@ -28,6 +28,7 @@ function EventEmitter() {
     domain = domain || require('domain');
     if (domain.active && !(this instanceof domain.Domain)) {
       this.domain = domain.active;
+      this.domain.members.push(this);
     }
   }
 }

--- a/test/simple/test-domain-run-bug.js
+++ b/test/simple/test-domain-run-bug.js
@@ -1,0 +1,69 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common.js');
+var net = require('net');
+var domain = require('domain');
+
+console.log('starting test ...');
+
+var connections =0;
+var server = net.createServer(function(socket) {
+  connections++;
+
+  socket.on('end', function() {
+    connections--;
+
+    if (connections === 0) {
+      server.close();
+    }
+  });
+
+  socket.write('hi');
+});
+
+server.listen(common.PORT, function() {
+  var d = domain.create();
+
+  d.on('error', function(err) {
+    assert.equal(d.members.length, 1);
+
+    console.log('caught domain exception: %s', err.message);
+    d.dispose();
+  });
+
+
+  d.run(function() {
+    var socket = net.createConnection(common.PORT);
+
+    socket.setEncoding('utf-8');
+
+    socket.on('data', function(data) {
+      console.log('received data from server: %s', data);
+      throw new Error('Boom!');
+    });
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(connections, 0);
+});


### PR DESCRIPTION
Problem: When creating streams inside of a domain, Domain#dispose() will
not clean them up.

This patch demonstrates this problem using a test case, and provides a
possible fix by also adding implicit domain members to the domain.

Considering that I don't understand the design decisions that went into
only tracking explicit members at this point, this patch should be
considered as a request for comment on the current behavior / to start a
discussion on improving it.
