### PR TITLE
https: fix renegotation attack protection

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -127,9 +127,12 @@ sent to the server on that socket.
 
 ### Event: 'clientError'
 
-`function (exception) { }`
+`function (exception, reserved) { }`
 
 If a client connection emits an 'error' event - it will forwarded here.
+
+The `reserved` argument must be ignored.
+
 
 ### server.listen(port, [hostname], [backlog], [callback])
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -367,10 +367,12 @@ SNI.
 
 ### Event: 'clientError'
 
-`function (exception) { }`
+`function (exception, reserved) { }`
 
 When a client connection emits an 'error' event before secure connection is
 established - it will be forwarded here.
+
+The `reserved` argument must be ignored.
 
 
 ### Event: 'newSession'

--- a/lib/http.js
+++ b/lib/http.js
@@ -1647,6 +1647,10 @@ function Server(requestListener) {
   this.httpAllowHalfOpen = false;
 
   this.addListener('connection', connectionListener);
+
+  this.addListener('clientError', function(err, conn) {
+    conn.destroy(err);
+  });
 }
 util.inherits(Server, net.Server);
 
@@ -1705,7 +1709,7 @@ function connectionListener(socket) {
   }
 
   socket.addListener('error', function(e) {
-    self.emit('clientError', e);
+    self.emit('clientError', e, this);
   });
 
   socket.ondata = function(d, start, end) {

--- a/lib/https.js
+++ b/lib/https.js
@@ -39,6 +39,10 @@ function Server(opts, requestListener) {
   if (requestListener) {
     this.addListener('request', requestListener);
   }
+
+  this.addListener('clientError', function(err, conn) {
+    conn.destroy(err);
+  });
 }
 inherits(Server, tls.Server);
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1155,7 +1155,7 @@ function Server(/* [options], listener */) {
       }
     });
     pair.on('error', function(err) {
-      self.emit('clientError', err);
+      self.emit('clientError', err, this);
     });
   });
 


### PR DESCRIPTION
Listen for the 'clientError' event that is emitted when a renegotation attack is detected and close the connection.

Fixes `test/pummel/test-https-ci-reneg-attack.js`
