### PR TITLE
Remove nodejs-dev from the community page.

### DIFF
--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -80,15 +80,12 @@
 
               <div class="row clearfix">
                   <div class="block">
-                      <h2 class="mailing">Mailing Lists</h2>
+                      <h2 class="mailing">Mailing List</h2>
 
                       <p>The <a
-                              href="http://groups.google.com/group/nodejs">user
-                              mailing list</a> is used for announcements, discussion,
-                          and flame wars about Node.  The <a
-                              href="http://groups.google.com/group/nodejs-dev">internal
-                              development mailing list</a> is used for discussion of
-                          internal design and feature proposals.</p>
+                              href="http://groups.google.com/group/nodejs">mailing
+                              list</a> is used for announcements, discussion, and
+                          flame wars about Node.</p>
                   </div>
 
                   <div class="block">


### PR DESCRIPTION
Just a friendly reminder that this is still here, following [the deprecation post](https://groups.google.com/d/topic/nodejs-dev/FhFhw5z48UQ/discussion).
