### PR TITLE
Fix for fs.appendFile failure when a callback isn't passed and an is error returned

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -818,8 +818,7 @@ fs.writeFileSync = function(path, data, encoding) {
 
 fs.appendFile = function(path, data, encoding_, callback) {
   var encoding = (typeof(encoding_) == 'string' ? encoding_ : 'utf8');
-  var callback_ = arguments[arguments.length - 1];
-  callback = (typeof(callback_) == 'function' ? callback_ : null);
+  var callback = makeCallback(arguments[arguments.length - 1]);
 
   fs.open(path, 'a', 438 /*=0666*/, function(err, fd) {
     if (err) return callback(err);


### PR DESCRIPTION
Documentation for 'fs.appendFile' marks the 'callback' argument as optional, but the code would fail if not passed a callback function and an error has occurred.

The code defaulted to 'null' which was later called as a function in the case of an error.

Fixed to use (the already defined) 'makeCallback' function.
