### PR TITLE
Auto-detect hardfloat eabi and armv7 variables on ARM based on compiler

### DIFF
--- a/configure
+++ b/configure
@@ -169,7 +169,6 @@ parser.add_option("--with-arm-float-abi",
     dest="arm_float_abi",
     help="Specifies which floating-point ABI to use. Valid values are: soft, softfp, hard")
 
-
 (options, args) = parser.parse_args()
 
 

--- a/configure
+++ b/configure
@@ -164,9 +164,9 @@ parser.add_option("--no-ifaddrs",
     dest="no_ifaddrs",
     help="Use on deprecated SunOS systems that do not support ifaddrs.h")
 
-parser.add_option("--with-float-abi",
+parser.add_option("--with-arm-float-abi",
     action="store",
-    dest="float_abi",
+    dest="arm_float_abi",
     help="Specifies which floating-point ABI to use. Valid values are: soft, softfp, hard")
 
 
@@ -193,6 +193,7 @@ def pkg_config(pkg):
   if (ret): return None
 
   return (libs, cflags)
+
 
 def cc_macros():
   """Checks predefined macros using the CC command."""
@@ -226,13 +227,15 @@ def cc_macros():
       k[key] = val
   return k
 
-def arm_arch_arm7():
+
+def is_arch_armv7():
   """Check for ARMv7 instructions"""
   cc_macros_cache = cc_macros()
-  return "__ARM_ARCH_7__" in cc_macros_cache or \
-        "__ARM_ARCH_7A__" in cc_macros_cache or \
-        "__ARM_ARCH_7R__" in cc_macros_cache or \
-        "__ARM_ARCH_7M__" in cc_macros_cache
+  return '__ARM_ARCH_7__' in cc_macros_cache or \
+        '__ARM_ARCH_7A__' in cc_macros_cache or \
+        '__ARM_ARCH_7R__' in cc_macros_cache or \
+        '__ARM_ARCH_7M__' in cc_macros_cache
+
 
 def arm_hard_float_abi():
   """Check for hardfloat or softfloat eabi on ARM"""
@@ -244,22 +247,23 @@ def arm_hard_float_abi():
   # GCC versions 4.5 may support hard-fp without defining __ARM_PCS or
   # __ARM_PCS_VFP.
 
-
-  if compiler_version() >= [False, 4, 6, 0]:
+  if compiler_version() >= (4, 6, 0):
     return "__ARM_PCS_VFP" in cc_macros()
-  elif compiler_version() < [False, 4, 5, 0]:
+  elif compiler_version() < (4, 5, 0):
+    return False
+  elif "__ARM_PCS_VFP" in cc_macros():
+    return True
+  elif "__ARM_PCS" in cc_macros() or "__SOFTFP" in cc_macros() or not "__VFP_FP__" in cc_macros():
     return False
   else:
-    if "__ARM_PCS_VFP" in cc_macros():
-      return True
-    elif "__ARM_PCS" in cc_macros() or "__SOFTFP" in cc_macros() or not "__VFP_FP__" in cc_macros():
-      return False
-    else:
-      print '''Node.js configure error: Your version of GCC does not report the FP ABI compiled for
+    print '''Node.js configure error: Your version of GCC does not report
+      the Floating-Point ABI to compile for your hardware
 
-        Please manually specify which floating-point ABI to use with the --with-float-abi option. 
-        '''
-      sys.exit()
+      Please manually specify which floating-point ABI to use with the 
+      --with-arm-float-abi option. 
+      '''
+    sys.exit()
+
 
 def host_arch_cc():
   """Host architecture check using the CC command."""
@@ -326,8 +330,12 @@ def configure_node(o):
   # V8 on ARM requires that armv7 is set. CPU Model detected by 
   # the presence of __ARM_ARCH_7__ and the like defines in compiler
   if target_arch == 'arm':
-    o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard") if options.float_abi else b(arm_hard_float_abi())
-    o['variables']['armv7'] = 1 if arm_arch_arm7() else 0
+    if options.arm_float_abi:
+      hard_float = b(options.arm_float_abi == 'hard')
+    else:
+      hard_float = b(arm_hard_float_abi())
+    o['variables']['v8_use_arm_eabi_hardfloat'] = hard_float
+    o['variables']['armv7'] = 1 if is_arch_armv7() else 0
 
   # clang has always supported -fvisibility=hidden, right?
   cc_version, is_clang = compiler_version()
@@ -373,8 +381,6 @@ def configure_libz(o):
 def configure_v8(o):
   o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
   o['variables']['node_shared_v8'] = b(options.shared_v8)
-
-  
 
   # assume shared_v8 if one of these is set?
   if options.shared_v8_libpath:

--- a/configure
+++ b/configure
@@ -323,9 +323,8 @@ def configure_node(o):
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
 
-  # V8 on ARM requires that armv7 is set. We don't have a good way to detect
-  # the CPU model right now so we pick a default and hope that it works okay
-  # for the majority of users.
+  # V8 on ARM requires that armv7 is set. CPU Model detected by 
+  # the presence of __ARM_ARCH_7__ and the like defines in compiler
   if target_arch == 'arm':
     if options.float_abi:
       o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")

--- a/configure
+++ b/configure
@@ -326,10 +326,7 @@ def configure_node(o):
   # V8 on ARM requires that armv7 is set. CPU Model detected by 
   # the presence of __ARM_ARCH_7__ and the like defines in compiler
   if target_arch == 'arm':
-    if options.float_abi:
-      o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")
-    else:
-      o['variables']['v8_use_arm_eabi_hardfloat'] = b(arm_hard_float_abi())
+    o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard") if options.float_abi else b(arm_hard_float_abi())
     o['variables']['armv7'] = 1 if arm_arch_arm7() else 0
 
   # clang has always supported -fvisibility=hidden, right?

--- a/configure
+++ b/configure
@@ -245,9 +245,9 @@ def arm_hard_float_abi():
   # __ARM_PCS_VFP.
 
 
-  if cc_version() >= [False, 4, 6, 0]:
+  if compiler_version() >= [False, 4, 6, 0]:
     return "__ARM_PCS_VFP" in cc_macros()
-  elif cc_version() < [False, 4, 5, 0]:
+  elif compiler_version() < [False, 4, 5, 0]:
     return False
   else:
     if "__ARM_PCS_VFP" in cc_macros():
@@ -327,7 +327,11 @@ def configure_node(o):
   # the CPU model right now so we pick a default and hope that it works okay
   # for the majority of users.
   if target_arch == 'arm':
-    o['variables']['armv7'] = 0 # FIXME
+    if options.float_abi:
+      o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")
+    else:
+      o['variables']['v8_use_arm_eabi_hardfloat'] = b(arm_hard_float_abi())
+    o['variables']['armv7'] = 1 if arm_arch_arm7() else 0
 
   # clang has always supported -fvisibility=hidden, right?
   cc_version, is_clang = compiler_version()
@@ -374,12 +378,7 @@ def configure_v8(o):
   o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
   o['variables']['node_shared_v8'] = b(options.shared_v8)
 
-  if o['variables']['target_arch'] == 'arm':
-    if options.float_abi:
-      o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")
-    else:
-      o['variables']['v8_use_arm_eabi_hardfloat'] = b(arm_hard_float_abi())
-    o['variables']['armv7'] = 1 if arm_arch_arm7() else 0
+  
 
   # assume shared_v8 if one of these is set?
   if options.shared_v8_libpath:

--- a/configure
+++ b/configure
@@ -231,10 +231,10 @@ def cc_macros():
 def is_arch_armv7():
   """Check for ARMv7 instructions"""
   cc_macros_cache = cc_macros()
-  return '__ARM_ARCH_7__' in cc_macros_cache or \
-        '__ARM_ARCH_7A__' in cc_macros_cache or \
-        '__ARM_ARCH_7R__' in cc_macros_cache or \
-        '__ARM_ARCH_7M__' in cc_macros_cache
+  return ('__ARM_ARCH_7__' in cc_macros_cache or
+          '__ARM_ARCH_7A__' in cc_macros_cache or
+          '__ARM_ARCH_7R__' in cc_macros_cache or
+          '__ARM_ARCH_7M__' in cc_macros_cache)
 
 
 def arm_hard_float_abi():
@@ -253,9 +253,9 @@ def arm_hard_float_abi():
     return False
   elif '__ARM_PCS_VFP' in cc_macros():
     return True
-  elif '__ARM_PCS' in cc_macros() or \
-        '__SOFTFP' in cc_macros() or \
-        not '__VFP_FP__' in cc_macros():
+  elif ('__ARM_PCS' in cc_macros() or
+        '__SOFTFP' in cc_macros() or
+        not '__VFP_FP__' in cc_macros()):
     return False
   else:
     print '''Node.js configure error: Your version of GCC does not report

--- a/configure
+++ b/configure
@@ -164,6 +164,16 @@ parser.add_option("--no-ifaddrs",
     dest="no_ifaddrs",
     help="Use on deprecated SunOS systems that do not support ifaddrs.h")
 
+parser.add_option("--with-hardfloat",
+    action="store_true",
+    dest="use_hardfloat",
+    help="Use ARM EABI calling convention where double arguments are passed in VFP registers")
+
+parser.add_option("--with-armv7",
+    action="store_true",
+    dest="use_armv7",
+    help="Optimise v8 for armv7")
+
 (options, args) = parser.parse_args()
 
 
@@ -327,6 +337,11 @@ def configure_libz(o):
 def configure_v8(o):
   o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
   o['variables']['node_shared_v8'] = b(options.shared_v8)
+
+  # todo: auto-detect these variables when not cross-compiling
+  if o['variables']['target_arch'] == 'arm':
+    o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.use_hardfloat)
+    o['variables']['armv7'] = b(options.use_armv7)   
 
   # assume shared_v8 if one of these is set?
   if options.shared_v8_libpath:

--- a/configure
+++ b/configure
@@ -248,12 +248,14 @@ def arm_hard_float_abi():
   # __ARM_PCS_VFP.
 
   if compiler_version() >= (4, 6, 0):
-    return "__ARM_PCS_VFP" in cc_macros()
+    return '__ARM_PCS_VFP' in cc_macros()
   elif compiler_version() < (4, 5, 0):
     return False
-  elif "__ARM_PCS_VFP" in cc_macros():
+  elif '__ARM_PCS_VFP' in cc_macros():
     return True
-  elif "__ARM_PCS" in cc_macros() or "__SOFTFP" in cc_macros() or not "__VFP_FP__" in cc_macros():
+  elif '__ARM_PCS' in cc_macros() or \
+        '__SOFTFP' in cc_macros() or \
+        not '__VFP_FP__' in cc_macros():
     return False
   else:
     print '''Node.js configure error: Your version of GCC does not report

--- a/configure
+++ b/configure
@@ -379,7 +379,7 @@ def configure_v8(o):
       o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")
     else:
       o['variables']['v8_use_arm_eabi_hardfloat'] = b(arm_hard_float_abi())
-    o['variables']['armv7'] = b(arm_arch_arm7())
+    o['variables']['armv7'] = 1 if arm_arch_arm7() else 0
 
   # assume shared_v8 if one of these is set?
   if options.shared_v8_libpath:

--- a/configure
+++ b/configure
@@ -164,10 +164,10 @@ parser.add_option("--no-ifaddrs",
     dest="no_ifaddrs",
     help="Use on deprecated SunOS systems that do not support ifaddrs.h")
 
-parser.add_option("--with-hardfloat",
-    action="store_true",
-    dest="use_hardfloat",
-    help="Use ARM EABI calling convention where double arguments are passed in VFP registers")
+parser.add_option("--with-float-abi",
+    action="store",
+    dest="float_abi",
+    help="Specifies which floating-point ABI to use. Valid values are: soft, softfp, hard")
 
 parser.add_option("--with-armv7",
     action="store_true",
@@ -198,9 +198,8 @@ def pkg_config(pkg):
 
   return (libs, cflags)
 
-
-def host_arch_cc():
-  """Host architecture check using the CC command."""
+def cc_macros():
+  """Checks predefined macros using the CC command."""
 
   try:
     p = subprocess.Popen(CC.split() + ['-dM', '-E', '-'],
@@ -215,7 +214,7 @@ def host_arch_cc():
         it in a non-standard prefix.
         '''
     sys.exit()
-
+  
   p.stdin.write('\n')
   out = p.communicate()[0]
 
@@ -229,6 +228,39 @@ def host_arch_cc():
       key = lst[1]
       val = lst[2]
       k[key] = val
+  return k
+
+def arm_hard_float_abi():
+  """Check for hardfloat or softfloat eabi on ARM"""
+  # GCC versions 4.6 and above define __ARM_PCS or __ARM_PCS_VFP to specify
+  # the Floating Point ABI used (PCS stands for Procedure Call Standard).
+  # We use these as well as a couple of other defines to statically determine
+  # what FP ABI used.
+  # GCC versions 4.4 and below don't support hard-fp.
+  # GCC versions 4.5 may support hard-fp without defining __ARM_PCS or
+  # __ARM_PCS_VFP.
+
+
+  if cc_version() >= [False, 4, 6, 0]:
+    return "__ARM_PCS_VFP" in cc_macros()
+  elif c_version() < [False, 4, 5, 0]:
+    return False
+  else:
+    if "__ARM_PCS_VFP" in cc_macros():
+      return True
+    elif "__ARM_PCS" in cc_macros() or "__SOFTFP" in cc_macros() or not "__VFP_FP__" in cc_macros():
+      return False
+    else:
+      print '''Node.js configure error: Your version of GCC does not report the FP ABI compiled for
+
+        Please manually specify which floating-point ABI to use with the --with-float-abi option. 
+        '''
+      sys.exit()
+
+def host_arch_cc():
+  """Host architecture check using the CC command."""
+
+  k = cc_macros()
 
   matchup = {
     '__x86_64__'  : 'x64',
@@ -338,9 +370,12 @@ def configure_v8(o):
   o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
   o['variables']['node_shared_v8'] = b(options.shared_v8)
 
-  # todo: auto-detect these variables when not cross-compiling
   if o['variables']['target_arch'] == 'arm':
-    o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.use_hardfloat)
+    if options.float_abi:
+      o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")
+    else:
+      o['variables']['v8_use_arm_eabi_hardfloat'] = b(arm_hard_float_abi())
+    # todo: auto-detect armv7 variable
     o['variables']['armv7'] = b(options.use_armv7)   
 
   # assume shared_v8 if one of these is set?

--- a/configure
+++ b/configure
@@ -169,10 +169,6 @@ parser.add_option("--with-float-abi",
     dest="float_abi",
     help="Specifies which floating-point ABI to use. Valid values are: soft, softfp, hard")
 
-parser.add_option("--with-armv7",
-    action="store_true",
-    dest="use_armv7",
-    help="Optimise v8 for armv7")
 
 (options, args) = parser.parse_args()
 
@@ -230,6 +226,14 @@ def cc_macros():
       k[key] = val
   return k
 
+def arm_arch_arm7():
+  """Check for ARMv7 instructions"""
+  cc_macros_cache = cc_macros()
+  return "__ARM_ARCH_7__" in cc_macros_cache or \
+        "__ARM_ARCH_7A__" in cc_macros_cache or \
+        "__ARM_ARCH_7R__" in cc_macros_cache or \
+        "__ARM_ARCH_7M__" in cc_macros_cache
+
 def arm_hard_float_abi():
   """Check for hardfloat or softfloat eabi on ARM"""
   # GCC versions 4.6 and above define __ARM_PCS or __ARM_PCS_VFP to specify
@@ -243,7 +247,7 @@ def arm_hard_float_abi():
 
   if cc_version() >= [False, 4, 6, 0]:
     return "__ARM_PCS_VFP" in cc_macros()
-  elif c_version() < [False, 4, 5, 0]:
+  elif cc_version() < [False, 4, 5, 0]:
     return False
   else:
     if "__ARM_PCS_VFP" in cc_macros():
@@ -375,8 +379,7 @@ def configure_v8(o):
       o['variables']['v8_use_arm_eabi_hardfloat'] = b(options.float_abi == "hard")
     else:
       o['variables']['v8_use_arm_eabi_hardfloat'] = b(arm_hard_float_abi())
-    # todo: auto-detect armv7 variable
-    o['variables']['armv7'] = b(options.use_armv7)   
+    o['variables']['armv7'] = b(arm_arch_arm7())
 
   # assume shared_v8 if one of these is set?
   if options.shared_v8_libpath:

--- a/configure
+++ b/configure
@@ -211,7 +211,7 @@ def cc_macros():
         it in a non-standard prefix.
         '''
     sys.exit()
-  
+
   p.stdin.write('\n')
   out = p.communicate()[0]
 
@@ -261,8 +261,8 @@ def arm_hard_float_abi():
     print '''Node.js configure error: Your version of GCC does not report
       the Floating-Point ABI to compile for your hardware
 
-      Please manually specify which floating-point ABI to use with the 
-      --with-arm-float-abi option. 
+      Please manually specify which floating-point ABI to use with the
+      --with-arm-float-abi option.
       '''
     sys.exit()
 
@@ -329,7 +329,7 @@ def configure_node(o):
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
 
-  # V8 on ARM requires that armv7 is set. CPU Model detected by 
+  # V8 on ARM requires that armv7 is set. CPU Model detected by
   # the presence of __ARM_ARCH_7__ and the like defines in compiler
   if target_arch == 'arm':
     if options.arm_float_abi:


### PR DESCRIPTION
This patch sets the `armv7` variable for v8 GYP files depending on the compiler defined macros, as well as `v8_use_arm_eabi_hardfloat` depending on both the GCC version and macros present. 

The code from `host_arch_cc` function has been moved into a `cc_macros` function to prevent code-duplication as the same logic is used by the new `arm_arch_arm7` and `arm_hard_float_abi` which return True if the build system is armv7 or hardfloat abi respectively.

Hardfloat detection code is based on [OS::ArmUsingHardFloat](http://v8.googlecode.com/svn/trunk/src/platform-linux.cc), but is not fool-proof on GCC version 4.5, and can be overridden with an added `--with-float-abi` option to the configure script to manually specify which float abi to use. 

Tested that it sets the build correct options with latest version of arm-bcm2708 cross compilers from raspberrypi/tools@ea20f345ee and Ubuntu's gcc-arm-linux-gnueabi package (actual compiled binaries not tested) and has no effect on other non-ARM architectures. 

Should help clear up some issues with people attempting to compile node.js directly on a raspberry pi, such as issue #3438, #3612, #3614, #3732 and others. Testing on actual hardware welcome!
