### PR TITLE
fs.readFile did not catch encoding error

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -172,7 +172,13 @@ fs.readFile = function(path, encoding_) {
         buffer = buffer.slice(0, pos);
       }
 
-      if (encoding) buffer = buffer.toString(encoding);
+      if (encoding && !er) {
+        try {
+          buffer = buffer.toString(encoding);
+        } catch (e) {
+          return callback(e);
+        }
+      }
       return callback(er, buffer);
     });
   }

--- a/test/simple/test-fs-readfile-badencoding.js
+++ b/test/simple/test-fs-readfile-badencoding.js
@@ -1,0 +1,32 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var fs = require('fs');
+var error;
+
+fs.readFile(__filename, 'utf9', function(err, content) {
+	error = err;
+});
+
+process.on('exit', function() {
+  assert.equal(true, error != null);
+});


### PR DESCRIPTION
If you passed an invalid encoding to `fs.readFile` the exception was not caught and not propagated to the callback. Instead the process would die with an unhandled exception.

Repro:

``` javascript
require('fs').readFile(__filename, "utf9", function(err, result) {
    console.log('err=' + err + ', result=' + result);
});
```

Output:

```
buffer.js:434
      throw new Error('Unknown encoding');
            ^
Error: Unknown encoding
    at Buffer.toString (buffer.js:434:13)
    at fs.readFile (fs.js:175:37)
    at Object.oncomplete (fs.js:297:15)
```

instead of:

```
err=Error: Unknown encoding, result=undefined
```

Notes: 
- I tested for `encoding && !er` because I don't want to clobber previous error. It would probably be better to test for `er` at the beginning of the `close` function.
- I added a test file and tried to follow the style of other test files. Don't know if this is what you expect, or if I put it in the right place (this is my first pull request).

Thanks @tchambard for spotting the problem.
