### PR TITLE
https: do not inherit options in createConnection

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -53,7 +53,7 @@ exports.createServer = function(opts, requestListener) {
 // HTTPS agents.
 
 function createConnection(/* [port, host, options] */) {
-  var options = util._extend({}, this.options);
+  var options = {};
 
   if (typeof arguments[0] === 'object') {
     options = util._extend(options, arguments[0]);


### PR DESCRIPTION
2b3ba3f538e9ff22cdb4172799ee38d06818165f causes the test failure as

```
$./node test/simple/test-https-pfx.js

assert.js:104
  throw new assert.AssertionError({
        ^
AssertionError: "DEPTH_ZERO_SELF_SIGNED_CERT" == "UNABLE_TO_GET_ISSUER_CERT"
    at Server.<anonymous> (/home/ohtsu/tmp/github/node/test/simple/test-https-pfx.js:40:10)
    at Server.EventEmitter.emit (events.js:91:17)
    at HTTPParser.parser.onIncoming (http.js:1792:12)
    at HTTPParser.parserOnHeadersComplete [as onHeadersComplete] (http.js:111:23)
    at CleartextStream.socket.ondata (http.js:1689:22)
    at CleartextStream.CryptoStream._push (tls.js:427:27)
    at SecurePair.cycle (tls.js:781:20)
    at EncryptedStream.CryptoStream.write (tls.js:168:13)
    at Socket.ondata (stream.js:38:26)
    at Socket.EventEmitter.emit (events.js:88:17)
```

In case of using globalAgent, tls.connect() must accept only host and port options. Options must not be inherited from this.options.
