### PR TITLE
clarify fs.symlink and fs.symlinkSync parameters

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -176,7 +176,7 @@ the completion callback.
 
 Synchronous link(2).
 
-## fs.symlink(destination, path, [type], [callback])
+## fs.symlink(srcpath, dstpath, [type], [callback])
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
@@ -185,7 +185,7 @@ used on Windows (ignored on other platforms).
 Note that Windows junction points require the destination path to be absolute.  When using
 `'junction'`, the `destination` argument will automatically be normalized to absolute path.
 
-## fs.symlinkSync(destination, path, [type])
+## fs.symlinkSync(srcpath, dstpath, [type])
 
 Synchronous symlink(2).
 


### PR DESCRIPTION
The documentation is confusing and inconsistent in the way parameters are named for fs.symlink and fs.symlinkSync. Using the same naming nomenclature as in fs.link and fs.linkSync.
