### PR TITLE
node dies on unexpected end of input currently

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -281,6 +281,13 @@ function REPLServer(prompt, stream, eval, useGlobal, ignoreUndefined) {
 
       // If error was SyntaxError and not JSON.parse error
       if (isSyntaxError(e)) {
+        if(cmd === undefined) {
+          self.outputStream.write(e + '\n')
+          self.bufferedCommand = '';
+          self.displayPrompt();
+          return;
+        }
+
         if (cmd.trim().match(/^npm /) && !self.bufferedCommand) {
           self.outputStream.write('npm should be run outside of the ' +
                                   'node repl, in your normal shell.\n' +


### PR DESCRIPTION
if you do a recent build of node, anything after c40875ee13d8bab0b909e917a12282b06b892037, 
you start it, and you type (and hit return):

> a(
> ... 

repl.js:284
        if (cmd.trim().match(/^npm /) && !self.bufferedCommand) {
                ^
TypeError: Cannot call method 'trim' of undefined
    at finish (repl.js:284:17)
    at REPLServer.self.eval (repl.js:118:5)
    at rli.on.e (repl.js:260:20)
    at REPLServer.self.eval (repl.js:118:5)
    at Interface.<anonymous> (repl.js:250:12)
    at Interface.EventEmitter.emit (events.js:88:17)
    at Interface._onLine (readline.js:183:10)
    at Interface._line (readline.js:504:8)
    at Interface._ttyWrite (readline.js:722:14)
    at ReadStream.<anonymous> (readline.js:105:12)

node dies. I don't think this is the desired behavior, is it? (not being sarcastic here I don't know if this may actually be desired).

my patch fixes this simply by adding a little block to check if cmd is undefined, and print the appropriate error message if that is the case.

now, with the patch: 

> a(
> ... 
> SyntaxError: Unexpected end of input
