### PR TITLE
set default bg color for docs site to white

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -8,6 +8,7 @@ body {
   font-size: 14px;
   line-height: 180%;
   color: black;
+  background-color: white;
   margin: 0; padding: 49px 0 0 0;
   border-top: 6px #8CC84B solid;
 }


### PR DESCRIPTION
most browsers default to white backgrounds anyway but this will override browsers that dont so that the docs are always readable
