### PR TITLE
http: remove API for setting headers with an array

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -570,25 +570,18 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
 
   if (headers) {
     var keys = Object.keys(headers);
-    var isArray = (Array.isArray(headers));
-    var field, value;
+    var value;
 
     for (var i = 0, l = keys.length; i < l; i++) {
       var key = keys[i];
-      if (isArray) {
-        field = headers[key][0];
-        value = headers[key][1];
-      } else {
-        field = key;
-        value = headers[key];
-      }
+      value = headers[key];
 
       if (Array.isArray(value)) {
         for (var j = 0; j < value.length; j++) {
-          store(field, value[j]);
+          store(key, value[j]);
         }
       } else {
-        store(field, value);
+        store(key, value);
       }
     }
   }
@@ -741,19 +734,10 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
 OutgoingMessage.prototype.addTrailers = function(headers) {
   this._trailer = '';
   var keys = Object.keys(headers);
-  var isArray = (Array.isArray(headers));
-  var field, value;
   for (var i = 0, l = keys.length; i < l; i++) {
     var key = keys[i];
-    if (isArray) {
-      field = headers[key][0];
-      value = headers[key][1];
-    } else {
-      field = key;
-      value = headers[key];
-    }
 
-    this._trailer += field + ': ' + value + CRLF;
+    this._trailer += key + ': ' + headers[key] + CRLF;
   }
 };
 
@@ -949,25 +933,10 @@ ServerResponse.prototype.writeHead = function(statusCode) {
     // Slow-case: when progressive API and header fields are passed.
     headers = this._renderHeaders();
 
-    if (Array.isArray(obj)) {
-      // handle array case
-      // TODO: remove when array is no longer accepted
-      var field;
-      for (var i = 0, len = obj.length; i < len; ++i) {
-        field = obj[i][0];
-        if (field in headers) {
-          obj.push([field, headers[field]]);
-        }
-      }
-      headers = obj;
-
-    } else {
-      // handle object case
-      var keys = Object.keys(obj);
-      for (var i = 0; i < keys.length; i++) {
-        var k = keys[i];
-        if (k) headers[k] = obj[k];
-      }
+    var keys = Object.keys(obj);
+    for (var i = 0; i < keys.length; i++) {
+      var k = keys[i];
+      if (k) headers[k] = obj[k];
     }
   } else if (this._headers) {
     // only progressive api is used

--- a/test/simple/test-http-server-multiheaders.js
+++ b/test/simple/test-http-server-multiheaders.js
@@ -47,24 +47,14 @@ srv.listen(common.PORT, function() {
     host: 'localhost',
     port: common.PORT,
     path: '/',
-    headers: [
-      ['accept', 'abc'],
-      ['accept', 'def'],
-      ['Accept', 'ghijklmnopqrst'],
-      ['host', 'foo'],
-      ['Host', 'bar'],
-      ['hOst', 'baz'],
-      ['www-authenticate', 'foo'],
-      ['WWW-Authenticate', 'bar'],
-      ['WWW-AUTHENTICATE', 'baz'],
-      ['x-foo', 'bingo'],
-      ['x-bar', 'banjo'],
-      ['x-bar', 'bango'],
-      ['sec-websocket-protocol', 'chat'],
-      ['sec-websocket-protocol', 'share'],
-      ['sec-websocket-extensions', 'foo; 1'],
-      ['sec-websocket-extensions', 'bar; 2'],
-      ['sec-websocket-extensions', 'baz']
-    ]
+    headers: {
+      accept: ['abc', 'def', 'ghijklmnopqrst'],
+      host: ['foo', 'bar', 'baz'],
+      'www-authenticate': ['foo', 'bar', 'baz'],
+      'x-foo': ['bingo'],
+      'x-bar': ['banjo', 'bango'],
+      'sec-websocket-protocol': ['chat', 'share'],
+      'sec-websocket-extensions': ['foo; 1', 'bar; 2', 'baz']
+    }
   });
 });

--- a/test/simple/test-http-set-cookies.js
+++ b/test/simple/test-http-set-cookies.js
@@ -27,13 +27,16 @@ var nresponses = 0;
 
 var server = http.createServer(function(req, res) {
   if (req.url == '/one') {
-    res.writeHead(200, [['set-cookie', 'A'],
-                        ['content-type', 'text/plain']]);
+    res.writeHead(200, {
+      'set-cookie': 'A',
+      'content-type': 'text/plain'
+    });
     res.end('one\n');
   } else {
-    res.writeHead(200, [['set-cookie', 'A'],
-                        ['set-cookie', 'B'],
-                        ['content-type', 'text/plain']]);
+    res.writeHead(200, {
+      'set-cookie': ['A', 'B'],
+      'content-type': 'text/plain'
+    });
     res.end('two\n');
   }
 });


### PR DESCRIPTION
This API wasn't documented anywhere and isn't a good API design by any
means.

Avoiding type checking in `ServerResponse#writeHead` makes it a bit
faster.

This does not modify `http.Client`, which is supposed to be removed
anyway.

Tests modified accordingly.
