### PR TITLE
tls: support unix domain socket/named pipe in tls.connect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -86,6 +86,7 @@ exports.connect = exports.createConnection = function() {
 
 // Returns an array [options] or [options, cb]
 // It is the same as the argument of Socket.prototype.connect().
+exports._normalizeConnectArgs = normalizeConnectArgs;
 function normalizeConnectArgs(args) {
   var options = {};
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1183,34 +1183,24 @@ Server.prototype.SNICallback = function(servername) {
 //  });
 //
 //
+function normalizeConnectArgs(listArgs) {
+  var args = net._normalizeConnectArgs(listArgs);
+  var options = args[0];
+  var cb = args[1];
+
+  if (typeof listArgs[1] === 'object') {
+    options = util._extend(options, listArgs[1]);
+  } else if (typeof listArgs[2] === 'object') {
+    options = util._extend(options, listArgs[2]);
+  }
+
+  return (cb) ? [options, cb] : [options];
+}
+
 exports.connect = function(/* [port, host], options, cb */) {
-  var options, port, host, cb;
-
-  if (typeof arguments[0] === 'object') {
-    options = arguments[0];
-  } else if (typeof arguments[1] === 'object') {
-    options = arguments[1];
-    port = arguments[0];
-  } else if (typeof arguments[2] === 'object') {
-    options = arguments[2];
-    port = arguments[0];
-    host = arguments[1];
-  } else {
-    // This is what happens when user passes no `options` argument, we can't
-    // throw `TypeError` here because it would be incompatible with old API
-    if (typeof arguments[0] === 'number') {
-      port = arguments[0];
-    }
-    if (typeof arguments[1] === 'string') {
-      host = arguments[1];
-    }
-  }
-
-  options = util._extend({ port: port, host: host }, options || {});
-
-  if (typeof arguments[arguments.length - 1] === 'function') {
-    cb = arguments[arguments.length - 1];
-  }
+  var args = normalizeConnectArgs(arguments);
+  var options = args[0];
+  var cb = args[1];
 
   var socket = options.socket ? options.socket : new net.Stream();
 
@@ -1235,11 +1225,12 @@ exports.connect = function(/* [port, host], options, cb */) {
   }
 
   if (!options.socket) {
-    socket.connect({
+    var connect_opt = (options.path && !options.port) ? {path: options.path} : {
       port: options.port,
       host: options.host,
       localAddress: options.localAddress
-    });
+    };
+    socket.connect(connect_opt);
   }
 
   pair.on('secure', function() {

--- a/test/simple/test-tls-connect-pipe.js
+++ b/test/simple/test-tls-connect-pipe.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var clientConnected = 0;
+var serverConnected = 0;
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var server = tls.Server(options, function(socket) {
+  ++serverConnected;
+  server.close();
+});
+server.listen(common.PIPE, function() {
+  var client = tls.connect(common.PIPE, function() {
+    ++clientConnected;
+    client.end();
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(clientConnected, 1);
+  assert.equal(serverConnected, 1);
+});


### PR DESCRIPTION
The first argument of tls.connect(), `port`,  in node-v0.8 takes only number type while that in node-v0.6 not. The following script does not work in node-v0.8 unless `port` is changed into `+port` to be number type.

``` javascript
var tls = require('tls');
var port = process.argv[3];
var host = process.argv[2];
var client = tls.connect(port, host, function() {
   console.log('connected');
   client.end();
});
```

This also causes the failure of `tls.connect()` with using Unix domain socket or Windows named pipe. 
Although `tls.connect(path, callback)` is not documented in the manual, there is no reason to prohibit it.
I made this commit against v0.8 branch to solve these two problems since this is a compatibility issue between v0.6 and v0.8.
