### PR TITLE
docs: better example for process.hrtime()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -489,14 +489,14 @@ primary use is for measuring performance between intervals.
 You may pass in the result of a previous call to `process.hrtime()` to get
 a diff reading, useful for benchmarks and measuring intervals:
 
-    var t = process.hrtime();
+    var time = process.hrtime();
     // [ 1800216, 927643717 ]
 
-    setTimeout(function() {
-      t = process.hrtime(t);
+    setTimeout(function () {
+      var diff = process.hrtime(time);
       // [ 1, 6962306 ]
 
-      console.log('benchmark took %d seconds and %d nanoseconds', t[0], t[1]);
+      console.log('benchmark took %d seconds and %d nanoseconds', diff[0], diff[1]);
       // benchmark took 1 seconds and 6962306 nanoseconds
     }, 1000);
 


### PR DESCRIPTION
`t` variable have two different datatypes there (current time and time difference), and it creates some confusion, see #3984
