### PR TITLE
Parallel make fails if "make clean" first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ endif
 # to check for changes.
 .PHONY: node node_g
 
-node: config.gypi
+node: config.gypi out/Makefile
 	$(MAKE) -C out BUILDTYPE=Release V=$(V)
 	ln -fs out/Release/node node
 
-node_g: config.gypi
+node_g: config.gypi out/Makefile
 	$(MAKE) -C out BUILDTYPE=Debug V=$(V)
 	ln -fs out/Debug/node node_g
 


### PR DESCRIPTION
make fails if
./configure && make clean && make -j6 

```
creating  ./config.gypi
creating  ./config.mk
rm -rf out/Makefile node node_g out/Release/node blog.html email.md
find out/ -name '*.o' -o -name '*.a' | xargs rm -rf
rm -rf node_modules
python tools/gyp_node -f make
make -C out BUILDTYPE=Release V=1
make[1]: *** No targets specified and no makefile found.  Stop.
make: *** [node] Error 2
make: *** Waiting for unfinished jobs....
```
