### PR TITLE
streams: remove useless line

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -99,7 +99,6 @@ Stream.prototype.pipe = function(dest, options) {
     source.removeListener('end', cleanup);
     source.removeListener('close', cleanup);
 
-    dest.removeListener('end', cleanup);
     dest.removeListener('close', cleanup);
   }
 


### PR DESCRIPTION
The removed line was removing a calllback that was never setup
in first place. 016afe2 forgot to remove this.
