### PR TITLE
Emit 'close' on destroy(), so that pipe is cleaned up

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -455,6 +455,7 @@ Zlib.prototype.destroy = function() {
   this.readable = false;
   this.writable = false;
   this._ended = true;
+  this.emit('close');
 };
 
 util.inherits(Deflate, Zlib);

--- a/test/simple/test-zlib-destroy.js
+++ b/test/simple/test-zlib-destroy.js
@@ -1,0 +1,36 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var zlib = require('zlib');
+
+['Deflate', 'Inflate', 'Gzip', 'Gunzip', 'DeflateRaw', 'InflateRaw', 'Unzip']
+  .forEach(function (name) {
+    var a = false;
+    var zStream = new zlib[name]();
+    zStream.on('close', function () {
+      a = true;
+    });
+    zStream.destroy();
+
+    assert.equal(a, true, name+'#destroy() must emit \'close\'');
+  });


### PR DESCRIPTION
This patch emits 'close' when you call destroy on a zlib stream.

For pipe to end properly, `destroy` needs to eventually emit 'close' once.

This is necessary is order to properly clean up any pipes that come off the stream.
pipe's event listeners will be cleaned up, and the call to destroy() will be propagated down the piped streams,
by calling `dest.destroy()`.

If close is not emitted, the rest of the stream will be expecting another call to `write()` or `end()` but it will never come.
