### PR TITLE
cluster 'listening' handler's port number when worker calls listen(0)

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -535,7 +535,7 @@ cluster._getServer = function(tcpSelf, address, port, addressType, fd, cb) {
     sendInternalMessage(cluster.worker, {
       cmd: 'listening',
       address: address,
-      port: port,
+      port: tcpSelf.address().port || port,
       addressType: addressType,
       fd: fd
     });

--- a/test/simple/test-cluster-listening-port.js
+++ b/test/simple/test-cluster-listening-port.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  var port = null;
+  cluster.fork();
+  cluster.on('listening', function(worker, address) {
+    port = address.port;
+    // ensure that the port is not 0 or null
+    assert(port);
+    // ensure that the port is numerical
+    assert.strictEqual(typeof(port), 'number');
+    worker.destroy();
+  });
+  process.on('exit', function() {
+    // ensure that the 'listening' handler has been called
+    assert(port);
+  });
+}
+else {
+  net.createServer(assert.fail).listen(0);
+}


### PR DESCRIPTION
http://nodejs.org/api/cluster.html#cluster_event_listening

According to the documentation, the event handler receives the `address` object with `port` property, which is set to the port that the worker passed to `listen()`. This covers the case where user manually specifies a port number, but if use specifies `0`, a random port is assigned.

In such a situation, the event handler should receive the randomly assigned port number, not `0`.

```
cluster = require 'cluster'
if not cluster.isMaster
    app = require('express').createServer()
    app.get '/*', (req, res) -> res.send "Hello Cluster"
    app.listen 0, ->
        console.log "I am listening on port " + app.address().port
        // output: I am listening on port 56789
else
    cluster.on 'listening', (worker, address) ->
        console.log "W#{worker.id} listening on port " + address.port
        // output: W1 listening on port 0
    cluster.fork()
```
