### PR TITLE
clarified documentation of Stream#destroy

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -174,8 +174,9 @@ Same as above but with a `buffer`.
 
 ### stream.destroy()
 
-Closes the underlying file descriptor. Stream will not emit any more events.
-Any queued write data will not be sent.
+Closes the underlying file descriptor. Stream is no longer `writable` nor `readable`.
+the stream will not emit any more 'data', or 'end' events. Any queued write data will not be sent.
+the stream should emit 'close' event once it's resources have been disposed of.
 
 ### stream.destroySoon()
 


### PR DESCRIPTION
`Stream#destroy` should emit 'close', once underlying resources are disposed of.
but should not emit any 'data', or 'end' events.
as the stream is no longer `readable` or `writable`.

this is more accurate to the actual code.

https://github.com/sockjs/sockjs-node/issues/79#issuecomment-6818937
