### PR TITLE
handle multiple values of 'proxy-authenticate'

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -401,6 +401,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
     case 'pragma':
     case 'link':
     case 'www-authenticate':
+    case 'proxy-authenticate':
     case 'sec-websocket-extensions':
     case 'sec-websocket-protocol':
       if (field in dest) {


### PR DESCRIPTION
Just as the 'WWW-Authenticate' HTTP header the 'Proxy-Authenticate' header might be received several times as well. Currently only one values is preserved. This change allows to receive multiple values concatenated by space and comma.
