### PR TITLE
doc: colorize deprecated api notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ website_files = \
 	out/doc/index.html    \
 	out/doc/v0.4_announcement.html   \
 	out/doc/cla.html      \
+	out/doc/doc.js    \
 	out/doc/sh_main.js    \
 	out/doc/sh_javascript.min.js \
 	out/doc/sh_vim-dark.css \

--- a/doc/api_assets/doc.css
+++ b/doc/api_assets/doc.css
@@ -1,0 +1,4 @@
+
+.api_stability_0 {
+  border-color: red;
+}

--- a/doc/doc.js
+++ b/doc/doc.js
@@ -1,0 +1,10 @@
+
+var nodes = document.getElementsByTagName('pre');
+
+for (var i=0 ; i< nodes.length ; ++i) {
+    var element = nodes.item(i);
+    if (element.innerHTML.indexOf('Stability: 0') >= 0) {
+        element.className += 'api_stability_0';
+    }
+}
+

--- a/doc/template.html
+++ b/doc/template.html
@@ -5,6 +5,7 @@
   <title>__SECTION__ Node.js __VERSION__ Manual &amp; Documentation</title>
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/sh.css">
+  <link rel="stylesheet" href="assets/doc.css">
   <link rel="canonical" href="http://nodejs.org/api/__FILENAME__.html">
 </head>
 <body class="alt apidoc" id="api-section-__FILENAME__">
@@ -69,6 +70,7 @@
         <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">license</a>.</p>
     </div>
 
+  <script src="../doc.js"></script>
   <script src="../sh_main.js"></script>
   <script src="../sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>


### PR DESCRIPTION
API stability notes are very easy to overlook since they are the same
color as other code snippets. Likewise, deprecated and non deprecated
api look the same and give no visual feedback (other than a number
change) that one should not use the particular api. Using red for the
outline of deprecated api notes brings attention to the fact they are
deprecated.
