### PR TITLE
test: prefer binding to localhost over 0.0.0.0

### DIFF
--- a/test/simple/test-child-process-disconnect.js
+++ b/test/simple/test-child-process-disconnect.js
@@ -49,7 +49,7 @@ if (process.argv[2] === 'child') {
     process.send('ready');
   });
 
-  server.listen(common.PORT);
+  server.listen(common.PORT, 'localhost');
 
 } else {
   // testcase

--- a/test/simple/test-child-process-fork-net.js
+++ b/test/simple/test-child-process-fork-net.js
@@ -111,7 +111,7 @@ if (process.argv[2] === 'child') {
       console.log('PARENT: server listening');
       child.send({what: 'server'}, server);
     });
-    server.listen(common.PORT);
+    server.listen(common.PORT, 'localhost');
 
     // handle client messages
     var messageHandlers = function(msg) {
@@ -163,7 +163,7 @@ if (process.argv[2] === 'child') {
     //
     // An isolated test for this would be lovely, but for now, this
     // will have to do.
-    server.listen(common.PORT + 1, function() {
+    server.listen(common.PORT + 1, 'localhost', function() {
       console.error('testSocket, listening');
       var connect = net.connect(common.PORT + 1);
       var store = '';

--- a/test/simple/test-child-process-fork2.js
+++ b/test/simple/test-child-process-fork2.js
@@ -36,7 +36,7 @@ var server = new net.Server(function(c) {
   c.destroy();
 });
 
-server.listen(common.PORT, /* backlog */ 9, function() {
+server.listen(common.PORT, 'localhost', /* backlog */ 9, function() {
   console.log('PARENT send child server handle');
   n.send({ hello: 'world' }, server._handle);
 });

--- a/test/simple/test-dgram-address.js
+++ b/test/simple/test-dgram-address.js
@@ -41,7 +41,7 @@ socket_ipv4.on('error', function(e) {
   socket_ipv4.close();
 });
 
-socket_ipv4.bind(common.PORT, localhost_ipv4);
+socket_ipv4.bind(common.PORT, 'localhost', localhost_ipv4);
 
 // IPv6 Test
 var localhost_ipv6 = '::1';
@@ -61,4 +61,4 @@ socket_ipv6.on('error', function(e) {
   socket_ipv6.close();
 });
 
-socket_ipv6.bind(common.PORT, localhost_ipv6);
+socket_ipv6.bind(common.PORT, 'localhost', localhost_ipv6);

--- a/test/simple/test-dgram-multicast-setTTL.js
+++ b/test/simple/test-dgram-multicast-setTTL.js
@@ -25,7 +25,7 @@ var common = require('../common'),
     thrown = false,
     socket = dgram.createSocket('udp4');
 
-socket.bind(common.PORT);
+socket.bind(common.PORT, '127.0.0.1');
 socket.setMulticastTTL(16);
 
 //Try to set an invalid TTL (valid ttl is > 0 and < 256)

--- a/test/simple/test-dgram-send-error.js
+++ b/test/simple/test-dgram-send-error.js
@@ -43,7 +43,7 @@ var socket = dgram.createSocket('udp4');
 
 socket.on('message', onMessage);
 socket.on('listening', doSend);
-socket.bind(common.PORT);
+socket.bind(common.PORT, 'localhost');
 
 function onMessage(message, info) {
   packetsReceived++;

--- a/test/simple/test-dgram-udp4.js
+++ b/test/simple/test-dgram-udp4.js
@@ -74,7 +74,7 @@ server.on('close', function() {
     clearTimeout(timer);
   }
 });
-server.bind(server_port);
+server.bind(server_port, '127.0.0.1');
 
 timer = setTimeout(function() {
   throw new Error('Timeout');

--- a/test/simple/test-domain-http-server.js
+++ b/test/simple/test-domain-http-server.js
@@ -58,10 +58,10 @@ var server = http.createServer(function(req, res) {
   });
 });
 
-server.listen(common.PORT, next);
+server.listen(common.PORT, 'localhost', next);
 
 function next() {
-  console.log('listening on localhost:%d', common.PORT);
+  console.log('listening on localhost:%d', common.PORT, 'localhost');
 
   // now hit it a few times
   var dom = domain.create();

--- a/test/simple/test-domain-multi.js
+++ b/test/simple/test-domain-multi.js
@@ -71,7 +71,7 @@ var server = http.createServer(function (req, res) {
     throw new Error('this kills domain B, not A');
   }));
 
-}).listen(common.PORT);
+}).listen(common.PORT, 'localhost');
 
 var c = domain.create();
 var req = http.get({ host: 'localhost', port: common.PORT })

--- a/test/simple/test-http-1.0.js
+++ b/test/simple/test-http-1.0.js
@@ -45,7 +45,7 @@ function test(handler, request_generator, response_validator) {
   var timer = setTimeout(cleanup, 1000);
   process.on('exit', cleanup);
 
-  server.listen(port);
+  server.listen(port, 'localhost');
   server.on('listening', function() {
     var c = net.createConnection(port);
 

--- a/test/simple/test-http-304.js
+++ b/test/simple/test-http-304.js
@@ -33,7 +33,7 @@ var s = http.createServer(function(request, response) {
   response.end();
 });
 
-s.listen(common.PORT, function() {
+s.listen(common.PORT, 'localhost', function() {
   childProcess.exec('curl -i http://127.0.0.1:' + common.PORT + '/',
                     function(err, stdout, stderr) {
                       if (err) throw err;

--- a/test/simple/test-http-abort-before-end.js
+++ b/test/simple/test-http-abort-before-end.js
@@ -27,7 +27,7 @@ var server = http.createServer(function(req, res) {
   assert(false); // should not be called
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = http.request({method: 'GET', host: '127.0.0.1', port: common.PORT});
 
   req.on('error', function(ex) {

--- a/test/simple/test-http-abort-client.js
+++ b/test/simple/test-http-abort-client.js
@@ -33,7 +33,7 @@ var server = http.Server(function(req, res) {
 
 var responseClose = false;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = http.get({
     port: common.PORT,
     headers: { connection: 'keep-alive' }

--- a/test/simple/test-http-after-connect.js
+++ b/test/simple/test-http-after-connect.js
@@ -44,7 +44,7 @@ server.on('connect', function(req, socket, firstBodyChunk) {
     socket.end();
   });
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = http.request({
     port: common.PORT,
     method: 'CONNECT',

--- a/test/simple/test-http-agent.js
+++ b/test/simple/test-http-agent.js
@@ -35,7 +35,7 @@ var responses = 0;
 var N = 10;
 var M = 10;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   for (var i = 0; i < N; i++) {
     setTimeout(function() {
       for (var j = 0; j < M; j++) {

--- a/test/simple/test-http-allow-req-after-204-res.js
+++ b/test/simple/test-http-allow-req-after-204-res.js
@@ -62,4 +62,4 @@ function nextRequest() {
   request.end();
 }
 
-server.listen(common.PORT, nextRequest);
+server.listen(common.PORT, 'localhost', nextRequest);

--- a/test/simple/test-http-bind-twice.js
+++ b/test/simple/test-http-bind-twice.js
@@ -34,10 +34,10 @@ function dontCall() {
 }
 
 var server1 = http.createServer(dontCall);
-server1.listen(common.PORT, '127.0.0.1', function() {});
+server1.listen(common.PORT, 'localhost', '127.0.0.1', function() {});
 
 var server2 = http.createServer(dontCall);
-server2.listen(common.PORT, '127.0.0.1', dontCall);
+server2.listen(common.PORT, 'localhost', '127.0.0.1', dontCall);
 
 server2.on('error', function(e) {
   assert.equal(e.code, 'EADDRINUSE');

--- a/test/simple/test-http-blank-header.js
+++ b/test/simple/test-http-blank-header.js
@@ -39,7 +39,7 @@ var server = http.createServer(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = net.createConnection(common.PORT);
 
   c.on('connect', function() {

--- a/test/simple/test-http-buffer-sanity.js
+++ b/test/simple/test-http-buffer-sanity.js
@@ -65,7 +65,7 @@ var web = http.Server(function(req, res) {
 
 var gotThanks = false;
 
-web.listen(common.PORT, function() {
+web.listen(common.PORT, 'localhost', function() {
   console.log('Making request');
 
   var req = http.request({

--- a/test/simple/test-http-chunked.js
+++ b/test/simple/test-http-chunked.js
@@ -37,7 +37,7 @@ var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain; charset=utf8'});
   res.end(UTF8_STRING, 'utf8');
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var data = '';
   var get = http.get({
     path: '/',

--- a/test/simple/test-http-client-abort.js
+++ b/test/simple/test-http-client-abort.js
@@ -53,7 +53,7 @@ var responses = 0;
 var N = http.Agent.defaultMaxSockets - 1;
 var requests = [];
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   console.log('Server listening.');
 
   for (var i = 0; i < N; i++) {

--- a/test/simple/test-http-client-abort2.js
+++ b/test/simple/test-http-client-abort2.js
@@ -30,7 +30,7 @@ var server = http.createServer(function(req, res) {
   res.end('Hello');
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = http.get({port: common.PORT}, function(res) {
     res.on('data', function(data) {
       req.abort();

--- a/test/simple/test-http-client-agent.js
+++ b/test/simple/test-http-client-agent.js
@@ -38,7 +38,7 @@ var server = http.Server(function(req, res) {
     res.end('Hello, World!');
   }
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   for (var i = 0; i < max; ++i) {
     request(i);
   }

--- a/test/simple/test-http-client-get-url.js
+++ b/test/simple/test-http-client-get-url.js
@@ -35,7 +35,7 @@ var server = http.createServer(function(req, res) {
   seen_req = true;
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.get('http://127.0.0.1:' + common.PORT + '/foo?bar');
 });
 

--- a/test/simple/test-http-client-parse-error.js
+++ b/test/simple/test-http-client-parse-error.js
@@ -36,7 +36,7 @@ var srv = net.createServer(function(c) {
 
 var parseError = false;
 
-srv.listen(common.PORT, '127.0.0.1', function() {
+srv.listen(common.PORT, 'localhost', '127.0.0.1', function() {
   var req = http.request({
     host: '127.0.0.1',
     port: common.PORT,

--- a/test/simple/test-http-client-race-2.js
+++ b/test/simple/test-http-client-race-2.js
@@ -47,7 +47,7 @@ var server = http.createServer(function(req, res) {
                 {'Content-Type': 'text/plain', 'Content-Length': body.length});
   res.end(body);
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 var body1 = '';
 var body2 = '';

--- a/test/simple/test-http-client-race.js
+++ b/test/simple/test-http-client-race.js
@@ -33,7 +33,7 @@ var server = http.createServer(function(req, res) {
                 {'Content-Type': 'text/plain', 'Content-Length': body.length});
   res.end(body);
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 var body1 = '';
 var body2 = '';

--- a/test/simple/test-http-client-upload-buf.js
+++ b/test/simple/test-http-client-upload-buf.js
@@ -43,7 +43,7 @@ var server = http.createServer(function(req, res) {
     res.end();
   });
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   var req = http.request({

--- a/test/simple/test-http-client-upload.js
+++ b/test/simple/test-http-client-upload.js
@@ -44,7 +44,7 @@ var server = http.createServer(function(req, res) {
     res.end();
   });
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   var req = http.request({

--- a/test/simple/test-http-connect.js
+++ b/test/simple/test-http-connect.js
@@ -45,7 +45,7 @@ server.on('connect', function(req, socket, firstBodyChunk) {
     socket.end(data);
   });
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = http.request({
     port: common.PORT,
     method: 'CONNECT',

--- a/test/simple/test-http-contentLength0.js
+++ b/test/simple/test-http-contentLength0.js
@@ -31,7 +31,7 @@ var s = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Length': '0 '});
   res.end();
 });
-s.listen(common.PORT, function() {
+s.listen(common.PORT, 'localhost', function() {
 
   var request = http.request({ port: common.PORT }, function(response) {
     console.log('STATUS: ' + response.statusCode);

--- a/test/simple/test-http-curl-chunk-problem.js
+++ b/test/simple/test-http-curl-chunk-problem.js
@@ -86,6 +86,6 @@ var server = http.createServer(function(req, res) {
 
 });
 
-server.listen(common.PORT, maybeMakeRequest);
+server.listen(common.PORT, 'localhost', maybeMakeRequest);
 
 console.log('Server running at http://localhost:8080');

--- a/test/simple/test-http-date-header.js
+++ b/test/simple/test-http-date-header.js
@@ -33,7 +33,7 @@ var server = http.createServer(function(req, res) {
   });
   res.end(testResBody);
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 
 server.addListener('listening', function() {

--- a/test/simple/test-http-default-encoding.js
+++ b/test/simple/test-http-default-encoding.js
@@ -43,7 +43,7 @@ var server = http.Server(function(req, res) {
   res.end('hello world\n');
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.request({
     port: common.PORT,
     path: '/',

--- a/test/simple/test-http-eof-on-connect.js
+++ b/test/simple/test-http-eof-on-connect.js
@@ -29,7 +29,7 @@ var http = require('http');
 // reproduceable on the first packet on the first connection to a server.
 
 var server = http.createServer(function(req, res) {});
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   net.createConnection(common.PORT).on('connect', function() {

--- a/test/simple/test-http-exceptions.js
+++ b/test/simple/test-http-exceptions.js
@@ -30,7 +30,7 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req;
   for (var i = 0; i < 4; i += 1) {
     req = http.get({ port: common.PORT, path: '/busy/' + i });

--- a/test/simple/test-http-expect-continue.js
+++ b/test/simple/test-http-expect-continue.js
@@ -48,7 +48,7 @@ server.on('checkContinue', function(req, res) {
     handler(req, res);
   }, 100);
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 
 

--- a/test/simple/test-http-extra-response.js
+++ b/test/simple/test-http-extra-response.js
@@ -60,7 +60,7 @@ var server = net.createServer(function(socket) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.get({ port: common.PORT }, function(res) {
     var buffer = '';
     console.log('Got res code: ' + res.statusCode);

--- a/test/simple/test-http-full-response.js
+++ b/test/simple/test-http-full-response.js
@@ -75,7 +75,7 @@ function runAb(opts, callback) {
   });
 }
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   runAb('-c 1 -n 10', function() {
     console.log('-c 1 -n 10 okay');
 

--- a/test/simple/test-http-get-pipeline-problem.js
+++ b/test/simple/test-http-get-pipeline-problem.js
@@ -53,7 +53,7 @@ var server = http.Server(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   for (var i = 0; i < total; i++) {
     (function() {
       var x = i;

--- a/test/simple/test-http-head-request.js
+++ b/test/simple/test-http-head-request.js
@@ -36,7 +36,7 @@ var server = http.createServer(function(req, res) {
 
 var gotEnd = false;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var request = http.request({
     port: common.PORT,
     method: 'HEAD',

--- a/test/simple/test-http-head-response-has-no-body-end.js
+++ b/test/simple/test-http-head-response-has-no-body-end.js
@@ -35,7 +35,7 @@ var server = http.createServer(function(req, res) {
   res.writeHead(200);
   res.end('FAIL'); // broken: sends FAIL from hot path.
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 var responseComplete = false;
 

--- a/test/simple/test-http-head-response-has-no-body.js
+++ b/test/simple/test-http-head-response-has-no-body.js
@@ -32,7 +32,7 @@ var server = http.createServer(function(req, res) {
   res.writeHead(200); // broken: defaults to TE chunked
   res.end();
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 var responseComplete = false;
 

--- a/test/simple/test-http-header-read.js
+++ b/test/simple/test-http-header-read.js
@@ -41,7 +41,7 @@ var s = http.createServer(function(req, res) {
   );
 });
 
-s.listen(common.PORT, runTest);
+s.listen(common.PORT, 'localhost', runTest);
 
 function runTest() {
   http.get({ port: common.PORT }, function(response) {

--- a/test/simple/test-http-host-headers.js
+++ b/test/simple/test-http-host-headers.js
@@ -69,8 +69,8 @@ function testHttp() {
     }
   }
 
-  httpServer.listen(common.PORT, function(er) {
-    console.error('listening on ' + common.PORT);
+  httpServer.listen(common.PORT, 'localhost', function(er) {
+    console.error('listening on ' + common.PORT, 'localhost');
 
     if (er) throw er;
 
@@ -121,7 +121,7 @@ function testHttps() {
     }
   }
 
-  httpsServer.listen(common.PORT, function(er) {
+  httpsServer.listen(common.PORT, 'localhost', function(er) {
     if (er) throw er;
 
     https.get({ method: 'GET',

--- a/test/simple/test-http-keep-alive-close-on-header.js
+++ b/test/simple/test-http-keep-alive-close-on-header.js
@@ -36,7 +36,7 @@ var server = http.createServer(function(req, res) {
 var connectCount = 0;
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var agent = new http.Agent({ maxSockets: 1 });
   var request = http.request({
     method: 'GET',

--- a/test/simple/test-http-keep-alive.js
+++ b/test/simple/test-http-keep-alive.js
@@ -36,7 +36,7 @@ var name = 'localhost:' + common.PORT;
 var agent = new http.Agent({maxSockets: 1});
 var headers = {'connection': 'keep-alive'};
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.get({
     path: '/', headers: headers, port: common.PORT, agent: agent
   }, function(response) {

--- a/test/simple/test-http-legacy.js
+++ b/test/simple/test-http-legacy.js
@@ -65,7 +65,7 @@ var server = http.createServer(function(req, res) {
   //assert.equal('127.0.0.1', res.connection.remoteAddress);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = http.createClient(common.PORT);
   var req = client.request('/hello', {'Accept': '*/*', 'Foo': 'bar'});
   setTimeout(function() {

--- a/test/simple/test-http-localaddress.js
+++ b/test/simple/test-http-localaddress.js
@@ -38,7 +38,7 @@ var server = http.createServer(function (req, res) {
   });
 });
 
-server.listen(common.PORT, "127.0.0.1", function() {
+server.listen(common.PORT, 'localhost', "127.0.0.1", function() {
   var options = { host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/simple/test-http-malformed-request.js
+++ b/test/simple/test-http-malformed-request.js
@@ -40,7 +40,7 @@ var server = http.createServer(function(req, res) {
 
   if (++nrequests_completed == nrequests_expected) server.close();
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   var c = net.createConnection(common.PORT);

--- a/test/simple/test-http-many-keep-alive-connections.js
+++ b/test/simple/test-http-many-keep-alive-connections.js
@@ -39,7 +39,7 @@ server.once('connection', function(c) {
   connection = c;
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var callee = arguments.callee;
   var request = http.get({
     port: common.PORT,

--- a/test/simple/test-http-max-headers-count.js
+++ b/test/simple/test-http-max-headers-count.js
@@ -52,7 +52,7 @@ var server = http.createServer(function(req, res) {
 });
 server.maxHeadersCount = max;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var maxAndExpected = [ // for client
     [20, 20],
     [1200, 1200],

--- a/test/simple/test-http-multi-line-headers.js
+++ b/test/simple/test-http-multi-line-headers.js
@@ -46,7 +46,7 @@ var server = net.createServer(function(conn) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.get({host: '127.0.0.1', port: common.PORT}, function(res) {
     assert.equal(res.headers['content-type'],
                  'text/plain;x-unix-mode=0600;name="hello.txt"');

--- a/test/simple/test-http-mutable-headers.js
+++ b/test/simple/test-http-mutable-headers.js
@@ -81,7 +81,7 @@ var s = http.createServer(function(req, res) {
   res.end(content);
 });
 
-s.listen(common.PORT, nextTest);
+s.listen(common.PORT, 'localhost', nextTest);
 
 
 function nextTest() {

--- a/test/simple/test-http-no-content-length.js
+++ b/test/simple/test-http-no-content-length.js
@@ -29,7 +29,7 @@ var body = '';
 var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   var req = http.get({port: common.PORT}, function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {

--- a/test/simple/test-http-parser-free.js
+++ b/test/simple/test-http-parser-free.js
@@ -29,7 +29,7 @@ var server = http.createServer(function(req, res) {
   res.end('Hello');
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.globalAgent.maxSockets = 1;
   var parser;
   for (var i = 0; i < N; ++i) {

--- a/test/simple/test-http-pause-resume-one-end.js
+++ b/test/simple/test-http-pause-resume-one-end.js
@@ -32,7 +32,7 @@ var server = http.Server(function(req, res) {
 
 var dataCount = 0, endCount = 0;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var opts = {
     port: common.PORT,
     headers: { connection: 'close' }

--- a/test/simple/test-http-pause.js
+++ b/test/simple/test-http-pause.js
@@ -46,7 +46,7 @@ var server = http.createServer(function(req, res) {
   }, 100);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = http.request({
     port: common.PORT,
     path: '/',

--- a/test/simple/test-http-pipe-fs.js
+++ b/test/simple/test-http-pipe-fs.js
@@ -36,7 +36,7 @@ var server = http.createServer(function(req, res) {
     res.writeHead(200);
     res.end();
   });
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   http.globalAgent.maxSockets = 1;
 
   for (var i = 0; i < 2; ++i) {

--- a/test/simple/test-http-proxy.js
+++ b/test/simple/test-http-proxy.js
@@ -99,10 +99,10 @@ function startReq() {
 }
 
 common.debug('listen proxy');
-proxy.listen(PROXY_PORT, startReq);
+proxy.listen(PROXY_PORT, 'localhost', startReq);
 
 common.debug('listen backend');
-backend.listen(BACKEND_PORT, startReq);
+backend.listen(BACKEND_PORT, 'localhost', startReq);
 
 process.on('exit', function() {
   assert.equal(body, 'hello world\n');

--- a/test/simple/test-http-request-end-twice.js
+++ b/test/simple/test-http-request-end-twice.js
@@ -30,7 +30,7 @@ var server = http.Server(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end('hello world\n');
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = http.get({port: common.PORT}, function(res) {
     res.on('end', function() {
       assert.ok(!req.end());

--- a/test/simple/test-http-request-end.js
+++ b/test/simple/test-http-request-end.js
@@ -40,7 +40,7 @@ var server = http.Server(function(req, res) {
   res.end('hello world\n');
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.request({
     port: common.PORT,
     path: '/',

--- a/test/simple/test-http-request-methods.js
+++ b/test/simple/test-http-request-methods.js
@@ -39,7 +39,7 @@ var http = require('http');
     res.write('world\n');
     res.end();
   });
-  server.listen(port);
+  server.listen(port, 'localhost');
 
   server.on('listening', function() {
     var c = net.createConnection(port);

--- a/test/simple/test-http-res-write-end-dont-take-array.js
+++ b/test/simple/test-http-res-write-end-dont-take-array.js
@@ -51,7 +51,7 @@ var server = http.createServer(function(req, res) {
   }
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // just make a request, other tests handle responses
   http.get({port: common.PORT}, function() {
     // lazy serial test, becuase we can only call end once per request

--- a/test/simple/test-http-response-close.js
+++ b/test/simple/test-http-response-close.js
@@ -39,7 +39,7 @@ var server = http.createServer(function(req, res) {
     responseGotEnd = true;
   });
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   console.error('make req');

--- a/test/simple/test-http-response-no-headers.js
+++ b/test/simple/test-http-response-no-headers.js
@@ -46,7 +46,7 @@ function test(httpVersion, callback) {
     });
   });
 
-  server.listen(common.PORT, '127.0.0.1', function() {
+  server.listen(common.PORT, 'localhost', '127.0.0.1', function() {
     var options = {
       host: '127.0.0.1',
       port: common.PORT

--- a/test/simple/test-http-response-readable.js
+++ b/test/simple/test-http-response-readable.js
@@ -28,7 +28,7 @@ var testServer = new http.Server(function(req, res) {
   res.end('Hello world');
 });
 
-testServer.listen(common.PORT, function() {
+testServer.listen(common.PORT, 'localhost', function() {
   http.get({ port: common.PORT }, function(res) {
     assert.equal(res.readable, true, 'res.readable initially true');
     res.on('end', function() {

--- a/test/simple/test-http-server-multiheaders.js
+++ b/test/simple/test-http-server-multiheaders.js
@@ -42,7 +42,7 @@ var srv = http.createServer(function(req, res) {
   srv.close();
 });
 
-srv.listen(common.PORT, function() {
+srv.listen(common.PORT, 'localhost', function() {
   http.get({
     host: 'localhost',
     port: common.PORT,

--- a/test/simple/test-http-server.js
+++ b/test/simple/test-http-server.js
@@ -67,7 +67,7 @@ var server = http.createServer(function(req, res) {
   }, 1);
 
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.httpAllowHalfOpen = true;
 

--- a/test/simple/test-http-set-cookies.js
+++ b/test/simple/test-http-set-cookies.js
@@ -37,7 +37,7 @@ var server = http.createServer(function(req, res) {
     res.end('two\n');
   }
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   //

--- a/test/simple/test-http-set-timeout.js
+++ b/test/simple/test-http-set-timeout.js
@@ -34,7 +34,7 @@ var server = http.createServer(function(req, res) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   console.log('Server running at http://127.0.0.1:' + common.PORT + '/');
 
   var errorTimer = setTimeout(function() {

--- a/test/simple/test-http-set-trailers.js
+++ b/test/simple/test-http-set-trailers.js
@@ -31,7 +31,7 @@ var server = http.createServer(function(req, res) {
   res.addTrailers({'x-foo': 'bar'});
   res.end('stuff' + '\n');
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 
 // first, we test an HTTP/1.0 request.

--- a/test/simple/test-http-should-keep-alive.js
+++ b/test/simple/test-http-should-keep-alive.js
@@ -46,7 +46,7 @@ var responses = 0;
 var server = net.createServer(function(socket) {
   socket.write(SERVER_RESPONSES[requests]);
   ++requests;
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   function makeRequest() {
     var req = http.get({port: common.PORT}, function(res) {
       assert.equal(req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],

--- a/test/simple/test-http-status-code.js
+++ b/test/simple/test-http-status-code.js
@@ -41,7 +41,7 @@ var s = http.createServer(function(req, res) {
   res.end('hello world\n');
 });
 
-s.listen(common.PORT, nextTest);
+s.listen(common.PORT, 'localhost', nextTest);
 
 
 function nextTest() {

--- a/test/simple/test-http-timeout.js
+++ b/test/simple/test-http-timeout.js
@@ -33,7 +33,7 @@ var server = http.createServer(function(req, res) {
 
 var agent = new http.Agent({maxSockets: 1});
 
-server.listen(port, function() {
+server.listen(port, 'localhost', function() {
 
   for (var i = 0; i < 11; ++i) {
     createRequest().end();

--- a/test/simple/test-http-upgrade-agent.js
+++ b/test/simple/test-http-upgrade-agent.js
@@ -50,7 +50,7 @@ var srv = net.createServer(function(c) {
 
 var gotUpgrade = false;
 
-srv.listen(common.PORT, '127.0.0.1', function() {
+srv.listen(common.PORT, 'localhost', '127.0.0.1', function() {
 
   var options = {
     port: common.PORT,

--- a/test/simple/test-http-upgrade-client.js
+++ b/test/simple/test-http-upgrade-client.js
@@ -50,7 +50,7 @@ var srv = net.createServer(function(c) {
 
 var gotUpgrade = false;
 
-srv.listen(common.PORT, '127.0.0.1', function() {
+srv.listen(common.PORT, 'localhost', '127.0.0.1', function() {
 
   var req = http.get({ port: common.PORT });
   req.on('upgrade', function(res, socket, upgradeHead) {

--- a/test/simple/test-http-upgrade-client2.js
+++ b/test/simple/test-http-upgrade-client2.js
@@ -37,7 +37,7 @@ server.on('upgrade', function(req, socket, head) {
 
 var successCount = 0;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
 
   function upgradeRequest(fn) {
     console.log('req');

--- a/test/simple/test-http-upgrade-server.js
+++ b/test/simple/test-http-upgrade-server.js
@@ -169,7 +169,7 @@ function test_standard_http() {
 
 var server = createTestServer();
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // All tests get chained after this:
   test_upgrade_with_listener(server);
 });

--- a/test/simple/test-http-upgrade-server2.js
+++ b/test/simple/test-http-upgrade-server2.js
@@ -46,7 +46,7 @@ process.on('uncaughtException', function(e) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = net.createConnection(common.PORT);
 
   c.on('connect', function() {

--- a/test/simple/test-http-url.parse-auth-with-header-in-request.js
+++ b/test/simple/test-http-url.parse-auth-with-header-in-request.js
@@ -44,7 +44,7 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   http.request(testURL).end();
 });

--- a/test/simple/test-http-url.parse-auth.js
+++ b/test/simple/test-http-url.parse-auth.js
@@ -40,7 +40,7 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   http.request(testURL).end();
 });

--- a/test/simple/test-http-url.parse-basic.js
+++ b/test/simple/test-http-url.parse-basic.js
@@ -45,7 +45,7 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   var clientRequest = http.request(testURL);
   // since there is a little magic with the agent

--- a/test/simple/test-http-url.parse-https.request.js
+++ b/test/simple/test-http-url.parse-https.request.js
@@ -47,7 +47,7 @@ var server = https.createServer(httpsOptions, function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   var clientRequest = https.request(testURL);
   // since there is a little magic with the agent

--- a/test/simple/test-http-url.parse-path.js
+++ b/test/simple/test-http-url.parse-path.js
@@ -39,7 +39,7 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   http.request(testURL).end();
 });

--- a/test/simple/test-http-url.parse-post.js
+++ b/test/simple/test-http-url.parse-post.js
@@ -46,7 +46,7 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   http.request(testURL).end();
 });

--- a/test/simple/test-http-url.parse-search.js
+++ b/test/simple/test-http-url.parse-search.js
@@ -40,7 +40,7 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   // make the request
   http.request(testURL).end();
 });

--- a/test/simple/test-http-wget.js
+++ b/test/simple/test-http-wget.js
@@ -49,7 +49,7 @@ var server = http.createServer(function(req, res) {
   res.write('world\n');
   res.end();
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   var c = net.createConnection(common.PORT);

--- a/test/simple/test-http-write-empty-string.js
+++ b/test/simple/test-http-write-empty-string.js
@@ -44,7 +44,7 @@ process.on('exit', function() {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.get({ port: common.PORT }, function(res) {
     assert.equal(200, res.statusCode);
     res.setEncoding('ascii');

--- a/test/simple/test-http.js
+++ b/test/simple/test-http.js
@@ -61,7 +61,7 @@ var server = http.Server(function(req, res) {
 
   //assert.equal('127.0.0.1', res.connection.remoteAddress);
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   var agent = new http.Agent({ port: common.PORT, maxSockets: 1 });

--- a/test/simple/test-https-agent.js
+++ b/test/simple/test-https-agent.js
@@ -48,7 +48,7 @@ var responses = 0;
 var N = 10;
 var M = 10;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   for (var i = 0; i < N; i++) {
     setTimeout(function() {
       for (var j = 0; j < M; j++) {

--- a/test/simple/test-https-client-reject.js
+++ b/test/simple/test-https-client-reject.js
@@ -41,7 +41,7 @@ var server = https.createServer(options, function(req, res) {
   ++reqCount;
   res.writeHead(200);
   res.end();
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   unauthorized();
 });
 

--- a/test/simple/test-https-connecting-to-http.js
+++ b/test/simple/test-https-connecting-to-http.js
@@ -44,7 +44,7 @@ var server = http.createServer(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = https.get({ port: common.PORT }, function(res) {
     resCount++;
   });

--- a/test/simple/test-https-drain.js
+++ b/test/simple/test-https-drain.js
@@ -44,7 +44,7 @@ var server = https.createServer(options, function(req, res) {
   req.pipe(res);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var resumed = false;
   var req = https.request({
     port: common.PORT,

--- a/test/simple/test-https-eof-for-eom.js
+++ b/test/simple/test-https-eof-for-eom.js
@@ -72,7 +72,7 @@ var gotHeaders = false;
 var gotEnd = false;
 var bodyBuffer = '';
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   console.log('1) Making Request');
   var req = https.get({ port: common.PORT }, function(res) {
     server.close();

--- a/test/simple/test-https-foafssl.js
+++ b/test/simple/test-https-foafssl.js
@@ -61,7 +61,7 @@ var server = https.createServer(options, function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var cmd = 'curl --insecure https://127.0.0.1:' + common.PORT + '/';
   cmd += ' --cert ' + join(common.fixturesDir, 'foafssl.crt');
   cmd += ' --key ' + join(common.fixturesDir, 'foafssl.key');

--- a/test/simple/test-https-invalid-key.js
+++ b/test/simple/test-https-invalid-key.js
@@ -46,7 +46,7 @@ server.on('clientError', function(err) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var req = https.get({port: common.PORT}, function(res) {
     assert(false);
   });

--- a/test/simple/test-https-localaddress.js
+++ b/test/simple/test-https-localaddress.js
@@ -44,7 +44,7 @@ var server = https.createServer(options, function (req, res) {
   });
 });
 
-server.listen(common.PORT, "127.0.0.1", function() {
+server.listen(common.PORT, 'localhost', "127.0.0.1", function() {
   var options = { host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/simple/test-https-simple.js
+++ b/test/simple/test-https-simple.js
@@ -51,7 +51,7 @@ var server = https.createServer(options, function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var cmd = 'curl --insecure https://127.0.0.1:' + common.PORT + '/';
   console.error('executing %j', cmd);
   exec(cmd, function(err, stdout, stderr) {

--- a/test/simple/test-https-socket-options.js
+++ b/test/simple/test-https-socket-options.js
@@ -52,7 +52,7 @@ var server_http = http.createServer(function(req, res) {
 });
 
 
-server_http.listen(common.PORT, function() {
+server_http.listen(common.PORT, 'localhost', function() {
   var req = http.request({ port: common.PORT }, function(res) {
     server_http.close();
   });
@@ -71,8 +71,8 @@ var server_https = https.createServer(options, function(req, res) {
   res.end(body);
 });
 
-server_https.listen(common.PORT+1, function() {
-  var req = https.request({ port: common.PORT+1 }, function(res) {
+server_https.listen(common.PORT + 1, 'localhost', function() {
+  var req = https.request({ port: common.PORT + 1 }, function(res) {
     server_https.close();
   });
   // These methods should exist on the request and get passed down to the socket

--- a/test/simple/test-https-timeout.js
+++ b/test/simple/test-https-timeout.js
@@ -38,7 +38,7 @@ var options = {
 // a server that never replies
 var server = https.createServer(options, function() {
   console.log('Got request.  Doing nothing.');
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   var req = https.request({
     host: 'localhost',
     port: common.PORT,

--- a/test/simple/test-listen-fd-cluster.js
+++ b/test/simple/test-listen-fd-cluster.js
@@ -88,7 +88,7 @@ function parent() {
   var server = net.createServer(function(conn) {
     console.error('connection on parent');
     conn.end('hello from parent\n');
-  }).listen(PORT, function() {
+  }).listen(PORT, 'localhost', function() {
     console.error('server listening on %d', PORT);
 
     var spawn = require('child_process').spawn;

--- a/test/simple/test-listen-fd-detached-inherit.js
+++ b/test/simple/test-listen-fd-detached-inherit.js
@@ -86,7 +86,7 @@ function parent() {
   var server = net.createServer(function(conn) {
     throw new Error('Should not see connections on parent');
     conn.end('HTTP/1.1 403 Forbidden\r\n\r\nI got problems.\r\n');
-  }).listen(PORT, function() {
+  }).listen(PORT, 'localhost', function() {
     console.error('server listening on %d', PORT);
 
     var child = spawn(process.execPath, [__filename, 'child'], {

--- a/test/simple/test-listen-fd-detached.js
+++ b/test/simple/test-listen-fd-detached.js
@@ -84,7 +84,7 @@ function parent() {
   var server = net.createServer(function(conn) {
     console.error('connection on parent');
     conn.end('hello from parent\n');
-  }).listen(PORT, function() {
+  }).listen(PORT, 'localhost', function() {
     console.error('server listening on %d', PORT);
 
     var spawn = require('child_process').spawn;

--- a/test/simple/test-listen-fd-server.js
+++ b/test/simple/test-listen-fd-server.js
@@ -95,7 +95,7 @@ function parent() {
   var server = net.createServer(function(conn) {
     console.error('connection on parent');
     conn.end('hello from parent\n');
-  }).listen(PORT, function() {
+  }).listen(PORT, 'localhost', function() {
     console.error('server listening on %d', PORT);
 
     var spawn = require('child_process').spawn;

--- a/test/simple/test-net-after-close.js
+++ b/test/simple/test-net-after-close.js
@@ -28,7 +28,7 @@ var server = net.createServer(function(s) {
   s.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = net.createConnection(common.PORT);
   c.on('close', function() {
     assert.strictEqual(c._handle, null);

--- a/test/simple/test-net-binary.js
+++ b/test/simple/test-net-binary.js
@@ -50,7 +50,7 @@ var echoServer = net.Server(function(connection) {
     connection.end();
   });
 });
-echoServer.listen(common.PORT);
+echoServer.listen(common.PORT, 'localhost');
 
 var recv = '';
 

--- a/test/simple/test-net-bind-twice.js
+++ b/test/simple/test-net-bind-twice.js
@@ -34,10 +34,10 @@ function dontCall() {
 }
 
 var server1 = net.createServer(dontCall);
-server1.listen(common.PORT, '127.0.0.1', function() {});
+server1.listen(common.PORT, 'localhost', '127.0.0.1', function() {});
 
 var server2 = net.createServer(dontCall);
-server2.listen(common.PORT, '127.0.0.1', dontCall);
+server2.listen(common.PORT, 'localhost', '127.0.0.1', dontCall);
 
 server2.on('error', function(e) {
   assert.equal(e.code, 'EADDRINUSE');

--- a/test/simple/test-net-bytes-stats.js
+++ b/test/simple/test-net-bytes-stats.js
@@ -40,7 +40,7 @@ var tcp = net.Server(function(s) {
   });
 });
 
-tcp.listen(common.PORT, function() {
+tcp.listen(common.PORT, 'localhost', function() {
   var socket = net.createConnection(tcpPort);
 
   socket.on('connect', function() {

--- a/test/simple/test-net-can-reset-timeout.js
+++ b/test/simple/test-net-can-reset-timeout.js
@@ -43,7 +43,7 @@ var server = net.createServer(function(stream) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = net.createConnection(common.PORT);
 
   c.on('data', function() {

--- a/test/simple/test-net-connect-buffer.js
+++ b/test/simple/test-net-connect-buffer.js
@@ -49,7 +49,7 @@ var tcp = net.Server(function(s) {
   });
 });
 
-tcp.listen(common.PORT, function() {
+tcp.listen(common.PORT, 'localhost', function() {
   var socket = net.Stream();
 
   console.log('Connecting to socket ');

--- a/test/simple/test-net-connect-options.js
+++ b/test/simple/test-net-connect-options.js
@@ -33,7 +33,7 @@ var server = net.createServer({allowHalfOpen: true}, function(socket) {
   socket.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = net.connect({
     host: '127.0.0.1',
     port: common.PORT,

--- a/test/simple/test-net-during-close.js
+++ b/test/simple/test-net-during-close.js
@@ -28,7 +28,7 @@ var server = net.createServer(function(socket) {
   socket.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = net.createConnection(common.PORT);
   server.close();
   // server connection event has not yet fired

--- a/test/simple/test-net-eaddrinuse.js
+++ b/test/simple/test-net-eaddrinuse.js
@@ -27,9 +27,9 @@ var server1 = net.createServer(function(socket) {
 });
 var server2 = net.createServer(function(socket) {
 });
-server1.listen(common.PORT);
+server1.listen(common.PORT, 'localhost');
 server2.on('error', function(error) {
   assert.equal(true, error.message.indexOf('EADDRINUSE') >= 0);
   server1.close();
 });
-server2.listen(common.PORT);
+server2.listen(common.PORT, 'localhost');

--- a/test/simple/test-net-keepalive.js
+++ b/test/simple/test-net-keepalive.js
@@ -34,7 +34,7 @@ var echoServer = net.createServer(function(connection) {
     connection.end();
   });
 });
-echoServer.listen(common.PORT);
+echoServer.listen(common.PORT, 'localhost');
 
 echoServer.on('listening', function() {
   var clientConnection = net.createConnection(common.PORT);

--- a/test/simple/test-net-large-string.js
+++ b/test/simple/test-net-large-string.js
@@ -41,7 +41,7 @@ var server = net.createServer(function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = net.createConnection(common.PORT);
   client.on('end', function() {
     server.close();

--- a/test/simple/test-net-reconnect.js
+++ b/test/simple/test-net-reconnect.js
@@ -44,7 +44,7 @@ var server = net.createServer(function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   console.log('listening');
   var client = net.createConnection(common.PORT);
 

--- a/test/simple/test-net-remote-address-port.js
+++ b/test/simple/test-net-remote-address-port.js
@@ -36,7 +36,7 @@ var server = net.createServer(function(socket) {
   });
 });
 
-server.listen(common.PORT, 'localhost', function() {
+server.listen(common.PORT, 'localhost', 'localhost', function() {
   var client = net.createConnection(common.PORT, 'localhost');
   var client2 = net.createConnection(common.PORT);
   client.on('connect', function() {

--- a/test/simple/test-net-server-address.js
+++ b/test/simple/test-net-server-address.js
@@ -32,7 +32,7 @@ server_ipv4.on('error', function(e) {
   console.log('Error on ipv4 socket: ' + e.toString());
 });
 
-server_ipv4.listen(common.PORT, localhost_ipv4, function() {
+server_ipv4.listen(common.PORT, 'localhost', localhost_ipv4, function() {
   var address_ipv4 = server_ipv4.address();
   assert.strictEqual(address_ipv4.address, localhost_ipv4);
   assert.strictEqual(address_ipv4.port, common.PORT);
@@ -49,7 +49,7 @@ server_ipv6.on('error', function(e) {
   console.log('Error on ipv6 socket: ' + e.toString());
 });
 
-server_ipv6.listen(common.PORT, localhost_ipv6, function() {
+server_ipv6.listen(common.PORT, 'localhost', localhost_ipv6, function() {
   var address_ipv6 = server_ipv6.address();
   assert.strictEqual(address_ipv6.address, localhost_ipv6);
   assert.strictEqual(address_ipv6.port, common.PORT);

--- a/test/simple/test-net-server-bind.js
+++ b/test/simple/test-net-server-bind.js
@@ -41,7 +41,7 @@ server0.listen(function() {
 var address1;
 var server1 = net.createServer(function(socket) { });
 
-server1.listen(common.PORT);
+server1.listen(common.PORT, 'localhost');
 
 setTimeout(function() {
   address1 = server1.address();
@@ -55,7 +55,7 @@ setTimeout(function() {
 var address2;
 var server2 = net.createServer(function(socket) { });
 
-server2.listen(common.PORT + 1, function() {
+server2.listen(common.PORT + 1, 'localhost', function() {
   address2 = server2.address();
   console.log('address2 %j', address2);
   server2.close();
@@ -67,7 +67,7 @@ server2.listen(common.PORT + 1, function() {
 var address3;
 var server3 = net.createServer(function(socket) { });
 
-server3.listen(common.PORT + 2, '0.0.0.0', 127, function() {
+server3.listen(common.PORT + 2, 'localhost', 127, function() {
   address3 = server3.address();
   console.log('address3 %j', address3);
   server3.close();
@@ -79,7 +79,7 @@ server3.listen(common.PORT + 2, '0.0.0.0', 127, function() {
 var address4;
 var server4 = net.createServer(function(socket) { });
 
-server4.listen(common.PORT + 3, 127, function() {
+server4.listen(common.PORT + 3, 'localhost', 127, function() {
   address4 = server4.address();
   console.log('address4 %j', address4);
   server4.close();

--- a/test/simple/test-net-server-close.js
+++ b/test/simple/test-net-server-close.js
@@ -48,7 +48,7 @@ server.on('close', function() {
   events.push('server');
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   net.createConnection(common.PORT);
   net.createConnection(common.PORT);
 });

--- a/test/simple/test-net-server-listen-remove-callback.js
+++ b/test/simple/test-net-server-listen-remove-callback.js
@@ -32,12 +32,12 @@ server.on('close', function() {
   assert.equal(0, listeners.length);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   server.close();
 });
 
 server.once('close', function() {
-  server.listen(common.PORT + 1, function() {
+  server.listen(common.PORT + 1, 'localhost', function() {
     server.close();
   });
 });

--- a/test/simple/test-net-server-max-connections.js
+++ b/test/simple/test-net-server-max-connections.js
@@ -41,7 +41,7 @@ var server = net.createServer(function(connection) {
   waits.push(function() { connection.end(); });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   makeConnection(0);
 });
 

--- a/test/simple/test-net-server-try-ports.js
+++ b/test/simple/test-net-server-try-ports.js
@@ -47,18 +47,18 @@ server2.on('error', function() {
 });
 
 
-server1.listen(common.PORT, function() {
+server1.listen(common.PORT, 'localhost', function() {
   console.error('server1 listening');
   server1listening = true;
   // This should make server2 emit EADDRINUSE
-  server2.listen(common.PORT);
+  server2.listen(common.PORT, 'localhost');
 
   // Wait a bit, now try again.
   // TODO, the listen callback should report if there was an error.
   // Then we could avoid this very unlikely but potential race condition
   // here.
   setTimeout(function() {
-    server2.listen(common.PORT + 1, function() {
+    server2.listen(common.PORT + 1, 'localhost', function() {
       console.error('server2 listening');
       server2listening = true;
 

--- a/test/simple/test-net-settimeout.js
+++ b/test/simple/test-net-settimeout.js
@@ -31,7 +31,7 @@ var T = 100;
 var server = net.createServer(function(c) {
   c.write('hello');
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 var socket = net.createConnection(common.PORT, 'localhost');
 

--- a/test/simple/test-net-socket-timeout.js
+++ b/test/simple/test-net-socket-timeout.js
@@ -26,7 +26,7 @@ var assert = require('assert');
 var timedout = false;
 
 var server = net.Server();
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var socket = net.createConnection(common.PORT);
   socket.setTimeout(100, function() {
     timedout = true;

--- a/test/simple/test-net-write-after-close.js
+++ b/test/simple/test-net-write-after-close.js
@@ -44,7 +44,7 @@ var server = net.createServer(function(socket) {
   }, 250);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = net.connect(common.PORT, function() {
     client.end();
   });

--- a/test/simple/test-net-write-connect-write.js
+++ b/test/simple/test-net-write-connect-write.js
@@ -27,7 +27,7 @@ var received = '';
 
 var server = net.createServer(function(socket) {
   socket.pipe(socket);
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   var conn = net.connect(common.PORT);
   conn.setEncoding('utf8');
   conn.write('before');

--- a/test/simple/test-net-write-slow.js
+++ b/test/simple/test-net-write-slow.js
@@ -48,7 +48,7 @@ var server = net.createServer(function(socket) {
   }
   socket.end();
 
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   var conn = net.connect(common.PORT);
   conn.on('data', function(buf) {
     received += buf.length;

--- a/test/simple/test-pipe-file-to-http.js
+++ b/test/simple/test-pipe-file-to-http.js
@@ -55,7 +55,7 @@ var server = http.createServer(function(req, res) {
     res.end();
   });
 });
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
 server.on('listening', function() {
   var cmd = common.ddCommand(filename, 10240);

--- a/test/simple/test-pipe.js
+++ b/test/simple/test-pipe.js
@@ -71,7 +71,7 @@ var web = http.Server(function(req, res) {
     process.exit(1);
   });
 });
-web.listen(webPort, startClient);
+web.listen(webPort, 'localhost', startClient);
 
 
 
@@ -101,7 +101,7 @@ var tcp = net.Server(function(s) {
     process.exit(1);
   });
 });
-tcp.listen(tcpPort, startClient);
+tcp.listen(tcpPort, 'localhost', startClient);
 
 
 function startClient() {

--- a/test/simple/test-pump-file2tcp-noexist.js
+++ b/test/simple/test-pump-file2tcp-noexist.js
@@ -45,7 +45,7 @@ var server = net.createServer(function(stream) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var conn = net.createConnection(common.PORT);
   conn.setEncoding('utf8');
   conn.on('data', function(chunk) {

--- a/test/simple/test-pump-file2tcp.js
+++ b/test/simple/test-pump-file2tcp.js
@@ -38,7 +38,7 @@ var server = net.createServer(function(stream) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var conn = net.createConnection(common.PORT);
   conn.setEncoding('utf8');
   conn.on('data', function(chunk) {

--- a/test/simple/test-regress-GH-1531.js
+++ b/test/simple/test-regress-GH-1531.js
@@ -41,7 +41,7 @@ var server = https.createServer(options, function(req, res) {
   res.end('hello world\n');
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   https.get({
     path: '/',
     port: common.PORT,

--- a/test/simple/test-regress-GH-746.js
+++ b/test/simple/test-regress-GH-746.js
@@ -37,7 +37,7 @@ var server = net.createServer(function(socket) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   console.log('listening...');
 
   net.createConnection(common.PORT);

--- a/test/simple/test-regress-GH-784.js
+++ b/test/simple/test-regress-GH-784.js
@@ -53,7 +53,7 @@ server.on('listening', pingping);
 
 function serverOn() {
   console.error('Server ON');
-  server.listen(common.PORT);
+  server.listen(common.PORT, 'localhost');
 }
 
 

--- a/test/simple/test-regress-GH-877.js
+++ b/test/simple/test-regress-GH-877.js
@@ -37,7 +37,7 @@ var server = http.createServer(function(req, res) {
 
 var addrString = '127.0.0.1:' + common.PORT;
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(common.PORT, 'localhost', '127.0.0.1', function() {
   for (var i = 0; i < N; i++) {
     var options = {
       host: '127.0.0.1',

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -169,7 +169,7 @@ function tcp_test() {
     repl.start(prompt_tcp, socket);
   });
 
-  server_tcp.listen(common.PORT, function() {
+  server_tcp.listen(common.PORT, 'localhost', function() {
     var read_buffer = '';
 
     client_tcp = net.createConnection(common.PORT);

--- a/test/simple/test-tcp-wrap-connect.js
+++ b/test/simple/test-tcp-wrap-connect.js
@@ -62,7 +62,7 @@ var server = require('net').Server(function(s) {
   });
 });
 
-server.listen(common.PORT, makeConnection);
+server.listen(common.PORT, 'localhost', makeConnection);
 
 process.on('exit', function() {
   assert.equal(1, shutdownCount);

--- a/test/simple/test-tcp-wrap-listen.js
+++ b/test/simple/test-tcp-wrap-listen.js
@@ -26,7 +26,7 @@ var TCP = process.binding('tcp_wrap').TCP;
 
 var server = new TCP();
 
-var r = server.bind('0.0.0.0', common.PORT);
+var r = server.bind('127.0.0.1', common.PORT);
 assert.equal(0, r);
 
 server.listen(128);

--- a/test/simple/test-tcp-wrap.js
+++ b/test/simple/test-tcp-wrap.js
@@ -27,11 +27,11 @@ var TCP = process.binding('tcp_wrap').TCP;
 var handle = new TCP();
 
 // Should be able to bind to the common.PORT
-var r = handle.bind('0.0.0.0', common.PORT);
+var r = handle.bind('127.0.0.1', common.PORT);
 assert.equal(0, r);
 
 // Should not be able to bind to the same port again
-var r = handle.bind('0.0.0.0', common.PORT);
+var r = handle.bind('127.0.0.1', common.PORT);
 assert.equal(-1, r);
 console.log(errno);
 assert.equal(errno, 'EINVAL');

--- a/test/simple/test-tls-client-reject.js
+++ b/test/simple/test-tls-client-reject.js
@@ -43,7 +43,7 @@ var server = tls.createServer(options, function(socket) {
     common.debug(data.toString());
     assert.equal(data, 'ok');
   });
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   unauthorized();
 });
 

--- a/test/simple/test-tls-client-resume.js
+++ b/test/simple/test-tls-client-resume.js
@@ -47,7 +47,7 @@ var server = tls.Server(options, function(socket) {
 });
 
 // start listening
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
 
   var session1 = null;
   var client1 = tls.connect({port: common.PORT}, function() {

--- a/test/simple/test-tls-client-verify.js
+++ b/test/simple/test-tls-client-verify.js
@@ -96,7 +96,7 @@ function testServers(index, servers, clientOptions, cb) {
     s.end('hello world\n');
   });
 
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, 'localhost', function() {
     var b = '';
 
     console.error('connecting...');

--- a/test/simple/test-tls-connect-given-socket.js
+++ b/test/simple/test-tls-connect-given-socket.js
@@ -37,7 +37,7 @@ var options = {
 var server = tls.createServer(options, function(socket) {
   serverConnected = true;
   socket.end('Hello');
-}).listen(common.PORT, function() {
+}).listen(common.PORT, 'localhost', function() {
   var socket = net.connect(common.PORT, function() {
     var client = tls.connect({socket: socket}, function() {
       clientConnected = true;

--- a/test/simple/test-tls-connect-simple.js
+++ b/test/simple/test-tls-connect-simple.js
@@ -38,7 +38,7 @@ var server = tls.Server(options, function(socket) {
   }
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client1 = tls.connect({port: common.PORT}, function() {
     ++clientConnected;
     client1.end();

--- a/test/simple/test-tls-getcipher.js
+++ b/test/simple/test-tls-getcipher.js
@@ -42,7 +42,7 @@ var server = tls.createServer(options, function(cleartextStream) {
   nconns++;
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(common.PORT, 'localhost', '127.0.0.1', function() {
   var client = tls.connect(common.PORT, '127.0.0.1',  function() {
     var cipher = client.getCipher();
     assert.equal(cipher.name, cipher_list[0]);

--- a/test/simple/test-tls-honorcipherorder.js
+++ b/test/simple/test-tls-honorcipherorder.js
@@ -45,7 +45,7 @@ function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
   var server = tls.createServer(soptions, function(cleartextStream) {
     nconns++;
   });
-  server.listen(common.PORT, localhost, function() {
+  server.listen(common.PORT, 'localhost', localhost, function() {
     var coptions = {secureProtocol: SSL_Method};
     if (clientCipher) {
       coptions.ciphers = clientCipher;

--- a/test/simple/test-tls-invalid-key.js
+++ b/test/simple/test-tls-invalid-key.js
@@ -46,7 +46,7 @@ server.on('clientError', function(err) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = tls.connect(common.PORT, function() {
     assert(false);
   });

--- a/test/simple/test-tls-junk-closes-server.js
+++ b/test/simple/test-tls-junk-closes-server.js
@@ -39,7 +39,7 @@ var server = tls.createServer(function(s) {
   s.pipe(s);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = net.createConnection(common.PORT);
 
   c.on('connect', function() {

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -73,7 +73,7 @@ var serverResults = [],
 var server = tls.createServer(serverOptions, function(c) {
   serverResults.push(c.npnProtocol);
 });
-server.listen(serverPort, startTest);
+server.listen(serverPort, 'localhost', startTest);
 
 function startTest() {
   function connectClient(options, callback) {

--- a/test/simple/test-tls-over-http-tunnel.js
+++ b/test/simple/test-tls-over-http-tunnel.js
@@ -98,9 +98,9 @@ var proxy = net.createServer(function(clientSocket) {
   });
 });
 
-server.listen(common.PORT);
+server.listen(common.PORT, 'localhost');
 
-proxy.listen(proxyPort, function() {
+proxy.listen(proxyPort, 'localhost', function() {
   console.log('CLIENT: Making CONNECT request');
 
   var req = http.request({

--- a/test/simple/test-tls-passphrase.js
+++ b/test/simple/test-tls-passphrase.js
@@ -45,7 +45,7 @@ var server = tls.Server({
 });
 
 var connectCount = 0;
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = tls.connect({
     port: common.PORT,
     key: key,

--- a/test/simple/test-tls-pause-close.js
+++ b/test/simple/test-tls-pause-close.js
@@ -65,7 +65,7 @@ var server = tls.createServer(options, function(s) {
   s.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var c = tls.connect({port: common.PORT}, function() {
     console.log('client connected');
     c.socket.on('end', function() {

--- a/test/simple/test-tls-pause.js
+++ b/test/simple/test-tls-pause.js
@@ -43,7 +43,7 @@ var server = tls.Server(options, function(socket) {
   socket.pipe(socket);
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var resumed = false;
   var client = tls.connect({port: common.PORT}, function() {
     client.pause();

--- a/test/simple/test-tls-peer-certificate-multi-keys.js
+++ b/test/simple/test-tls-peer-certificate-multi-keys.js
@@ -41,7 +41,7 @@ var verified = false;
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var socket = tls.connect({port: common.PORT}, function() {
     var peerCert = socket.getPeerCertificate();
     common.debug(util.inspect(peerCert));

--- a/test/simple/test-tls-peer-certificate.js
+++ b/test/simple/test-tls-peer-certificate.js
@@ -41,7 +41,7 @@ var verified = false;
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var socket = tls.connect({port: common.PORT}, function() {
     var peerCert = socket.getPeerCertificate();
     common.debug(util.inspect(peerCert));

--- a/test/simple/test-tls-remote.js
+++ b/test/simple/test-tls-remote.js
@@ -44,7 +44,7 @@ var server = tls.Server(options, function(s) {
   s.end();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(common.PORT, 'localhost', '127.0.0.1', function() {
   assert.equal(server.address().address, '127.0.0.1');
   assert.equal(server.address().port, common.PORT);
 

--- a/test/simple/test-tls-request-timeout.js
+++ b/test/simple/test-tls-request-timeout.js
@@ -41,7 +41,7 @@ var server = tls.Server(options, function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var socket = tls.connect({port: common.PORT});
 });
 

--- a/test/simple/test-tls-server-verify.js
+++ b/test/simple/test-tls-server-verify.js
@@ -272,7 +272,7 @@ function runTest(testIndex) {
     }
   }
 
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, 'localhost', function() {
     if (tcase.debug) {
       console.error('TLS server running on port ' + common.PORT);
     } else {

--- a/test/simple/test-tls-session-cache.js
+++ b/test/simple/test-tls-session-cache.js
@@ -55,7 +55,7 @@ function doTest() {
     ++requestCount;
     cleartext.end();
   });
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, 'localhost', function() {
     var client = spawn('openssl', [
       's_client',
       '-connect', 'localhost:' + common.PORT,

--- a/test/simple/test-tls-set-encoding.js
+++ b/test/simple/test-tls-set-encoding.js
@@ -40,7 +40,7 @@ var server = tls.Server(options, function(socket) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   var client = tls.connect({port: common.PORT});
 
   var buffer = '';

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -89,7 +89,7 @@ var server = tls.createServer(serverOptions, function(c) {
 server.addContext('a.example.com', SNIContexts['a.example.com']);
 server.addContext('*.test.com', SNIContexts['asterisk.test.com']);
 
-server.listen(serverPort, startTest);
+server.listen(serverPort, 'localhost', startTest);
 
 function startTest() {
   function connectClient(options, callback) {

--- a/test/simple/test-zerolengthbufferbug.js
+++ b/test/simple/test-zerolengthbufferbug.js
@@ -36,7 +36,7 @@ var server = http.createServer(function(req, res) {
 var gotResponse = false;
 var resBodySize = 0;
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, 'localhost', function() {
   http.get({ port: common.PORT }, function(res) {
     gotResponse = true;
 


### PR DESCRIPTION
On source based distributions where testing is encouraged, where tests are ran under a network sandbox, that disallows binding to 0.0.0.0, the tests as is will fail.
