### PR TITLE
process: add `process.activeHandles`

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -501,4 +501,10 @@ a diff reading, useful for benchmarks and measuring intervals:
       // benchmark took 1 seconds and 6962306 nanoseconds
     }, 1000);
 
+## process.activeHandles
+
+The total number of active handles in the current event loop. The handles of
+`dgram`, `server`, `socket` and `timers` can be controlled to be active or
+inactive with their `ref()` and `unref()` methods.
+
 [EventEmitter]: events.html#events_class_events_eventemitter

--- a/src/node.cc
+++ b/src/node.cc
@@ -1346,6 +1346,10 @@ Handle<Value> GetActiveHandles(const Arguments& args) {
   return scope.Close(ary);
 }
 
+Handle<Value> ActiveHandlesGetter(Local<String> property,
+				  const AccessorInfo& info) {
+  return Integer::New(uv_default_loop()->active_handles);
+}
 
 static Handle<Value> Abort(const Arguments& args) {
   abort();
@@ -2243,6 +2247,8 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
                        DebugPortGetter,
                        DebugPortSetter);
 
+  process->SetAccessor(String::New("activeHandles"),
+		       ActiveHandlesGetter);
 
   // define various internal methods
   NODE_SET_METHOD(process, "_getActiveRequests", GetActiveRequests);

--- a/test/simple/test-dgram-unref.js
+++ b/test/simple/test-dgram-unref.js
@@ -27,7 +27,10 @@ var closed = false;
 
 var s = dgram.createSocket('udp4');
 s.bind();
+var activeHandles = process.activeHandles;
 s.unref();
+assert.strictEqual(activeHandles - 1, process.activeHandles,
+                   'activeHandels should be decremented');
 
 setTimeout(function() {
   closed = true;

--- a/test/simple/test-net-server-unref.js
+++ b/test/simple/test-net-server-unref.js
@@ -27,7 +27,10 @@ var closed = false;
 
 var s = net.createServer();
 s.listen();
+var activeHandles = process.activeHandles;
 s.unref();
+assert.strictEqual(activeHandles - 1, process.activeHandles,
+                   'activeHandels should be decremented');
 
 setTimeout(function() {
   closed = true;

--- a/test/simple/test-pipe-unref.js
+++ b/test/simple/test-pipe-unref.js
@@ -27,7 +27,9 @@ var closed = false;
 
 var s = net.Server();
 s.listen(common.PIPE);
+var activeHandles = process.activeHandles;
 s.unref();
+assert.strictEqual(activeHandles - 1, process.activeHandles);
 
 setTimeout(function() {
   closed = true;

--- a/test/simple/test-timers-unref.js
+++ b/test/simple/test-timers-unref.js
@@ -31,22 +31,31 @@ var interval_fired = false,
 var LONG_TIME = 10 * 1000;
 var SHORT_TIME = 100;
 
+var activeHandles = process.activeHandles;
 setInterval(function() {
   interval_fired = true;
 }, LONG_TIME).unref();
+assert.strictEqual(activeHandles, process.activeHandles,
+                   'activeHandels should not be changed');
 
 setTimeout(function() {
   timeout_fired = true;
 }, LONG_TIME).unref();
+assert.strictEqual(activeHandles, process.activeHandles,
+                   'activeHandels should not be changed');
 
 interval = setInterval(function() {
   unref_interval = true;
   clearInterval(interval);
 }, SHORT_TIME).unref();
+assert.strictEqual(activeHandles, process.activeHandles,
+                   'activeHandels should not be changed');
 
 setTimeout(function() {
   unref_timer = true;
 }, SHORT_TIME).unref();
+assert.strictEqual(activeHandles, process.activeHandles,
+                   'activeHandels should not be changed');
 
 check_unref = setInterval(function() {
   if (checks > 5 || (unref_interval && unref_timer))


### PR DESCRIPTION
This api shows the total number of active handles in the current event loop. 

This is beneficial to check the change of active handles of dgram, server, socket and timers after using their ref() and unref() methods. See the tests for examples.

We can also obtain the total number of active handles by using process._getActiveHandles().length, so the alternative is to change it to be a public API.
