### PR TITLE
stream: notify user of to pipe state via 'unpipe' event.

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -101,6 +101,8 @@ Stream.prototype.pipe = function(dest, options) {
 
     dest.removeListener('end', cleanup);
     dest.removeListener('close', cleanup);
+
+    source.emit('unpipe', dest);
   }
 
   source.on('end', cleanup);
@@ -109,7 +111,7 @@ Stream.prototype.pipe = function(dest, options) {
   dest.on('end', cleanup);
   dest.on('close', cleanup);
 
-  dest.emit('pipe', source);
+  dest.emit('pipe', source, cleanup);
 
   // Allow for unix-like usage: A.pipe(B).pipe(C)
   return dest;


### PR DESCRIPTION
this does not change the semantics of any of the current `Stream` methods or events,
but makes only a _tiny_ two line change, which gives the user a lot more power.

firstly, by emitting pipe's internal cleanup function to the `dest` it gives the option of disconnecting the stream.

secondly, by emitting source.emit('unpipe', dest) it allows the source to know when the pipe is disconnected.

this would allow users to do things like

``` js
requestThatMayFail
  .on('pipe', function (source, unpipe) {
    requestThatMayFail.unpipe = unpipe
  })
  .on('error', function (){
    requestThatMayFail.unpipe()
  })

stream
  .pipe(requestThatMayFail)
stream
  .pipe(aVeryReliableStream)

```

Also, it would become possible to notify the upstream pipeline that the pipe has ended,
which could be necessary for long pipelines. 
(such was the intention of: https://github.com/joyent/node/pull/3759 ) but with out changing any semantics.
