### PR TITLE
zlib: emit "close" if Z_STREAM_END occurs.

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -392,7 +392,7 @@ Zlib.prototype._process = function() {
   req.callback = callback;
   this._processing = req;
 
-  function callback(availInAfter, availOutAfter, buffer) {
+  function callback(err, availInAfter, availOutAfter, buffer) {
     if (self._hadError) return;
 
     var have = availOutBefore - availOutAfter;
@@ -438,6 +438,10 @@ Zlib.prototype._process = function() {
     self._processing = false;
     if (cb) cb();
     self._process();
+
+    if (err == binding.Z_STREAM_END) {
+      self.emit('close');
+    }
   }
 };
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -346,7 +346,6 @@ Zlib.prototype.end = function end(chunk, cb) {
   var self = this;
   this._ending = true;
   var ret = this.write(chunk, function() {
-    self.emit('end');
     if (cb) cb();
   });
   this._ended = true;
@@ -440,7 +439,7 @@ Zlib.prototype._process = function() {
     self._process();
 
     if (err == binding.Z_STREAM_END) {
-      self.emit('close');
+      self.emit('end');
     }
   }
 };

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -211,7 +211,8 @@ class ZCtx : public ObjectWrap {
     // call the write() cb
     assert(ctx->handle_->Get(callback_sym)->IsFunction() &&
            "Invalid callback");
-    Local<Value> args[2] = { avail_in, avail_out };
+    Local<Value> args[3] = { Local<Value>::New(Number::New(ctx->err_)),
+                             avail_in, avail_out };
     MakeCallback(ctx->handle_, callback_sym, ARRAY_SIZE(args), args);
 
     ctx->Unref();


### PR DESCRIPTION
In src/node_zlib.cc, Z_OK, Z_STREAM_END and Z_BUF_ERROR has been ignored because they are considered normal statuses.

But Z_STREAM_END must be handled. Even if zlib does not end when it meets Z_STREAM_END, it should at least tell user so that user can stop it.

(Actaully, I believe "end" is better than "close" for this case, but emitting "end" may cause exception because zlib does not allow to write something to itself if zlib._ended is true.)
