### PR TITLE
build: don't use "-Wnewline-eof" on OS X

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -190,7 +190,6 @@
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'GCC_VERSION': '4.2',
-          'GCC_WARN_ABOUT_MISSING_NEWLINE': 'YES',  # -Wnewline-eof
           'PREBINDING': 'NO',                       # No -Wl,-prebind
           'MACOSX_DEPLOYMENT_TARGET': '10.5',       # -mmacosx-version-min=10.5
           'USE_HEADERMAP': 'NO',


### PR DESCRIPTION
This is the only thing preventing a manually compiled version of GCC (rather than Apple's provided llvm-gcc or gcc 4.2) from working properly, so we might as well enable support for that.

With this patch I was able to compile node using a manually compiled gcc 4.7.1.

@isaacs @bnoordhuis Any objections?
