### PR TITLE
test: fix failing due to too early timeout

### DIFF
--- a/test/simple/test-http-client-timeout-agent.js
+++ b/test/simple/test-http-client-timeout-agent.js
@@ -23,13 +23,15 @@ var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
+var timeout = 15*1000;
+var max_requests = 30;
 var request_number = 0;
 var requests_sent = 0;
 var requests_done = 0;
 var options = {
   method: 'GET',
   port: common.PORT,
-  host: '127.0.0.1',
+  host: '127.0.0.1'
 };
 
 //http.globalAgent.maxSockets = 15;
@@ -50,7 +52,9 @@ var server = http.createServer(function(req, res) {
 server.listen(options.port, options.host, function() {
   var req;
 
-  for (requests_sent = 0; requests_sent < 30; requests_sent+=1) {
+  for (requests_sent = 0; requests_sent < max_requests;
+       requests_sent++) {
+    
     options.path = '/' + requests_sent;
     req = http.request(options);
     req.id = requests_sent;
@@ -60,7 +64,7 @@ server.listen(options.port, options.host, function() {
       });
       res.on('end', function(data) {
         console.log('res#'+this.req.id+' end');
-        requests_done += 1;
+        if (++requests_done === max_requests) finish();
       });
     });
     req.on('close', function() {
@@ -74,13 +78,18 @@ server.listen(options.port, options.host, function() {
       var req = this;
       console.log('req#'+this.id + ' timeout');
       req.abort();
-      requests_done += 1;
+      if (++requests_done === max_requests) finish();
     });
     req.end();
   }
-  setTimeout(function() {
+  var tid = setTimeout(function() {
+    finish();
+  }, timeout);
+  
+  function finish() {
+    clearTimeout(tid);
     server.close();
-  }, 150);
+  }
 });
 
 process.on('exit', function() {


### PR DESCRIPTION
The current timeout of test/simple/test-http-client-timeout-agent.js is just 150[msec] until finishing all 30 http test requests but it is often too early to finish them on a slow machine as

```
> ./node test/simple/test-http-client-timeout-agent.js
res#0 data:0
(snip)
req#23 error
done=25 sent=30

assert.js:102
  throw new assert.AssertionError({
        ^
AssertionError: timeout on http request called too much
```

This patch extends its timeout to 15sec but finishes testing just after completing all test requests. 

```
> ./node test/simple/test-http-client-timeout-agent.js
res#0 data:0
(snip)
req#29 error
done=30 sent=30
```
