### PR TITLE
Remove EventEmitter#domain clobbering by 'domain' module.

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -80,7 +80,7 @@ Domain.prototype.enter = function() {
 
   // note that this might be a no-op, but we still need
   // to push it onto the stack so that we can pop it later.
-  exports.active = process.domain = this;
+  exports.active = process._domain = this;
   stack.push(this);
 };
 
@@ -94,7 +94,7 @@ Domain.prototype.exit = function() {
   } while (d && d !== this);
 
   exports.active = stack[stack.length - 1];
-  process.domain = exports.active;
+  process._domain = exports.active;
 };
 
 // note: this works for timers as well.
@@ -103,11 +103,11 @@ Domain.prototype.add = function(ee) {
   if (this._disposed) return;
 
   // already added to this domain.
-  if (ee.domain === this) return;
+  if (ee._domain === this) return;
 
   // has a domain already - remove it first.
-  if (ee.domain) {
-    ee.domain.remove(ee);
+  if (ee._domain) {
+    ee._domain.remove(ee);
   }
 
   // check for circular Domain->Domain links.
@@ -119,18 +119,18 @@ Domain.prototype.add = function(ee) {
   // d.add(e);
   // e.add(d);
   // e.emit('error', er); // RangeError, stack overflow!
-  if (this.domain && (ee instanceof Domain)) {
-    for (var d = this.domain; d; d = d.domain) {
+  if (this._domain && (ee instanceof Domain)) {
+    for (var d = this._domain; d; d = d._domain) {
       if (ee === d) return;
     }
   }
 
-  ee.domain = this;
+  ee._domain = this;
   this.members.push(ee);
 };
 
 Domain.prototype.remove = function(ee) {
-  ee.domain = null;
+  ee._domain = null;
   var index = this.members.indexOf(ee);
   if (index !== -1) {
     this.members.splice(index, 1);
@@ -202,7 +202,7 @@ Domain.prototype.bind = function(cb, interceptError) {
     self.exit();
     return ret;
   };
-  b.domain = this;
+  b._domain = this;
   return b;
 };
 
@@ -244,7 +244,7 @@ Domain.prototype.dispose = function() {
   });
 
   // remove from parent domain, if there is one.
-  if (this.domain) this.domain.remove(this);
+  if (this._domain) this._domain.remove(this);
 
   // kill the references so that they can be properly gc'ed.
   this.members.length = 0;

--- a/lib/events.js
+++ b/lib/events.js
@@ -27,7 +27,7 @@ function EventEmitter() {
     // if there is an active domain, then attach to it.
     domain = domain || require('domain');
     if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
+      this._domain = domain.active;
     }
   }
 }
@@ -53,12 +53,12 @@ EventEmitter.prototype.emit = function() {
     if (!this._events || !this._events.error ||
         (isArray(this._events.error) && !this._events.error.length))
     {
-      if (this.domain) {
+      if (exports.usingDomains && this._domain) {
         var er = arguments[1];
         er.domain_emitter = this;
-        er.domain = this.domain;
+        er.domain = this._domain;
         er.domain_thrown = false;
-        this.domain.emit('error', er);
+        this._domain.emit('error', er);
         return false;
       }
 
@@ -76,8 +76,8 @@ EventEmitter.prototype.emit = function() {
   if (!handler) return false;
 
   if (typeof handler == 'function') {
-    if (this.domain) {
-      this.domain.enter();
+    if (exports.usingDomains && this._domain) {
+      this._domain.enter();
     }
     switch (arguments.length) {
       // fast cases
@@ -97,14 +97,14 @@ EventEmitter.prototype.emit = function() {
         for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
         handler.apply(this, args);
     }
-    if (this.domain) {
-      this.domain.exit();
+    if (exports.usingDomains && this._domain) {
+      this._domain.exit();
     }
     return true;
 
   } else if (isArray(handler)) {
-    if (this.domain) {
-      this.domain.enter();
+    if (exports.usingDomains && this._domain) {
+      this._domain.enter();
     }
     var l = arguments.length;
     var args = new Array(l - 1);
@@ -114,8 +114,8 @@ EventEmitter.prototype.emit = function() {
     for (var i = 0, l = listeners.length; i < l; i++) {
       listeners[i].apply(this, args);
     }
-    if (this.domain) {
-      this.domain.exit();
+    if (exports.usingDomains && this._domain) {
+      this._domain.exit();
     }
     return true;
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -92,9 +92,9 @@ function insert(item, msecs) {
           // hack should be removed.
           //
           // https://github.com/joyent/node/issues/2631
-          if (first.domain) {
-            if (first.domain._disposed) continue;
-            first.domain.enter();
+          if (first._domain) {
+            if (first._domain._disposed) continue;
+            first._domain.enter();
           }
           try {
             first._onTimeout();
@@ -102,7 +102,7 @@ function insert(item, msecs) {
             if (!process.listeners('uncaughtException').length) throw e;
             process.emit('uncaughtException', e);
           }
-          if (first.domain) first.domain.exit();
+          if (first._domain) first._domain.exit();
         }
       }
 
@@ -196,7 +196,7 @@ exports.setTimeout = function(callback, after) {
     }
   }
 
-  if (process.domain) timer.domain = process.domain;
+  if (process._domain) timer._domain = process._domain;
 
   exports.active(timer);
 
@@ -219,7 +219,7 @@ exports.clearTimeout = function(timer) {
 exports.setInterval = function(callback, repeat) {
   var timer = new Timer();
 
-  if (process.domain) timer.domain = process.domain;
+  if (process._domain) timer._domain = process._domain;
 
   repeat *= 1; // coalesce to number or NaN
 
@@ -259,7 +259,7 @@ Timeout.prototype.unref = function() {
     this._handle = new Timer();
     this._handle.ontimeout = this._onTimeout;
     this._handle.start(delay, 0);
-    this._handle.domain = this.domain;
+    this._handle._domain = this._domain;
     this._handle.unref();
   } else {
     this._handle.unref();
@@ -302,11 +302,11 @@ function processImmediate() {
   } else {
     immediate = L.shift(immediateQueue);
 
-    if (immediate.domain) immediate.domain.enter();
+    if (immediate._domain) immediate._domain.enter();
 
     immediate._onTimeout();
 
-    if (immediate.domain) immediate.domain.exit();
+    if (immediate._domain) immediate._domain.exit();
   }
 }
 
@@ -331,7 +331,7 @@ exports.setImmediate = function(callback) {
     immediateQueue.started = true;
   }
 
-  if (process.domain) immediate.domain = process.domain;
+  if (process._domain) immediate._domain = process._domain;
 
   L.append(immediateQueue, immediate);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2863,7 +2863,7 @@ int Start(int argc, char *argv[]) {
     Context::Scope context_scope(context);
 
     process_symbol = NODE_PSYMBOL("process");
-    domain_symbol = NODE_PSYMBOL("domain");
+    domain_symbol = NODE_PSYMBOL("_domain");
 
     // Use original argv, as we're just copying values out of it.
     Handle<Object> process_l = SetupProcessObject(argc, argv);

--- a/src/node.js
+++ b/src/node.js
@@ -239,7 +239,7 @@
 
   startup.processMakeCallback = function() {
     process._makeCallback = function(obj, fn, args) {
-      var domain = obj.domain;
+      var domain = obj._domain;
       if (domain) {
         if (domain._disposed) return;
         domain.enter();
@@ -316,9 +316,9 @@
         while (nextTickIndex < nextTickLength) {
           var tock = nextTickQueue[nextTickIndex++];
           var callback = tock.callback;
-          if (tock.domain) {
-            if (tock.domain._disposed) continue;
-            tock.domain.enter();
+          if (tock._domain) {
+            if (tock._domain._disposed) continue;
+            tock._domain.enter();
           }
           var threw = true;
           try {
@@ -329,8 +329,8 @@
             // so we can't clear the tickDepth at this point.
             if (threw) tickDone(tickDepth);
           }
-          if (tock.domain) {
-            tock.domain.exit();
+          if (tock._domain) {
+            tock._domain.exit();
           }
         }
         nextTickQueue.splice(0, nextTickIndex);
@@ -349,7 +349,7 @@
       if (process._exiting) return;
 
       var tock = { callback: callback };
-      if (process.domain) tock.domain = process.domain;
+      if (process._domain) tock._domain = process._domain;
       nextTickQueue.push(tock);
       if (nextTickQueue.length) {
         process._needTickCallback();

--- a/test/simple/test-domain-noclobber.js
+++ b/test/simple/test-domain-noclobber.js
@@ -1,0 +1,56 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Make sure the EventEmitter#domain is not clobbered by domain module.
+// See https://github.com/joyent/node/issues/3922
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+var util   = require('util');
+var EventEmitter = events.EventEmitter;
+
+
+util.inherits(WebSite, EventEmitter);
+
+function WebSite(domain) {
+    EventEmitter.apply(this);
+    this.domain = domain;
+}
+
+
+var website = new WebSite("google.com");
+website.on("ping", function() {});
+website.emit("ping"); // This line must not throw exception.
+
+
+// Even after require-ing domain module (which have side effects).
+require('domain');
+
+var website2 = new WebSite("google.com");
+website2.on("ping", function() {});
+website2.emit("ping");
+
+
+process.on('exit', function() {
+  console.log('ok');
+});


### PR DESCRIPTION
Field clobbering is removed on 2 levels:
- The field itself is renamed to '_domain', according to conventions for internal field naming.
- The 'events.usingDomains' is checked so that programs that don't use 'domains' module are not affected even if they use '_domain' field.

Fixes #3922.
Test included.
