### PR TITLE
Fix to remove the first-arg, in case arguments length is more than 2

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -185,7 +185,7 @@ Domain.prototype.bind = function(cb, interceptError) {
           // slower for less common case: cb(er, foo, bar, baz, ...)
           args = new Array(len - 1);
           for (var i = 1; i < len; i++) {
-            args[i] = arguments[i - 1];
+            args[i - 1] = arguments[i];
           }
           break;
       }

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -150,6 +150,15 @@ function fn2(data) {
 var bound = d.intercept(fn2);
 bound(null, 'data');
 
+// intercepted should never pass first argument to callback
+// even if arguments length is more than 2.
+function fn3(data, data2) {
+  assert.equal(data, 'data', 'should not be null err argument');
+  assert.equal(data2, 'data2', 'should not be data argument');
+}
+
+bound = d.intercept(fn3);
+bound(null, 'data', 'data2');
 
 // throwing in a bound fn is also caught,
 // even if it's asynchronous, by hitting the


### PR DESCRIPTION
Hi

This fixes the first-arg removal behavior in domain.intercept().
In case arguments length of an intercepted function is more than 2, first-arg removal is failed. 
