### PR TITLE
fs: fix ReadStream / WriteStream missing callback

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1367,7 +1367,10 @@ ReadStream.prototype._emitData = function(d) {
 ReadStream.prototype.destroy = function(cb) {
   var self = this;
 
-  if (!this.readable) return;
+  if (!this.readable) {
+    if (cb) process.nextTick(function() { cb(null); });
+    return;
+  }
   this.readable = false;
 
   function close() {
@@ -1570,7 +1573,10 @@ WriteStream.prototype.end = function(data, encoding, cb) {
 WriteStream.prototype.destroy = function(cb) {
   var self = this;
 
-  if (!this.writable) return;
+  if (!this.readable) {
+    if (cb) process.nextTick(function() { cb(null); });
+    return;
+  }
   this.writable = false;
 
   function close() {

--- a/test/simple/test-fs-read-stream.js
+++ b/test/simple/test-fs-read-stream.js
@@ -86,6 +86,11 @@ var file2 = fs.createReadStream(fn);
 file2.destroy(function(err) {
   assert.ok(!err);
   callbacks.destroy++;
+
+  file2.destroy(function(err) {
+    assert.ok(!err);
+    callbacks.destroy++;
+  });
 });
 
 var file3 = fs.createReadStream(fn, {encoding: 'utf8'});
@@ -107,7 +112,7 @@ file3.on('close', function() {
 process.on('exit', function() {
   assert.equal(1, callbacks.open);
   assert.equal(1, callbacks.end);
-  assert.equal(1, callbacks.destroy);
+  assert.equal(2, callbacks.destroy);
 
   assert.equal(2, callbacks.close);
 


### PR DESCRIPTION
This fixes an error introduced in commit 47d6a946562b7825579211b0d617aee32bdf6f74.

The error causes fs.ReadStream.destroy() and fs.WriteStream.destroy() to never call the supplied callback when the object was already destroyed.
