### PR TITLE
timers: fix handling of large timeouts

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -170,8 +170,9 @@ exports.active = function(item) {
 exports.setTimeout = function(callback, after) {
   var timer;
 
-  after = ~~after;
-  if (after < 1 || after > TIMEOUT_MAX) {
+  after *= 1; // coalesce to number or NaN
+
+  if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     after = 1; // schedule on next tick, follows browser behaviour
   }
 
@@ -222,8 +223,9 @@ exports.setInterval = function(callback, repeat) {
 
   if (process.domain) timer.domain = process.domain;
 
-  repeat = ~~repeat;
-  if (repeat < 1 || repeat > TIMEOUT_MAX) {
+  repeat *= 1; // coalesce to number or NaN
+
+  if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour
   }
 

--- a/test/simple/test-timers.js
+++ b/test/simple/test-timers.js
@@ -45,7 +45,8 @@ var inputs = [
   1,
   1.0,
   10,
-  2147483648 // browser behaviour: timeouts > 2^31-1 run on next tick
+  2147483648,     // browser behaviour: timeouts > 2^31-1 run on next tick
+  12345678901234  // ditto
 ];
 
 var timeouts = [];


### PR DESCRIPTION
Don't use the double-negate trick to coalesce the timeout argument into a
number, it produces the wrong result for very large timeouts.

Example:

```
setTimeout(cb, 1e10); // doesn't work, ~~1e10 == 1410065408
```
