### PR TITLE
Fix bug in sample code for child_process.spawn()

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -306,7 +306,7 @@ Example: A very elaborate way to run 'ps ax | grep ssh'
     });
 
     grep.stdout.on('data', function (data) {
-      console.log(data);
+      console.log('' + data);
     });
 
     grep.stderr.on('data', function (data) {


### PR DESCRIPTION
Before this patch, the sample app for child_process.spawn() outputs the raw Buffer, so the output might look like this:

```
<Buffer 20 39 31 35 33 20 20 20 3f 3f 20 20 53 20 20 20 20 20 20 30 3a 30 30 2e 36 35 20 2f 75 73 72 2f 62 69 6e 2f 73 73 68 2d 61 67 65 6e 74 20 2d 6c 0a>
```

After the patch, the output of the sample app looks like this instead:

```
9153   ??  S      0:00.65 /usr/bin/ssh-agent -l
```
