### PR TITLE
module.require === require

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -358,11 +358,6 @@ Module.prototype.load = function(filename) {
 };
 
 
-Module.prototype.require = function(path) {
-  return Module._load(path, this);
-};
-
-
 // Resolved path to process.argv[1] will be lazily placed here
 // (needed for setting breakpoint when called with --debug-brk)
 var resolvedArgv;
@@ -375,8 +370,10 @@ Module.prototype._compile = function(content, filename) {
   content = content.replace(/^\#\!.*/, '');
 
   function require(path) {
-    return self.require(path);
+    return Module._load(path, self);
   }
+
+  self.require = require;
 
   require.resolve = function(request) {
     return Module._resolveFilename(request, self);

--- a/test/simple/test-require-vs-module-require.js
+++ b/test/simple/test-require-vs-module-require.js
@@ -1,0 +1,29 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+
+// `module.require` and `require` must be strictly equal
+assert.strictEqual(require, module.require);
+
+console.log('ok');


### PR DESCRIPTION
Maybe, for coherence and clarity `module.require` must be strictly equal to `require`

For instance, even if this is not generally recommended, it should be possible to call something like `module.require.resolve()`

Very minor change is done here and test included : this is foremost a simple suggestion to be discussed.
