### PR TITLE
timer: change new Date to Date.now for performance

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -51,7 +51,7 @@ var lists = {};
 // the main function - creates lists on demand and the watchers associated
 // with them.
 function insert(item, msecs) {
-  item._idleStart = new Date();
+  item._idleStart = Date.now();
   item._idleTimeout = msecs;
 
   if (msecs < 0) return;
@@ -71,8 +71,8 @@ function insert(item, msecs) {
     list.ontimeout = function() {
       debug('timeout callback ' + msecs);
 
-      var now = new Date();
-      debug('now: ' + now);
+      var now = Date.now();
+      debug('now: ' + (new Date(now)));
 
       var first;
       while (first = L.peek(list)) {
@@ -155,7 +155,7 @@ exports.active = function(item) {
     if (!list || L.isEmpty(list)) {
       insert(item, msecs);
     } else {
-      item._idleStart = new Date();
+      item._idleStart = Date.now();
       L.append(list, item);
     }
   }


### PR DESCRIPTION
Date.now() is much faster than (new Date()).getTime() as http://jsperf.com/native-date-now-vs-new-date-gettime.

Benchmark results are
before(current master):

```
> ./node benchmark/settimeout.js
wait...
smaller is better
startup: 46550
done: 29490
```

after(this commit):

```
> ./node benchmark/settimeout.js
wait...
smaller is better
startup: 11661
done: 7371
```
