### PR TITLE
always link sunos builds with libumem

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -231,6 +231,7 @@
         [ 'OS=="solaris"', {
           'libraries': [
             '-lkstat',
+            '-lumem',
           ],
         }],
       ],


### PR DESCRIPTION
Better malloc perf, better debuggability. Win. 
