### PR TITLE
domain: fix dispose call inside another domain

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -210,7 +210,7 @@ Domain.prototype.dispose = function() {
   if (this._disposed) return;
 
   // if we're the active domain, then get out now.
-  this.exit();
+  if (exports.active === this) this.exit();
 
   this.emit('dispose');
 

--- a/test/simple/test-domain-dispose-exit.js
+++ b/test/simple/test-domain-dispose-exit.js
@@ -1,0 +1,16 @@
+
+var domain = require('domain');
+var assert = require('assert');
+
+var d = domain.create();
+
+d.run(function () {
+  
+  var dd = domain.create();
+  dd.run(function () {
+    d.dispose();
+    
+    assert.strictEqual(domain.active, dd);
+  });
+});
+


### PR DESCRIPTION
since 040057167653e8e6ce4d5a368fbc6d73bb541e28 dispose exits the domain
however if the active domain wasn't the disposed domain, then the active
domain would get out of sync (`domain.active === undefined`).

/cc @isaacs
