### PR TITLE
Minor there / their typo

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -268,7 +268,7 @@ The method takes an optional callback argument which will be called when finishe
 
 * {Object}
 
-In the cluster all living worker objects are stored in this object by there
+In the cluster all living worker objects are stored in this object using their
 `id` as the key. This makes it easy to loop through all living workers.
 
     // Go through all workers


### PR DESCRIPTION
Noticed a very minor typo of there / their in this line of the Cluster docs:
"In the cluster all living worker objects are stored in this object by **there** id as the key. This makes it easy to loop through all living workers."

Since we're denoting a property 'id' _owned_ by the worker, we should use the possessive form 'their'.

Also changed 'by' to 'using' since "by their id as the key" is a bit grammatically awkward.
