### PR TITLE
child_process: Fix stdout=null when stdio=['pipe']

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -709,9 +709,10 @@ ChildProcess.prototype.spawn = function(options) {
   }
 
   // At least 3 stdio will be created
-  if (stdio.length < 3) {
-    stdio = stdio.concat(new Array(3 - stdio.length));
-  }
+  // Don't concat() a new Array() because it would be sparse, and
+  // stdio.reduce() would skip the sparse elements of stdio.
+  // See http://stackoverflow.com/a/5501711/3561
+  while (stdio.length < 3) stdio.push(undefined);
 
   // Translate stdio into C++-readable form
   // (i.e. PipeWraps or fds)

--- a/test/simple/test-child-process-stdio.js
+++ b/test/simple/test-child-process-stdio.js
@@ -1,0 +1,36 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+var options = {stdio: ['pipe']};
+var child = common.spawnPwd(options);
+
+assert.notEqual(child.stdout, null);
+assert.notEqual(child.stderr, null);
+
+options = {stdio: 'ignore'};
+child = common.spawnPwd(options);
+
+assert.equal(child.stdout, null);
+assert.equal(child.stderr, null);


### PR DESCRIPTION
Previously, a command with a short stdio array would result in the child's
stdout and stderr objects set to null. For example:

```
var c = child_process.spawn(cmd, args, {stdio: ['pipe']});
// results in c.stdout === null.
```

The expected behavior is the above line functioning the same as this one:

```
var c = child_process.spawn(cmd, args, {stdio: ['pipe', null, null]});
// provides correct (non-null) c.stdout; as does the above, after this fix.
```
