### PR TITLE
Fixed a typo in the comments of EventEmitter#addListener

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -361,7 +361,7 @@ server. An alternative wound be to execute `worker.destroy()` after 2 seconds, b
 that would normally not allow the worker to do any cleanup if needed.
 
     if (cluster.isMaster) {
-      var worker = cluser.fork();
+      var worker = cluster.fork();
       var timeout;
 
       worker.on('listening', function(address) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -131,8 +131,8 @@ EventEmitter.prototype.addListener = function(type, listener) {
 
   if (!this._events) this._events = {};
 
-  // To avoid recursion in the case that type == "newListeners"! Before
-  // adding it to the listeners, first emit "newListeners".
+  // To avoid recursion in the case that type == "newListener"! Before
+  // adding it to the listeners, first emit "newListener".
   this.emit('newListener', type, typeof listener.listener === 'function' ?
             listener.listener : listener);
 


### PR DESCRIPTION
It referred to "newListeners", which should say "newListener" instead.
