### PR TITLE
Fix shebang in tools/doc/generate.js

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -1,4 +1,4 @@
-#!node
+#!/usr/bin/env node
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION
A shebang must be an absolute path, but tools/doc/generate.js starts with `#!node` at the moment. Replace the shebang with `#!/usr/bin/env node`.
