### PR TITLE
url: Fixes `resolve` to work as documented

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -369,6 +369,7 @@ function urlFormat(obj) {
 }
 
 function urlResolve(source, relative) {
+  relative = relative || {};
   return urlFormat(urlResolveObject(source, relative));
 }
 

--- a/test/simple/test-url-resolve.js
+++ b/test/simple/test-url-resolve.js
@@ -1,0 +1,28 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var url = require('url');
+
+var urlObject = { protocol: "https", host: "localhost", pathname: "/foo" };
+
+assert.equal(url.resolve(urlObject), "https://localhost/foo");


### PR DESCRIPTION
`url.resolve` with arity of one (e.g. `url.resolve({host:"localhost"})`) would throw because the `relative` would be `null` (which has no properties)

``` js
url.js:322
  var auth = obj.auth || ;
                ^
TypeError: Cannot read property auth of undefined
    at urlFormat (url.js:322:17)
    at urlResolveObject (url.js:379:23)
    at Object.urlResolve [as resolve] (url.js:372:20)
    at Object.<anonymous> (/Users/dscape/Desktop/dev/node/test/simple/test-url-resolve.js:28:18)
    at Module._compile (module.js:454:26)
    at Object.Module._extensions..js (module.js:472:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:497:10)
    at process.startup.processNextTick.process._tickCallback (node.js:325:13)
```

This fix resolves that problem by making sure that if a `relative` doesn't exist it defaults to empty object
