### PR TITLE
repl: fix crashes when buffering command

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -281,7 +281,7 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
       // If error was SyntaxError and not JSON.parse error
       if (isSyntaxError(e)) {
-        if (cmd.trim().match(/^npm /) && !self.bufferedCommand) {
+        if (!self.bufferedCommand && cmd.trim().match(/^npm /)) {
           self.outputStream.write('npm should be run outside of the ' +
                                   'node repl, in your normal shell.\n' +
                                   '(Press Control-D to exit.)\n');

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -150,7 +150,9 @@ function error_test() {
       expect: '1' },
     // npm prompt error message
     { client: client_unix, send: 'npm install foobar',
-      expect: expect_npm }
+      expect: expect_npm },
+    { client: client_unix, send: '(function () {\n\nreturn 1;\n})()',
+      expect: '1' }
   ]);
 }
 


### PR DESCRIPTION
Wrong order of operands was causing problems while trying to use command
buffering:

```
> {
...   a: 3,
...

repl.js:284
        if (cmd.trim().match(/^npm /) && !self.bufferedCommand) {
                ^
TypeError: Cannot call method 'trim' of undefined
    at finish (repl.js:284:17)
    at REPLServer.self.eval (repl.js:118:5)
    at rli.on.e (repl.js:260:20)
    at REPLServer.self.eval (repl.js:118:5)
    at Interface.<anonymous> (repl.js:250:12)
    at Interface.EventEmitter.emit (events.js:88:17)
    at Interface._onLine (readline.js:183:10)
    at Interface._line (readline.js:502:8)
    at Interface._ttyWrite (readline.js:720:14)
    at ReadStream.<anonymous> (readline.js:105:12)
```
