### PR TITLE
http: Bubble http parser errors up to ClientResponse or ClientRequest object instead of the underlying socket

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1367,7 +1367,9 @@ function socketOnData(d, start, end) {
   if (ret instanceof Error) {
     debug('parse error');
     freeParser(parser, req);
-    socket.destroy(ret);
+    socket.destroy();
+    req.emit('error', ret);
+    req._hadError = true;
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade or CONNECT
     var bytesParsed = ret;

--- a/test/simple/test-http-client-parse-error.js
+++ b/test/simple/test-http-client-parse-error.js
@@ -25,37 +25,35 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 
+var connects = 0;
+var parseErrors = 0;
+
 // Create a TCP server
-var srv = net.createServer(function(c) {
-  c.write('bad http - should trigger parse error\r\n');
-
+net.createServer(function(c) {
   console.log('connection');
-
-  c.on('end', function() { c.end(); });
+  if (++connects === 1) {
+    c.end('HTTP/1.1 302 Object Moved\r\nContent-Length: 0\r\n\r\nhi world');
+  } else {
+    c.end('bad http - should trigger parse error\r\n');
+    this.close();
+  }
+}).listen(common.PORT, '127.0.0.1', function() {
+  for (var i = 0; i < 2; i++) {
+    http.request({
+      host: '127.0.0.1',
+      port: common.PORT,
+      method: 'GET',
+      path: '/'
+    }).on('error', function(e) {
+      console.log('got error from client');
+      assert.ok(e.message.indexOf('Parse Error') >= 0);
+      assert.equal(e.code, 'HPE_INVALID_CONSTANT');
+      parseErrors++;
+    }).end();
+  }
 });
-
-var parseError = false;
-
-srv.listen(common.PORT, '127.0.0.1', function() {
-  var req = http.request({
-    host: '127.0.0.1',
-    port: common.PORT,
-    method: 'GET',
-    path: '/'});
-  req.end();
-
-  req.on('error', function(e) {
-    console.log('got error from client');
-    srv.close();
-    assert.ok(e.message.indexOf('Parse Error') >= 0);
-    assert.equal(e.code, 'HPE_INVALID_CONSTANT');
-    parseError = true;
-  });
-});
-
 
 process.on('exit', function() {
-  assert.ok(parseError);
+  assert(parseErrors === 2);
 });
-
 


### PR DESCRIPTION
Closes #3776

Would something like this also make it into v0.8 or no?
