### PR TITLE
Adding support for environmental variables to control util.inspect color

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -146,15 +146,15 @@ var colors = {
 
 // Don't use 'blue' not visible on cmd.exe
 var styles = {
-  'special': 'cyan',
-  'number': 'yellow',
-  'boolean': 'yellow',
-  'undefined': 'grey',
-  'null': 'bold',
-  'string': 'green',
-  'date': 'magenta',
+  'special': process.env.NODE_COLOR_SPECIAL || 'cyan',
+  'number': process.env.NODE_COLOR_NUMBER || 'yellow',
+  'boolean': process.env.NODE_COLOR_BOOLEAN || 'yellow',
+  'undefined': process.env.NODE_COLOR_UNDEFINED || 'grey',
+  'null': process.env.NODE_COLOR_NULL || 'bold',
+  'string': process.env.NODE_COLOR_STRING || 'green',
+  'date': process.env.NODE_COLOR_DATE || 'magenta',
   // "name": intentionally not styling
-  'regexp': 'red'
+  'regexp': process.env.NODE_COLOR_REGEX || 'red'
 };
 
 


### PR DESCRIPTION
Set environmental variables to customize coloring of util.inspect

Colors are:
- NODE_COLOR_SPECIAL
- NODE_COLOR_NUMBER
- NODE_COLOR_BOOLEAN
- NODE_COLOR_UNDEFINED
- NODE_COLOR_NULL
- NODE_COLOR_STRING
- NODE_COLOR_DATE
- NODE_COLOR_REGEX

![Colors](http://daveeddy.com/static/media/github/node-inspect-patch-1.png)
