### PR TITLE
cli: main module via stdin always print result

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -143,6 +143,9 @@
         process.stdin.resume();
         process.stdin.setEncoding('utf8');
 
+        // Always print result to console.log 
+        process._print_eval = true;
+
         var code = '';
         process.stdin.on('data', function(d) {
           code += d;

--- a/test/message/stdin_messages.js
+++ b/test/message/stdin_messages.js
@@ -28,7 +28,6 @@ var spawn = require('child_process').spawn;
 function run(cmd, strict, cb) {
   var args = [];
   if (strict) args.push('--use_strict');
-  args.push('-p');
   var child = spawn(process.execPath, args);
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stdout);


### PR DESCRIPTION
`node -p` is no longer valid in the case of pipe input as.

``` bash
$echo "(function(){return 'foo'})();" | ./node -p
Error: -p requires an argument
```

And the above without `-p` prints nothing. 
This commit is for being consistent printing behaviors between eval and executing main module via stdin as

``` bash
$echo "(function(){return 'foo'})();" | ./node
foo
```
