### PR TITLE
crypto: add crypto.getHashes()

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -21,6 +21,16 @@ Example:
     console.log(ciphers); // ['AES128-SHA', 'AES256-SHA', ...]
 
 
+## crypto.getHashes()
+
+Returns an array with the names of the supported hash algorithms.
+
+Example:
+
+    var hashes = crypto.getHashes();
+    console.log(hashes); // ['sha', 'sha1', 'sha1WithRSAEncryption', ...]
+
+
 ## crypto.createCredentials(details)
 
 Creates a credentials object, with the optional details being a dictionary with keys:

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -35,6 +35,7 @@ try {
   var randomBytes = binding.randomBytes;
   var pseudoRandomBytes = binding.pseudoRandomBytes;
   var getCiphers = binding.getCiphers;
+  var getHashes = binding.getHashes;
   var crypto = true;
 } catch (e) {
 
@@ -196,3 +197,18 @@ exports.rng = randomBytes;
 exports.prng = pseudoRandomBytes;
 
 exports.getCiphers = getCiphers;
+
+exports.getHashes = function() {
+  var names = getHashes.call(null, arguments);
+
+  // Drop all-caps names in favor of their lowercase aliases,
+  // for example, 'sha1' instead of 'SHA1'.
+  var ctx = {};
+  names = names.forEach(function(name) {
+    if (/^[0-9A-Z\-]+$/.test(name)) name = name.toLowerCase();
+    ctx[name] = true;
+  });
+  names = Object.getOwnPropertyNames(ctx);
+
+  return names;
+};

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -196,7 +196,11 @@ exports.pseudoRandomBytes = pseudoRandomBytes;
 exports.rng = randomBytes;
 exports.prng = pseudoRandomBytes;
 
-exports.getCiphers = getCiphers;
+
+exports.getCiphers = function() {
+  return getCiphers.call(null, arguments).sort();
+};
+
 
 exports.getHashes = function() {
   var names = getHashes.call(null, arguments);
@@ -210,5 +214,5 @@ exports.getHashes = function() {
   });
   names = Object.getOwnPropertyNames(ctx);
 
-  return names;
+  return names.sort();
 };

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4646,6 +4646,23 @@ Handle<Value> GetCiphers(const Arguments& args) {
 }
 
 
+static void add_hash_to_array(const EVP_MD* md,
+                              const char* from,
+                              const char* to,
+                              void* arg) {
+  Local<Array>& arr = *static_cast<Local<Array>*>(arg);
+  arr->Set(arr->Length(), String::New(from));
+}
+
+
+Handle<Value> GetHashes(const Arguments& args) {
+  HandleScope scope;
+  Local<Array> arr = Array::New();
+  EVP_MD_do_all_sorted(add_hash_to_array, &arr);
+  return scope.Close(arr);
+}
+
+
 void InitCrypto(Handle<Object> target) {
   HandleScope scope;
 
@@ -4686,6 +4703,7 @@ void InitCrypto(Handle<Object> target) {
   NODE_SET_METHOD(target, "randomBytes", RandomBytes<RAND_bytes>);
   NODE_SET_METHOD(target, "pseudoRandomBytes", RandomBytes<RAND_pseudo_bytes>);
   NODE_SET_METHOD(target, "getCiphers", GetCiphers);
+  NODE_SET_METHOD(target, "getHashes", GetHashes);
 
   subject_symbol    = NODE_PSYMBOL("subject");
   issuer_symbol     = NODE_PSYMBOL("issuer");

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -684,9 +684,18 @@ testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
            '\x56\xfa\x6a\xa7\x55\x48\x09\x9d\xcc\x37\xd7\xf0\x34' +
            '\x25\xe0\xc3');
 
+function assertSorted(list) {
+  for (var i = 0, k = list.length - 1; i < k; ++i) {
+    var a = list[i + 0];
+    var b = list[i + 1];
+    assert(a <= b);
+  }
+}
+
 // Assume that we have at least AES256-SHA.
 assert.notEqual(0, crypto.getCiphers());
 assert.notEqual(-1, crypto.getCiphers().indexOf('AES256-SHA'));
+assertSorted(crypto.getCiphers());
 
 // Assert that we have sha and sha1 but not SHA and SHA1.
 assert.notEqual(0, crypto.getHashes());
@@ -694,3 +703,4 @@ assert.notEqual(-1, crypto.getHashes().indexOf('sha1'));
 assert.notEqual(-1, crypto.getHashes().indexOf('sha'));
 assert.equal(-1, crypto.getHashes().indexOf('SHA1'));
 assert.equal(-1, crypto.getHashes().indexOf('SHA'));
+assertSorted(crypto.getHashes());

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -687,3 +687,10 @@ testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
 // Assume that we have at least AES256-SHA.
 assert.notEqual(0, crypto.getCiphers());
 assert.notEqual(-1, crypto.getCiphers().indexOf('AES256-SHA'));
+
+// Assert that we have sha and sha1 but not SHA and SHA1.
+assert.notEqual(0, crypto.getHashes());
+assert.notEqual(-1, crypto.getHashes().indexOf('sha1'));
+assert.notEqual(-1, crypto.getHashes().indexOf('sha'));
+assert.equal(-1, crypto.getHashes().indexOf('SHA1'));
+assert.equal(-1, crypto.getHashes().indexOf('SHA'));


### PR DESCRIPTION
Second commit sorts the return values of `crypto.getHashes()` and `crypto.getCiphers()` for the sake of aesthetics.

/cc @isaacs
