### PR TITLE
child_process.spawn doc fix, args must escape spaces to get passed correctly.

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -243,6 +243,7 @@ there is no IPC channel keeping it alive. When calling this method the
 
 * `command` {String} The command to run
 * `args` {Array} List of string arguments
+  * Note that when passing strings with spaces, spaces must be escaped with a preceeding backslash.
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
   * `stdio` {Array|String} Child's stdio configuration. (See below)


### PR DESCRIPTION
Quoted strings as args do not work, you must escape the space.  Example myprog -o "Long option, that takes a string".  Args would be ["-o", "Long\ option,\ that\ takes\ a\ string"]
