### PR TITLE
Makefile helpers for precompiled binary tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ tar: $(TARBALL)
 $(BINARYTAR):
 	rm -rf $(BINARYNAME)
 	rm -rf out/deps out/Release
-	./configure --prefix=/ --without-snapshot
+	./configure --prefix=/ --without-snapshot --dest-cpu=$(DESTCPU)
 	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
 	cp README.md $(BINARYNAME)
 	cp LICENSE $(BINARYNAME)

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,8 @@ $(TARBALL): node doc
 	rm -rf $(TARNAME)
 	gzip -f -9 $(TARNAME).tar
 
+tar: $(TARBALL)
+
 $(BINARYTAR):
 	rm -rf $(BINARYNAME)
 	rm -rf out/deps out/Release
@@ -296,4 +298,4 @@ cpplint:
 
 lint: jslint cpplint
 
-.PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean check uninstall install install-includes install-bin all staticlib dynamiclib test test-all website-upload pkg blog blogclean
+.PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean check uninstall install install-includes install-bin all staticlib dynamiclib test test-all website-upload pkg blog blogclean tar

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,8 @@ $(BINARYTAR):
 	rm -rf $(BINARYNAME)
 	gzip -f -9 $(BINARYNAME).tar
 
+binary: $(BINARYTAR)
+
 dist-upload: $(TARBALL) $(PKG)
 	ssh node@nodejs.org mkdir -p web/nodejs.org/dist/$(VERSION)
 	scp $(TARBALL) node@nodejs.org:~/web/nodejs.org/dist/$(VERSION)/$(TARBALL)
@@ -298,4 +300,4 @@ cpplint:
 
 lint: jslint cpplint
 
-.PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean check uninstall install install-includes install-bin all staticlib dynamiclib test test-all website-upload pkg blog blogclean tar
+.PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean check uninstall install install-includes install-bin all staticlib dynamiclib test test-all website-upload pkg blog blogclean tar binary

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,15 @@ docclean:
 
 VERSION=v$(shell $(PYTHON) tools/getnodeversion.py)
 PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
+ifeq ($(DESTCPU),x64)
+ARCH=x86_64
+else
+ifeq ($(DESTCPU),ia32)
+ARCH=i386
+else
 ARCH=$(shell uname -m)
+endif
+endif
 TARNAME=node-$(VERSION)
 TARBALL=$(TARNAME).tar.gz
 BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,12 @@ docclean:
 	-rm -rf out/doc
 
 VERSION=v$(shell $(PYTHON) tools/getnodeversion.py)
+PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(shell uname -m)
 TARNAME=node-$(VERSION)
 TARBALL=$(TARNAME).tar.gz
+BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)
+BINARYTAR=$(BINARYNAME).tar.gz
 PKG=out/$(TARNAME).pkg
 packagemaker=/Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker
 
@@ -255,6 +259,18 @@ $(TARBALL): node doc
 	tar -cf $(TARNAME).tar $(TARNAME)
 	rm -rf $(TARNAME)
 	gzip -f -9 $(TARNAME).tar
+
+$(BINARYTAR):
+	rm -rf $(BINARYNAME)
+	rm -rf out/deps out/Release
+	./configure --prefix=/ --without-snapshot
+	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
+	cp README.md $(BINARYNAME)
+	cp LICENSE $(BINARYNAME)
+	cp ChangeLog $(BINARYNAME)
+	tar -cf $(BINARYNAME).tar $(BINARYNAME)
+	rm -rf $(BINARYNAME)
+	gzip -f -9 $(BINARYNAME).tar
 
 dist-upload: $(TARBALL) $(PKG)
 	ssh node@nodejs.org mkdir -p web/nodejs.org/dist/$(VERSION)

--- a/tools/email-footer.md
+++ b/tools/email-footer.md
@@ -8,6 +8,14 @@ Windows x64 Installer: http://nodejs.org/dist/__VERSION__/x64/node-__VERSION__-x
 
 Windows x64 Files: http://nodejs.org/dist/__VERSION__/x64/
 
+Linux 32-bit Binary Package: http://nodejs.org/dist/__VERSION__/node-__VERSION__-linux-i686.tar.gz
+
+Linux 64-bit Binary Package: http://nodejs.org/dist/__VERSION__/node-__VERSION__-linux-x86_64.tar.gz
+
+Solaris 32-bit Binary Package: http://nodejs.org/dist/__VERSION__/node-__VERSION__-sunos-i386.tar.gz
+
+Solaris 64-bit Binary Package: http://nodejs.org/dist/__VERSION__/node-__VERSION__-sunos-x86_64.tar.gz
+
 Other release files: http://nodejs.org/dist/__VERSION__/
 
 Website: http://nodejs.org/docs/__VERSION__/

--- a/tools/install.py
+++ b/tools/install.py
@@ -125,7 +125,7 @@ def waf_files(action):
           'tools/wafadmin/Tools/xlc.py',
           'tools/wafadmin/Tools/xlcxx.py',
           'tools/wafadmin/Utils.py'],
-          'lib/node/')
+          'lib/node/wafadmin/')
 
 def update_shebang(path, shebang):
   print 'updating shebang of %s' % path

--- a/tools/install.py
+++ b/tools/install.py
@@ -154,7 +154,15 @@ def npm_files(action):
     action([link_path], 'bin/npm')
   elif action == install:
     try_symlink('../lib/node_modules/npm/bin/npm-cli.js', link_path)
-    shebang = os.path.join(node_prefix, 'bin/node')
+    if os.environ['PORTABLE']:
+      # This crazy hack is necessary to make the shebang execute the copy
+      # of node relative to the same directory as the npm script. The precompiled
+      # binary tarballs use a prefix of "/" which gets translated to "/bin/node"
+      # in the regular shebang modifying logic, which is incorrect since the
+      # precompiled bundle should be able to be extracted anywhere and "just work"
+      shebang = '/bin/sh\n// 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"'
+    else:
+      shebang = os.path.join(node_prefix, 'bin/node')
     update_shebang(link_path, shebang)
   else:
     assert(0) # unhandled action type

--- a/tools/install.py
+++ b/tools/install.py
@@ -91,7 +91,9 @@ def waf_files(action):
           'tools/wafadmin/Scripting.py',
           'tools/wafadmin/TaskGen.py',
           'tools/wafadmin/Task.py',
-          'tools/wafadmin/Tools/ar.py',
+          'tools/wafadmin/Utils.py'],
+          'lib/node/wafadmin/')
+  action(['tools/wafadmin/Tools/ar.py',
           'tools/wafadmin/Tools/cc.py',
           'tools/wafadmin/Tools/ccroot.py',
           'tools/wafadmin/Tools/compiler_cc.py',
@@ -123,9 +125,8 @@ def waf_files(action):
           'tools/wafadmin/Tools/unittestw.py',
           'tools/wafadmin/Tools/winres.py',
           'tools/wafadmin/Tools/xlc.py',
-          'tools/wafadmin/Tools/xlcxx.py',
-          'tools/wafadmin/Utils.py'],
-          'lib/node/wafadmin/')
+          'tools/wafadmin/Tools/xlcxx.py'],
+          'lib/node/wafadmin/Tools/')
 
 def update_shebang(path, shebang):
   print 'updating shebang of %s to %s' % (path, shebang)

--- a/tools/install.py
+++ b/tools/install.py
@@ -128,7 +128,7 @@ def waf_files(action):
           'lib/node/wafadmin/')
 
 def update_shebang(path, shebang):
-  print 'updating shebang of %s' % path
+  print 'updating shebang of %s to %s' % (path, shebang)
   s = open(path, 'r').read()
   s = re.sub(r'#!.*\n', '#!' + shebang + '\n', s)
   open(path, 'w').write(s)
@@ -153,7 +153,8 @@ def npm_files(action):
     action([link_path], 'bin/npm')
   elif action == install:
     try_symlink('../lib/node_modules/npm/bin/npm-cli.js', link_path)
-    update_shebang(link_path, node_prefix + '/bin/node')
+    shebang = os.path.join(node_prefix, 'bin/node')
+    update_shebang(link_path, shebang)
   else:
     assert(0) # unhandled action type
 


### PR DESCRIPTION
This is for #3741.

Now we can do `make binary` in the repo and it'll generate a precompiled tarball package for the current platform, in the form of `node-v$(VERSION)-$(PLATFORM)-$(ARCH).tar.gz`, which ends up something like: `node-v0.8.6-linux-x86_64.tar.gz`.

My make-fu is weak so there's definitely things that can be improved.

@bnoordhuis You should definitely check out the first few commits as they fix bugs in the new python installer script.
