### PR TITLE
genv8constants is much slower than necessary due to Python pipe buffering

### DIFF
--- a/tools/genv8constants.py
+++ b/tools/genv8constants.py
@@ -17,7 +17,7 @@ if len(sys.argv) != 3:
 
 outfile = file(sys.argv[1], 'w');
 pipe = subprocess.Popen([ 'objdump', '-z', '-D', sys.argv[2] ],
-    stdout=subprocess.PIPE).stdout;
+    bufsize=-1, stdout=subprocess.PIPE).stdout;
 pattern = re.compile('00000000 <(v8dbg_.*)>:');
 numpattern = re.compile('[0-9a-fA-F]{2}');
 


### PR DESCRIPTION
For details, see:

http://docs.python.org/library/subprocess.html?highlight=subprocess.popen#subprocess.Popen

Here's the relevant bit, with emphasis added:

> _bufsize_, if given, has the same meaning as the corresponding argument
> to the built-in open() function: 0 means unbuffered, 1 means line buffered,
> any other positive value means use a buffer of (approximately) that size.
> A negative bufsize means to use the system default, which usually means
> fully buffered. **The default value for bufsize is 0 (unbuffered).**
