### PR TITLE
debugger: handle SIGINT as ^C

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -782,9 +782,10 @@ function Interface(stdin, stdout, args) {
     process.exit(0);
   });
 
-  process.on('exit', function() {
-    self.killChild();
-  });
+  // Handle all possible exits
+  process.on('exit', this.killChild.bind(this));
+  process.once('SIGTERM', process.exit.bind(process, 0));
+  process.once('SIGHUP', process.exit.bind(process, 0));
 
   var proto = Interface.prototype,
       ignored = ['pause', 'resume', 'exitRepl', 'handleBreak',

--- a/test/simple/test-debugger-repl-utf8.js
+++ b/test/simple/test-debugger-repl-utf8.js
@@ -155,7 +155,8 @@ setTimeout(function() {
     err = err + '. Expected: ' + expected[0].lines.shift();
   }
   quit();
-  child.kill('SIGKILL');
+  child.kill('SIGINT');
+  child.kill('SIGTERM');
 
   // give the sigkill time to work.
   setTimeout(function() {

--- a/test/simple/test-debugger-repl.js
+++ b/test/simple/test-debugger-repl.js
@@ -192,7 +192,8 @@ setTimeout(function() {
     err = err + '. Expected: ' + expected[0].lines.shift();
   }
   quit();
-  child.kill('SIGKILL');
+  child.kill('SIGINT');
+  child.kill('SIGTERM');
 
   // give the sigkill time to work.
   setTimeout(function() {


### PR DESCRIPTION
Receing SIGINT signal should not just close process, but close child
process too.
