### PR TITLE
readline: fix for unicode prompts

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -136,7 +136,7 @@ Interface.prototype.setPrompt = function(prompt, length) {
   } else {
     var lines = prompt.split(/[\r\n]/);
     var lastLine = lines[lines.length - 1];
-    this._promptLength = Buffer.byteLength(lastLine);
+    this._promptLength = lastLine.length;
   }
 };
 


### PR DESCRIPTION
Bug:

With a unicode prompt, type some text into it, move the cursor backwards and forwards, delete some characters, etc, the cursor and the text are mangled and misplaced.

I.e. Run this script:

```
var readline = require('readline');

var rl = readline.createInterface({
  input: process.stdin,
  output: process.stdout
});

rl.setPrompt('✪☪⍟✩');

rl.on('line', function (cmd) {
  console.log('You just typed: '+cmd);
  rl.prompt();
});

rl.prompt();
```

Fix: use the prompts character length instead of the utf-8 byte length as the cursor offset.

This patch will fix ttys running utf-8. However, ASCII ttys are still weird for unicode prompts (cursor location more left than should be.) Arguably writing utf-8 to ASCII ttys is broken anyway, and should be up to application to detect (using $LANG and $LC_*) and use an ASCII prompt. Nevertheless, this patch makes it better than it was before.
