### PR TITLE
Make possible to get Buffer from crypto calls

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1096,16 +1096,9 @@ Local<Value> Encode(const void *buf, size_t len, enum encoding encoding) {
   HandleScope scope;
 
   if (encoding == BUFFER) {
-    if (!len) {
-      Buffer* buffer = Buffer::New(0);
-      return scope.Close(Local<Object>::New(buffer->handle_));
-    }
-
-    char* _buffer = new char[len];
-    memcpy(_buffer, buf, len);
-
-    Buffer* buffer = Buffer::New(_buffer, len, EncodeBufferFree, NULL);
-    return scope.Close(Local<Object>::New(buffer->handle_));
+    Buffer* buffer = Buffer::New(len);
+    memcpy(Buffer::Data(buffer), buf, len);
+    return scope.Close(buffer->handle_);
   }
 
   if (!len) return scope.Close(String::Empty());

--- a/src/node.cc
+++ b/src/node.cc
@@ -1088,10 +1088,6 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
   }
 }
 
-void EncodeBufferFree(char* data, void* hint) {
-  delete[] data;
-}
-
 Local<Value> Encode(const void *buf, size_t len, enum encoding encoding) {
   HandleScope scope;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1069,6 +1069,8 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
     return BINARY;
   } else if (strcasecmp(*encoding, "hex") == 0) {
     return HEX;
+  } else if (strcasecmp(*encoding, "buffer") == 0) {
+    return BUFFER;
   } else if (strcasecmp(*encoding, "raw") == 0) {
     if (!no_deprecation) {
       fprintf(stderr, "'raw' (array of integers) has been removed. "
@@ -1081,8 +1083,6 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
                       "Please update your code.\n");
     }
     return BINARY;
-  } else if (strcasecmp(*encoding, "buffer") == 0) {
-    return BUFFER;
   } else {
     return _default;
   }
@@ -1092,9 +1092,7 @@ Local<Value> Encode(const void *buf, size_t len, enum encoding encoding) {
   HandleScope scope;
 
   if (encoding == BUFFER) {
-    Buffer* buffer = Buffer::New(len);
-    memcpy(Buffer::Data(buffer), buf, len);
-    return scope.Close(buffer->handle_);
+    return scope.Close(Buffer::New(static_cast<const char*>(buf), len)->handle_);
   }
 
   if (!len) return scope.Close(String::Empty());

--- a/src/node.cc
+++ b/src/node.cc
@@ -1081,13 +1081,32 @@ enum encoding ParseEncoding(Handle<Value> encoding_v, enum encoding _default) {
                       "Please update your code.\n");
     }
     return BINARY;
+  } else if (strcasecmp(*encoding, "buffer") == 0) {
+    return BUFFER;
   } else {
     return _default;
   }
 }
 
+void EncodeBufferFree(char* data, void* hint) {
+  delete[] data;
+}
+
 Local<Value> Encode(const void *buf, size_t len, enum encoding encoding) {
   HandleScope scope;
+
+  if (encoding == BUFFER) {
+    if (!len) {
+      Buffer* buffer = Buffer::New(0);
+      return scope.Close(Local<Object>::New(buffer->handle_));
+    }
+
+    char* _buffer = new char[len];
+    memcpy(_buffer, buf, len);
+
+    Buffer* buffer = Buffer::New(_buffer, len, EncodeBufferFree, NULL);
+    return scope.Close(Local<Object>::New(buffer->handle_));
+  }
 
   if (!len) return scope.Close(String::Empty());
 

--- a/src/node.h
+++ b/src/node.h
@@ -127,7 +127,7 @@ void SetPrototypeMethod(target_t target,
 #define NODE_SET_METHOD node::SetMethod
 #define NODE_SET_PROTOTYPE_METHOD node::SetPrototypeMethod
 
-enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX};
+enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
 enum encoding ParseEncoding(v8::Handle<v8::Value> encoding_v,
                             enum encoding _default = BINARY);
 NODE_EXTERN void FatalException(v8::TryCatch &try_catch);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -137,14 +137,14 @@ Buffer* Buffer::New(size_t length) {
 }
 
 
-Buffer* Buffer::New(char* data, size_t length) {
+Buffer* Buffer::New(const char* data, size_t length) {
   HandleScope scope;
 
   Local<Value> arg = Integer::NewFromUnsigned(0);
   Local<Object> obj = constructor_template->GetFunction()->NewInstance(1, &arg);
 
   Buffer *buffer = ObjectWrap::Unwrap<Buffer>(obj);
-  buffer->Replace(data, length, NULL, NULL);
+  buffer->Replace(const_cast<char*>(data), length, NULL, NULL);
 
   return buffer;
 }
@@ -198,6 +198,8 @@ Buffer::~Buffer() {
 }
 
 
+// if replace doesn't have a callback, data must be copied
+// const_cast in Buffer::New requires this
 void Buffer::Replace(char *data, size_t length,
                      free_callback callback, void *hint) {
   HandleScope scope;

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -97,10 +97,14 @@ class NODE_EXTERN Buffer: public ObjectWrap {
   static v8::Handle<v8::Object> New(v8::Handle<v8::String> string);
 
   static void Initialize(v8::Handle<v8::Object> target);
-  static Buffer* New(size_t length); // public constructor
-  static Buffer* New(char *data, size_t len); // public constructor
+
+  // public constructor
+  static Buffer* New(size_t length);
+  // public constructor - data is copied
+  static Buffer* New(const char *data, size_t len);
+  // public constructor
   static Buffer* New(char *data, size_t length,
-                     free_callback callback, void *hint); // public constructor
+                     free_callback callback, void *hint);
 
   private:
   static v8::Handle<v8::Value> New(const v8::Arguments &args);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2497,11 +2497,11 @@ class Cipher : public ObjectWrap {
         base64(out, out_len, &out_hexdigest, &out_hex_len);
         outString = Encode(out_hexdigest, out_hex_len, BINARY);
         delete [] out_hexdigest;
-      } else if (enc == BINARY) {
-        outString = Encode(out, out_len, BINARY);
+      } else if (enc == BINARY || enc == BUFFER) {
+        outString = Encode(out, out_len, enc);
       } else {
         fprintf(stderr, "node-crypto : Cipher .update encoding "
-                        "can be binary, hex or base64\n");
+                        "can be binary, hex, base64 or buffer\n");
       }
     }
 
@@ -2570,11 +2570,11 @@ class Cipher : public ObjectWrap {
       base64(out_value, out_len, &out_hexdigest, &out_hex_len);
       outString = Encode(out_hexdigest, out_hex_len, BINARY);
       delete [] out_hexdigest;
-    } else if (enc == BINARY) {
-      outString = Encode(out_value, out_len, BINARY);
+    } else if (enc == BINARY || enc == BUFFER) {
+      outString = Encode(out_value, out_len, enc);
     } else {
       fprintf(stderr, "node-crypto : Cipher .final encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     delete [] out_value;
@@ -2909,12 +2909,12 @@ class Decipher : public ObjectWrap {
       len = ciphertext_len;
       alloc_buf = true;
 
-    } else if (enc == BINARY) {
+    } else if (enc == BINARY || enc == BUFFER) {
       // Binary - do nothing
 
     } else {
       fprintf(stderr, "node-crypto : Decipher .update encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     unsigned char *out=0;
@@ -3216,11 +3216,11 @@ class Hmac : public ObjectWrap {
       base64(md_value, md_len, &md_hexdigest, &md_hex_len);
       outString = Encode(md_hexdigest, md_hex_len, BINARY);
       delete [] md_hexdigest;
-    } else if (enc == BINARY) {
-      outString = Encode(md_value, md_len, BINARY);
+    } else if (enc == BINARY || enc == BUFFER) {
+      outString = Encode(md_value, md_len, enc);
     } else {
       fprintf(stderr, "node-crypto : Hmac .digest encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
     delete [] md_value;
     return scope.Close(outString);
@@ -3371,11 +3371,11 @@ class Hash : public ObjectWrap {
       base64(md_value, md_len, &md_hexdigest, &md_hex_len);
       outString = Encode(md_hexdigest, md_hex_len, BINARY);
       delete [] md_hexdigest;
-    } else if (enc == BINARY) {
-      outString = Encode(md_value, md_len, BINARY);
+    } else if (enc == BINARY || enc == BUFFER) {
+      outString = Encode(md_value, md_len, enc);
     } else {
       fprintf(stderr, "node-crypto : Hash .digest encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     return scope.Close(outString);
@@ -3573,12 +3573,12 @@ class Sign : public ObjectWrap {
       base64(md_value, md_len, &md_hexdigest, &md_hex_len);
       outString = Encode(md_hexdigest, md_hex_len, BINARY);
       delete [] md_hexdigest;
-    } else if (enc == BINARY) {
-      outString = Encode(md_value, md_len, BINARY);
+    } else if (enc == BINARY || enc == BUFFER) {
+      outString = Encode(md_value, md_len, enc);
     } else {
       outString = String::New("");
       fprintf(stderr, "node-crypto : Sign .sign encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     delete [] md_value;
@@ -3825,11 +3825,11 @@ class Verify : public ObjectWrap {
       unbase64(hbuf, hlen, (char **)&dbuf, &dlen);
       r = verify->VerifyFinal(kbuf, klen, dbuf, dlen);
       delete [] dbuf;
-    } else if (enc == BINARY) {
+    } else if (enc == BINARY || enc == BUFFER) {
       r = verify->VerifyFinal(kbuf, klen, hbuf, hlen);
     } else {
       fprintf(stderr, "node-crypto : Verify .verify encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     delete [] kbuf;
@@ -4381,11 +4381,11 @@ class DiffieHellman : public ObjectWrap {
     } else if (enc == BASE64) {
       unbase64((unsigned char*)*buf, len, &retbuf, &retlen);
 
-    } else if (enc == BINARY) {
+    } else if (enc == BINARY || enc == BUFFER) {
       // Binary - do nothing
     } else {
       fprintf(stderr, "node-crypto : Diffie-Hellman parameter encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     if (retbuf != 0) {
@@ -4415,11 +4415,11 @@ class DiffieHellman : public ObjectWrap {
       base64(reinterpret_cast<unsigned char*>(buf), len, &retbuf, &retlen);
       outString = Encode(retbuf, retlen, BINARY);
       delete [] retbuf;
-    } else if (enc == BINARY) {
-      outString = Encode(buf, len, BINARY);
+    } else if (enc == BINARY || enc == BUFFER) {
+      outString = Encode(buf, len, enc);
     } else {
       fprintf(stderr, "node-crypto : Diffie-Hellman parameter encoding "
-                      "can be binary, hex or base64\n");
+                      "can be binary, hex, base64 or buffer\n");
     }
 
     return scope.Close(outString);

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -369,6 +369,7 @@ var a0 = crypto.createHash('sha1').update('Test123').digest('hex');
 var a1 = crypto.createHash('md5').update('Test123').digest('binary');
 var a2 = crypto.createHash('sha256').update('Test123').digest('base64');
 var a3 = crypto.createHash('sha512').update('Test123').digest(); // binary
+var a4 = crypto.createHash('sha512').update('Test123').digest('buffer');
 
 assert.equal(a0, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
 assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
@@ -381,6 +382,12 @@ assert.equal(a3, '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
                  '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
                  '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
              'Test SHA512 as assumed binary');
+assert.ok(a4 instanceof Buffer, 'Test SHA512 if output is Buffer');
+assert.deepEqual(a4,
+             new Buffer('c12834f1031f6497214f27d4432f26517ad494156cb8'+
+                        '8d512bdb1dc4b57db2d692a3dfa269a19b0a0a2a0fd7'+
+                        'd6a2a885e33c839c93c206da30a187392847ed27', 'hex'),
+             'Test SHA512 as assumed buffer');
 
 // Test multiple updates to same hash
 var h1 = crypto.createHash('sha1').update('Test123').digest('hex');


### PR DESCRIPTION
See #3986

This allows to call this to get buffer:

``` js
var crypto = require('crypto');
var hash = crypto.createHash('sha1');
hash.update('test');
var buf = hash.digest('buffer');
// buf now contains <SlowBuffer a9 4a 8f ... bb d3>
```

Tests needed, I can write them next week, so busy now...
