### PR TITLE
defer dgram listening event

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -43,11 +43,6 @@ function isIP(address) {
 
 
 function lookup(address, family, callback) {
-  // implicit 'bind before send' needs to run on the same tick
-  var matchedFamily = isIP(address);
-  if (matchedFamily)
-    return callback(null, address, matchedFamily);
-
   if (!dns)
     dns = require('dns');
 
@@ -110,6 +105,23 @@ exports.createSocket = function(type, listener) {
   return new Socket(type, listener);
 };
 
+Socket.prototype._bind = function(ip, port) {
+  var ret;
+
+  if (!ip) {
+    if (this.type == 'udp4')
+      ip = '0.0.0.0';
+    else if (this.type == 'udp6')
+      ip = '::0';
+  }
+
+  ret = this._handle.bind(ip, port || 0, /*flags=*/0);
+
+  if (!ret)
+    this._bound = true;
+
+  return ret;
+};
 
 Socket.prototype.bind = function(port, address) {
   var self = this;
@@ -119,22 +131,17 @@ Socket.prototype.bind = function(port, address) {
   // resolve address first
   self._handle.lookup(address, function(err, ip) {
     if (!err) {
-      if (self._handle.bind(ip, port || 0, /*flags=*/0)) {
+      if (self._bind(ip, port)) {
         err = errnoException(errno, 'bind');
       }
       else {
-        self._bound = true;
         self._startReceiving();
         self.emit('listening');
       }
     }
 
     if (err) {
-      // caller may not have had a chance yet to register its
-      // error event listener so defer the error to the next tick
-      process.nextTick(function() {
-        self.emit('error', err);
-      });
+      self.emit('error', err);
     }
   });
 };
@@ -314,7 +321,7 @@ Socket.prototype._startReceiving = function() {
     return;
 
   if (!this._bound) {
-    this.bind(); // bind to random port
+    this._bind(); // bind to random port
 
     // sanity check
     if (!this._bound)

--- a/test/simple/test-dgram-broadcast-multi-process.js
+++ b/test/simple/test-dgram-broadcast-multi-process.js
@@ -162,7 +162,9 @@ if (process.argv[2] !== 'child') {
   // bind the address explicitly for sending
   // INADDR_BROADCAST to only one interface
   sendSocket.bind(common.PORT, bindAddress);
-  sendSocket.setBroadcast(true);
+  sendSocket.on('listening', function () {
+    sendSocket.setBroadcast(true);
+  });
 
   sendSocket.on('close', function() {
     console.error('[PARENT] sendSocket closed');

--- a/test/simple/test-dgram-listen-after-bind.js
+++ b/test/simple/test-dgram-listen-after-bind.js
@@ -19,25 +19,25 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var common = require('../common'),
-    assert = require('assert'),
-    dgram = require('dgram'),
-    thrown = false,
-    socket = dgram.createSocket('udp4');
+var common = require('../common');
+var assert = require('assert');
+var dgram = require('dgram');
 
-socket.bind(common.PORT);
-socket.on('listening', function () {
-  socket.setMulticastTTL(16);
+var socket = dgram.createSocket('udp4');
 
-  //Try to set an invalid TTL (valid ttl is > 0 and < 256)
-  try {
-    socket.setMulticastTTL(1000);
-  } catch (e) {
-    thrown = true;
-  }
+socket.bind();
 
-  assert(thrown, 'Setting an invalid multicast TTL should throw some error');
-
-  //close the socket
+var fired = false;
+var timer = setTimeout(function () {
   socket.close();
+}, 100);
+
+socket.on('listening', function () {
+  clearTimeout(timer);
+  fired = true;
+  socket.close();
+});
+
+socket.on('close', function () {
+  assert(fired, 'listening should fire after bind');
 });

--- a/test/simple/test-dgram-multicast-multi-process.js
+++ b/test/simple/test-dgram-multicast-multi-process.js
@@ -149,10 +149,13 @@ if (process.argv[2] !== 'child') {
   // call is what creates the actual socket...
   sendSocket.bind();
 
-  sendSocket.setTTL(1);
-  sendSocket.setBroadcast(true);
-  sendSocket.setMulticastTTL(1);
-  sendSocket.setMulticastLoopback(true);
+  // The socket is actually created async now
+  sendSocket.on('listening', function () {
+    sendSocket.setTTL(1);
+    sendSocket.setBroadcast(true);
+    sendSocket.setMulticastTTL(1);
+    sendSocket.setMulticastLoopback(true);
+  });
 
   sendSocket.on('close', function() {
     console.error('[PARENT] sendSocket closed');
@@ -221,5 +224,7 @@ if (process.argv[2] === 'child') {
 
   listenSocket.bind(common.PORT);
 
-  listenSocket.addMembership(LOCAL_BROADCAST_HOST);
+  listenSocket.on('listening', function () {
+    listenSocket.addMembership(LOCAL_BROADCAST_HOST);
+  });
 }


### PR DESCRIPTION
dgram `.bind`'s `._handle.lookup` may be synchronous if bind is called without an address or if address is indeed an ip. This means 'listening' may fire before a caller has assigned a handler for the event.

This patch defers that event.

However if `.bind` is called with a dns name the event may be deferred a second tick since `dns` implicitly defers requests.
