### PR TITLE
Buffer: include encoding value in exception when invalid

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -84,7 +84,7 @@ SlowBuffer.prototype.toString = function(encoding, start, end) {
       return this.ucs2Slice(start, end);
 
     default:
-      throw new Error('Unknown encoding');
+      throw new Error('Unknown encoding: ' + encoding);
   }
 };
 
@@ -170,7 +170,7 @@ SlowBuffer.prototype.write = function(string, offset, length, encoding) {
       return this.ucs2Write(string, offset, length);
 
     default:
-      throw new Error('Unknown encoding');
+      throw new Error('Unknown encoding: ' + encoding);
   }
 };
 
@@ -402,7 +402,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       break;
 
     default:
-      throw new Error('Unknown encoding');
+      throw new Error('Unknown encoding: ' + encoding);
   }
 
   Buffer._charsWritten = SlowBuffer._charsWritten;
@@ -459,7 +459,7 @@ Buffer.prototype.toString = function(encoding, start, end) {
       return this.parent.ucs2Slice(start, end);
 
     default:
-      throw new Error('Unknown encoding');
+      throw new Error('Unknown encoding: ' + encoding);
   }
 };
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -125,6 +125,24 @@ try {
 }
 assert.strictEqual('sourceStart out of bounds', caught_error.message);
 
+// invalid encoding for Buffer.toString
+caught_error = null;
+try {
+  var copied = b.toString('invalid');
+} catch (err) {
+  caught_error = err;
+}
+assert.strictEqual('Unknown encoding: invalid', caught_error.message);
+
+// invalid encoding for Buffer.write
+caught_error = null;
+try {
+  var copied = b.write('test string', 0, 5, 'invalid');
+} catch (err) {
+  caught_error = err;
+}
+assert.strictEqual('Unknown encoding: invalid', caught_error.message);
+
 // a too-low sourceEnd will get caught by earlier checks
 
 // try to copy ending after the end of b
@@ -599,6 +617,24 @@ assert.equal(0xee, b[0]);
 assert.equal(0xad, b[1]);
 assert.equal(0xbe, b[2]);
 assert.equal(0xef, b[3]);
+
+// testing invalid encoding on SlowBuffer.toString
+caught_error = null;
+try {
+  var copied = b.toString('invalid');
+} catch (err) {
+  caught_error = err;
+}
+assert.strictEqual('Unknown encoding: invalid', caught_error.message);
+
+// testing invalid encoding on SlowBuffer.write
+caught_error = null;
+try {
+  var copied = b.write('some string', 0, 5, 'invalid');
+} catch (err) {
+  caught_error = err;
+}
+assert.strictEqual('Unknown encoding: invalid', caught_error.message);
 
 
 // This should not segfault the program.


### PR DESCRIPTION
Encoding failures can be somewhat confusing, especially when they are due to control flow frameworks auto-filling parameters from the previous step output values to functions (such as toString and write) that developers don't expect to take an encoding parameter. By outputting the value as part of the message, should make it easier to track down these sort of bugs.
