### PR TITLE
Ability to specify "last result variable name" for REPL (instead of hardcoding `_`)

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -75,7 +75,7 @@ exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
   'string_decoder', 'tls', 'tty', 'url', 'util', 'vm', 'zlib'];
 
 
-function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
+function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined, lastResultVariable) {
   if (!(this instanceof REPLServer)) {
     return new REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined);
   }
@@ -92,6 +92,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     eval_ = options.eval;
     useGlobal = options.useGlobal;
     ignoreUndefined = options.ignoreUndefined;
+    lastResultVariable = options.lastResultVariable;
     prompt = options.prompt;
   } else if (typeof prompt != 'string') {
     throw new Error('An options Object, or a prompt String are required');
@@ -103,6 +104,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
   self.useGlobal = !!useGlobal;
   self.ignoreUndefined = !!ignoreUndefined;
+  self.lastResultVariable = lastResultVariable || '_';
 
   self.eval = eval_ || function(code, context, file, cb) {
     var err, result;
@@ -228,7 +230,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
         self.outputStream.write('A different "' + cmd +
                                 '" already exists globally\n');
       } else {
-        self.context._ = self.context[cmd] = lib;
+        self.context[self.lastResultVariable] = self.context[cmd] = lib;
         self.outputStream.write(self.writer(lib) + '\n');
       }
       self.displayPrompt();
@@ -306,7 +308,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
       // If we got any output - print it (if no error)
       if (!e && (!self.ignoreUndefined || ret !== undefined)) {
-        self.context._ = ret;
+        self.context[self.lastResultVariable] = ret;
         self.outputStream.write(self.writer(ret) + '\n');
       }
 


### PR DESCRIPTION
What are your thoughts about being able to tell the `node` command/REPL to use a different value other than `_` to hold the last result?

The main reason is, if you want to use the `underscore.js` module in the context of the REPL, you essentially have to do one of the following:
#### 1. Declare it at the top of each file

``` javascript
var _ = require('underscore');

// code
```

An issue with this is you can't access the last return value from anywhere in that script. I don't know why you would want to, but there's a limitation there. Also, this means you have to declare `var _ = require('underscore')` in every module, which is only "required" for the underscore module since it conflicts with the explicitly set `_` in the REPL.
#### 2. Declare it every time you use it

``` javascript
var a = function() {
  var _ = require('underscore');
  // code
}
var b = function() {
  var _ = require('underscore');
  // code
}
```

I would like to be able to set the underscore module to a global variable, `global._ = require('underscore');`, since it is used so much and is basically a standard js core-extension library. But if it's set to a global variable, the first time there is a return value (in an async function, see https://gist.github.com/gists/3220108), the `_` variable which was the underscore module gets replaced with the last return value.

If you could run the `node` command with a flag specifying the "last result variable name", that would be pretty awesome:

```
node --last-result $_
> "a string"
"a string"
> $_
"a string"
> _
undefined
```

What are your thoughts about this?
