### PR TITLE
Allow tls.connect to start on server-side sockets and add tls.start as a simple wrapper for tls.connect

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1172,27 +1172,44 @@ exports.connect = function(/* [port, host], options, cb */) {
   return cleartext;
 };
 
-// Target API:
-// 
+// starts TLS on a given socket, be it client or server
+// for a server-side socket, asServer has to be passed as a boolean
+// var assert = require('assert');
 // var net = require('net');
 // var tls = require('tls');
-// var s = net.connect(8000, "google"com");
-// s.on("connect", function() {
-//  var encryptedStream = tls.start(s, {function() {
-//    encryptedStream
+// var client = net.connect(443, 'google.com', function() {
+//   var encryptedStream = tls.start(client, function() {
+//    // secure connection in here!
+//    client.end();
 //  });
-//
+//});
 exports.start = function(socket /* [options], [asServer], cb */) {
-  var cb, options, asServer;
+  var cb, options = {}, asServer;
+
+  if(!socket) {
+    throw new Error("First parameter as socket is required");
+  }
+
+
+  // callback is always last argument
   if (typeof arguments[arguments.length - 1] === 'function') {
     cb = arguments[arguments.length - 1];
   }
+  // options passed as second argument
   if (typeof arguments[1] === 'object') {
     options = arguments[1];
+    if (typeof arguments[2] == 'boolean') {
+      asServer = arguments[2];
+    }
   }
-  if (typeof arguments[2] == 'boolean') {
-    asServer = arguments[2];
+  // no options passed
+  else if(typeof arguments[1] == 'boolean') {
+    asServer = arguments[1];
   }
+  
+  // revert encoding as TLS requires a binary stream
+  socket.setEncoding(null);
+
   options = util._extend({
               socket: socket,
               // allow asServer to be passed either through argument

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1208,7 +1208,7 @@ exports.start = function(socket /* [options], [asServer], cb */) {
   }
   
   // revert encoding as TLS requires a binary stream
-  socket.setEncoding(null);
+  socket.setEncoding(undefined);
 
   options = util._extend({
               socket: socket,

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1119,7 +1119,8 @@ exports.connect = function(/* [port, host], options, cb */) {
   var sslcontext = crypto.createCredentials(options);
 
   convertNPNProtocols(options.NPNProtocols, this);
-  var pair = new SecurePair(sslcontext, false, true,
+
+  var pair = new SecurePair(sslcontext, options.asServer?true:false, true,
                             options.rejectUnauthorized === true ? true : false,
                             {
                               NPNProtocols: this.NPNProtocols,
@@ -1169,6 +1170,36 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   cleartext._controlReleased = true;
   return cleartext;
+};
+
+// Target API:
+// 
+// var net = require('net');
+// var tls = require('tls');
+// var s = net.connect(8000, "google"com");
+// s.on("connect", function() {
+//  var encryptedStream = tls.start(s, {function() {
+//    encryptedStream
+//  });
+//
+exports.start = function(socket /* [options], [asServer], cb */) {
+  var cb, options, asServer;
+  if (typeof arguments[arguments.length - 1] === 'function') {
+    cb = arguments[arguments.length - 1];
+  }
+  if (typeof arguments[1] === 'object') {
+    options = arguments[1];
+  }
+  if (typeof arguments[2] == 'boolean') {
+    asServer = arguments[2];
+  }
+  options = util._extend({
+              socket: socket,
+              // allow asServer to be passed either through argument
+              // or through options
+              asServer: asServer || options.asServer
+              }, options || {});
+  return exports.connect(options, cb);
 };
 
 

--- a/test/simple/test-tls-start-client-server.js
+++ b/test/simple/test-tls-start-client-server.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+var net = require('net');
+var common = require('../common');
+var fs = require('fs');
+var tls = require('tls');
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverOptions = {
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert')
+};
+
+
+var serverSecurelyConnected = false;
+var clientSecurelyConnected = false;
+
+net.createServer(function(socket) {
+  var encryptedStream = tls.start(socket, serverOptions, true, function() {
+    serverSecurelyConnected = true;
+  });
+}).listen(9999);
+
+
+
+var client = net.connect(9999, function() {
+  var encryptedStream = tls.start(client, function() {
+    clientSecurelyConnected = true;
+    if(serverSecurelyConnected) {
+      process.exit(0);
+    }
+    assert.fail("Client connected securely to the server but server does "
+                + "not know this", "Both client and server should be "
+                + "connected", "tls.start failed");
+	});
+});
+
+setTimeout(function() {
+  assert.fail("tls.start failed, client has not been able to upgrade connection");
+}, 100);

--- a/test/simple/test-tls-start-client.js
+++ b/test/simple/test-tls-start-client.js
@@ -1,0 +1,11 @@
+var assert = require('assert');
+var net = require('net');
+var tls = require('tls');
+
+var client = net.connect(443, 'google.com', function() {
+	var encryptedStream = tls.start(client, function() {
+		assert.ok(encryptedStream.authorized, "When connected, connection should yield authorized");
+		client.end();
+	});
+
+});


### PR DESCRIPTION
I have found a piece of code floating on the internet to initiate a TLS function in the middle of a TCP connection, but the code in question has not functioned well. I decided to look into tls.js module whether it can do it all with some minor adjustment.

There was a previous pull request for this function https://github.com/joyent/node/pull/848
However, current state of connect does not allow to start TLS arbitralily on a server-side socket.

Thus, I propose a very simple change to `tls.connect` allowing to say whether we want a server side socket via `options.asServer` but also I add a very nice intuitive wrapper called tls.start and two tests.

`tls.start` is in the same style as `child_process.fork` so I think it fits together inside node.

I am willing to update documention if a green light is given to this improvements.
