### PR TITLE
Http Agent, allow free sockets to linger for re-use

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1150,7 +1150,7 @@ function Agent(options) {
 util.inherits(Agent, EventEmitter);
 exports.Agent = Agent;
 
-Agent.defaultMaxSockets = 65000;
+Agent.defaultMaxSockets = 5;
 // keep idle (sockets with no active http requests) 
 // connections around for this long.
 Agent.defaultFreeSocketTimeout = 60000;

--- a/lib/http.js
+++ b/lib/http.js
@@ -1022,30 +1022,26 @@ ServerResponse.prototype.writeHeader = function() {
 // concerned with managing a connection pool.
 
 
-//global override for free connection timeout
-var globalFreeConnectionTimeout = 0;
+// bypass Agent options and use this timeout always, if > 0
+var globalFreeSocketTimeout = 0;
 
-function setFreeConnectionTimeout (val) {
-  globalFreeConnectionTimeout = val;
+function setFreeSocketTimeout (val) {
+  globalFreeSocketTimeout = val;
 } 
 
-exports.setFreeConnectionTimeout = setFreeConnectionTimeout;
+exports.setFreeSocketTimeout = setFreeSocketTimeout;
 
-/**
- * Structure to hold the idle timer associated with a free connected socket.
- * @param {net.Socket} socket
- * @constructor
- */
-function FreeConnectedSocket (socket) {
+// Structure to hold the idle timer associated with a free connected socket.
+
+function FreeSocket (socket) {
   this.socket = socket;
   this.timer = null;
 }
 
-/**
- * Clears the timer, sets all internal values to null.
- * @return {net.Socket} Could be null if this doesn't contain a socket.
- */
-FreeConnectedSocket.prototype.removeSocket = function () {
+// Clears the timer, sets all internal values to null.
+// Could return null
+
+FreeSocket.prototype.removeSocket = function () {
   var socket = this.socket;
   if (this.timer) {
     clearTimeout(this.timer);
@@ -1055,10 +1051,8 @@ FreeConnectedSocket.prototype.removeSocket = function () {
   return socket;
 };
 
-/**
- * Delete current timer, if exists, set the new timer starting now.
- */
-FreeConnectedSocket.prototype.restartTimer = function (clbTimeout, timeout) {
+// Delete current timer, if exists. Set the new timer starting now.
+FreeSocket.prototype.restartTimer = function (clbTimeout, timeout) {
   if (this.timer) {
     clearTimeout(this.timer);
     this.timer = null;
@@ -1069,15 +1063,14 @@ FreeConnectedSocket.prototype.restartTimer = function (clbTimeout, timeout) {
   },timeout);
 };
 
-/**
- * Helper to remove an item from a container that holds sockets indexed by name and then object reference.
- * 
- * @param  {Object} obj       to be removed
- * @param  {String} name      "host:port" form to identify a socket
- * @param  {Object} container Object used as a hashmap container
- * @return {boolean}           returns true if an object was found and deleted, false if no such object was found.
- */
-function deleteFromContainer (obj, name, container, compareFunc) {
+// Helper to remove an item from a socket container.
+// The container is a collection of sockets indexed by [name]:[socket]
+// obj       socket to be removed
+// name      "host:port" form to identify the destination
+// container Object used as a hashmap container
+// returns true if an object was found and deleted, false if not found.
+
+function deleteFromSocketContainer (obj, name, container, compareFunc) {
   var objectsWithName = container[name];
 
   if (objectsWithName) {
@@ -1113,11 +1106,11 @@ function Agent(options) {
   self.options = options || {};
   self.requests = {};
   self.sockets = {};
-  /**
-   * Sockets that are connected to a remote host, but are "free" in that they can be assigned to a request.
-   */
-  self.freeConnectedSockets = {};
-  self.freeConnectionTimeout = self.options.freeConnectionTimeout || Agent.defaultFreeConnectionTimeout;
+  // free sockets are connected to a remote host, but are "free" in that they 
+  // can be assigned to a request.
+  self.freeSockets = {}; 
+  self.freeSocketTimeout = self.options.freeSocketTimeout || 
+    Agent.defaultFreeSocketTimeout;
   self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets;
   self.on('free', function(socket, host, port, localAddress) {
     var name = host + ':' + port;
@@ -1125,11 +1118,12 @@ function Agent(options) {
       name += ':' + localAddress;
     }
 
-    //the 'free' event is emitted via the socket for 2 reasons
-    //1) the http request has ended and Connection: Keep-alive was successful making the socket available for
-    //requests. @see http.js::responseOnEnd()
-    //2) A socket closes and there are queued requests in self.requests, which will cause a new socket to be created
-    //and emit the 'free' event allowing the new socket on the next queued request. @see Agent::removeSocket()
+    // the 'free' event is emitted via the socket for 2 reasons
+    // 1) the http request has ended and Connection: Keep-alive was successful 
+    // making the socket available for requests. @see http.js::responseOnEnd()
+    // 2) A socket closes and there are queued requests in self.requests, which 
+    // will cause a new socket to be created and emit the 'free' event allowing 
+    // the new socket on the next queued request. @see Agent::removeSocket()
 
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket);
@@ -1138,16 +1132,16 @@ function Agent(options) {
         delete self.requests[name];
       }
     } else {
-      if (self.freeConnectionTimeout <= 0) {
- 	// If there are no pending requests just destroy the
+      if (self.freeSocketTimeout <= 0) {
+ 	    // If there are no pending requests just destroy the
         // socket and it will get removed from the pool. This
         // gets us out of timeout issues and allows us to
         // default to Connection:keep-alive.
         socket.destroy();
       } else {
-        //Remove from the active sockets collection, add to the free and connected collection.
-        deleteFromContainer(socket, name, this.sockets);
-        self.addFreeConnectedSocket(name,socket);
+        // hang on to this socket for future use
+        deleteFromSocketContainer(socket, name, this.sockets);
+        self.addFreeSocket(name,socket);
       }
     }
   });
@@ -1156,13 +1150,10 @@ function Agent(options) {
 util.inherits(Agent, EventEmitter);
 exports.Agent = Agent;
 
-Agent.defaultMaxSockets = 5;
-/**
- * For Connection: Keep-alive sockets, keep idle (sockets with no active http requests) 
- * connections around for this long.
- * @type {Number} Timeout in milliseconds
- */
-Agent.defaultFreeConnectionTimeout = 60000;
+Agent.defaultMaxSockets = 65000;
+// keep idle (sockets with no active http requests) 
+// connections around for this long.
+Agent.defaultFreeSocketTimeout = 60000;
 
 Agent.prototype.defaultPort = 80;
 Agent.prototype.addRequest = function(req, host, port, localAddress) {
@@ -1173,9 +1164,9 @@ Agent.prototype.addRequest = function(req, host, port, localAddress) {
     name += ':' + localAddress;
   }
 
-  //try to use a free connected socket first, then attempt to create a new one, finally 
-  //queue the request if no socket can be allocated.
-  socket = this.allocateFreeConnectedSocket(name);
+  // try to use a free connected socket first, then attempt to create a new one.
+  // queue the request if no socket can be allocated.
+  socket = this.allocateFreeSocket(name);
   
   if (socket) {
     req.onSocket(socket);
@@ -1218,7 +1209,7 @@ Agent.prototype.createSocket = function(name, host, port, localAddress) {
   var onRemove = function() {
     // We need this function for cases like HTTP 'upgrade'
     // (defined by WebSockets) where we need to remove a socket from the pool
-    //  because it'll be locked up indefinitely
+    // because it'll be locked up indefinitely
     self.removeSocket(s, name, host, port, localAddress);
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
@@ -1227,15 +1218,17 @@ Agent.prototype.createSocket = function(name, host, port, localAddress) {
   s.on('agentRemove', onRemove);
   return s;
 };
+
+function compareFreeSocket (socket, freeSocket) {
+  return freeSocket.socket === socket;
+}
+
 Agent.prototype.removeSocket = function(s, name, host, port, localAddress) {
   
-  if (false === deleteFromContainer(s,name,this.sockets)) {
-    //removeSocket is called when a socket closes, this could be for an active socket (above) or a free connected socket
-    //logger.trace('attempting to remove socket from freeConnectedSockets');
-    var compareSocket = function (socket, obj) {
-      return obj.socket === socket;
-    }
-    deleteFromContainer(s,name,this.freeConnectedSockets,compareSocket);
+  // removeSocket could be for an active socket or a free socket 
+  // try active socket first, if not found try free sockets
+  if (false === deleteFromSocketContainer(s,name,this.sockets)) {
+    deleteFromSocketContainer(s,name,this.freeSockets,compareFreeSocket);
   }
   if (this.requests[name] && this.requests[name].length) {
     // If we have pending requests and a socket gets closed a new one
@@ -1244,35 +1237,33 @@ Agent.prototype.removeSocket = function(s, name, host, port, localAddress) {
   }
 };
 
-Agent.prototype.destroyFreeConnections = function () {
+Agent.prototype.destroyFreeSockets = function () {
   var prop,idx,
     toDestroy = [];
 
-  for (prop in this.freeConnectedSockets) {
-    if (this.freeConnectedSockets.hasOwnProperty(prop)) {
-      for (idx = 0; idx < this.freeConnectedSockets[prop].length; idx++) {
-        toDestroy.push(this.freeConnectedSockets[prop][idx]);
+  for (prop in this.freeSockets) {
+    if (this.freeSockets.hasOwnProperty(prop)) {
+      for (idx = 0; idx < this.freeSockets[prop].length; idx++) {
+        toDestroy.push(this.freeSockets[prop][idx]);
       }
     }
   }
-  //dont mess with the internal lists, it *may* be possible they are modified synchronously after calling destroy().
+  // dont mess with the internal lists, it *may* be possible they are modified 
+  // synchronously after calling destroy().
   for (idx = 0; idx < toDestroy.length; idx++) {
     toDestroy[idx].destroy();
   }
 };
 
-Agent.prototype.getFreeConnectionTimeout = function () {
-  return globalFreeConnectionTimeout || this.freeConnectionTimeout;
+Agent.prototype.getFreeSocketTimeout = function () {
+  return globalFreeSocketTimeout || this.freeSocketTimeout;
 };
 
-/**
- * Add the socket to the list of available "free" connected sockets.  Free and connected sockets are sockets
- * that are available for use in a future request and are still connected to a remote host:port.
- * @param {string} name   "host:port"
- * @param {net.Socket} socket [description]
- */
-Agent.prototype.addFreeConnectedSocket = function (name,socket) {
-  var freeConnectedSocket = null,
+// Add the socket to the list of "free" sockets.  
+// Free sockets are connected to a remote host:port, and available for requests.
+
+Agent.prototype.addFreeSocket = function (name,socket) {
+  var freeSocket = null,
     self = this;
 
   if (!name) {
@@ -1286,51 +1277,45 @@ Agent.prototype.addFreeConnectedSocket = function (name,socket) {
     return; //BAD
   }
 
-  if (!this.freeConnectedSockets[name]) {
-    this.freeConnectedSockets[name] = [];
+  if (!this.freeSockets[name]) {
+    this.freeSockets[name] = [];
   } else {
-    if (-1 !== this.freeConnectedSockets[name].indexOf(socket)) {
-      //logger.error('Cannot add duplicate socket to freeConnectedSockets container');
+    if (-1 !== this.freeSockets[name].indexOf(socket)) {
       return;
     }
-  }
+  }  
 
-  //logger.trace('Adding freeConnectedSocket with timeout: ',name,self.getFreeConnectionTimeout());
-
-  freeConnectedSocket = new FreeConnectedSocket(socket);
-  freeConnectedSocket.restartTimer(function () {
-    //logger.trace('freeConnected timer fired',name);
-    var freesocket = freeConnectedSocket.removeSocket();
-    if (freesocket) {
-      //logger.trace('destroying idle connection: ',name);
+  freeSocket = new FreeSocket(socket);
+  freeSocket.restartTimer(function onFreeSocketTimeout () {    
+    var freesocket = freeSocket.removeSocket();
+    if (freesocket) {      
       freesocket.destroy();
+      deleteFromSocketContainer(freeSocket, name, self.freeSockets);
     }
-    deleteFromContainer(freeConnectedSocket, name, self.freeConnectedSockets);
-  },self.getFreeConnectionTimeout());
+  },self.getFreeSocketTimeout());
 
-  this.freeConnectedSockets[name].push(freeConnectedSocket);
+  this.freeSockets[name].push(freeSocket);
 };
 
-/**
- * If one exists, allocate an existing free connected socket.
- * The socket will be added to the list of active sockets.
- * @return {net.Socket} or null if none found.
- */
-Agent.prototype.allocateFreeConnectedSocket = function (name) {
-  var freeConnectedSocket = null,
+// If on exists grab a free socket from this.freeSockets and move it to
+// this.sockets. Return the socket or null if there are no free sockets.
+// like createSocket, this.sockets is modified and the socket is returned
+
+Agent.prototype.allocateFreeSocket = function (name) {
+  var freeSocket = null,
     socket = null;
 
-  if (!this.freeConnectedSockets[name]) {
+  if (!this.freeSockets[name]) {
     return null;
   }
 
-  if (this.freeConnectedSockets[name].length === 0) {
+  if (this.freeSockets[name].length === 0) {
     //should never happen, but anyway
-    delete this.freeConnectedSockets[name];
+    delete this.freeSockets[name];
     return null;
   }
-  freeConnectedSocket = this.freeConnectedSockets[name].shift();
-  socket = freeConnectedSocket.removeSocket();
+  freeSocket = this.freeSockets[name].shift();
+  socket = freeSocket.removeSocket();
   
   if (!this.sockets[name]) {
     this.sockets[name] = [];

--- a/lib/http.js
+++ b/lib/http.js
@@ -1021,6 +1021,91 @@ ServerResponse.prototype.writeHeader = function() {
 // ClientRequest.onSocket(). The Agent is now *strictly*
 // concerned with managing a connection pool.
 
+
+//global override for free connection timeout
+var globalFreeConnectionTimeout = 0;
+
+function setFreeConnectionTimeout (val) {
+  globalFreeConnectionTimeout = val;
+} 
+
+exports.setFreeConnectionTimeout = setFreeConnectionTimeout;
+
+/**
+ * Structure to hold the idle timer associated with a free connected socket.
+ * @param {net.Socket} socket
+ * @constructor
+ */
+function FreeConnectedSocket (socket) {
+  this.socket = socket;
+  this.timer = null;
+}
+
+/**
+ * Clears the timer, sets all internal values to null.
+ * @return {net.Socket} Could be null if this doesn't contain a socket.
+ */
+FreeConnectedSocket.prototype.removeSocket = function () {
+  var socket = this.socket;
+  if (this.timer) {
+    clearTimeout(this.timer);
+  }
+  this.timer = null;
+  this.socket = null;
+  return socket;
+};
+
+/**
+ * Delete current timer, if exists, set the new timer starting now.
+ */
+FreeConnectedSocket.prototype.restartTimer = function (clbTimeout, timeout) {
+  if (this.timer) {
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  this.timer = setTimeout(function () {
+    clbTimeout();
+  },timeout);
+};
+
+/**
+ * Helper to remove an item from a container that holds sockets indexed by name and then object reference.
+ * 
+ * @param  {Object} obj       to be removed
+ * @param  {String} name      "host:port" form to identify a socket
+ * @param  {Object} container Object used as a hashmap container
+ * @return {boolean}           returns true if an object was found and deleted, false if no such object was found.
+ */
+function deleteFromContainer (obj, name, container, compareFunc) {
+  var objectsWithName = container[name];
+
+  if (objectsWithName) {
+    var index = -1;
+
+    if (!compareFunc) {
+      index = objectsWithName.indexOf(obj);
+    } else {
+      var idx = 0;
+      for (;idx < objectsWithName.length; idx++) {
+        if (true === compareFunc(obj,objectsWithName[idx])) {
+          index = idx;
+          break;
+        }
+      }
+    }
+    if (index !== -1) {
+      objectsWithName.splice(index, 1);
+      if (objectsWithName.length === 0) {
+        // don't leak
+        delete container[name];
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
 function Agent(options) {
   EventEmitter.call(this);
 
@@ -1028,12 +1113,23 @@ function Agent(options) {
   self.options = options || {};
   self.requests = {};
   self.sockets = {};
+  /**
+   * Sockets that are connected to a remote host, but are "free" in that they can be assigned to a request.
+   */
+  self.freeConnectedSockets = {};
+  self.freeConnectionTimeout = self.options.freeConnectionTimeout || Agent.defaultFreeConnectionTimeout;
   self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets;
   self.on('free', function(socket, host, port, localAddress) {
     var name = host + ':' + port;
     if (localAddress) {
       name += ':' + localAddress;
     }
+
+    //the 'free' event is emitted via the socket for 2 reasons
+    //1) the http request has ended and Connection: Keep-alive was successful making the socket available for
+    //requests. @see http.js::responseOnEnd()
+    //2) A socket closes and there are queued requests in self.requests, which will cause a new socket to be created
+    //and emit the 'free' event allowing the new socket on the next queued request. @see Agent::removeSocket()
 
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket);
@@ -1042,11 +1138,17 @@ function Agent(options) {
         delete self.requests[name];
       }
     } else {
-      // If there are no pending requests just destroy the
-      // socket and it will get removed from the pool. This
-      // gets us out of timeout issues and allows us to
-      // default to Connection:keep-alive.
-      socket.destroy();
+      if (self.freeConnectionTimeout <= 0) {
+ 	// If there are no pending requests just destroy the
+        // socket and it will get removed from the pool. This
+        // gets us out of timeout issues and allows us to
+        // default to Connection:keep-alive.
+        socket.destroy();
+      } else {
+        //Remove from the active sockets collection, add to the free and connected collection.
+        deleteFromContainer(socket, name, this.sockets);
+        self.addFreeConnectedSocket(name,socket);
+      }
     }
   });
   self.createConnection = net.createConnection;
@@ -1055,17 +1157,32 @@ util.inherits(Agent, EventEmitter);
 exports.Agent = Agent;
 
 Agent.defaultMaxSockets = 5;
+/**
+ * For Connection: Keep-alive sockets, keep idle (sockets with no active http requests) 
+ * connections around for this long.
+ * @type {Number} Timeout in milliseconds
+ */
+Agent.defaultFreeConnectionTimeout = 60000;
 
 Agent.prototype.defaultPort = 80;
 Agent.prototype.addRequest = function(req, host, port, localAddress) {
-  var name = host + ':' + port;
+  var name = host + ':' + port,
+    socket = null;
+    
   if (localAddress) {
     name += ':' + localAddress;
   }
-  if (!this.sockets[name]) {
-    this.sockets[name] = [];
+
+  //try to use a free connected socket first, then attempt to create a new one, finally 
+  //queue the request if no socket can be allocated.
+  socket = this.allocateFreeConnectedSocket(name);
+  
+  if (socket) {
+    req.onSocket(socket);
+    return; 
   }
-  if (this.sockets[name].length < this.maxSockets) {
+
+  if (!this.sockets[name] || (this.sockets[name].length < this.maxSockets)) {
     // If we are under maxSockets create a new one.
     req.onSocket(this.createSocket(name, host, port, localAddress));
   } else {
@@ -1111,20 +1228,115 @@ Agent.prototype.createSocket = function(name, host, port, localAddress) {
   return s;
 };
 Agent.prototype.removeSocket = function(s, name, host, port, localAddress) {
-  if (this.sockets[name]) {
-    var index = this.sockets[name].indexOf(s);
-    if (index !== -1) {
-      this.sockets[name].splice(index, 1);
-      if (this.sockets[name].length === 0) {
-        // don't leak
-        delete this.sockets[name];
-      }
+  
+  if (false === deleteFromContainer(s,name,this.sockets)) {
+    //removeSocket is called when a socket closes, this could be for an active socket (above) or a free connected socket
+    //logger.trace('attempting to remove socket from freeConnectedSockets');
+    var compareSocket = function (socket, obj) {
+      return obj.socket === socket;
     }
+    deleteFromContainer(s,name,this.freeConnectedSockets,compareSocket);
   }
   if (this.requests[name] && this.requests[name].length) {
     // If we have pending requests and a socket gets closed a new one
+    // needs to be created to take over in the pool for the one that closed.
     this.createSocket(name, host, port, localAddress).emit('free');
   }
+};
+
+Agent.prototype.destroyFreeConnections = function () {
+  var prop,idx,
+    toDestroy = [];
+
+  for (prop in this.freeConnectedSockets) {
+    if (this.freeConnectedSockets.hasOwnProperty(prop)) {
+      for (idx = 0; idx < this.freeConnectedSockets[prop].length; idx++) {
+        toDestroy.push(this.freeConnectedSockets[prop][idx]);
+      }
+    }
+  }
+  //dont mess with the internal lists, it *may* be possible they are modified synchronously after calling destroy().
+  for (idx = 0; idx < toDestroy.length; idx++) {
+    toDestroy[idx].destroy();
+  }
+};
+
+Agent.prototype.getFreeConnectionTimeout = function () {
+  return globalFreeConnectionTimeout || this.freeConnectionTimeout;
+};
+
+/**
+ * Add the socket to the list of available "free" connected sockets.  Free and connected sockets are sockets
+ * that are available for use in a future request and are still connected to a remote host:port.
+ * @param {string} name   "host:port"
+ * @param {net.Socket} socket [description]
+ */
+Agent.prototype.addFreeConnectedSocket = function (name,socket) {
+  var freeConnectedSocket = null,
+    self = this;
+
+  if (!name) {
+    if (socket) {
+      socket.destroy();
+    }
+    return; //BAD
+  }
+
+  if (!socket) {
+    return; //BAD
+  }
+
+  if (!this.freeConnectedSockets[name]) {
+    this.freeConnectedSockets[name] = [];
+  } else {
+    if (-1 !== this.freeConnectedSockets[name].indexOf(socket)) {
+      //logger.error('Cannot add duplicate socket to freeConnectedSockets container');
+      return;
+    }
+  }
+
+  //logger.trace('Adding freeConnectedSocket with timeout: ',name,self.getFreeConnectionTimeout());
+
+  freeConnectedSocket = new FreeConnectedSocket(socket);
+  freeConnectedSocket.restartTimer(function () {
+    //logger.trace('freeConnected timer fired',name);
+    var freesocket = freeConnectedSocket.removeSocket();
+    if (freesocket) {
+      //logger.trace('destroying idle connection: ',name);
+      freesocket.destroy();
+    }
+    deleteFromContainer(freeConnectedSocket, name, self.freeConnectedSockets);
+  },self.getFreeConnectionTimeout());
+
+  this.freeConnectedSockets[name].push(freeConnectedSocket);
+};
+
+/**
+ * If one exists, allocate an existing free connected socket.
+ * The socket will be added to the list of active sockets.
+ * @return {net.Socket} or null if none found.
+ */
+Agent.prototype.allocateFreeConnectedSocket = function (name) {
+  var freeConnectedSocket = null,
+    socket = null;
+
+  if (!this.freeConnectedSockets[name]) {
+    return null;
+  }
+
+  if (this.freeConnectedSockets[name].length === 0) {
+    //should never happen, but anyway
+    delete this.freeConnectedSockets[name];
+    return null;
+  }
+  freeConnectedSocket = this.freeConnectedSockets[name].shift();
+  socket = freeConnectedSocket.removeSocket();
+  
+  if (!this.sockets[name]) {
+    this.sockets[name] = [];
+  }
+  this.sockets[name].push(socket);
+  return socket;
 };
 
 var globalAgent = new Agent();


### PR DESCRIPTION
The goal is to re-use connection:keep-alive sockets that are connected to a remote endpoint.  Outbound http requests could use one of these sockets instead of creating a new connection.  The current re-use logic will only re-use a connection if requests to a particular endpoint have exceeded the max value and are queued waiting to be sent.
