### PR TITLE
Partial fix for issue 3452, syntax errors in vm.runInThisContext don't display proper line numbers

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -590,8 +590,8 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname) { ',
-    '\n});'
+  	process._moduleWrapPrefix,
+  	process._moduleWrapSuffix
   ];
 
   NativeModule.prototype.compile = function() {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -62,6 +62,9 @@ inline static int snprintf(char* buf, unsigned int len, const char* fmt, ...) {
 # define ROUND_UP(a, b) ((a) % (b) ? ((a) + (b)) - ((a) % (b)) : (a))
 #endif
 
+#define MODULE_WRAP_PREFIX "(function (exports, require, module, __filename, __dirname) { "
+#define MODULE_WRAP_SUFFIX "\n});"
+
 // this would have been a template function were it not for the fact that g++
 // sometimes fails to resolve it...
 #define THROW_ERROR(fun)                                                      \

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -393,10 +393,12 @@ Handle<Value> WrappedScript::EvalMachine(const Arguments& args) {
     script = output_flag == returnResult ? Script::Compile(code, filename)
                                          : Script::New(code, filename);
     if (script.IsEmpty()) {
-      // FIXME UGLY HACK TO DISPLAY SYNTAX ERRORS.
+      //V8 TryCatch.ReThrow is broken.  Calling it resets the stack trace to
+      //the place where ReThrow was called.  This makes it impossible to get a stack
+      //trace after the an error has been rethrown.  Until this V8 bug is fixed, this
+      //display_error argument makes it possible to log the location information.
       if (display_error) DisplayExceptionLine(try_catch);
 
-      // Hack because I can't get a proper stacktrace on SyntaxError
       return try_catch.ReThrow();
     }
   } else {

--- a/test/message/vm_display_errors.js
+++ b/test/message/vm_display_errors.js
@@ -1,0 +1,12 @@
+// Tests that when you add the display_error flag to a vm.createScript
+// call, that you will get the correct line / column displayed.
+// NOTE: This test should be deleted as soon as the V8 bug that causes rethrown
+// exceptions to get new stack traces is fixed.  At that time it should be
+// replaced with a test that shows that stack traces in Syntax Errors
+// are reported normally
+var common = require('../common');
+common.error('before');
+
+require("vm").createScript('invalidJsHere ?= 1;', "myfilename.js", true);
+
+common.error('after');

--- a/test/message/vm_display_errors.out
+++ b/test/message/vm_display_errors.out
@@ -1,0 +1,19 @@
+before 
+
+myfilename.js:1
+invalidJsHere ?= 1;
+               ^
+
+vm.js:*
+  var ns = new binding.NodeScript(code, ctx, filename);
+           ^
+SyntaxError: Unexpected token =
+    at new Script (vm.js:*)
+    at Function.Script.createScript (vm.js:*)
+    at Object.<anonymous> (*/vm_display_errors.js:*)
+    at Module._compile (module.js:*)
+    at Object.Module._extensions..js (module.js:*)
+    at Module.load (module.js:*)
+    at Function.Module._load (module.js:*)
+    at Module.runMain (module.js:*)
+    at process.startup.processNextTick.process._tickCallback (node.js:*)


### PR DESCRIPTION
This pull request (https://github.com/joyent/node/pull/3502) was already open and had been reviewed, but in the process of cleaning up my commit history, I took some action which inadvertently closed my old pull request.  Sorry about that.
