### PR TITLE
cluster, net: move internal parts out of cluster

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -191,8 +191,9 @@ And the child would the recive the server object as:
       }
     });
 
-Note that the server is now shared between the parent and child, this means
-that some connections will be handled by the parent and some by the child.
+Note that the server is now shared between the parent and child. This means
+that any connections will be load balanced between the servers provided there
+is a `connection` listener.
 
 **send socket object**
 
@@ -357,9 +358,9 @@ index corresponds to a fd in the child.  The value is one of the following:
    ignored node will open `/dev/null` and attach it to the child's fd.
 4. `Stream` object - Share a readable or writable stream that refers to a tty,
    file, socket, or a pipe with the child process. The stream's underlying
-   file descriptor is duplicated in the child process to the fd that 
+   file descriptor is duplicated in the child process to the fd that
    corresponds to the index in the `stdio` array.
-5. Positive integer - The integer value is interpreted as a file descriptor 
+5. Positive integer - The integer value is interpreted as a file descriptor
    that is is currently open in the parent process. It is shared with the child
    process, similar to how `Stream` objects can be shared.
 6. `null`, `undefined` - Use default value. For stdio fds 0, 1 and 2 (in other
@@ -388,7 +389,7 @@ Example:
     spawn('prg', [], { stdio: ['pipe', null, null, null, 'pipe'] });
 
 If the `detached` option is set, the child process will be made the leader of a
-new process group.  This makes it possible for the child to continue running 
+new process group.  This makes it possible for the child to continue running
 after the parent exits.
 
 By default, the parent will wait for the detached child to exit.  To prevent

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -10,6 +10,8 @@ this module with `require('net');`
 
 Creates a new TCP server. The `connectionListener` argument is
 automatically set as a listener for the ['connection'][] event.
+If the server has no `connection` listener it will not accept
+connections until it gets one.
 
 `options` is an object with the following defaults:
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -101,7 +101,7 @@ var handleConversion = {
       var self = this;
 
       var server = new net.Server();
-      server.listen(handle, function() {
+      server._listen(handle, function() {
         emit(server);
       });
     }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -157,24 +157,20 @@ function handleResponse(outMessage, outHandle, inMessage, inHandle, worker) {
 // Handle messages from both master and workers
 var messageHandler = {};
 function handleMessage(worker, inMessage, inHandle) {
+  if (!isInternalMessage(inMessage)) return;
 
   // Remove internal prefix
   var message = util._extend({}, inMessage);
   message.cmd = inMessage.cmd.substr(INTERNAL_PREFIX.length);
 
-  var respondUsed = false;
   function respond(outMessage, outHandler) {
-    respondUsed = true;
     handleResponse(outMessage, outHandler, inMessage, inHandle, worker);
   }
 
   // Run handler if it exists
   if (messageHandler[message.cmd]) {
     messageHandler[message.cmd](message, worker, respond);
-  }
-
-  // Send respond if it hasn't been called yet
-  if (respondUsed === false) {
+  } else {
     respond();
   }
 }
@@ -183,11 +179,13 @@ function handleMessage(worker, inMessage, inHandle) {
 if (cluster.isMaster) {
 
   // Handle online messages from workers
-  messageHandler.online = function(message, worker) {
+  messageHandler.online = function(message, worker, send) {
     worker.state = 'online';
     debug('Worker ' + worker.process.pid + ' online');
     worker.emit('online');
     cluster.emit('online', worker);
+
+    send();
   };
 
   // Handle queryServer messages from workers
@@ -195,46 +193,38 @@ if (cluster.isMaster) {
 
     // This sequence of information is unique to the connection
     // but not to the worker
-    var args = [message.address,
-                message.port,
-                message.addressType,
-                message.fd];
-    var key = args.join(':');
-    var handler;
+    var args = message.args;
+    var key = JSON.stringify(args);
 
     if (serverHandlers.hasOwnProperty(key)) {
-      handler = serverHandlers[key];
-    } else {
-      handler = serverHandlers[key] = net._createServerHandle.apply(net, args);
+      send({}, serverHandlers[key]);
+      return;
     }
 
-    // echo callback with the fd handler associated with it
-    send({}, handler);
+    var server = serverHandlers[key] = net.Server();
+    server.once('listening', function () {
+      send({}, server);
+    });
+    server.listen.apply(server, args);
   };
 
   // Handle listening messages from workers
-  messageHandler.listening = function(message, worker) {
+  messageHandler.listening = function(message, worker, send) {
 
     worker.state = 'listening';
 
     // Emit listening, now that we know the worker is listening
-    worker.emit('listening', {
-      address: message.address,
-      port: message.port,
-      addressType: message.addressType,
-      fd: message.fd
-    });
-    cluster.emit('listening', worker, {
-      address: message.address,
-      port: message.port,
-      addressType: message.addressType,
-      fd: message.fd
-    });
+    worker.emit('listening', message.address);
+    cluster.emit('listening', worker, message.address);
+
+    send();
   };
 
   // Handle suicide messages from workers
-  messageHandler.suicide = function(message, worker) {
+  messageHandler.suicide = function(message, worker, send) {
     worker.suicide = true;
+
+    send();
   };
 
 }
@@ -243,8 +233,9 @@ if (cluster.isMaster) {
 else if (cluster.isWorker) {
 
   // Handle worker.disconnect from master
-  messageHandler.disconnect = function(message, worker) {
+  messageHandler.disconnect = function(message, worker, send) {
     worker.disconnect();
+    send();
   };
 }
 
@@ -519,38 +510,33 @@ cluster._setupWorker = function() {
 };
 
 // Internal function. Called by lib/net.js when attempting to bind a server.
-cluster._getServer = function(tcpSelf, address, port, addressType, fd, cb) {
-  // This can only be called from a worker.
-  assert(cluster.isWorker);
+if (cluster.isWorker) {
+  var localListen = net.Server.prototype.listen;
+  net.Server.prototype.listen = function() {
+    var self = this;
+    var args = Array.prototype.slice.call(arguments);
 
-  // Store tcp instance for later use
-  var key = [address, port, addressType, fd].join(':');
-  serverListeners[key] = tcpSelf;
+    // filter out callback
+    if (typeof args[args.length - 1] === 'function') {
+      this.once('listening', args.pop());
+    }
 
-  // Send a listening message to the master
-  tcpSelf.once('listening', function() {
-    cluster.worker.state = 'listening';
-    sendInternalMessage(cluster.worker, {
-      cmd: 'listening',
-      address: address,
-      port: port,
-      addressType: addressType,
-      fd: fd
+    // add server (used by. dissconnect)
+    serverListeners[JSON.stringify(args)] = this;
+
+    // send callback to master, telling that worker is listening
+    this.once('listening', function() {
+      cluster.worker.state = 'listening';
+
+      var message = { cmd: 'listening', address: this.address() };
+      sendInternalMessage(cluster.worker, message);
     });
-  });
 
-  // Request the fd handler from the master process
-  var message = {
-    cmd: 'queryServer',
-    address: address,
-    port: port,
-    addressType: addressType,
-    fd: fd
+    // request server
+    var message = { cmd: 'queryServer', args: args };
+
+    sendInternalMessage(cluster.worker, message, function (msg, server) {
+      localListen.call(self, server);
+    });
   };
-
-  // The callback will be stored until the master has responded
-  sendInternalMessage(cluster.worker, message, function(msg, handle) {
-    cb(handle);
-  });
-
-};
+}

--- a/lib/net.js
+++ b/lib/net.js
@@ -895,18 +895,6 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   var self = this;
   var r = 0;
 
-  // If there is not yet a handle, we need to create one and bind.
-  // In the case of a server sent via IPC, we don't need to do this.
-  if (!self._handle) {
-    self._handle = createServerHandle(address, port, addressType, fd);
-    if (!self._handle) {
-      process.nextTick(function() {
-        self.emit('error', errnoException(errno, 'listen'));
-      });
-      return;
-    }
-  }
-
   self._handle.onconnection = onconnection;
   self._handle.owner = self;
 
@@ -921,15 +909,13 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
     process.nextTick(function() {
       self.emit('error', errnoException(errno, 'listen'));
     });
-    return;
+    return r;
   }
 
   // generate connection key, this should be unique to the connection
   this._connectionKey = addressType + ':' + address + ':' + port;
 
-  process.nextTick(function() {
-    self.emit('listening');
-  });
+  return r;
 };
 
 
@@ -939,10 +925,46 @@ function listen(self, address, port, addressType, backlog, fd) {
   if (cluster.isWorker) {
     cluster._getServer(self, address, port, addressType, fd, function(handle) {
       self._handle = handle;
-      self._listen2(address, port, addressType, backlog, fd);
+      var r = self._listen2(address, port, addressType, backlog, fd);
+      if (r === 0) {
+        self.emit('listening');
+      }
     });
   } else {
-    self._listen2(address, port, addressType, backlog, fd);
+    // If there is not yet a handle, we need to create one and bind.
+    // In the case of a server sent via IPC, we don't need to do this.
+    if (!self._handle) {
+      self._handle = createServerHandle(address, port, addressType, fd);
+      if (!self._handle) {
+        process.nextTick(function() {
+          self.emit('error', errnoException(errno, 'listen'));
+        });
+        return;
+      }
+    }
+
+    // self._handle.listen will be called lazy
+    // if there are no connection listeners
+    if (self.listeners('connection').length === 0) {
+      self.on('newListener', function removeme(name) {
+        if (name !== 'connection') return;
+
+        self.removeListener('newListener', removeme);
+        self._listen2(address, port, addressType, backlog, fd);
+      });
+
+      process.nextTick(function() {
+        self.emit('listening');
+      });
+      return;
+    }
+
+    var r = self._listen2(address, port, addressType, backlog, fd);
+    if (r === 0) {
+      process.nextTick(function() {
+        self.emit('listening');
+      });
+    }
   }
 }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -834,8 +834,7 @@ exports.Server = Server;
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
 
 
-var createServerHandle = exports._createServerHandle =
-    function(address, port, addressType, fd) {
+var createServerHandle = function(address, port, addressType, fd) {
   var r = 0;
   // assign handle in listen, and clean up if bind or listen fails
   var handle;
@@ -920,56 +919,43 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
 
 function listen(self, address, port, addressType, backlog, fd) {
-  if (!cluster) cluster = require('cluster');
-
-  if (cluster.isWorker) {
-    cluster._getServer(self, address, port, addressType, fd, function(handle) {
-      self._handle = handle;
-      var r = self._listen2(address, port, addressType, backlog, fd);
-      if (r === 0) {
-        self.emit('listening');
-      }
-    });
-  } else {
-    // If there is not yet a handle, we need to create one and bind.
-    // In the case of a server sent via IPC, we don't need to do this.
+  // If there is not yet a handle, we need to create one and bind.
+  // In the case of a server sent via IPC, we don't need to do this.
+  if (!self._handle) {
+    self._handle = createServerHandle(address, port, addressType, fd);
     if (!self._handle) {
-      self._handle = createServerHandle(address, port, addressType, fd);
-      if (!self._handle) {
-        process.nextTick(function() {
-          self.emit('error', errnoException(errno, 'listen'));
-        });
-        return;
-      }
-    }
-
-    // self._handle.listen will be called lazy
-    // if there are no connection listeners
-    if (self.listeners('connection').length === 0) {
-      self.on('newListener', function removeme(name) {
-        if (name !== 'connection') return;
-
-        self.removeListener('newListener', removeme);
-        self._listen2(address, port, addressType, backlog, fd);
-      });
-
       process.nextTick(function() {
-        self.emit('listening');
+        self.emit('error', errnoException(errno, 'listen'));
       });
       return;
     }
+  }
 
-    var r = self._listen2(address, port, addressType, backlog, fd);
-    if (r === 0) {
-      process.nextTick(function() {
-        self.emit('listening');
-      });
-    }
+  // self._handle.listen will be called lazy
+  // if there are no connection listeners
+  if (self.listeners('connection').length === 0) {
+    self.on('newListener', function removeme(name) {
+      if (name !== 'connection') return;
+
+      self.removeListener('newListener', removeme);
+      self._listen2(address, port, addressType, backlog, fd);
+    });
+
+    process.nextTick(function() {
+      self.emit('listening');
+    });
+    return;
+  }
+
+  var r = self._listen2(address, port, addressType, backlog, fd);
+  if (r === 0) {
+    process.nextTick(function() {
+      self.emit('listening');
+    });
   }
 }
 
-
-Server.prototype.listen = function() {
+Server.prototype._listen = function() {
   var self = this;
 
   var lastArg = arguments[arguments.length - 1];
@@ -1028,6 +1014,8 @@ Server.prototype.listen = function() {
   }
   return self;
 };
+
+Server.prototype.listen = Server.prototype._listen;
 
 Server.prototype.address = function() {
   if (this._handle && this._handle.getsockname) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -970,6 +970,7 @@ Server.prototype._listen = function() {
   var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
 
   var TCP = process.binding('tcp_wrap').TCP;
+  var Pipe = process.binding('pipe_wrap').Pipe;
 
   if (arguments.length == 0 || typeof arguments[0] == 'function') {
     // Don't bind(). OS will assign a port with INADDR_ANY.
@@ -983,7 +984,7 @@ Server.prototype._listen = function() {
     } else if (h.handle) {
       h = h.handle;
     }
-    if (h instanceof TCP) {
+    if (h instanceof TCP || h instanceof Pipe) {
       self._handle = h;
       listen(self, null, -1, -1, backlog);
     } else if (h.fd && typeof h.fd === 'number' && h.fd >= 0) {

--- a/test/simple/test-cluster-basic.js
+++ b/test/simple/test-cluster-basic.js
@@ -136,8 +136,7 @@ else if (cluster.isMaster) {
           assert.equal(arguments.length, 1);
           var expect = { address: '127.0.0.1',
                          port: common.PORT,
-                         addressType: 4,
-                         fd: undefined };
+                         family: 'IPv4'};
           assert.deepEqual(arguments[0], expect);
           break;
 

--- a/test/simple/test-net-lazy-listen.js
+++ b/test/simple/test-net-lazy-listen.js
@@ -1,0 +1,182 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var net = require('net');
+var fork = require('child_process').fork;
+
+if (process.argv[2] === 'worker') {
+  process.once('disconnect', function () {
+    process.exit(0);
+  });
+
+  process.on('message', function (msg, server) {
+    if (msg !== 'server') return;
+
+    server.on('connection', function (socket) {
+      socket.end(process.argv[3]);
+    });
+
+    process.send('listen');
+  });
+
+  process.send('online');
+  return;
+}
+
+var workers = [];
+
+function spawn(server, id, cb) {
+ // create a worker
+  var worker = fork(__filename, ['worker', id]);
+  workers[id] = worker;
+
+  // wait for ready
+  worker.on('message', function (msg) {
+    switch (msg) {
+      case 'online':
+        worker.send('server', server);
+        break;
+      case 'listen':
+        cb(worker);
+        break;
+      default:
+        throw new Error('got wrong message' + msg);
+    }
+  });
+
+  return worker;
+}
+
+// create a server instance there don't take connections
+var server = net.createServer().listen(common.PORT, function () {
+
+  setTimeout(function() {
+      console.log('spawn worker#0');
+      spawn(server, 0, function () {
+        console.log('worker#0 spawned');
+      });
+  }, 250);
+
+  console.log('testing for standby, expect id 0');
+  testResponse([0], function () {
+
+    // test with two worker, expect id response to be 0 or 1
+    testNewWorker(1, [0, 1], function () {
+
+      // kill worker#0, expect id response to be 1
+      testWorkerDeath(0, [1], function () {
+
+        // close server, expect all connections to continue
+        testServerClose(server, [1], function () {
+
+          // killing worker#1, expect all connections to fail
+          testWorkerDeath(1, [], function () {
+            console.log('test complete');
+          });
+        });
+      });
+    });
+  });
+});
+
+function testServerClose(server, expect, cb) {
+  console.log('closeing server');
+  server.close(function () {
+    testResponse(expect, cb);
+  });
+}
+
+function testNewWorker(workerId, exptect, cb) {
+  console.log('spawning worker#' + workerId);
+  spawn(server, 1, function () {
+    testResponse(exptect, cb);
+  });
+}
+
+function testWorkerDeath(workerID, exptect, cb) {
+  // killing worker#1, expect all connections to fail
+  console.log('killing worker#' + workerID);
+  workers[workerID].kill();
+  workers[workerID].once('exit', function () {
+    testResponse(exptect, cb);
+  });
+}
+
+function testResponse(expect, cb) {
+  // make 25 connections
+  var count = 25;
+  var missing = expect.slice(0);
+
+  var i = count;
+  while (i--) {
+    makeConnection(function (error, id) {
+      if (expect.length === 0) {
+        if (error === null) {
+          throw new Error('connect should not be possible');
+        }
+      } else {
+        if (expect.indexOf(id) === -1) {
+          throw new Error('got unexpected response: ' + id +
+                          ', expected: ' + expect.join(', '));
+        }
+
+        var index = missing.indexOf(id);
+        if (index !== -1) missing.splice(index, 1);
+      }
+
+      count -= 1;
+      if (count === 0) {
+        if (missing.length !== 0) {
+          throw new Error('no connection responsed with the following id: ' +
+                          missing.join(', '));
+        }
+        cb();
+      }
+    });
+  }
+}
+
+function makeConnection(cb) {
+  var client = net.connect({ port: common.PORT });
+
+  var id = null;
+  client.once('data', function(data) {
+    id = parseInt(data, 10);
+  });
+
+  var error = null;
+  client.once('error', function (e) {
+    error = e;
+  });
+
+  client.setTimeout(500);
+
+  client.on('close', function () {
+    cb(error, id);
+  });
+}
+
+process.on('exit', function () {
+  workers.forEach(function (worker) {
+    try { worker.kill(); } catch(e) {}
+  });
+});


### PR DESCRIPTION
With this patch it is possible to write a cluster-like module as an userland module, without using any internal API.  

@isaacs I had hoped to remove the `net._createServerHandle` from `cluster` and `net`, but the transparency that cluster provide and depend on seams to make this very hard.

_This patch is target 0.9._
