### PR TITLE
Use correct timezone information on Solaris

### DIFF
--- a/deps/v8/src/platform-solaris.cc
+++ b/deps/v8/src/platform-solaris.cc
@@ -125,12 +125,8 @@ const char* OS::LocalTimezone(double time) {
 
 
 double OS::LocalTimeOffset() {
-  // On Solaris, struct tm does not contain a tm_gmtoff field.
-  time_t utc = time(NULL);
-  ASSERT(utc != -1);
-  struct tm* loc = localtime(&utc);
-  ASSERT(loc != NULL);
-  return static_cast<double>((mktime(loc) - utc) * msPerSecond);
+  tzset();
+  return -static_cast<double>(timezone * msPerSecond);
 }
 
 


### PR DESCRIPTION
This patch for V8, authored by Maciej Malecki (see http://codereview.chromium.org/10967066/ ), solves a critical bug in timezone handling on Solaris (an its derivatives, like Joyent's SmartOS).

The patch has been tested for correctness (see the code review linked above).

Until the patch gets accepted upstream, I suggest applying it against the V8 sources bundled with Node.JS. Without it, Node.JS date handling on Solaris is fundamentally broken for any zones except UTC, as it fails to take any timezone offset into account!
