### PR TITLE
Fix node.cc, node_crypto.cc compiler warnings.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2731,7 +2731,7 @@ char** Init(int argc, char *argv[]) {
     // a breakpoint on the first line of the startup script
     v8argc += 2;
     v8argv = new char*[v8argc];
-    memcpy(v8argv, argv, sizeof(argv) * option_end_index);
+    memcpy(v8argv, argv, sizeof(*argv) * option_end_index);
     v8argv[option_end_index] = const_cast<char*>("--expose_debug_as");
     v8argv[option_end_index + 1] = const_cast<char*>("v8debug");
   }


### PR DESCRIPTION
I noticed this node.cc -Wsizeof-array-argument warning:

```
../src/node.cc:2734:32: warning: sizeof on array function parameter will return
      size of 'char **' instead of 'char *[]' [-Wsizeof-array-argument]
    memcpy(v8argv, argv, sizeof(argv) * option_end_index);
                               ^
../src/node.cc:2714:29: note: declared here
char** Init(int argc, char *argv[]) {
                            ^
```

This code should be calling `sizeof(*argv)` to get the size of the elements in the array.

---

I noticed this node_crypto.cc -Wautological-compare warning:

```
../src/node_crypto.cc:4531:19: warning: self-comparison always evaluates to true
      [-Wtautological-compare]
    if (generator == RAND_bytes)
                  ^
../src/node_crypto.cc:4601:19: note: in instantiation of function template
      specialization 'node::crypto::RandomBytesWork<RAND_bytes>' requested here
                  RandomBytesWork<generator>,
                  ^
../src/node_crypto.cc:4657:42: note: in instantiation of function template
      specialization 'node::crypto::RandomBytes<RAND_bytes>' requested here
  NODE_SET_METHOD(target, "randomBytes", RandomBytes<RAND_bytes>);
                                         ^
```

This is fixed by simply moving the work done in `case 0` to a specialized function that avoids the need for the comparison.
