### PR TITLE
Report invalid stream given to chid_process.spawn stdio option

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -357,6 +357,8 @@ index corresponds to a fd in the child.  The value is one of the following:
    file, socket, or a pipe with the child process. The stream's underlying
    file descriptor is duplicated in the child process to the fd that 
    corresponds to the index in the `stdio` array.
+   Note that stream must have a valid file descriptor,
+   that means file must be opened.
 5. Positive integer - The integer value is interpreted as a file descriptor 
    that is is currently open in the parent process. It is shared with the child
    process, similar to how `Stream` objects can be shared.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -775,6 +775,9 @@ ChildProcess.prototype.spawn = function(options) {
     } else {
       // Cleanup
       cleanup();
+      if(stdio && stdio.fd === null) {
+        throw new TypeError('Incorrect value for stdio: Stream is not opened');
+      }
       throw new TypeError('Incorrect value for stdio stream: ' + stdio);
     }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -775,7 +775,7 @@ ChildProcess.prototype.spawn = function(options) {
     } else {
       // Cleanup
       cleanup();
-      if(stdio && stdio.fd === null) {
+      if (stdio && stdio.fd === null) {
         throw new TypeError('Incorrect value for stdio: Stream is not opened');
       }
       throw new TypeError('Incorrect value for stdio stream: ' + stdio);


### PR DESCRIPTION
This should make error message in #4030 less confusing
