### PR TITLE
openssl: some thread safety improvements

### DIFF
--- a/deps/openssl/openssl/crypto/bio/bio.h
+++ b/deps/openssl/openssl/crypto/bio/bio.h
@@ -112,6 +112,7 @@ extern "C" {
 #define BIO_TYPE_DESCRIPTOR	0x0100	/* socket, fd, connect or accept */
 #define BIO_TYPE_FILTER		0x0200
 #define BIO_TYPE_SOURCE_SINK	0x0400
+#define BIO_TYPE_NO_EX_DATA	0x0800
 
 /* BIO_FILENAME_READ|BIO_CLOSE to open or close on free.
  * BIO_set_fp(in,stdin,BIO_NOCLOSE); */

--- a/deps/openssl/openssl/crypto/cryptlib.c
+++ b/deps/openssl/openssl/crypto/cryptlib.c
@@ -629,6 +629,10 @@ int CRYPTO_add_lock(int *pointer, int amount, int type, const char *file,
 		}
 	else
 		{
+#if defined(__GNUC__) && \
+    ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1))
+		return __sync_add_and_fetch(pointer, amount);
+#else
 		CRYPTO_lock(CRYPTO_LOCK|CRYPTO_WRITE,type,file,line);
 
 		ret= *pointer+amount;
@@ -645,6 +649,7 @@ int CRYPTO_add_lock(int *pointer, int amount, int type, const char *file,
 #endif
 		*pointer=ret;
 		CRYPTO_lock(CRYPTO_UNLOCK|CRYPTO_WRITE,type,file,line);
+#endif
 		}
 	return(ret);
 	}


### PR DESCRIPTION
- BIO: add BIO_TYPE_NO_EX_DATA option to allow constructing BIOs without
  ex data
- CRYPTO: CRYPTO_add_lock should use atomic instructions where possible

/cc @bnoordhuis

---

I'm also going to send those patches to upstream... watch openssl-dev mailing list.
