### PR TITLE
Domain binding on defining event listeners

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -118,7 +118,13 @@ EventEmitter.prototype.emit = function() {
 
     var listeners = handler.slice();
     for (var i = 0, l = listeners.length; i < l; i++) {
+      if (listeners[i].domain) {
+        listeners[i].domain.enter();
+      }
       listeners[i].apply(this, args);
+      if (listeners[i].domain) {
+        listeners[i].domain.exit();
+      }
     }
     if (this.domain) {
       this.domain.exit();
@@ -138,7 +144,9 @@ EventEmitter.prototype.addListener = function(type, listener) {
   if (!this._events) this._events = {};
 
   // Attach current domain to listener
-  if (process.domain) listener.domain = process.domain;
+  if (process.domain) {
+    listener.domain = process.domain;
+  }
 
   // To avoid recursion in the case that type == "newListeners"! Before
   // adding it to the listeners, first emit "newListeners".

--- a/lib/events.js
+++ b/lib/events.js
@@ -131,6 +131,9 @@ EventEmitter.prototype.addListener = function(type, listener) {
 
   if (!this._events) this._events = {};
 
+  // Attach current domain to listener
+  if (process.domain) listener.domain = process.domain;
+
   // To avoid recursion in the case that type == "newListeners"! Before
   // adding it to the listeners, first emit "newListeners".
   this.emit('newListener', type, typeof listener.listener === 'function' ?

--- a/lib/events.js
+++ b/lib/events.js
@@ -79,6 +79,9 @@ EventEmitter.prototype.emit = function() {
     if (this.domain) {
       this.domain.enter();
     }
+    if (handler.domain) {
+      handler.domain.enter();
+    }
     switch (arguments.length) {
       // fast cases
       case 1:
@@ -96,6 +99,9 @@ EventEmitter.prototype.emit = function() {
         var args = new Array(l - 1);
         for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
         handler.apply(this, args);
+    }
+    if (handler.domain) {
+      handler.domain.exit();
     }
     if (this.domain) {
       this.domain.exit();

--- a/test/simple/test-domain-stream.js
+++ b/test/simple/test-domain-stream.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Tests of domain covering stream callbacks.
+
+var assert = require('assert');
+var common = require('../common');
+var domain = require('domain');
+var events = require('events');
+var net = require('net');
+
+var server = net.createServer();
+var dom = domain.create();
+
+dom.on('error', function(error) {
+  console.log('Exception caught by domain!');
+});
+
+dom.run(function() {
+  server.on('connection', function(socket) {
+    socket.end();
+    server.close();
+    throw new Error('Exception inside callback inside domain!');
+  });
+});
+
+var port = common.PORT;
+server.listen(port, function() {
+  net.createConnection(port);
+});
+
+process.on('exit', function() {
+  console.log('ok');
+});


### PR DESCRIPTION
Premise: Domains work best only in a synchronous flow. To cover async situations, though, timers bind current domain to their callbacks and event emitters store it in their constructor. (maybe other stuff as well...)

Problem: Async callbacks returned from low-level libraries, like in the case of net streams, are not covered. If the event emitter was not defined inside a certain domain, nor will listeners added to it get bound to any present domain. 

Solution: Binding domains on adding event listeners and activating them on emit. (similar to how intervals handle domains)
