### PR TITLE
stream: propagate 'error' and 'close' to destroy(), in both directions.

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -124,8 +124,8 @@ Stream.prototype.pipe = function(dest, options) {
 
   source.on('end', cleanup);
 
+  //source.on('close', onsourceclose); is only set when the stream is not stdio
   dest.on('close', ondestclose);
-  source.on('close', onsourceclose);
 
   dest.emit('pipe', source);
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -55,7 +55,7 @@ Stream.prototype.pipe = function(dest, options) {
   // source gets the 'end' or 'close' events.  Only dest.end() once.
   if (!dest._isStdio && (!options || options.end !== false)) {
     source.on('end', onend);
-    source.on('close', onclose);
+    source.on('close', onsourceclose);
   }
 
   var didOnEnd = false;
@@ -67,23 +67,43 @@ Stream.prototype.pipe = function(dest, options) {
   }
 
 
-  function onclose() {
+  function onsourceclose() {
     if (didOnEnd) return;
     didOnEnd = true;
-
+    //cleanup first,
+    //because we are not interested in any events that dest.destroy() emits.
+    cleanup();
     dest.destroy();
   }
 
-  // don't leave dangling pipes when there are errors.
-  function onerror(er) {
+  function ondestclose() {
+    if (didOnEnd) return;
+    didOnEnd = true;
+    //cleanup first,
+    //because we are not interested in any events that source.destroy() emits.
     cleanup();
+    source.destroy();
+  }
+
+  // don't leave dangling pipes when there are errors.
+  function onsourceerror(er) {
+    cleanup();
+    if (dest.destroy) dest.destroy();
     if (this.listeners('error').length === 0) {
       throw er; // Unhandled stream error in pipe.
     }
   }
 
-  source.on('error', onerror);
-  dest.on('error', onerror);
+  function ondesterror(er) {
+    cleanup();
+    if (source.destroy) source.destroy();
+    if (this.listeners('error').length === 0) {
+      throw er; // Unhandled stream error in pipe.
+    }
+  }
+
+  source.on('error', onsourceerror);
+  dest.on('error', ondesterror);
 
   // remove all the event listeners that were added.
   function cleanup() {
@@ -91,23 +111,21 @@ Stream.prototype.pipe = function(dest, options) {
     dest.removeListener('drain', ondrain);
 
     source.removeListener('end', onend);
-    source.removeListener('close', onclose);
 
-    source.removeListener('error', onerror);
-    dest.removeListener('error', onerror);
+    source.removeListener('error', onsourceerror);
+    dest.removeListener('error', ondesterror);
+
+    source.removeListener('close', onsourceclose);
+    dest.removeListener('close', ondestclose);
 
     source.removeListener('end', cleanup);
-    source.removeListener('close', cleanup);
-
     dest.removeListener('end', cleanup);
-    dest.removeListener('close', cleanup);
   }
 
   source.on('end', cleanup);
-  source.on('close', cleanup);
 
-  dest.on('end', cleanup);
-  dest.on('close', cleanup);
+  dest.on('close', ondestclose);
+  source.on('close', onsourceclose);
 
   dest.emit('pipe', source);
 


### PR DESCRIPTION
I'm making this pull request mainly for the pourpose of discussion.

Propagate the termination of a stream to the rest of the pipeline.
In node 0.8.4, emitting 'error' or 'close' events terminates the stream.
All listeners are cleaned up, so no more data will be passed.

However, the rest of the pipeline needs to be notified of this,
so that it can dispose of it's resources. in 0.8.4,
`source.emit('close') ---> dest.destroy()` I have extended this pattern:

``` js
source.emit('close') ----> dest.destroy()
source.emit('error') ----> dest.destroy()
dest.emit('close') ------> source.destroy()
dest.emit('error') ------> source.destroy()
```

notice that the 'close' and 'error' listeners are nearly identical.
it may be worth merging them into a single event?
