### PR TITLE
Copy uv-linux.h when installing

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -133,6 +133,7 @@ def files(action):
           'deps/uv/include/uv-private/ngx-queue.h',
           'deps/uv/include/uv-private/tree.h',
           'deps/uv/include/uv-private/uv-unix.h',
+          'deps/uv/include/uv-private/uv-linux.h',
           'deps/uv/include/uv-private/uv-win.h'],
           'include/node/uv-private/')
   action(['doc/node.1'], 'share/man/man1/')


### PR DESCRIPTION
Without this, extensions like sqlite-fts won't compile, and will fail
with the following error:

bewest@ripen:~/Documents/git/node-sqlite-fts$ npm install

> sqlite-fts@0.0.9 preinstall /home/bewest/Documents/git/node-sqlite-fts
> node-waf configure build
> [...]
> 'configure' finished successfully (0.470s)
> Waf: Entering directory home/bewest/Documents/git/node-sqlite-fts/build'
> [3/9] cxx: src/sqlite3_bindings.cc -> build/Release/src/sqlite3_bindings_3.o
> [4/9] cxx: src/database.cc -> build/Release/src/database_3.o
> In file included from /usr/local/include/node/uv.h:61In file included from /usr/local/include/node/uv.h:61,
>                  from /usr/local/include/node/node.h:61,
>                  from /usr/local/include/node/node.h:61,
>                  from ../src/database.cc:19,
>                  from ../src/sqlite3_bindings.cc:18:
> :
> /usr/local/include/node/uv-private/uv-unix.h:58:23:/usr/local/include/node/uv-private/uv-unix.h:58:23:  error: error: uv-linux.h: No such file or directoryuv-linux.h: No such file or directory
> Waf: Leaving directory home/bewest/Documents/git/node-sqlite-fts/build'
> Build failed:
> [...]

This includes uv-private/uv-unix.h into the install directory when installing node.
