### PR TITLE
Timers explode when date has been stubbed

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -26,8 +26,8 @@ var assert = require('assert').ok;
 // Timeout values > TIMEOUT_MAX are set to 1.
 var TIMEOUT_MAX = 2147483647; // 2^31-1
 
-//Hold reference to the global date so if stubbed the times still work
-var Date = this.Date;
+//Hold reference to the global date so if stubbed the timers still work
+var Date = global.Date;
 
 var debug;
 if (process.env.NODE_DEBUG && /timer/.test(process.env.NODE_DEBUG)) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -26,6 +26,9 @@ var assert = require('assert').ok;
 // Timeout values > TIMEOUT_MAX are set to 1.
 var TIMEOUT_MAX = 2147483647; // 2^31-1
 
+//Hold reference to the global date so if stubbed the times still work
+var Date = this.Date;
+
 var debug;
 if (process.env.NODE_DEBUG && /timer/.test(process.env.NODE_DEBUG)) {
   debug = function() { require('util').error.apply(this, arguments); };

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -44,6 +44,15 @@ setTimeout(function() {
   setTimeout_called = true;
 }, 1000);
 
+assert.doesNotThrow(function() {
+  var copy = Date;
+  Date = 'Not a Date';
+  interval_count = 0;
+  setInterval(function() { clearInterval(this); }, 100);
+  setTimeout(function() { return true; }, 100);
+  Date = copy;
+}, TypeError);
+
 // this timer shouldn't execute
 var id = setTimeout(function() { assert.equal(true, false); }, 500);
 clearTimeout(id);


### PR DESCRIPTION
Timers in node all throw an exception when date has been stubbed, mocked, or modified and does not respond like a Date.

To allow for testing and to make times more self-relient the timers module now holds it's own copy of Date rather that referring to the global all over.

_Use cases_
- Libraries like Timecop.js can be turned into a full npm modules
- tests can have timeouts that do not freeze when time is modified
