### PR TITLE
Expose ref/unref for Socket, Server, and Timers

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -207,3 +207,15 @@ this.
 
 If `multicastInterface` is not specified, the OS will try to drop membership to all valid
 interfaces.
+
+### dgram.unref()
+
+Calling `unref` on a socket will allow the program to exit if this is the only
+active socket in the event system. If the socket is already `unref`d calling
+`unref` again will have no effect.
+
+### dgram.ref()
+
+Opposite of `unref`, calling `ref` on a previously `unref`d socket will *not*
+let the program exit if it's the only socket left (the default behavior). If
+the socket is `ref`d calling `ref` again will have no effect.

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -207,6 +207,18 @@ Example:
 
 Don't call `server.address()` until the `'listening'` event has been emitted.
 
+### server.unref()
+
+Calling `unref` on a server will allow the program to exit if this is the only
+active server in the event system. If the server is already `unref`d calling
+`unref` again will have no effect.
+
+### server.ref()
+
+Opposite of `unref`, calling `ref` on a previously `unref`d server will *not*
+let the program exit if it's the only server left (the default behavior). If
+the server is `ref`d calling `ref` again will have no effect.
+
 ### server.maxConnections
 
 Set this property to reject connections when the server's connection count gets
@@ -384,6 +396,18 @@ Returns the bound address, the address family name and port of the
 socket as reported by the operating system. Returns an object with
 three properties, e.g.
 `{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`
+
+### socket.unref()
+
+Calling `unref` on a socket will allow the program to exit if this is the only
+active socket in the event system. If the socket is already `unref`d calling
+`unref` again will have no effect.
+
+### socket.ref()
+
+Opposite of `unref`, calling `ref` on a previously `unref`d socket will *not*
+let the program exit if it's the only socket left (the default behavior). If
+the socket is `ref`d calling `ref` again will have no effect.
 
 ### socket.remoteAddress
 

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -29,3 +29,20 @@ you can also pass arguments to the callback.
 ## clearInterval(intervalId)
 
 Stops a interval from triggering.
+
+## unref()
+
+The opaque value returned by `setTimeout` and `setInterval` also has the method
+`timer.unref()` which will allow you to create a timer that is active but if
+it is the only item left in the event loop won't keep the program running.
+If the timer is already `unref`d calling `unref` again will have no effect.
+
+In the case of `setTimeout` when you `unref` you create a separate timer that
+will wakeup the event loop, creating too many of these may adversely effect
+event loop performance -- use wisely.
+
+## ref()
+
+If you had previously `unref()`d a timer you can call `ref()` to explicitly
+request the timer hold the program open. If the timer is already `ref`d calling
+`ref` again will have no effect.

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -351,6 +351,17 @@ function onMessage(handle, slab, start, len, rinfo) {
 }
 
 
+Socket.prototype.ref = function() {
+  if (this._handle)
+    this._handle.ref();
+};
+
+
+Socket.prototype.unref = function() {
+  if (this._handle)
+    this._handle.unref();
+};
+
 // TODO share with net_uv and others
 function errnoException(errorno, syscall) {
   var e = new Error(syscall + ' ' + errorno);

--- a/lib/net.js
+++ b/lib/net.js
@@ -716,6 +716,19 @@ Socket.prototype.connect = function(options, cb) {
 };
 
 
+Socket.prototype.ref = function() {
+  if (this._handle)
+    this._handle.ref();
+};
+
+
+Socket.prototype.unref = function() {
+  if (this._handle)
+    this._handle.unref();
+};
+
+
+
 function afterConnect(status, handle, req, readable, writable) {
   var self = handle.owner;
 
@@ -1091,6 +1104,16 @@ Server.prototype._setupSlave = function(socketList) {
     this._slaves = [];
   }
   this._slaves.push(socketList);
+};
+
+Server.prototype.ref = function() {
+  if (this._handle)
+    this._handle.ref();
+};
+
+Server.prototype.unref = function() {
+  if (this._handle)
+    this._handle.unref();
 };
 
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -47,7 +47,6 @@ if (process.env.NODE_DEBUG && /timer/.test(process.env.NODE_DEBUG)) {
 // value = list
 var lists = {};
 
-
 // the main function - creates lists on demand and the watchers associated
 // with them.
 function insert(item, msecs) {
@@ -151,6 +150,7 @@ exports.enroll = function(item, msecs) {
 exports.active = function(item) {
   var msecs = item._idleTimeout;
   if (msecs >= 0) {
+
     var list = lists[msecs];
     if (!list || L.isEmpty(list)) {
       insert(item, msecs);
@@ -176,9 +176,7 @@ exports.setTimeout = function(callback, after) {
     after = 1; // schedule on next tick, follows browser behaviour
   }
 
-  timer = { _idleTimeout: after };
-  timer._idlePrev = timer;
-  timer._idleNext = timer;
+  timer = new Timeout(after);
 
   if (arguments.length <= 2) {
     timer._onTimeout = callback;
@@ -209,7 +207,7 @@ exports.setTimeout = function(callback, after) {
 exports.clearTimeout = function(timer) {
   if (timer && (timer.ontimeout || timer._onTimeout)) {
     timer.ontimeout = timer._onTimeout = null;
-    if (timer instanceof Timer) {
+    if (timer instanceof Timer || timer instanceof Timeout) {
       timer.close(); // for after === 0
     } else {
       exports.unenroll(timer);
@@ -243,5 +241,39 @@ exports.clearInterval = function(timer) {
   if (timer instanceof Timer) {
     timer.ontimeout = null;
     timer.close();
+  }
+};
+
+var Timeout = function(after) {
+  this._idleTimeout = after;
+  this._idlePrev = this;
+  this._idleNext = this;
+  this._when = Date.now() + after;
+};
+
+Timeout.prototype.unref = function() {
+  if (!this._handle) {
+    exports.unenroll(this);
+    this._handle = new Timer();
+    this._handle.ontimeout = this._onTimeout;
+    this._handle.start(this._when - Date.now(), 0);
+    this._handle.unref();
+  } else {
+    this._handle.unref();
+  }
+};
+
+Timeout.prototype.ref = function() {
+  if (this._handle)
+    this._handle.ref();
+};
+
+Timeout.prototype.close = function() {
+  this._onTimeout = null;
+  if (this._handle) {
+    this._handle.ontimeout = null;
+    this._handle.close();
+  } else {
+    exports.unenroll(this);
   }
 };

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -84,6 +84,7 @@ void PipeWrap::Initialize(Handle<Object> target) {
 
   NODE_SET_PROTOTYPE_METHOD(t, "close", HandleWrap::Close);
   NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
+  NODE_SET_PROTOTYPE_METHOD(t, "ref", HandleWrap::Ref);
 
   NODE_SET_PROTOTYPE_METHOD(t, "readStart", StreamWrap::ReadStart);
   NODE_SET_PROTOTYPE_METHOD(t, "readStop", StreamWrap::ReadStop);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -96,6 +96,9 @@ void TCPWrap::Initialize(Handle<Object> target) {
 
   NODE_SET_PROTOTYPE_METHOD(t, "close", HandleWrap::Close);
 
+  NODE_SET_PROTOTYPE_METHOD(t, "ref", HandleWrap::Ref);
+  NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
+
   NODE_SET_PROTOTYPE_METHOD(t, "readStart", StreamWrap::ReadStart);
   NODE_SET_PROTOTYPE_METHOD(t, "readStop", StreamWrap::ReadStop);
   NODE_SET_PROTOTYPE_METHOD(t, "shutdown", StreamWrap::Shutdown);

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -52,6 +52,8 @@ class TimerWrap : public HandleWrap {
     constructor->SetClassName(String::NewSymbol("Timer"));
 
     NODE_SET_PROTOTYPE_METHOD(constructor, "close", HandleWrap::Close);
+    NODE_SET_PROTOTYPE_METHOD(constructor, "ref", HandleWrap::Ref);
+    NODE_SET_PROTOTYPE_METHOD(constructor, "unref", HandleWrap::Unref);
 
     NODE_SET_PROTOTYPE_METHOD(constructor, "start", Start);
     NODE_SET_PROTOTYPE_METHOD(constructor, "stop", Stop);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -110,6 +110,9 @@ void UDPWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "setBroadcast", SetBroadcast);
   NODE_SET_PROTOTYPE_METHOD(t, "setTTL", SetTTL);
 
+  NODE_SET_PROTOTYPE_METHOD(t, "ref", HandleWrap::Ref);
+  NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
+
   target->Set(String::NewSymbol("UDP"),
               Persistent<FunctionTemplate>::New(t)->GetFunction());
 }

--- a/test/simple/test-dgram-unref.js
+++ b/test/simple/test-dgram-unref.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var dgram = require('dgram');
+var closed = false;
+
+var s = dgram.createSocket('udp4');
+s.bind();
+s.unref();
+
+setTimeout(function() {
+  closed = true;
+  s.close();
+}, 1000).unref();
+
+process.on('exit', function() {
+  assert.strictEqual(closed, false, 'Unrefd socket should not hold loop open');
+});

--- a/test/simple/test-net-connect-unref.js
+++ b/test/simple/test-net-connect-unref.js
@@ -1,0 +1,45 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var client, killed = false, ended = false;
+var TIMEOUT = 10 * 1000
+
+client = net.createConnection(53, '8.8.8.8', function() {
+  client.unref();
+});
+
+client.on('close', function() {
+  ended = true;
+});
+
+setTimeout(function() {
+  killed = true;
+  client.end();
+}, TIMEOUT).unref();
+
+process.on('exit', function() {
+  assert.strictEqual(killed, false, 'A client should have connected');
+  assert.strictEqual(ended, false, 'A client should stay connected');
+});

--- a/test/simple/test-net-server-unref.js
+++ b/test/simple/test-net-server-unref.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var net = require('net');
+var closed = false;
+
+var s = net.createServer();
+s.listen();
+s.unref();
+
+setTimeout(function() {
+  closed = true;
+  s.close();
+}, 1000).unref();
+
+process.on('exit', function() {
+  assert.strictEqual(closed, false, 'Unrefd socket should not hold loop open');
+});

--- a/test/simple/test-pipe-unref.js
+++ b/test/simple/test-pipe-unref.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var net = require('net');
+var closed = false;
+
+var s = net.Server();
+s.listen(common.PIPE);
+s.unref();
+
+setTimeout(function() {
+  closed = true;
+  s.close();
+}, 1000).unref();
+
+process.on('exit', function() {
+  assert.strictEqual(closed, false, 'Unrefd socket should not hold loop open');
+});

--- a/test/simple/test-timers-unref.js
+++ b/test/simple/test-timers-unref.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var interval_fired = false,
+    timeout_fired = false,
+    unref_interval = false,
+    unref_timer = false,
+    interval, check_unref, checks = 0;
+
+var LONG_TIME = 10 * 1000;
+var SHORT_TIME = 100;
+
+setInterval(function() {
+  interval_fired = true;
+}, LONG_TIME).unref();
+
+setTimeout(function() {
+  timeout_fired = true;
+}, LONG_TIME).unref();
+
+interval = setInterval(function() {
+  unref_interval = true;
+  clearInterval(interval);
+}, SHORT_TIME).unref();
+
+setTimeout(function() {
+  unref_timer = true;
+}, SHORT_TIME).unref();
+
+check_unref = setInterval(function() {
+  if (checks > 5 || (unref_interval && unref_timer))
+    clearInterval(check_unref);
+  checks += 1;
+}, 100);
+
+process.on('exit', function() {
+  assert.strictEqual(interval_fired, false, 'Interval should not fire');
+  assert.strictEqual(timeout_fired, false, 'Timeout should not fire');
+  assert.strictEqual(unref_timer, true, 'An unrefd timeout should still fire');
+  assert.strictEqual(unref_interval, true, 'An unrefd interval should still fire');
+});


### PR DESCRIPTION
This exposes the underlying handle `ref` and `unref` for `dgram.Socket`, `net.Socket`, `net.Server`, and `timers`.

Ideal for users who want to create such items but not have them keep the program running. For instance a logging connection, a keep-alive'd socket, or a timer that monitors statistics.

Calling `unref()` on one of these objects will unreference the handle in the event loop, calling `ref()` will restore it and hold the loop open as usual.

Fixes #2718
