### PR TITLE
Prohibit same listeners in EventEmitter. Closes #964.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -136,18 +136,23 @@ EventEmitter.prototype.addListener = function(type, listener) {
   this.emit('newListener', type, typeof listener.listener === 'function' ?
             listener.listener : listener);
 
-  if (!this._events[type]) {
+  var previous = this._events[type];
+
+  if (!previous) {
     // Optimize the case of one listener. Don't need the extra array object.
     this._events[type] = listener;
-  } else if (isArray(this._events[type])) {
+  } else if (isArray(previous)) {
 
     // If we've already got an array, just append.
-    this._events[type].push(listener);
+    if (previous.indexOf(listener) === -1) {
+      previous.push(listener);
+    }
 
   } else {
     // Adding the second element, need to change to array.
-    this._events[type] = [this._events[type], listener];
-
+    if (previous !== listener) {
+      this._events[type] = [previous, listener];
+    }
   }
 
   // Check for listener leak

--- a/test/simple/test-event-emitter-same-events.js
+++ b/test/simple/test-event-emitter-same-events.js
@@ -1,0 +1,20 @@
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var calls = 0;
+
+var emitter = new events.EventEmitter();
+
+function listener() {
+  calls++;
+}
+
+emitter.on('message', listener);
+emitter.on('message', listener);
+emitter.on('message', listener);
+emitter.emit('message');
+assert.equal(calls, 1);
+
+emitter.emit('message');
+assert.equal(calls, 2);


### PR DESCRIPTION
`EventEmitter` currently allows to register same listeners on same type more than once.
1. The behavior isn't useful.
2. It contradicts with browsers implementation of `EventTarget` / `EventDispatcher`.
3. It makes easy to introduce stupid bugs that are hard to catch.

The code spawned three messages on <0.9.x and will spawn only one with my patch.

``` javascript
const emitter = new (require('events').EventEmitter);
const log = function() {console.log('Hello')};
emitter.on('message', log);
emitter.on('message', log);
emitter.on('message', log);
emitter.emit('message');
```
