### PR TITLE
Domain stack leak

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -41,6 +41,7 @@ exports.create = exports.createDomain = function(cb) {
 // it's possible to enter one domain while already inside
 // another one.  the stack is each entered domain.
 var stack = [];
+exports._stack = stack;
 // the active domain is always the one that we're currently in.
 exports.active = null;
 
@@ -58,6 +59,7 @@ function uncaughtHandler(er) {
       domain_thrown: true
     });
     exports.active.emit('error', er);
+    exports.active.exit();
   } else if (process.listeners('uncaughtException').length === 1) {
     // if there are other handlers, then they'll take care of it.
     // but if not, then we need to crash now.

--- a/test/simple/test-domain-stack.js
+++ b/test/simple/test-domain-stack.js
@@ -1,0 +1,46 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Make sure that the domain stack doesn't get out of hand.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var events = require('events');
+
+var a = domain.create();
+a.name = 'a';
+
+a.on('error', function() {
+  if (domain._stack.length > 5) {
+    console.error('leaking!', domain._stack);
+    process.exit(1);
+  }
+});
+
+var foo = a.bind(function() {
+  throw new Error('error from foo');
+});
+
+for (var i = 0; i < 1000; i++) {
+  process.nextTick(foo);
+}


### PR DESCRIPTION
Because a throw jumps out of the current run-to-completion flow, errors that are caught by domains never end up calling `domain.exit()`, resulting in an explosion of the domain stack.

Fix: Call `domain.exit()` after emitting the error event on the domain.
