### PR TITLE
tls, https: default to rejectUnauthorized=true in tls.connect and https.request

### DIFF
--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -119,7 +119,7 @@ The following options from [tls.connect()][] can also be specified. However, a
 - `rejectUnauthorized`: If `true`, the server certificate is verified against
   the list of supplied CAs. An `'error'` event is emitted if verification
   fails. Verification happens at the connection level, *before* the HTTP
-  request is sent. Default `false`.
+  request is sent. Default `true`.
 
 In order to specify these options, use a custom `Agent`.
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -240,7 +240,7 @@ Creates a new client connection to the given `port` and `host` (old API) or
 
   - `rejectUnauthorized`: If `true`, the server certificate is verified against
     the list of supplied CAs. An `'error'` event is emitted if verification
-    fails. Default: `false`.
+    fails. Default: `true`.
 
   - `NPNProtocols`: An array of string or `Buffer` containing supported NPN
     protocols. `Buffer` should have following format: `0x05hello0x05world`,

--- a/lib/https.js
+++ b/lib/https.js
@@ -21,6 +21,7 @@
 
 var tls = require('tls');
 var http = require('http');
+var util = require('util');
 var url = require('url');
 var inherits = require('util').inherits;
 
@@ -97,11 +98,25 @@ exports.request = function(options, cb) {
     throw new Error('Protocol:' + options.protocol + ' not supported.');
   }
 
-  if (options.agent === undefined) {
-    options.agent = globalAgent;
+  options = util._extend({
+    createConnection: createConnection,
+    defaultPort: 443
+  }, options);
+
+  if (typeof options.agent === 'undefined') {
+    if (typeof options.ca === 'undefined' &&
+        typeof options.cert === 'undefined' &&
+        typeof options.ciphers === 'undefined' &&
+        typeof options.key === 'undefined' &&
+        typeof options.passphrase === 'undefined' &&
+        typeof options.pfx === 'undefined' &&
+        typeof options.rejectUnauthorized === 'undefined') {
+      options.agent = globalAgent;
+    } else {
+      options.agent = new Agent(options);
+    }
   }
-  options.createConnection = createConnection;
-  options.defaultPort = options.defaultPort || 443;
+
   return new http.ClientRequest(options, cb);
 };
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1272,6 +1272,11 @@ exports.connect = function(/* [port, host], options, cb */) {
   var options = args[0];
   var cb = args[1];
 
+  var defaults = {
+    rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
+  };
+  options = util._extend(defaults, options || {});
+
   var socket = options.socket ? options.socket : new net.Stream();
 
   var sslcontext = crypto.createCredentials(options);

--- a/test/fixtures/GH-892-request.js
+++ b/test/fixtures/GH-892-request.js
@@ -21,9 +21,6 @@
 
 // Called by test/pummel/test-regress-GH-892.js
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var https = require('https');
 var fs = require('fs');
 var assert = require('assert');
@@ -35,7 +32,8 @@ var gotResponse = false;
 
 var options = {
   method: 'POST',
-  port: PORT
+  port: PORT,
+  rejectUnauthorized: false
 };
 
 var req = https.request(options, function(res) {

--- a/test/fixtures/GH-892-request.js
+++ b/test/fixtures/GH-892-request.js
@@ -19,7 +19,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Called by test/simple/test-regress-GH-892.js
+// Called by test/pummel/test-regress-GH-892.js
+
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var https = require('https');
 var fs = require('fs');

--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -19,8 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 
@@ -53,7 +50,10 @@ var count = 0;
 var gotResEnd = false;
 
 server.listen(common.PORT, function() {
-  https.get({ port: common.PORT }, function(res) {
+  https.get({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function(res) {
     console.log('response!');
 
     res.on('data', function(d) {

--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -19,11 +19,12 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
-
 // Server sends a large string. Client counts bytes and pauses every few
 // seconds. Makes sure that pause and resume work properly.
+
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -22,9 +22,6 @@
 // Server sends a large string. Client counts bytes and pauses every few
 // seconds. Makes sure that pause and resume work properly.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -56,7 +53,10 @@ var server = tls.Server(options, function(socket) {
 var recvCount = 0;
 
 server.listen(common.PORT, function() {
-  var client = tls.connect(common.PORT);
+  var client = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
 
   client.on('data', function(d) {
     process.stdout.write('.');

--- a/test/simple/test-http-host-headers.js
+++ b/test/simple/test-http-host-headers.js
@@ -19,8 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var http = require('http'),
     https = require('https'),

--- a/test/simple/test-http-host-headers.js
+++ b/test/simple/test-http-host-headers.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var http = require('http'),
     https = require('https'),
     fs = require('fs'),
@@ -74,35 +71,50 @@ function testHttp() {
 
     if (er) throw er;
 
-    http.get({ method: 'GET',
+    http.get({
+      method: 'GET',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower);
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower);
 
-    http.request({ method: 'GET',
+    http.request({
+      method: 'GET',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    http.request({ method: 'POST',
+    http.request({
+      method: 'POST',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    http.request({ method: 'PUT',
+    http.request({
+      method: 'PUT',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    http.request({ method: 'DELETE',
+    http.request({
+      method: 'DELETE',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
   });
 }
 
@@ -124,40 +136,58 @@ function testHttps() {
   httpsServer.listen(common.PORT, function(er) {
     if (er) throw er;
 
-    https.get({ method: 'GET',
+    https.get({
+      method: 'GET',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower);
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower);
 
-    https.request({ method: 'GET',
+    https.request({
+      method: 'GET',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    https.request({ method: 'POST',
+    https.request({
+      method: 'POST',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    https.request({ method: 'PUT',
+    https.request({
+      method: 'PUT',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    https.request({ method: 'DELETE',
+    https.request({
+      method: 'DELETE',
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
 
-    https.get({ method: 'GET',
+    https.get({
+      method: 'GET',
       path: '/setHostFalse' + (counter++),
       host: 'localhost',
       setHost: false,
-      port: common.PORT }, cb).on('error', thrower).end();
+      port: common.PORT,
+      rejectUnauthorized: false
+    }, cb).on('error', thrower).end();
   });
 }

--- a/test/simple/test-http-url.parse-https.request.js
+++ b/test/simple/test-http-url.parse-https.request.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');

--- a/test/simple/test-http-url.parse-https.request.js
+++ b/test/simple/test-http-url.parse-https.request.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');
@@ -36,6 +33,7 @@ var httpsOptions = {
 };
 
 var testURL = url.parse('https://localhost:' + common.PORT);
+testURL.rejectUnauthorized = false;
 
 function check(request) {
   // assert that I'm https

--- a/test/simple/test-https-agent.js
+++ b/test/simple/test-https-agent.js
@@ -19,16 +19,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
-
 if (!process.versions.openssl) {
   console.error('Skipping because node compiled without OpenSSL.');
   process.exit(0);
 }
-
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
@@ -55,7 +49,11 @@ server.listen(common.PORT, function() {
   for (var i = 0; i < N; i++) {
     setTimeout(function() {
       for (var j = 0; j < M; j++) {
-        https.get({ port: common.PORT, path: '/' }, function(res) {
+        https.get({
+          path: '/',
+          port: common.PORT,
+          rejectUnauthorized: false
+        }, function(res) {
           console.log(res.statusCode);
           if (++responses == N * M) server.close();
         }).on('error', function(e) {

--- a/test/simple/test-https-agent.js
+++ b/test/simple/test-https-agent.js
@@ -27,6 +27,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');

--- a/test/simple/test-https-client-get-url.js
+++ b/test/simple/test-https-client-get-url.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');

--- a/test/simple/test-https-client-reject.js
+++ b/test/simple/test-https-client-reject.js
@@ -47,21 +47,21 @@ var server = https.createServer(options, function(req, res) {
 
 function unauthorized() {
   var req = https.request({
-    port: common.PORT
+    port: common.PORT,
+    rejectUnauthorized: false
   }, function(res) {
     assert(!req.socket.authorized);
     rejectUnauthorized();
   });
   req.on('error', function(err) {
-    assert(false);
+    throw err;
   });
   req.end();
 }
 
 function rejectUnauthorized() {
   var options = {
-    port: common.PORT,
-    rejectUnauthorized: true
+    port: common.PORT
   };
   options.agent = new https.Agent(options);
   var req = https.request(options, function(res) {
@@ -76,7 +76,6 @@ function rejectUnauthorized() {
 function authorized() {
   var options = {
     port: common.PORT,
-    rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))]
   };
   options.agent = new https.Agent(options);

--- a/test/simple/test-https-drain.js
+++ b/test/simple/test-https-drain.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');
@@ -50,8 +47,9 @@ var server = https.createServer(options, function(req, res) {
 server.listen(common.PORT, function() {
   var resumed = false;
   var req = https.request({
+    method: 'POST',
     port: common.PORT,
-    method: 'POST'
+    rejectUnauthorized: false
   }, function(res) {
     var timer;
     res.pause();

--- a/test/simple/test-https-drain.js
+++ b/test/simple/test-https-drain.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');

--- a/test/simple/test-https-eof-for-eom.js
+++ b/test/simple/test-https-eof-for-eom.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
-
 // I hate HTTP. One way of terminating an HTTP response is to not send
 // a content-length header, not send a transfer-encoding: chunked header,
 // and simply terminate the TCP connection. That is identity
@@ -33,9 +30,6 @@ if (!process.versions.openssl) {
   console.error('Skipping because node compiled without OpenSSL.');
   process.exit(0);
 }
-
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
@@ -77,7 +71,10 @@ var bodyBuffer = '';
 
 server.listen(common.PORT, function() {
   console.log('1) Making Request');
-  var req = https.get({ port: common.PORT }, function(res) {
+  var req = https.get({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function(res) {
     server.close();
     console.log('3) Client got response headers.');
 

--- a/test/simple/test-https-eof-for-eom.js
+++ b/test/simple/test-https-eof-for-eom.js
@@ -34,6 +34,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-https-localaddress.js
+++ b/test/simple/test-https-localaddress.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var https = require('https'),
     fs = require('fs'),
@@ -48,11 +45,14 @@ var server = https.createServer(options, function (req, res) {
 });
 
 server.listen(common.PORT, "127.0.0.1", function() {
-  var options = { host: 'localhost',
+  var options = {
+    host: 'localhost',
     port: common.PORT,
     path: '/',
     method: 'GET',
-    localAddress: '127.0.0.2' };
+    localAddress: '127.0.0.2',
+    rejectUnauthorized: false
+  };
 
   var req = https.request(options, function(res) {
     res.on('end', function() {

--- a/test/simple/test-https-localaddress.js
+++ b/test/simple/test-https-localaddress.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var https = require('https'),
     fs = require('fs'),

--- a/test/simple/test-https-pfx.js
+++ b/test/simple/test-https-pfx.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');

--- a/test/simple/test-https-pfx.js
+++ b/test/simple/test-https-pfx.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var https = require('https');
@@ -35,12 +32,13 @@ var options = {
   path: '/',
   pfx: pfx,
   passphrase: 'sample',
-  requestCert: true
+  requestCert: true,
+  rejectUnauthorized: false
 };
 
 var server = https.createServer(options, function(req, res) {
   assert.equal(req.socket.authorized, false); // not a client cert
-  assert.equal(req.socket.authorizationError, 'UNABLE_TO_GET_ISSUER_CERT');
+  assert.equal(req.socket.authorizationError, 'DEPTH_ZERO_SELF_SIGNED_CERT');
   res.writeHead(200);
   res.end('OK');
 });

--- a/test/simple/test-https-socket-options.js
+++ b/test/simple/test-https-socket-options.js
@@ -19,16 +19,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
-
 if (!process.versions.openssl) {
   console.error('Skipping because node compiled without OpenSSL.');
   process.exit(0);
 }
-
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
@@ -56,7 +50,10 @@ var server_http = http.createServer(function(req, res) {
 
 
 server_http.listen(common.PORT, function() {
-  var req = http.request({ port: common.PORT }, function(res) {
+  var req = http.request({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function(res) {
     server_http.close();
   });
   // These methods should exist on the request and get passed down to the socket
@@ -75,7 +72,10 @@ var server_https = https.createServer(options, function(req, res) {
 });
 
 server_https.listen(common.PORT+1, function() {
-  var req = https.request({ port: common.PORT+1 }, function(res) {
+  var req = https.request({
+    port: common.PORT + 1,
+    rejectUnauthorized: false
+  }, function(res) {
     server_https.close();
   });
   // These methods should exist on the request and get passed down to the socket

--- a/test/simple/test-https-socket-options.js
+++ b/test/simple/test-https-socket-options.js
@@ -27,6 +27,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 

--- a/test/simple/test-https-strict.js
+++ b/test/simple/test-https-strict.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 

--- a/test/simple/test-https-timeout.js
+++ b/test/simple/test-https-timeout.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');

--- a/test/simple/test-https-timeout.js
+++ b/test/simple/test-https-timeout.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
@@ -46,7 +43,8 @@ var server = https.createServer(options, function() {
     host: 'localhost',
     port: common.PORT,
     path: '/',
-    method: 'GET'
+    method: 'GET',
+    rejectUnauthorized: false
   });
   req.setTimeout(10);
   req.end();

--- a/test/simple/test-regress-GH-1531.js
+++ b/test/simple/test-regress-GH-1531.js
@@ -27,6 +27,9 @@ if (!process.versions.openssl) {
 var https = require('https');
 var assert = require('assert');
 var fs = require('fs');
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 
 var options = {

--- a/test/simple/test-regress-GH-1531.js
+++ b/test/simple/test-regress-GH-1531.js
@@ -27,9 +27,6 @@ if (!process.versions.openssl) {
 var https = require('https');
 var assert = require('assert');
 var fs = require('fs');
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 
 var options = {
@@ -46,9 +43,10 @@ var server = https.createServer(options, function(req, res) {
 
 server.listen(common.PORT, function() {
   https.get({
+    agent: false,
     path: '/',
     port: common.PORT,
-    agent: false
+    rejectUnauthorized: false
   }, function(res) {
     console.error(res.statusCode);
     gotCallback = true;

--- a/test/simple/test-tls-client-reject.js
+++ b/test/simple/test-tls-client-reject.js
@@ -48,7 +48,10 @@ var server = tls.createServer(options, function(socket) {
 });
 
 function unauthorized() {
-  var socket = tls.connect(common.PORT, function() {
+  var socket = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     assert(!socket.authorized);
     socket.end();
     rejectUnauthorized();
@@ -60,9 +63,7 @@ function unauthorized() {
 }
 
 function rejectUnauthorized() {
-  var socket = tls.connect(common.PORT, {
-    rejectUnauthorized: true
-  }, function() {
+  var socket = tls.connect(common.PORT, function() {
     assert(false);
   });
   socket.on('error', function(err) {
@@ -74,7 +75,6 @@ function rejectUnauthorized() {
 
 function authorized() {
   var socket = tls.connect(common.PORT, {
-    rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))]
   }, function() {
     assert(socket.authorized);

--- a/test/simple/test-tls-client-resume.js
+++ b/test/simple/test-tls-client-resume.js
@@ -28,6 +28,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-client-resume.js
+++ b/test/simple/test-tls-client-resume.js
@@ -28,9 +28,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -53,7 +50,10 @@ var server = tls.Server(options, function(socket) {
 server.listen(common.PORT, function() {
 
   var session1 = null;
-  var client1 = tls.connect({port: common.PORT}, function() {
+  var client1 = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     console.log('connect1');
     assert.ok(!client1.isSessionReused(), 'Session *should not* be reused.');
     session1 = client1.getSession();
@@ -62,7 +62,12 @@ server.listen(common.PORT, function() {
   client1.on('close', function() {
     console.log('close1');
 
-    var opts = { 'session': session1, port: common.PORT };
+    var opts = {
+      port: common.PORT,
+      rejectUnauthorized: false,
+      session: session1
+    };
+
     var client2 = tls.connect(opts, function() {
       console.log('connect2');
       assert.ok(client2.isSessionReused(), 'Session *should* be reused.');

--- a/test/simple/test-tls-client-verify.js
+++ b/test/simple/test-tls-client-verify.js
@@ -59,6 +59,9 @@ var testCases =
     ];
 
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');

--- a/test/simple/test-tls-client-verify.js
+++ b/test/simple/test-tls-client-verify.js
@@ -59,9 +59,6 @@ var testCases =
     ];
 
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
@@ -137,7 +134,8 @@ function runTest(testIndex) {
     port: common.PORT,
     ca: tcase.ca.map(loadPEM),
     key: loadPEM(tcase.key),
-    cert: loadPEM(tcase.cert)
+    cert: loadPEM(tcase.cert),
+    rejectUnauthorized: false
   };
 
 

--- a/test/simple/test-tls-connect-given-socket.js
+++ b/test/simple/test-tls-connect-given-socket.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-connect-given-socket.js
+++ b/test/simple/test-tls-connect-given-socket.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -41,8 +38,14 @@ var server = tls.createServer(options, function(socket) {
   serverConnected = true;
   socket.end('Hello');
 }).listen(common.PORT, function() {
-  var socket = net.connect(common.PORT, function() {
-    var client = tls.connect({socket: socket}, function() {
+  var socket = net.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
+    var client = tls.connect({
+      rejectUnauthorized: false,
+      socket: socket
+    }, function() {
       clientConnected = true;
       var data = '';
       client.on('data', function(chunk) {

--- a/test/simple/test-tls-connect-pipe.js
+++ b/test/simple/test-tls-connect-pipe.js
@@ -37,7 +37,8 @@ var server = tls.Server(options, function(socket) {
   server.close();
 });
 server.listen(common.PIPE, function() {
-  var client = tls.connect(common.PIPE, function() {
+  var options = { rejectUnauthorized: false };
+  var client = tls.connect(common.PIPE, options, function() {
     ++clientConnected;
     client.end();
   });

--- a/test/simple/test-tls-connect-simple.js
+++ b/test/simple/test-tls-connect-simple.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -42,12 +39,18 @@ var server = tls.Server(options, function(socket) {
 });
 
 server.listen(common.PORT, function() {
-  var client1 = tls.connect({port: common.PORT}, function() {
+  var client1 = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     ++clientConnected;
     client1.end();
   });
 
-  var client2 = tls.connect({port: common.PORT});
+  var client2 = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
   client2.on('secureConnect', function() {
     ++clientConnected;
     client2.end();

--- a/test/simple/test-tls-connect-simple.js
+++ b/test/simple/test-tls-connect-simple.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-getcipher.js
+++ b/test/simple/test-tls-getcipher.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-getcipher.js
+++ b/test/simple/test-tls-getcipher.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -46,7 +43,11 @@ var server = tls.createServer(options, function(cleartextStream) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var client = tls.connect(common.PORT, '127.0.0.1',  function() {
+  var client = tls.connect({
+    host: '127.0.0.1',
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     var cipher = client.getCipher();
     assert.equal(cipher.name, cipher_list[0]);
     assert(cipher_version_pattern.test(cipher.version));

--- a/test/simple/test-tls-honorcipherorder.js
+++ b/test/simple/test-tls-honorcipherorder.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -49,7 +46,10 @@ function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
     nconns++;
   });
   server.listen(common.PORT, localhost, function() {
-    var coptions = {secureProtocol: SSL_Method};
+    var coptions = {
+      rejectUnauthorized: false,
+      secureProtocol: SSL_Method
+    };
     if (clientCipher) {
       coptions.ciphers = clientCipher;
     }

--- a/test/simple/test-tls-honorcipherorder.js
+++ b/test/simple/test-tls-honorcipherorder.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -25,9 +25,6 @@ if (!process.features.tls_npn) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),
@@ -55,19 +52,22 @@ var clientsOptions = [{
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
-  NPNProtocols: ['a', 'b', 'c']
+  NPNProtocols: ['a', 'b', 'c'],
+  rejectUnauthorized: false
 },{
   port: serverPort,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
-  NPNProtocols: ['c', 'b', 'e']
+  NPNProtocols: ['c', 'b', 'e'],
+  rejectUnauthorized: false
 },{
   port: serverPort,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
-  NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  NPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+  rejectUnauthorized: false
 }];
 
 var serverResults = [],

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -25,6 +25,9 @@ if (!process.features.tls_npn) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),

--- a/test/simple/test-tls-over-http-tunnel.js
+++ b/test/simple/test-tls-over-http-tunnel.js
@@ -19,16 +19,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-
-
 if (!process.versions.openssl) {
   console.error('Skipping because node compiled without OpenSSL.');
   process.exit(0);
 }
-
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
@@ -153,7 +147,8 @@ proxy.listen(proxyPort, function() {
       key: key,
       cert: cert,
       socket: socket,  // reuse the socket
-      agent: false
+      agent: false,
+      rejectUnauthorized: false
     }, function(res) {
       assert.equal(200, res.statusCode);
 

--- a/test/simple/test-tls-over-http-tunnel.js
+++ b/test/simple/test-tls-over-http-tunnel.js
@@ -27,6 +27,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 

--- a/test/simple/test-tls-passphrase.js
+++ b/test/simple/test-tls-passphrase.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -53,7 +50,8 @@ server.listen(common.PORT, function() {
     port: common.PORT,
     key: key,
     passphrase: 'passphrase',
-    cert: cert
+    cert: cert,
+    rejectUnauthorized: false
   }, function() {
     ++connectCount;
   });
@@ -67,7 +65,8 @@ assert.throws(function() {
     port: common.PORT,
     key: key,
     passphrase: 'invalid',
-    cert: cert
+    cert: cert,
+    rejectUnauthorized: false
   });
 });
 

--- a/test/simple/test-tls-passphrase.js
+++ b/test/simple/test-tls-passphrase.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-pause-close.js
+++ b/test/simple/test-tls-pause-close.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-pause-close.js
+++ b/test/simple/test-tls-pause-close.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -69,7 +66,10 @@ var server = tls.createServer(options, function(s) {
 });
 
 server.listen(common.PORT, function() {
-  var c = tls.connect({port: common.PORT}, function() {
+  var c = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     console.log('client connected');
     c.socket.on('end', function() {
       console.log('client socket ended');

--- a/test/simple/test-tls-pause.js
+++ b/test/simple/test-tls-pause.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-pause.js
+++ b/test/simple/test-tls-pause.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -48,7 +45,10 @@ var server = tls.Server(options, function(socket) {
 
 server.listen(common.PORT, function() {
   var resumed = false;
-  var client = tls.connect({port: common.PORT}, function() {
+  var client = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     client.pause();
     common.debug('paused');
     send();

--- a/test/simple/test-tls-peer-certificate-multi-keys.js
+++ b/test/simple/test-tls-peer-certificate-multi-keys.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-peer-certificate-multi-keys.js
+++ b/test/simple/test-tls-peer-certificate-multi-keys.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -45,7 +42,10 @@ var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
 server.listen(common.PORT, function() {
-  var socket = tls.connect({port: common.PORT}, function() {
+  var socket = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     var peerCert = socket.getPeerCertificate();
     common.debug(util.inspect(peerCert));
     assert.deepEqual(peerCert.subject.OU,

--- a/test/simple/test-tls-peer-certificate.js
+++ b/test/simple/test-tls-peer-certificate.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -45,7 +42,10 @@ var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
 server.listen(common.PORT, function() {
-  var socket = tls.connect({port: common.PORT}, function() {
+  var socket = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     var peerCert = socket.getPeerCertificate();
     common.debug(util.inspect(peerCert));
     assert.equal(peerCert.subject.subjectAltName,

--- a/test/simple/test-tls-peer-certificate.js
+++ b/test/simple/test-tls-peer-certificate.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-remote.js
+++ b/test/simple/test-tls-remote.js
@@ -24,6 +24,9 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-remote.js
+++ b/test/simple/test-tls-remote.js
@@ -24,9 +24,6 @@ if (!process.versions.openssl) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -51,7 +48,11 @@ server.listen(common.PORT, '127.0.0.1', function() {
   assert.equal(server.address().address, '127.0.0.1');
   assert.equal(server.address().port, common.PORT);
 
-  var c = tls.connect({port: common.PORT, host: '127.0.0.1'}, function() {
+  var c = tls.connect({
+    host: '127.0.0.1',
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, function() {
     assert.equal(c.address().address, c.socket.address().address);
     assert.equal(c.address().port, c.socket.address().port);
 

--- a/test/simple/test-tls-request-timeout.js
+++ b/test/simple/test-tls-request-timeout.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-request-timeout.js
+++ b/test/simple/test-tls-request-timeout.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -45,7 +42,10 @@ var server = tls.Server(options, function(socket) {
 });
 
 server.listen(common.PORT, function() {
-  var socket = tls.connect({port: common.PORT});
+  var socket = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
 });
 
 process.on('exit', function() {

--- a/test/simple/test-tls-set-encoding.js
+++ b/test/simple/test-tls-set-encoding.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');

--- a/test/simple/test-tls-set-encoding.js
+++ b/test/simple/test-tls-set-encoding.js
@@ -19,9 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common');
 var assert = require('assert');
 var tls = require('tls');
@@ -44,7 +41,10 @@ var server = tls.Server(options, function(socket) {
 
 
 server.listen(common.PORT, function() {
-  var client = tls.connect({port: common.PORT});
+  var client = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
 
   var buffer = '';
 

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -28,6 +28,9 @@ if (!process.features.tls_sni) {
   process.exit(0);
 }
 
+// disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -28,9 +28,6 @@ if (!process.features.tls_sni) {
   process.exit(0);
 }
 
-// disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),
@@ -67,19 +64,22 @@ var clientsOptions = [{
   key: loadPEM('agent1-key'),
   cert: loadPEM('agent1-cert'),
   ca: [loadPEM('ca1-cert')],
-  servername: 'a.example.com'
+  servername: 'a.example.com',
+  rejectUnauthorized: false
 },{
   port: serverPort,
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   ca: [loadPEM('ca2-cert')],
-  servername: 'b.test.com'
+  servername: 'b.test.com',
+  rejectUnauthorized: false
 },{
   port: serverPort,
   key: loadPEM('agent3-key'),
   cert: loadPEM('agent3-cert'),
   ca: [loadPEM('ca1-cert')],
-  servername: 'c.wrong.com'
+  servername: 'c.wrong.com',
+  rejectUnauthorized: false
 }];
 
 var serverResults = [],


### PR DESCRIPTION
Quoting the commit log:

```
tls, https: validate server certificates by default

This commit changes the default value of the rejectUnauthorized option from
false to true.

What that means is that tls.connect(), https.get() and https.request() will
reject invalid server certificates from now on, including self-signed
certificates.

There is an escape hatch: if you set the NODE_TLS_REJECT_UNAUTHORIZED
environment variable to the literal string "0", node.js reverts to its
old behavior.

Fixes #3949.
```

The second commit updates the tests to set `rejectUnauthorized` explicitly instead of mucking with the environment.

Suggested reviewer: @indutny
