### PR TITLE
punycode: Update to v1.1.1

### DIFF
--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -35,8 +35,6 @@
 	/** Error messages */
 	errors = {
 		'overflow': 'Overflow: input needs wider integers to process.',
-		'ucs2decode': 'UCS-2(decode): illegal sequence',
-		'ucs2encode': 'UCS-2(encode): illegal value',
 		'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
 		'invalid-input': 'Invalid input'
 	},
@@ -112,14 +110,17 @@
 		    extra;
 		while (counter < length) {
 			value = string.charCodeAt(counter++);
-			if ((value & 0xF800) == 0xD800) {
+			if ((value & 0xF800) == 0xD800 && counter < length) {
+				// high surrogate, and there is a next character
 				extra = string.charCodeAt(counter++);
-				if ((value & 0xFC00) != 0xD800 || (extra & 0xFC00) != 0xDC00) {
-					error('ucs2decode');
+				if ((extra & 0xFC00) == 0xDC00) { // low surrogate
+					output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
+				} else {
+					output.push(value, extra);
 				}
-				value = ((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000;
+			} else {
+				output.push(value);
 			}
-			output.push(value);
 		}
 		return output;
 	}
@@ -135,9 +136,6 @@
 	function ucs2encode(array) {
 		return map(array, function(value) {
 			var output = '';
-			if ((value & 0xF800) == 0xD800) {
-				error('ucs2encode');
-			}
 			if (value > 0xFFFF) {
 				value -= 0x10000;
 				output += stringFromCharCode(value >>> 10 & 0x3FF | 0xD800);
@@ -472,7 +470,7 @@
 		 * @memberOf punycode
 		 * @type String
 		 */
-		'version': '1.0.0',
+		'version': '1.1.1',
 		/**
 		 * An object of methods to convert from JavaScript's internal character
 		 * representation (UCS-2) to decimal Unicode code points, and back.

--- a/test/simple/test-punycode.js
+++ b/test/simple/test-punycode.js
@@ -179,4 +179,17 @@ for (var encoded in tests) {
   }
 }
 
+// BMP code point
+assert.equal(punycode.ucs2.encode([0x61]), 'a');
+// supplementary code point (surrogate pair)
+assert.equal(punycode.ucs2.encode([0x1D306]), '\uD834\uDF06');
+// high surrogate
+assert.equal(punycode.ucs2.encode([0xD800]), '\uD800');
+// high surrogate followed by non-surrogates
+assert.equal(punycode.ucs2.encode([0xD800, 0x61, 0x62]), '\uD800ab');
+// low surrogate
+assert.equal(punycode.ucs2.encode([0xDC00]), '\uDC00');
+// low surrogate followed by non-surrogates
+assert.equal(punycode.ucs2.encode([0xDC00, 0x61, 0x62]), '\uDC00ab');
+
 assert.equal(errors, 0);


### PR DESCRIPTION
The only change is that this version supports orphaned surrogates in `ucs2encode` and `ucs2decode`. For example, `require('punycode').ucs2.encode([0xD800])` now returns `'\uD800'` rather than throwing an error.
