### PR TITLE
move setImmediate from timer to uv_check

### DIFF
--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -49,9 +49,10 @@ request the timer hold the program open. If the timer is already `ref`d calling
 
 ## setImmediate(callback, [arg], [...])
 
-To schedule the "immediate" execution of `callback`. Returns an `immediateId`
-for possible use with `clearImmediate()`. Optionally you can also pass
-arguments to the callback.
+To schedule the "immediate" execution of `callback` after I/O events
+callbacks and before `setTimeout` and `setInterval` . Returns an
+`immediateId` for possible use with `clearImmediate()`. Optionally you
+can also pass arguments to the callback.
 
 Immediates are queued in the order created, and are popped off the queue once
 per loop iteration. This is different from `process.nextTick` which will

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -292,29 +292,21 @@ Timeout.prototype.close = function() {
 };
 
 
-var immediateTimer = null;
-var immediateQueue = { started: false };
+var immediateQueue = {};
 L.init(immediateQueue);
 
 
-function lazyImmediateInit() { // what's in a name?
-  if (immediateTimer) return;
-  immediateTimer = new Timer;
-  immediateTimer.ontimeout = processImmediate;
-}
-
-
 function processImmediate() {
-  var immediate;
-  if (L.isEmpty(immediateQueue)) {
-    immediateTimer.stop();
-    immediateQueue.started = false;
-  } else {
-    immediate = L.shift(immediateQueue);
+  var immediate = L.shift(immediateQueue);
 
+  if (L.isEmpty(immediateQueue)) {
+    process._needImmediateCallback = false;
+  }
+
+  if (immediate._onImmediate) {
     if (immediate.domain) immediate.domain.enter();
 
-    immediate._onTimeout();
+    immediate._onImmediate();
 
     if (immediate.domain) immediate.domain.exit();
   }
@@ -326,19 +318,19 @@ exports.setImmediate = function(callback) {
 
   L.init(immediate);
 
-  immediate._onTimeout = callback;
+  immediate._onImmediate = callback;
 
   if (arguments.length > 1) {
     args = Array.prototype.slice.call(arguments, 1);
-    immediate._onTimeout = function() {
+
+    immediate._onImmediate = function() {
       callback.apply(null, args);
     };
   }
 
-  if (!immediateQueue.started) {
-    lazyImmediateInit();
-    immediateTimer.start(0, 1);
-    immediateQueue.started = true;
+  if (!process._needImmediateCallback) {
+    process._needImmediateCallback = true;
+    process._immediateCallback = processImmediate;
   }
 
   if (process.domain) immediate.domain = process.domain;
@@ -352,12 +344,11 @@ exports.setImmediate = function(callback) {
 exports.clearImmediate = function(immediate) {
   if (!immediate) return;
 
-  immediate._onTimeout = undefined;
+  immediate._onImmediate = undefined;
 
   L.remove(immediate);
 
   if (L.isEmpty(immediateQueue)) {
-    immediateTimer.stop();
-    immediateQueue.started = false;
+    process._needImmediateCallback = false;
   }
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -134,6 +134,11 @@ static uv_idle_t tick_spinner;
 static bool need_tick_cb;
 static Persistent<String> tick_callback_sym;
 
+static uv_check_t check_immediate_watcher;
+static uv_idle_t idle_immediate_dummy;
+static bool need_immediate_cb;
+static Persistent<String> immediate_callback_sym;
+
 
 #ifdef OPENSSL_NPN_NEGOTIATED
 static bool use_npn = true;
@@ -208,6 +213,27 @@ static void StartTickSpinner() {
 static Handle<Value> NeedTickCallback(const Arguments& args) {
   StartTickSpinner();
   return Undefined(node_isolate);
+}
+
+
+static void CheckImmediate(uv_check_t* handle, int status) {
+  assert(handle == &check_immediate_watcher);
+  assert(status == 0);
+
+  HandleScope scope;
+
+  if (immediate_callback_sym.IsEmpty()) {
+    immediate_callback_sym = NODE_PSYMBOL("_immediateCallback");
+  }
+
+  MakeCallback(process, immediate_callback_sym, 0, NULL);
+}
+
+
+static void IdleImmediateDummy(uv_idle_t* handle, int status) {
+  // Do nothing. Only for maintaining event loop
+  assert(handle == &idle_immediate_dummy);
+  assert(status == 0);
 }
 
 
@@ -2184,6 +2210,35 @@ static Handle<Value> DebugProcess(const Arguments& args);
 static Handle<Value> DebugPause(const Arguments& args);
 static Handle<Value> DebugEnd(const Arguments& args);
 
+
+Handle<Value> NeedImmediateCallbackGetter(Local<String> property,
+                                          const AccessorInfo& info) {
+  return Boolean::New(need_immediate_cb);
+}
+
+
+static void NeedImmediateCallbackSetter(Local<String> property,
+                                        Local<Value> value,
+                                        const AccessorInfo& info) {
+  HandleScope scope;
+
+  bool bool_value = value->BooleanValue();
+
+  if (need_immediate_cb == bool_value) return;
+
+  need_immediate_cb = bool_value;
+
+  if (need_immediate_cb) {
+    uv_check_start(&check_immediate_watcher, node::CheckImmediate);
+    // idle handle is needed only to maintain event loop
+    uv_idle_start(&idle_immediate_dummy, node::IdleImmediateDummy);
+  } else {
+    uv_check_stop(&check_immediate_watcher);
+    uv_idle_stop(&idle_immediate_dummy);
+  }
+}
+
+
 Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   HandleScope scope;
 
@@ -2277,6 +2332,9 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
   process->Set(String::NewSymbol("pid"), Integer::New(getpid(), node_isolate));
   process->Set(String::NewSymbol("features"), GetFeatures());
+  process->SetAccessor(String::New("_needImmediateCallback"),
+                       NeedImmediateCallbackGetter,
+                       NeedImmediateCallbackSetter);
 
   // -e, --eval
   if (eval_string) {
@@ -2858,6 +2916,10 @@ char** Init(int argc, char *argv[]) {
 #endif // __POSIX__
 
   uv_idle_init(uv_default_loop(), &tick_spinner);
+
+  uv_check_init(uv_default_loop(), &check_immediate_watcher);
+  uv_unref((uv_handle_t*) &check_immediate_watcher);
+  uv_idle_init(uv_default_loop(), &idle_immediate_dummy);
 
   V8::SetFatalErrorHandler(node::OnFatalError);
 


### PR DESCRIPTION
`uv_check` is the robust place to invoke `setImmediate` callbacks after `process.nextTick` and before timers(`setTimeout/setInterval`) for the following two reason.
#### 1. `immediateTimer.start(0, 1)` does not keep zero timeout value

The following  test of setImmediate recursion shows its callbacks need time more than 1msec at every time. This is because of `uv_timer_again()` as commented in https://github.com/joyent/libuv/commit/90a75b0d8485d802a69056e7e63ae1ce749c69de#include-uv-h-P19 This would cause missing invocation of callbacks immediately after `uv_poll()`.

``` javascript
function recur(n) {
  var i = 0, max = n * 100, start = Date.now();
  (function f() {
    if ( i++ < max) {
      setImmediate(f);
    } else {
      var etime = Date.now() - start;
      console.log('iter=', max,', elapsed time=', etime , ', ave=', etime/max);
      if (n < 10) recur(++n);
      return;
    }
  })();
}
recur(1);
```

The resut is

``` bash
> ./node ~/setImmedaite_recur_test.js
iter= 100 , elapsed time= 130 , ave= 1.3
iter= 200 , elapsed time= 263 , ave= 1.315
iter= 300 , elapsed time= 397 , ave= 1.3233333333333333
iter= 400 , elapsed time= 528 , ave= 1.32
iter= 500 , elapsed time= 650 , ave= 1.3
iter= 600 , elapsed time= 780 , ave= 1.3
iter= 700 , elapsed time= 900 , ave= 1.2857142857142858
iter= 800 , elapsed time= 1039 , ave= 1.29875
iter= 900 , elapsed time= 1179 , ave= 1.31
iter= 1000 , elapsed time= 1308 , ave= 1.308
```
#### 2. callback order changes when timeout value collides with another timers

It has a possibility for `setImmediate` to have the same timeout value as that of another timers. If this happens, the callback order is defined by the value of pointer of handles as
https://github.com/joyent/libuv/blob/master/src/unix/timer.c#L30-33
I think that `setImmediate callback` should be invoked after `process.nextTick` and before another timers. If not, the order has to be absolutely defined. 

In both cases above, we can resolve them by fixing libuv, but I think that it is best to move the place of `setImmediate` to `uv_check` where old `process.nextTick` was invoked.
