### PR TITLE
Enable color customization of `util.inspect`

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -81,12 +81,35 @@ in `null` for `depth`.
 
 If `colors` is `true`, the output will be styled with ANSI color codes.
 Defaults to `false`.
+Colors are customizable, see below.
 
 Example of inspecting all properties of the `util` object:
 
     var util = require('util');
 
     console.log(util.inspect(util, true, null));
+
+### Customizing `util.inspect` colors
+
+Color output (if enabled) of `util.inspect` is customizable globally
+via `util.inspect.styles` and `util.inspect.colors` objects.
+
+`util.inspect.styles` is map assigning each style a color
+from `util.inspect.colors`.
+Highlighted styles and their default values are:
+ * `number` (yellow)
+ * `boolean` (yellow)
+ * `string` (green)
+ * `date` (magenta)
+ * `regexp` (red)
+ * `null` (bold)
+ * `undefined` (grey)
+ * `special` - only function at this time (cyan)
+ * `name` (intentionally not styling)
+
+Predefined color codes are: `white`, `grey`, `black`, `blue`, `cyan`, 
+`green`, `magenta`, `red` and `yellow`.
+There are also `bold`, `italic`, `underline` and `inverse` codes.
 
 
 ## util.isArray(object)

--- a/lib/util.js
+++ b/lib/util.js
@@ -128,24 +128,24 @@ exports.inspect = inspect;
 
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
-var colors = {
-  'bold' : [1, 22],
-  'italic' : [3, 23],
-  'underline' : [4, 24],
-  'inverse' : [7, 27],
-  'white' : [37, 39],
-  'grey' : [90, 39],
-  'black' : [30, 39],
-  'blue' : [34, 39],
-  'cyan' : [36, 39],
-  'green' : [32, 39],
-  'magenta' : [35, 39],
-  'red' : [31, 39],
-  'yellow' : [33, 39]
+inspect.colors = {
+  'bold' : ['\u001b[1m', '\u001b[22m'],
+  'italic' : ['\u001b[3m', '\u001b[23m'],
+  'underline' : ['\u001b[4m', '\u001b[24m'],
+  'inverse' : ['\u001b[7m', '\u001b[27m'],
+  'white' : ['\u001b[37m', '\u001b[39m'],
+  'grey' : ['\u001b[90m', '\u001b[39m'],
+  'black' : ['\u001b[30m', '\u001b[39m'],
+  'blue' : ['\u001b[34m', '\u001b[39m'],
+  'cyan' : ['\u001b[36m', '\u001b[39m'],
+  'green' : ['\u001b[32m', '\u001b[39m'],
+  'magenta' : ['\u001b[35m', '\u001b[39m'],
+  'red' : ['\u001b[31m', '\u001b[39m'],
+  'yellow' : ['\u001b[33m', '\u001b[39m']
 };
 
 // Don't use 'blue' not visible on cmd.exe
-var styles = {
+inspect.styles = {
   'special': 'cyan',
   'number': 'yellow',
   'boolean': 'yellow',
@@ -159,11 +159,11 @@ var styles = {
 
 
 function stylizeWithColor(str, styleType) {
-  var style = styles[styleType];
+  var style = inspect.styles[styleType];
 
   if (style) {
-    return '\u001b[' + colors[style][0] + 'm' + str +
-           '\u001b[' + colors[style][1] + 'm';
+    return inspect.colors[style][0] + str +
+           inspect.colors[style][1];
   } else {
     return str;
   }

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -107,3 +107,25 @@ assert.doesNotThrow(function() {
 // GH-2225
 var x = { inspect: util.inspect };
 assert.ok(util.inspect(x).indexOf('inspect') != -1);
+
+// util.inspect.styles and util.inspect.colors
+function test_color_style(style, input, implicit) {
+  var color_name = util.inspect.styles[style];
+  var color = ['', ''];
+  if(util.inspect.colors[color_name])
+    color = util.inspect.colors[color_name];
+
+  var without_color = util.inspect(input, false, 0, false);
+  var with_color = util.inspect(input, false, 0, true);
+  assert.equal(with_color, color[0] + without_color + color[1], 
+    'util.inspect color for style '+style);
+}
+
+test_color_style('special', function(){});
+test_color_style('number', 123.456);
+test_color_style('boolean', true);
+test_color_style('undefined', undefined);
+test_color_style('null', null);
+test_color_style('string', 'test string');
+test_color_style('date', new Date);
+test_color_style('regexp', /regexp/);


### PR DESCRIPTION
This is rewrite of #3701 and #3603 before.

This patch introduce `util.inspect.styles` and `util.inspect.colors` objects, which enables customization of color sequences.
