### PR TITLE
installer.js won't use dest_dir for looking if npmDir is a symlink

### DIFF
--- a/tools/installer.js
+++ b/tools/installer.js
@@ -130,7 +130,7 @@ if (cmd === 'install') {
     // a bit annoying.  If it's a symlink, skip it.
     var isSymlink = false;
     var exists = true;
-    var npmDir = path.resolve(node_prefix, 'lib/node_modules/npm');
+    var npmDir = path.join(dest_dir, node_prefix, 'lib/node_modules/npm');
     try {
       var st = fs.lstatSync(npmDir);
       isSymlink = st.isSymbolicLink();


### PR DESCRIPTION
DESTDIR on make install will not get used on finding out, if npm is a symlink. Installer.js will always use the predefined /usr/lib/node_modules/npm, which isn't the expected behavior.
