### PR TITLE
child_process: emit error on exec failure

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -658,6 +658,12 @@ function ChildProcess() {
     // - normally terminated processes don't touch this.signalCode
     // - signaled processes don't touch this.exitCode
     //
+    // new in 0.9.x:
+    //
+    // - spawn failures are reported with exitCode == -1
+    //
+    var err = (exitCode == -1) ? errnoException(errno, 'spawn') : null;
+
     if (signalCode) {
       self.signalCode = signalCode;
     } else {
@@ -671,7 +677,11 @@ function ChildProcess() {
     self._handle.close();
     self._handle = null;
 
-    self.emit('exit', self.exitCode, self.signalCode);
+    if (exitCode == -1) {
+      self.emit('error', err);
+    } else {
+      self.emit('exit', self.exitCode, self.signalCode);
+    }
 
     maybeClose(self);
   };

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -294,9 +294,14 @@ class ProcessWrap : public HandleWrap {
       String::New(signo_string(term_signal))
     };
 
+    if (exit_status == -1) {
+      SetErrno(uv_last_error(uv_default_loop()));
+    }
+
     if (onexit_sym.IsEmpty()) {
       onexit_sym = NODE_PSYMBOL("onexit");
     }
+
     MakeCallback(wrap->object_, onexit_sym, ARRAY_SIZE(argv), argv);
   }
 

--- a/test/simple/test-child-process-cwd.js
+++ b/test/simple/test-child-process-cwd.js
@@ -53,6 +53,8 @@ function testCwd(options, forCode, forData) {
   });
 
   returns++;
+
+  return child;
 }
 
 // Assume these exist, and 'pwd' gives us the right directory back
@@ -64,8 +66,19 @@ if (process.platform == 'win32') {
   testCwd({cwd: '/'}, 0, '/');
 }
 
-// Assume this doesn't exist, we expect exitcode=127
-testCwd({cwd: 'does-not-exist'}, 127);
+// Assume does-not-exist doesn't exist, expect exitCode=-1 and errno=ENOENT
+(function() {
+  var errors = 0;
+
+  testCwd({cwd: 'does-not-exist'}, -1).on('error', function(e) {
+    assert.equal(e.code, 'ENOENT');
+    errors++;
+  });
+
+  process.on('exit', function() {
+    assert.equal(errors, 1);
+  });
+})();
 
 // Spawn() shouldn't try to chdir() so this should just work
 testCwd(undefined, 0);

--- a/test/simple/test-child-process-exec-error.js
+++ b/test/simple/test-child-process-exec-error.js
@@ -1,0 +1,40 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var child_process = require('child_process');
+
+function test(fun, code) {
+  var errors = 0;
+
+  fun('does-not-exist', function(err) {
+    assert.equal(err.code, code);
+    errors++;
+  });
+
+  process.on('exit', function() {
+    assert.equal(errors, 1);
+  });
+}
+
+test(child_process.exec, 127); // exit code of /bin/sh or cmd.exe
+test(child_process.execFile, 'ENOENT');


### PR DESCRIPTION
libuv calls the exit cb with exit code == -1 when it fails to spawn the new process. Anticipate that and emit the error on the ChildProcess object. Fixes simple/test-child-process-cwd.
