### PR TITLE
Fixed a bug with last command repeating in debugger

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -952,7 +952,7 @@ Interface.prototype.controlEval = function(code, context, filename, callback) {
   try {
     // Repeat last command if empty line are going to be evaluated
     if (this.repl.rli.history && this.repl.rli.history.length > 0) {
-      if (code === '(undefined\n)') {
+      if (code === '(\n)') {
         code = '(' + this.repl.rli.history[0] + '\n)';
       }
     }


### PR DESCRIPTION
Debugger usually repeat it's last command if user submits an empty line. Unfortunately, this functionality depends on a bug that got fixed in joyent/node@9126dd2d903f3cf842f0c11a8349d794dde68e98 .

PS: Repl has history only if output is a terminal. So I see no way to test it using automated scripts.
