### PR TITLE
Fix `fs.read` bailout

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -341,10 +341,10 @@ fs.openSync = function(path, flags, mode) {
 fs.read = function(fd, buffer, offset, length, position, callback) {
   if (!Buffer.isBuffer(buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
-    var cb = arguments[4],
-        encoding = arguments[3];
-    position = arguments[2];
-    length = arguments[1];
+    var cb = position,
+        encoding = length;
+    position = offset;
+    length = buffer;
     buffer = new Buffer(length);
     offset = 0;
 


### PR DESCRIPTION
When profiling my application I noticed that V8 bails out on `fs.read`
function, due to access to `arguments` array when named paramaters are
given.
