### PR TITLE
add filename to JSON.parse require() errors

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -471,7 +471,12 @@ Module._extensions['.js'] = function(module, filename) {
 // Native extension for .json
 Module._extensions['.json'] = function(module, filename) {
   var content = NativeModule.require('fs').readFileSync(filename, 'utf8');
-  module.exports = JSON.parse(stripBOM(content));
+  try {
+    module.exports = JSON.parse(stripBOM(content));
+  } catch (err) {
+    err.message = filename + ': ' + err.message;
+    throw err;
+  }
 };
 
 

--- a/test/fixtures/invalid.json
+++ b/test/fixtures/invalid.json
@@ -1,0 +1,5 @@
+{
+  "name": "foo",
+  "version": "0.0.1"
+  "description": "im broken"
+}

--- a/test/simple/test-require-json.js
+++ b/test/simple/test-require-json.js
@@ -1,3 +1,23 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var assert = require('assert');
 

--- a/test/simple/test-require-json.js
+++ b/test/simple/test-require-json.js
@@ -1,0 +1,9 @@
+
+var assert = require('assert');
+
+try {
+  require('../fixtures/invalid.json');
+} catch (err) {
+  var i = err.message.indexOf('test/fixtures/invalid.json: Unexpected string')
+  assert(-1 != i, 'require() json error should include path');
+}


### PR DESCRIPTION
otherwise it can be quite difficult to figure
out which file is busted, in our case during a build phase
