### PR TITLE
Use shlex instead of string split to parse CC

### DIFF
--- a/configure
+++ b/configure
@@ -3,6 +3,7 @@ import optparse
 import os
 import pprint
 import re
+import shlex
 import subprocess
 import sys
 
@@ -205,7 +206,7 @@ def cc_macros():
   """Checks predefined macros using the CC command."""
 
   try:
-    p = subprocess.Popen(CC.split() + ['-dM', '-E', '-'],
+    p = subprocess.Popen(shlex.split(CC) + ['-dM', '-E', '-'],
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
@@ -225,7 +226,6 @@ def cc_macros():
 
   k = {}
   for line in out:
-    import shlex
     lst = shlex.split(line)
     if len(lst) > 2:
       key = lst[1]
@@ -310,13 +310,13 @@ def host_arch_win():
 
 def compiler_version():
   try:
-    proc = subprocess.Popen(CC.split() + ['--version'], stdout=subprocess.PIPE)
+    proc = subprocess.Popen(shlex.split(CC) + ['--version'], stdout=subprocess.PIPE)
   except WindowsError:
     return (0, False)
 
   is_clang = 'clang' in proc.communicate()[0].split('\n')[0]
 
-  proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
+  proc = subprocess.Popen(shlex.split(CC) + ['-dumpversion'], stdout=subprocess.PIPE)
   version = tuple(map(int, proc.communicate()[0].split('.')))
 
   return (version, is_clang)


### PR DESCRIPTION
Simple enough. I haven't heard of anyone having issues but with this, but it's probably a good idea to Do It Right(tm).
