### PR TITLE
build: remove jslint test/ on Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -183,7 +183,7 @@ goto exit
 :jslint
 echo running jslint
 set PYTHONPATH=tools/closure_linter/
-python tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ -r test/ --exclude_files lib/punycode.js
+python tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
 goto exit
 
 :help


### PR DESCRIPTION
It's a lot of annoying warnings after make test. See 605927fbd9c2fbcd7d88a8f8159a9ca78417a6d0
