### PR TITLE
stream: delete unnecessary code

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -77,9 +77,6 @@ Stream.prototype.pipe = function(dest, options) {
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (this.listeners('error').length === 0) {
-      throw er; // Unhandled stream error in pipe.
-    }
   }
 
   source.on('error', onerror);


### PR DESCRIPTION
No need to check error listener count. EventEmitter does this already.
