### PR TITLE
doc: consistent use of the callback argument

### DIFF
--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -184,9 +184,9 @@ from that one, and bound to this one instead.
 The opposite of `domain.add(emitter)`.  Removes domain handling from the
 specified emitter.
 
-### domain.bind(cb)
+### domain.bind(callback)
 
-* `cb` {Function} The callback function
+* `callback` {Function} The callback function
 * return: {Function} The bound function
 
 The returned function will be a wrapper around the supplied callback
@@ -210,16 +210,16 @@ thrown will be routed to the domain's `error` event.
       // with the normal line number and stack message.
     });
 
-### domain.intercept(cb)
+### domain.intercept(callback)
 
-* `cb` {Function} The callback function
+* `callback` {Function} The callback function
 * return: {Function} The intercepted function
 
-This method is almost identical to `domain.bind(cb)`.  However, in
+This method is almost identical to `domain.bind(callback)`.  However, in
 addition to catching thrown errors, it will also intercept `Error`
 objects sent as the first argument to the function.
 
-In this way, the common `if (er) return cb(er);` pattern can be replaced
+In this way, the common `if (er) return callback(er);` pattern can be replaced
 with a single error handler in a single place.
 
 #### Example

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -156,10 +156,10 @@ This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'][] event.  See also [net.Server.listen(path)][].
 
 
-### server.listen(handle, [listeningListener])
+### server.listen(handle, [callback])
 
 * `handle` {Object}
-* `listeningListener` {Function}
+* `callback` {Function}
 
 The `handle` object can be set to either a server or socket (anything
 with an underlying `_handle` member), or a `{fd: <n>}` object.
@@ -172,9 +172,9 @@ Listening on a file descriptor is not supported on Windows.
 
 This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'](net.html#event_listening_) event.
-See also [net.Server.listen()](net.html#server.listen).
+See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
 
-### server.close([cb])
+### server.close([callback])
 
 Stops the server from accepting new connections.  See [net.Server.close()][].
 
@@ -917,9 +917,9 @@ Resumes a paused response.
 [http.request()]: #http_http_request_options_callback
 [http.ServerRequest]: #http_class_http_serverrequest
 ['listening']: net.html#net_event_listening
-[net.Server.close()]: net.html#net_server_close_cb
-[net.Server.listen(path)]: net.html#net_server_listen_path_listeninglistener
-[net.Server.listen(port)]: net.html#net_server_listen_port_host_backlog_listeninglistener
+[net.Server.close()]: net.html#net_server_close_callback
+[net.Server.listen(path)]: net.html#net_server_listen_path_callback
+[net.Server.listen(port)]: net.html#net_server_listen_port_host_backlog_callback
 [Readable Stream]: stream.html#stream_readable_stream
 [socket.setKeepAlive()]: net.html#net_socket_setkeepalive_enable_initialdelay
 [socket.setNoDelay()]: net.html#net_socket_setnodelay_nodelay

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -46,6 +46,17 @@ Or
       res.end("hello world\n");
     }).listen(8000);
 
+
+### server.listen(port, [host], [backlog], [callback])
+### server.listen(path, [callback])
+### server.listen(handle, [callback])
+
+See [http.listen()][] for details.
+
+### server.close([callback])
+
+See [http.close()][] for details.
+
 ## https.request(options, callback)
 
 Makes a request to a secure web server.
@@ -193,6 +204,8 @@ Global instance of [https.Agent][] for all HTTPS client requests.
 
 [Agent]: #https_class_https_agent
 [globalAgent]: #https_https_globalagent
+[http.listen()]: http.html#http_server_listen_port_hostname_backlog_callback
+[http.close()]: http.html#http_server_close_callback
 [http.Agent]: http.html#http_class_http_agent
 [http.request()]: http.html#http_http_request_options_callback
 [https.Agent]: #https_class_https_agent

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -118,7 +118,7 @@ The `connectListener` parameter will be added as an listener for the
 This class is used to create a TCP or UNIX server.
 A server is a `net.Socket` that can listen for new incoming connections.
 
-### server.listen(port, [host], [backlog], [listeningListener])
+### server.listen(port, [host], [backlog], [callback])
 
 Begin accepting connections on the specified `port` and `host`.  If the
 `host` is omitted, the server will accept connections directed to any
@@ -130,7 +130,7 @@ The actual length will be determined by your OS through sysctl settings such as
 parameter is 511 (not 512).
 
 This function is asynchronous.  When the server has been bound,
-['listening'][] event will be emitted.  The last parameter `listeningListener`
+['listening'][] event will be emitted.  The last parameter `callback`
 will be added as an listener for the ['listening'][] event.
 
 One issue some users run into is getting `EADDRINUSE` errors. This means that
@@ -150,18 +150,18 @@ would be to wait a second and then try again. This can be done with
 (Note: All sockets in Node set `SO_REUSEADDR` already)
 
 
-### server.listen(path, [listeningListener])
+### server.listen(path, [callback])
 
 Start a UNIX socket server listening for connections on the given `path`.
 
 This function is asynchronous.  When the server has been bound,
-['listening'][] event will be emitted.  The last parameter `listeningListener`
+['listening'][] event will be emitted.  The last parameter `callback`
 will be added as an listener for the ['listening'][] event.
 
-### server.listen(handle, [listeningListener])
+### server.listen(handle, [callback])
 
 * `handle` {Object}
-* `listeningListener` {Function}
+* `callback` {Function}
 
 The `handle` object can be set to either a server or socket (anything
 with an underlying `_handle` member), or a `{fd: <n>}` object.
@@ -174,10 +174,10 @@ Listening on a file descriptor is not supported on Windows.
 
 This function is asynchronous.  When the server has been bound,
 ['listening'](#event_listening_) event will be emitted.
-the last parameter `listeningListener` will be added as an listener for the
+the last parameter `callback` will be added as an listener for the
 ['listening'](#event_listening_) event.
 
-### server.close([cb])
+### server.close([callback])
 
 Stops the server from accepting new connections and keeps existing
 connections. This function is asynchronous, the server is finally

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -208,8 +208,8 @@ You can test this server by connecting to it with `openssl s_client`:
     openssl s_client -connect 127.0.0.1:8000
 
 
-## tls.connect(options, [secureConnectListener])
-## tls.connect(port, [host], [options], [secureConnectListener])
+## tls.connect(options, [callback])
+## tls.connect(port, [host], [options], [callback])
 
 Creates a new client connection to the given `port` and `host` (old API) or
 `options.port` and `options.host`. (If `host` is omitted, it defaults to
@@ -249,7 +249,7 @@ Creates a new client connection to the given `port` and `host` (old API) or
 
   - `servername`: Servername for SNI (Server Name Indication) TLS extension.
 
-The `secureConnectListener` parameter will be added as a listener for the
+The `callback` parameter will be added as a listener for the
 ['secureConnect'][] event.
 
 `tls.connect()` returns a [CleartextStream][] object.


### PR DESCRIPTION
Lately I have been working on a debugging module for monkey-patching all async operations in nodecode. In order for it not to require a lot of maintines and be super generic, I use the nodecode json formated documented and search for `callback`.

However for some unknow reason not all async methods use the `callback` name, this pull request fixes that.
