### PR TITLE
Crypto buffers

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -87,14 +87,15 @@ Returned by `crypto.createHash`.
 
 Updates the hash content with the given `data`, the encoding of which is given
 in `input_encoding` and can be `'buffer'`, `'utf8'`, `'ascii'` or `'binary'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
+
 This can be called many times with new data as it is streamed.
 
 ### hash.digest([encoding])
 
 Calculates the digest of all of the passed data to be hashed.
 The `encoding` can be `'buffer'`, `'hex'`, `'binary'` or `'base64'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 Note: `hash` object can not be used after `digest()` method been called.
 
@@ -121,7 +122,7 @@ This can be called many times with new data as it is streamed.
 
 Calculates the digest of all of the passed data to the hmac.
 The `encoding` can be `'buffer'`, `'hex'`, `'binary'` or `'base64'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 Note: `hmac` object can not be used after `digest()` method been called.
 
@@ -157,17 +158,18 @@ Returned by `crypto.createCipher` and `crypto.createCipheriv`.
 
 Updates the cipher with `data`, the encoding of which is given in
 `input_encoding` and can be `'buffer'`, `'utf8'`, `'ascii'` or `'binary'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 The `output_encoding` specifies the output format of the enciphered data,
-and can be `'buffer'`, `'binary'`, `'base64'` or `'hex'`. Defaults to `'binary'`.
+and can be `'buffer'`, `'binary'`, `'base64'` or `'hex'`. Defaults to
+`'buffer'`.
 
 Returns the enciphered contents, and can be called many times with new data as it is streamed.
 
 ### cipher.final([output_encoding])
 
 Returns any remaining enciphered contents, with `output_encoding` being one of:
-`'buffer'`, `'binary'`, `'base64'` or `'hex'`. Defaults to `'binary'`.
+`'buffer'`, `'binary'`, `'base64'` or `'hex'`. Defaults to `'buffer'`.
 
 Note: `cipher` object can not be used after `final()` method been called.
 
@@ -197,18 +199,18 @@ Returned by `crypto.createDecipher` and `crypto.createDecipheriv`.
 ### decipher.update(data, [input_encoding], [output_encoding])
 
 Updates the decipher with `data`, which is encoded in `'buffer'`, `'binary'`,
-`'base64'` or `'hex'`. Defaults to `'binary'`.
+`'base64'` or `'hex'`. Defaults to `'buffer'`.
 
 The `output_decoding` specifies in what format to return the deciphered
 plaintext: `'buffer'`, `'binary'`, `'ascii'` or `'utf8'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 ### decipher.final([output_encoding])
 
 Returns any remaining plaintext which is deciphered,
 with `output_encoding` being one of: `'buffer'`, `'binary'`, `'ascii'` or
 `'utf8'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 Note: `decipher` object can not be used after `final()` method been called.
 
@@ -241,7 +243,7 @@ Calculates the signature on all the updated data passed through the signer.
 `private_key` is a string containing the PEM encoded private key for signing.
 
 Returns the signature in `output_format` which can be `'buffer'`, `'binary'`,
-`'hex'` or `'base64'`. Defaults to `'binary'`.
+`'hex'` or `'base64'`. Defaults to `'buffer'`.
 
 Note: `signer` object can not be used after `sign()` method been called.
 
@@ -267,7 +269,7 @@ Verifies the signed data by using the `object` and `signature`. `object` is  a
 string containing a PEM encoded object, which can be one of RSA public key,
 DSA public key, or X.509 certificate. `signature` is the previously calculated
 signature for the data, in the `signature_format` which can be `'buffer'`,
-`'binary'`, `'hex'` or `'base64'`. Defaults to `'binary'`.
+`'binary'`, `'hex'` or `'base64'`. Defaults to `'buffer'`.
 
 Returns true or false depending on the validity of the signature for the data and public key.
 
@@ -283,7 +285,7 @@ given bit length. The generator used is `2`.
 Creates a Diffie-Hellman key exchange object using the supplied prime. The
 generator used is `2`. Encoding can be `'buffer'`, `'binary'`, `'hex'`, or
 `'base64'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 ## Class: DiffieHellman
 
@@ -296,7 +298,7 @@ Returned by `crypto.createDiffieHellman`.
 Generates private and public Diffie-Hellman key values, and returns the
 public key in the specified encoding. This key should be transferred to the
 other party. Encoding can be `'binary'`, `'hex'`, or `'base64'`.
-Defaults to `'binary'`.
+Defaults to `'buffer'`.
 
 ### diffieHellman.computeSecret(other_public_key, [input_encoding], [output_encoding])
 
@@ -304,38 +306,39 @@ Computes the shared secret using `other_public_key` as the other party's
 public key and returns the computed shared secret. Supplied key is
 interpreted using specified `input_encoding`, and secret is encoded using
 specified `output_encoding`. Encodings can be `'buffer'`, `'binary'`, `'hex'`,
-or `'base64'`. The input encoding defaults to `'binary'`.
+or `'base64'`. The input encoding defaults to `'buffer'`.
 If no output encoding is given, the input encoding is used as output encoding.
 
 ### diffieHellman.getPrime([encoding])
 
 Returns the Diffie-Hellman prime in the specified encoding, which can be
-`'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
+`'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'buffer'`.
 
 ### diffieHellman.getGenerator([encoding])
 
 Returns the Diffie-Hellman prime in the specified encoding, which can be
-`'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
+`'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'buffer'`.
 
 ### diffieHellman.getPublicKey([encoding])
 
 Returns the Diffie-Hellman public key in the specified encoding, which can
-be `'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
+be `'binary'`, `'hex'`, or `'base64'`. Defaults to `'buffer'`.
 
 ### diffieHellman.getPrivateKey([encoding])
 
 Returns the Diffie-Hellman private key in the specified encoding, which can
-be `'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'binary'`.
+be `'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to
+`'buffer'`.
 
 ### diffieHellman.setPublicKey(public_key, [encoding])
 
 Sets the Diffie-Hellman public key. Key encoding can be `'buffer', ``'binary'`,
-`'hex'` or `'base64'`. Defaults to `'binary'`.
+`'hex'` or `'base64'`. Defaults to `'buffer'`.
 
 ### diffieHellman.setPrivateKey(public_key, [encoding])
 
 Sets the Diffie-Hellman private key. Key encoding can be `'buffer'`, `'binary'`,
-`'hex'` or `'base64'`. Defaults to `'binary'`.
+`'hex'` or `'base64'`. Defaults to `'buffer'`.
 
 ## crypto.getDiffieHellman(group_name)
 
@@ -361,8 +364,8 @@ Example (obtaining a shared secret):
     alice.generateKeys();
     bob.generateKeys();
 
-    var alice_secret = alice.computeSecret(bob.getPublicKey(), 'binary', 'hex');
-    var bob_secret = bob.computeSecret(alice.getPublicKey(), 'binary', 'hex');
+    var alice_secret = alice.computeSecret(bob.getPublicKey(), null, 'hex');
+    var bob_secret = bob.computeSecret(alice.getPublicKey(), null, 'hex');
 
     /* alice_secret and bob_secret should be the same */
     console.log(alice_secret == bob_secret);

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -376,6 +376,10 @@ Asynchronous PBKDF2 applies pseudorandom function HMAC-SHA1 to derive
 a key of given length from the given password, salt and iterations.
 The callback gets two arguments `(err, derivedKey)`.
 
+## crypto.pbkdf2Sync(password, salt, iterations, keylen)
+
+Synchronous PBKDF2 function.  Returns derivedKey or throws error.
+
 ## crypto.randomBytes(size, [callback])
 
 Generates cryptographically strong pseudo-random data. Usage:

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -5,8 +5,7 @@
 
 Use `require('crypto')` to access this module.
 
-The crypto module requires OpenSSL to be available on the underlying
-platform.  It offers a way of encapsulating secure credentials to be
+The crypto module offers a way of encapsulating secure credentials to be
 used as part of a secure HTTPS net or http connection.
 
 It also offers a set of wrappers for OpenSSL's hash, hmac, cipher,

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -5,11 +5,12 @@
 
 Use `require('crypto')` to access this module.
 
-The crypto module requires OpenSSL to be available on the underlying platform.
-It offers a way of encapsulating secure credentials to be used as part
-of a secure HTTPS net or http connection.
+The crypto module requires OpenSSL to be available on the underlying
+platform.  It offers a way of encapsulating secure credentials to be
+used as part of a secure HTTPS net or http connection.
 
-It also offers a set of wrappers for OpenSSL's hash, hmac, cipher, decipher, sign and verify methods.
+It also offers a set of wrappers for OpenSSL's hash, hmac, cipher,
+decipher, sign and verify methods.
 
 
 ## crypto.getCiphers()
@@ -34,30 +35,38 @@ Example:
 
 ## crypto.createCredentials(details)
 
-Creates a credentials object, with the optional details being a dictionary with keys:
+Creates a credentials object, with the optional details being a
+dictionary with keys:
 
-* `pfx` : A string or buffer holding the PFX or PKCS12 encoded private key, certificate and CA certificates
+* `pfx` : A string or buffer holding the PFX or PKCS12 encoded private
+  key, certificate and CA certificates
 * `key` : A string holding the PEM encoded private key
 * `passphrase` : A string of passphrase for the private key or pfx
 * `cert` : A string holding the PEM encoded certificate
-* `ca` : Either a string or list of strings of PEM encoded CA certificates to trust.
-* `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate Revocation List)
-* `ciphers`: A string describing the ciphers to use or exclude. Consult
-  <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for details
-  on the format.
+* `ca` : Either a string or list of strings of PEM encoded CA
+  certificates to trust.
+* `crl` : Either a string or list of strings of PEM encoded CRLs
+  (Certificate Revocation List)
+* `ciphers`: A string describing the ciphers to use or exclude.
+  Consult
+  <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT>
+  for details on the format.
 
-If no 'ca' details are given, then node.js will use the default publicly trusted list of CAs as given in
+If no 'ca' details are given, then node.js will use the default
+publicly trusted list of CAs as given in
 <http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>.
 
 
 ## crypto.createHash(algorithm)
 
-Creates and returns a hash object, a cryptographic hash with the given algorithm
-which can be used to generate hash digests.
+Creates and returns a hash object, a cryptographic hash with the given
+algorithm which can be used to generate hash digests.
 
-`algorithm` is dependent on the available algorithms supported by the version
-of OpenSSL on the platform. Examples are `'sha1'`, `'md5'`, `'sha256'`, `'sha512'`, etc.
-On recent releases, `openssl list-message-digest-algorithms` will display the available digest algorithms.
+`algorithm` is dependent on the available algorithms supported by the
+version of OpenSSL on the platform. Examples are `'sha1'`, `'md5'`,
+`'sha256'`, `'sha512'`, etc.  On recent releases, `openssl
+list-message-digest-algorithms` will display the available digest
+algorithms.
 
 Example: this program that takes the sha1 sum of a file
 
@@ -85,27 +94,29 @@ Returned by `crypto.createHash`.
 
 ### hash.update(data, [input_encoding])
 
-Updates the hash content with the given `data`, the encoding of which is given
-in `input_encoding` and can be `'buffer'`, `'utf8'`, `'ascii'` or `'binary'`.
-Defaults to `'buffer'`.
+Updates the hash content with the given `data`, the encoding of which
+is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
+`'binary'`.  If no encoding is provided, then a buffer is expected.
 
 This can be called many times with new data as it is streamed.
 
 ### hash.digest([encoding])
 
-Calculates the digest of all of the passed data to be hashed.
-The `encoding` can be `'buffer'`, `'hex'`, `'binary'` or `'base64'`.
-Defaults to `'buffer'`.
+Calculates the digest of all of the passed data to be hashed.  The
+`encoding` can be `'hex'`, `'binary'` or `'base64'`.  If no encoding
+is provided, then a buffer is returned.
 
-Note: `hash` object can not be used after `digest()` method been called.
+Note: `hash` object can not be used after `digest()` method been
+called.
 
 
 ## crypto.createHmac(algorithm, key)
 
-Creates and returns a hmac object, a cryptographic hmac with the given algorithm and key.
+Creates and returns a hmac object, a cryptographic hmac with the given
+algorithm and key.
 
-`algorithm` is dependent on the available algorithms supported by OpenSSL - see createHash above.
-`key` is the hmac key to be used.
+`algorithm` is dependent on the available algorithms supported by
+OpenSSL - see createHash above.  `key` is the hmac key to be used.
 
 ## Class: Hmac
 
@@ -115,38 +126,40 @@ Returned by `crypto.createHmac`.
 
 ### hmac.update(data)
 
-Update the hmac content with the given `data`.
-This can be called many times with new data as it is streamed.
+Update the hmac content with the given `data`.  This can be called
+many times with new data as it is streamed.
 
 ### hmac.digest([encoding])
 
-Calculates the digest of all of the passed data to the hmac.
-The `encoding` can be `'buffer'`, `'hex'`, `'binary'` or `'base64'`.
-Defaults to `'buffer'`.
+Calculates the digest of all of the passed data to the hmac.  The
+`encoding` can be `'hex'`, `'binary'` or `'base64'`.  If no encoding
+is provided, then a buffer is returned.
 
-Note: `hmac` object can not be used after `digest()` method been called.
+Note: `hmac` object can not be used after `digest()` method been
+called.
 
 
 ## crypto.createCipher(algorithm, password)
 
-Creates and returns a cipher object, with the given algorithm and password.
+Creates and returns a cipher object, with the given algorithm and
+password.
 
-`algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc.
-On recent releases, `openssl list-cipher-algorithms` will display the
-available cipher algorithms.
-`password` is used to derive key and IV, which must be a `'binary'` encoded
-string or a [buffer](buffer.html).
+`algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc.  On
+recent releases, `openssl list-cipher-algorithms` will display the
+available cipher algorithms.  `password` is used to derive key and IV,
+which must be a `'binary'` encoded string or a [buffer](buffer.html).
 
 ## crypto.createCipheriv(algorithm, key, iv)
 
-Creates and returns a cipher object, with the given algorithm, key and iv.
+Creates and returns a cipher object, with the given algorithm, key and
+iv.
 
-`algorithm` is the same as the argument to `createCipher()`.
-`key` is the raw key used by the algorithm.
-`iv` is an [initialization
+`algorithm` is the same as the argument to `createCipher()`.  `key` is
+the raw key used by the algorithm.  `iv` is an [initialization
 vector](http://en.wikipedia.org/wiki/Initialization_vector).
 
-`key` and `iv` must be `'binary'` encoded strings or [buffers](buffer.html).
+`key` and `iv` must be `'binary'` encoded strings or
+[buffers](buffer.html).
 
 ## Class: Cipher
 
@@ -157,38 +170,43 @@ Returned by `crypto.createCipher` and `crypto.createCipheriv`.
 ### cipher.update(data, [input_encoding], [output_encoding])
 
 Updates the cipher with `data`, the encoding of which is given in
-`input_encoding` and can be `'buffer'`, `'utf8'`, `'ascii'` or `'binary'`.
-Defaults to `'buffer'`.
+`input_encoding` and can be `'utf8'`, `'ascii'` or `'binary'`.  If no
+encoding is provided, then a buffer is expected.
 
-The `output_encoding` specifies the output format of the enciphered data,
-and can be `'buffer'`, `'binary'`, `'base64'` or `'hex'`. Defaults to
-`'buffer'`.
+The `output_encoding` specifies the output format of the enciphered
+data, and can be `'binary'`, `'base64'` or `'hex'`.  If no encoding is
+provided, then a buffer iis returned.
 
-Returns the enciphered contents, and can be called many times with new data as it is streamed.
+Returns the enciphered contents, and can be called many times with new
+data as it is streamed.
 
 ### cipher.final([output_encoding])
 
-Returns any remaining enciphered contents, with `output_encoding` being one of:
-`'buffer'`, `'binary'`, `'base64'` or `'hex'`. Defaults to `'buffer'`.
+Returns any remaining enciphered contents, with `output_encoding`
+being one of: `'binary'`, `'base64'` or `'hex'`.  If no encoding is
+provided, then a buffer is returned.
 
-Note: `cipher` object can not be used after `final()` method been called.
+Note: `cipher` object can not be used after `final()` method been
+called.
 
 ### cipher.setAutoPadding(auto_padding=true)
 
-You can disable automatic padding of the input data to block size. If `auto_padding` is false,
-the length of the entire input data must be a multiple of the cipher's block size or `final` will fail.
-Useful for non-standard padding, e.g. using `0x0` instead of PKCS padding. You must call this before `cipher.final`.
+You can disable automatic padding of the input data to block size. If
+`auto_padding` is false, the length of the entire input data must be a
+multiple of the cipher's block size or `final` will fail.  Useful for
+non-standard padding, e.g. using `0x0` instead of PKCS padding. You
+must call this before `cipher.final`.
 
 
 ## crypto.createDecipher(algorithm, password)
 
-Creates and returns a decipher object, with the given algorithm and key.
-This is the mirror of the [createCipher()][] above.
+Creates and returns a decipher object, with the given algorithm and
+key.  This is the mirror of the [createCipher()][] above.
 
 ## crypto.createDecipheriv(algorithm, key, iv)
 
-Creates and returns a decipher object, with the given algorithm, key and iv.
-This is the mirror of the [createCipheriv()][] above.
+Creates and returns a decipher object, with the given algorithm, key
+and iv.  This is the mirror of the [createCipheriv()][] above.
 
 ## Class: Decipher
 
@@ -198,33 +216,36 @@ Returned by `crypto.createDecipher` and `crypto.createDecipheriv`.
 
 ### decipher.update(data, [input_encoding], [output_encoding])
 
-Updates the decipher with `data`, which is encoded in `'buffer'`, `'binary'`,
-`'base64'` or `'hex'`. Defaults to `'buffer'`.
+Updates the decipher with `data`, which is encoded in `'binary'`,
+`'base64'` or `'hex'`.  If no encoding is provided, then a buffer is
+expected.
 
-The `output_decoding` specifies in what format to return the deciphered
-plaintext: `'buffer'`, `'binary'`, `'ascii'` or `'utf8'`.
-Defaults to `'buffer'`.
+The `output_decoding` specifies in what format to return the
+deciphered plaintext: `'binary'`, `'ascii'` or `'utf8'`.  If no
+encoding is provided, then a buffer is returned.
 
 ### decipher.final([output_encoding])
 
-Returns any remaining plaintext which is deciphered,
-with `output_encoding` being one of: `'buffer'`, `'binary'`, `'ascii'` or
-`'utf8'`.
-Defaults to `'buffer'`.
+Returns any remaining plaintext which is deciphered, with
+`output_encoding` being one of: `'binary'`, `'ascii'` or `'utf8'`.  If
+no encoding is provided, then a buffer is returned.
 
-Note: `decipher` object can not be used after `final()` method been called.
+Note: `decipher` object can not be used after `final()` method been
+called.
 
 ### decipher.setAutoPadding(auto_padding=true)
 
-You can disable auto padding if the data has been encrypted without standard block padding to prevent
-`decipher.final` from checking and removing it. Can only work if the input data's length is a multiple of the
-ciphers block size. You must call this before streaming data to `decipher.update`.
+You can disable auto padding if the data has been encrypted without
+standard block padding to prevent `decipher.final` from checking and
+removing it. Can only work if the input data's length is a multiple of
+the ciphers block size. You must call this before streaming data to
+`decipher.update`.
 
 ## crypto.createSign(algorithm)
 
-Creates and returns a signing object, with the given algorithm.
-On recent OpenSSL releases, `openssl list-public-key-algorithms` will display
-the available signing algorithms. Examples are `'RSA-SHA256'`.
+Creates and returns a signing object, with the given algorithm.  On
+recent OpenSSL releases, `openssl list-public-key-algorithms` will
+display the available signing algorithms. Examples are `'RSA-SHA256'`.
 
 ## Class: Signer
 
@@ -234,18 +255,21 @@ Returned by `crypto.createSign`.
 
 ### signer.update(data)
 
-Updates the signer object with data.
-This can be called many times with new data as it is streamed.
+Updates the signer object with data.  This can be called many times
+with new data as it is streamed.
 
 ### signer.sign(private_key, [output_format])
 
-Calculates the signature on all the updated data passed through the signer.
-`private_key` is a string containing the PEM encoded private key for signing.
+Calculates the signature on all the updated data passed through the
+signer.  `private_key` is a string containing the PEM encoded private
+key for signing.
 
-Returns the signature in `output_format` which can be `'buffer'`, `'binary'`,
-`'hex'` or `'base64'`. Defaults to `'buffer'`.
+Returns the signature in `output_format` which can be `'binary'`,
+`'hex'` or `'base64'`. If no encoding is provided, then a buffer is
+returned.
 
-Note: `signer` object can not be used after `sign()` method been called.
+Note: `signer` object can not be used after `sign()` method been
+called.
 
 ## crypto.createVerify(algorithm)
 
@@ -260,32 +284,34 @@ Returned by `crypto.createVerify`.
 
 ### verifier.update(data)
 
-Updates the verifier object with data.
-This can be called many times with new data as it is streamed.
+Updates the verifier object with data.  This can be called many times
+with new data as it is streamed.
 
 ### verifier.verify(object, signature, [signature_format])
 
-Verifies the signed data by using the `object` and `signature`. `object` is  a
-string containing a PEM encoded object, which can be one of RSA public key,
-DSA public key, or X.509 certificate. `signature` is the previously calculated
-signature for the data, in the `signature_format` which can be `'buffer'`,
-`'binary'`, `'hex'` or `'base64'`. Defaults to `'buffer'`.
+Verifies the signed data by using the `object` and `signature`.
+`object` is  a string containing a PEM encoded object, which can be
+one of RSA public key, DSA public key, or X.509 certificate.
+`signature` is the previously calculated signature for the data, in
+the `signature_format` which can be `'binary'`, `'hex'` or `'base64'`.
+If no encoding is specified, then a buffer is expected.
 
-Returns true or false depending on the validity of the signature for the data and public key.
+Returns true or false depending on the validity of the signature for
+the data and public key.
 
-Note: `verifier` object can not be used after `verify()` method been called.
+Note: `verifier` object can not be used after `verify()` method been
+called.
 
 ## crypto.createDiffieHellman(prime_length)
 
-Creates a Diffie-Hellman key exchange object and generates a prime of the
-given bit length. The generator used is `2`.
+Creates a Diffie-Hellman key exchange object and generates a prime of
+the given bit length. The generator used is `2`.
 
 ## crypto.createDiffieHellman(prime, [encoding])
 
-Creates a Diffie-Hellman key exchange object using the supplied prime. The
-generator used is `2`. Encoding can be `'buffer'`, `'binary'`, `'hex'`, or
-`'base64'`.
-Defaults to `'buffer'`.
+Creates a Diffie-Hellman key exchange object using the supplied prime.
+The generator used is `2`. Encoding can be `'binary'`, `'hex'`, or
+`'base64'`.  If no encoding is specified, then a buffer is expected.
 
 ## Class: DiffieHellman
 
@@ -295,65 +321,70 @@ Returned by `crypto.createDiffieHellman`.
 
 ### diffieHellman.generateKeys([encoding])
 
-Generates private and public Diffie-Hellman key values, and returns the
-public key in the specified encoding. This key should be transferred to the
-other party. Encoding can be `'binary'`, `'hex'`, or `'base64'`.
-Defaults to `'buffer'`.
+Generates private and public Diffie-Hellman key values, and returns
+the public key in the specified encoding. This key should be
+transferred to the other party. Encoding can be `'binary'`, `'hex'`,
+or `'base64'`.  If no encoding is provided, then a buffer is returned.
 
 ### diffieHellman.computeSecret(other_public_key, [input_encoding], [output_encoding])
 
-Computes the shared secret using `other_public_key` as the other party's
-public key and returns the computed shared secret. Supplied key is
-interpreted using specified `input_encoding`, and secret is encoded using
-specified `output_encoding`. Encodings can be `'buffer'`, `'binary'`, `'hex'`,
-or `'base64'`. The input encoding defaults to `'buffer'`.
-If no output encoding is given, the input encoding is used as output encoding.
+Computes the shared secret using `other_public_key` as the other
+party's public key and returns the computed shared secret. Supplied
+key is interpreted using specified `input_encoding`, and secret is
+encoded using specified `output_encoding`. Encodings can be
+`'binary'`, `'hex'`, or `'base64'`. If the input encoding is not
+provided, then a buffer is expected.
+
+If no output encoding is given, then a buffer is returned.
 
 ### diffieHellman.getPrime([encoding])
 
-Returns the Diffie-Hellman prime in the specified encoding, which can be
-`'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'buffer'`.
+Returns the Diffie-Hellman prime in the specified encoding, which can
+be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided,
+then a buffer is returned.
 
 ### diffieHellman.getGenerator([encoding])
 
-Returns the Diffie-Hellman prime in the specified encoding, which can be
-`'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to `'buffer'`.
+Returns the Diffie-Hellman prime in the specified encoding, which can
+be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided,
+then a buffer is returned.
 
 ### diffieHellman.getPublicKey([encoding])
 
-Returns the Diffie-Hellman public key in the specified encoding, which can
-be `'binary'`, `'hex'`, or `'base64'`. Defaults to `'buffer'`.
+Returns the Diffie-Hellman public key in the specified encoding, which
+can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided,
+then a buffer is returned.
 
 ### diffieHellman.getPrivateKey([encoding])
 
-Returns the Diffie-Hellman private key in the specified encoding, which can
-be `'buffer'`, `'binary'`, `'hex'`, or `'base64'`. Defaults to
-`'buffer'`.
+Returns the Diffie-Hellman private key in the specified encoding,
+which can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is
+provided, then a buffer is returned.
 
 ### diffieHellman.setPublicKey(public_key, [encoding])
 
-Sets the Diffie-Hellman public key. Key encoding can be `'buffer', ``'binary'`,
-`'hex'` or `'base64'`. Defaults to `'buffer'`.
+Sets the Diffie-Hellman public key. Key encoding can be `'binary'`,
+`'hex'` or `'base64'`. If no encoding is provided, then a buffer is
+expected.
 
 ### diffieHellman.setPrivateKey(public_key, [encoding])
 
-Sets the Diffie-Hellman private key. Key encoding can be `'buffer'`, `'binary'`,
-`'hex'` or `'base64'`. Defaults to `'buffer'`.
+Sets the Diffie-Hellman private key. Key encoding can be `'binary'`,
+`'hex'` or `'base64'`. If no encoding is provided, then a buffer is
+expected.
 
 ## crypto.getDiffieHellman(group_name)
 
-Creates a predefined Diffie-Hellman key exchange object.
-The supported groups are: `'modp1'`, `'modp2'`, `'modp5'`
-(defined in [RFC 2412][])
-and `'modp14'`, `'modp15'`, `'modp16'`, `'modp17'`, `'modp18'`
-(defined in [RFC 3526][]).
-The returned object mimics the interface of objects created by
-[crypto.createDiffieHellman()][] above, but
-will not allow to change the keys (with
-[diffieHellman.setPublicKey()][] for example).
-The advantage of using this routine is that the parties don't have to
-generate nor exchange group modulus beforehand, saving both processor and
-communication time.
+Creates a predefined Diffie-Hellman key exchange object.  The
+supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in [RFC
+2412][]) and `'modp14'`, `'modp15'`, `'modp16'`, `'modp17'`,
+`'modp18'` (defined in [RFC 3526][]).  The returned object mimics the
+interface of objects created by [crypto.createDiffieHellman()][]
+above, but will not allow to change the keys (with
+[diffieHellman.setPublicKey()][] for example).  The advantage of using
+this routine is that the parties don't have to generate nor exchange
+group modulus beforehand, saving both processor and communication
+time.
 
 Example (obtaining a shared secret):
 
@@ -398,32 +429,46 @@ Generates cryptographically strong pseudo-random data. Usage:
       // handle error
     }
 
-## Proposed API Changes in Future Versions of Node
+## crypto.DEFAULT_ENCODING
+
+The default encoding to use for functions that can take either strings
+or buffers.  The default value is `'buffer'`, which makes it default
+to using Buffer objects.  This is here to make the crypto module more
+easily compatible with legacy programs that expected `'binary'` to be
+the default encoding.
+
+Note that new programs will probably expect buffers, so only use this
+as a temporary measure.
+
+## Recent API Changes
 
 The Crypto module was added to Node before there was the concept of a
 unified Stream API, and before there were Buffer objects for handling
 binary data.
 
 As such, the streaming classes don't have the typical methods found on
-other Node classes, and many methods accept and return Binary-encoded
-strings by default rather than Buffers.
+other Node classes, and many methods accepted and returned
+Binary-encoded strings by default rather than Buffers.  This was
+changed to use Buffers by default instead.
 
-A future version of node will make Buffers the default data type.
-This will be a breaking change for some use cases, but not all.
+This is a breaking change for some use cases, but not all.
 
 For example, if you currently use the default arguments to the Sign
 class, and then pass the results to the Verify class, without ever
 inspecting the data, then it will continue to work as before.  Where
-you now get a binary string and then present the binary string to the
-Verify object, you'll get a Buffer, and present the Buffer to the
-Verify object.
+you once got a binary string and then presented the binary string to
+the Verify object, you'll now get a Buffer, and present the Buffer to
+the Verify object.
 
-However, if you are doing things with the string data that will not
+However, if you were doing things with the string data that will not
 work properly on Buffers (such as, concatenating them, storing in
 databases, etc.), or you are passing binary strings to the crypto
 functions without an encoding argument, then you will need to start
 providing encoding arguments to specify which encoding you'd like to
-use.
+use.  To switch to the previous style of using binary strings by
+default, set the `crypto.DEFAULT_ENCODING` field to 'binary'.  Note
+that new programs will probably expect buffers, so only use this as a
+temporary measure.
 
 Also, a Streaming API will be provided, but this will be done in such
 a way as to preserve the legacy API surface.

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -458,6 +458,19 @@ DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
 
 
 exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
+  if (typeof callback !== 'function')
+    throw new Error('No callback provided to pbkdf2');
+
+  return pbkdf2(password, salt, iterations, keylen, callback);
+};
+
+
+exports.pbkdf2Sync = function(password, salt, iterations, keylen) {
+  return pbkdf2(password, salt, iterations, keylen);
+};
+
+
+function pbkdf2(password, salt, iterations, keylen, callback) {
   password = toBuf(password);
   salt = toBuf(salt);
 
@@ -476,11 +489,8 @@ exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
     var ret = binding.PBKDF2(password, salt, iterations, keylen);
     return ret.toString(encoding);
   }
-};
+}
 
-exports.pbkdf2Sync = function(password, salt, iterations, keylen) {
-  return exports.pbkdf2(password, salt, iterations, keylen);
-};
 
 
 exports.randomBytes = randomBytes;

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -37,6 +37,20 @@ try {
   var crypto = false;
 }
 
+// This is here because many functions accepted binary strings without
+// any explicit encoding in older versions of node, and we don't want
+// to break them unnecessarily.
+function toBuf(str, encoding) {
+  encoding = encoding || 'binary';
+  if (typeof str === 'string') {
+    if (encoding === 'buffer')
+      encoding = 'binary';
+    str = new Buffer(str, encoding);
+  }
+  return str;
+}
+
+
 var assert = require('assert');
 var StringDecoder = require('string_decoder').StringDecoder;
 
@@ -117,11 +131,11 @@ exports.createCredentials = function(options, context) {
   if (options.pfx) {
     var pfx = options.pfx;
     var passphrase = options.passphrase;
-    // legacy
-    if (typeof pfx === 'string')
-      pfx = new Buffer(pfx, 'binary');
-    if (passphrase && typeof passphrase === 'string')
-      passphrase = new Buffer(passphrase, 'binary');
+
+    pfx = toBuf(pfx);
+    if (passphrase)
+      passphrase = toBuf(passphrase);
+
     if (passphrase) {
       c.context.loadPKCS12(pfx, passphrase);
     } else {
@@ -140,19 +154,18 @@ function Hash(algorithm) {
   this._binding = new binding.Hash(algorithm);
 }
 
+
 Hash.prototype.update = function(data, encoding) {
   encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding === 'buffer')
-    encoding = null;
-  if (typeof data === 'string')
-    data = new Buffer(data, encoding);
+  data = toBuf(data, encoding);
   this._binding.update(data);
   return this;
 };
 
+
 Hash.prototype.digest = function(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  var result = this._binding.digest('buffer');
+  var result = this._binding.digest();
   if (outputEncoding && outputEncoding !== 'buffer')
     result = result.toString(outputEncoding);
   return result;
@@ -165,11 +178,9 @@ function Hmac(hmac, key) {
   if (!(this instanceof Hmac))
     return new Hmac(hmac, key);
   this._binding = new binding.Hmac();
-  // legacy
-  if (typeof key === 'string')
-    key = new Buffer(key, 'binary');
-  this._binding.init(hmac, key);
+  this._binding.init(hmac, toBuf(key));
 }
+
 
 Hmac.prototype.update = Hash.prototype.update;
 Hmac.prototype.digest = Hash.prototype.digest;
@@ -188,21 +199,17 @@ function Cipher(cipher, password) {
     return new Cipher(cipher, password);
   this._binding = new binding.Cipher;
 
-  // legacy.
-  if (typeof password === 'string')
-    password = new Buffer(password, 'binary');
-
-  this._binding.init(cipher, password);
+  this._binding.init(cipher, toBuf(password));
   this._decoder = null;
 }
+
 
 Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
   inputEncoding = inputEncoding || exports.DEFAULT_ENCODING;
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  if (inputEncoding && inputEncoding !== 'buffer')
-    data = new Buffer(data, inputEncoding);
+  data = toBuf(data, inputEncoding);
 
-  var ret = this._binding.update(data, 'buffer', 'buffer');
+  var ret = this._binding.update(data);
 
   if (outputEncoding && outputEncoding !== 'buffer') {
     this._decoder = getDecoder(this._decoder, outputEncoding);
@@ -211,10 +218,11 @@ Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
 
   return ret;
 };
+
 
 Cipher.prototype.final = function(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  var ret = this._binding.final('buffer');
+  var ret = this._binding.final();
 
   if (outputEncoding && outputEncoding !== 'buffer') {
     this._decoder = getDecoder(this._decoder, outputEncoding);
@@ -223,6 +231,7 @@ Cipher.prototype.final = function(outputEncoding) {
 
   return ret;
 };
+
 
 Cipher.prototype.setAutoPadding = function(ap) {
   this._binding.setAutoPadding(ap);
@@ -235,19 +244,16 @@ exports.createCipheriv = exports.Cipheriv = Cipheriv;
 function Cipheriv(cipher, key, iv) {
   if (!(this instanceof Cipheriv))
     return new Cipheriv(cipher, key, iv);
-  // legacy
-  if (typeof key === 'string')
-    key = new Buffer(key, 'binary');
-  if (typeof iv === 'string')
-    iv = new Buffer(iv, 'binary');
   this._binding = new binding.Cipher();
-  this._binding.initiv(cipher, key, iv);
+  this._binding.initiv(cipher, toBuf(key), toBuf(iv));
   this._decoder = null;
 }
+
 
 Cipheriv.prototype.update = Cipher.prototype.update;
 Cipheriv.prototype.final = Cipher.prototype.final;
 Cipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
+
 
 
 exports.createDecipher = exports.Decipher = Decipher;
@@ -255,14 +261,11 @@ function Decipher(cipher, password) {
   if (!(this instanceof Decipher))
     return new Decipher(cipher, password);
 
-  // legacy.
-  if (typeof password === 'string')
-    password = new Buffer(password, 'binary');
-
   this._binding = new binding.Decipher;
-  this._binding.init(cipher, password);
+  this._binding.init(cipher, toBuf(password));
   this._decoder = null;
 }
+
 
 Decipher.prototype.update = Cipher.prototype.update;
 Decipher.prototype.final = Cipher.prototype.final;
@@ -270,24 +273,23 @@ Decipher.prototype.finaltol = Cipher.prototype.final;
 Decipher.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
 
 
+
 exports.createDecipheriv = exports.Decipheriv = Decipheriv;
 function Decipheriv(cipher, key, iv) {
   if (!(this instanceof Decipheriv))
     return new Decipheriv(cipher, key, iv);
-  // legacy
-  if (typeof key === 'string')
-    key = new Buffer(key, 'binary');
-  if (typeof iv === 'string')
-    iv = new Buffer(iv, 'binary');
+
   this._binding = new binding.Decipher;
-  this._binding.initiv(cipher, key, iv);
+  this._binding.initiv(cipher, toBuf(key), toBuf(iv));
   this._decoder = null;
 }
+
 
 Decipheriv.prototype.update = Cipher.prototype.update;
 Decipheriv.prototype.final = Cipher.prototype.final;
 Decipheriv.prototype.finaltol = Cipher.prototype.final;
 Decipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
+
 
 
 exports.createSign = exports.Sign = Sign;
@@ -298,19 +300,20 @@ function Sign(algorithm) {
   this._binding.init(algorithm);
 }
 
+
 Sign.prototype.update = Hash.prototype.update;
 
-Sign.prototype.sign = function(key, encoding) {
-  // legacy.
-  if (typeof key === 'string')
-    key = new Buffer(key, 'binary');
 
+Sign.prototype.sign = function(key, encoding) {
   encoding = encoding || exports.DEFAULT_ENCODING;
-  var ret = this._binding.sign(key, 'buffer');
+  var ret = this._binding.sign(toBuf(key));
+
   if (encoding && encoding !== 'buffer')
     ret = ret.toString(encoding);
+
   return ret;
 };
+
 
 
 exports.createVerify = exports.Verify = Verify;
@@ -322,21 +325,16 @@ function Verify(algorithm) {
   this._binding.init(algorithm);
 }
 
+
 Verify.prototype.update = Hash.prototype.update;
 
+
 Verify.prototype.verify = function(object, signature, sigEncoding) {
-  // legacy.
-  if (typeof object === 'string')
-    object = new Buffer(object, 'binary');
-
   sigEncoding = sigEncoding || exports.DEFAULT_ENCODING;
-  if (sigEncoding === 'buffer')
-    sigEncoding = null;
-  if (sigEncoding || typeof signature === 'string')
-    signature = new Buffer(signature, sigEncoding);
-
-  return this._binding.verify(object, signature, 'buffer');
+  return this._binding.verify(toBuf(object), toBuf(signature, sigEncoding));
 };
+
+
 
 exports.createDiffieHellman = exports.DiffieHellman = DiffieHellman;
 
@@ -348,89 +346,10 @@ function DiffieHellman(sizeOrKey, encoding) {
     this._binding = new binding.DiffieHellman();
   else {
     encoding = encoding || exports.DEFAULT_ENCODING;
-    if (encoding === 'buffer')
-      encoding = null;
-    if (typeof sizeOrKey === 'string')
-      sizeOrKey = new Buffer(sizeOrKey, encoding);
-    this._binding = new binding.DiffieHellman(sizeOrKey, 'buffer');
+    sizeOrKey = toBuf(sizeOrKey, encoding);
+    this._binding = new binding.DiffieHellman(sizeOrKey);
   }
 }
-
-DiffieHellman.prototype.generateKeys = function(encoding) {
-  var keys = this._binding.generateKeys('buffer');
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding && encoding !== 'buffer')
-    keys = keys.toString(encoding);
-  return keys;
-};
-
-DiffieHellman.prototype.computeSecret = function(key, inEnc, outEnc) {
-  inEnc = inEnc || exports.DEFAULT_ENCODING;
-  outEnc = outEnc || exports.DEFAULT_ENCODING;
-  if (inEnc === 'buffer')
-    inEnc = null;
-  if (outEnc === 'buffer')
-    outEnc = null;
-  if (inEnc || typeof key === 'string')
-    key = new Buffer(key, inEnc);
-  var ret = this._binding.computeSecret(key, 'buffer', 'buffer');
-  if (outEnc)
-    ret = ret.toString(outEnc);
-  return ret;
-};
-
-DiffieHellman.prototype.getPrime = function(encoding) {
-  var prime = this._binding.getPrime('buffer');
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding && encoding !== 'buffer')
-    prime = prime.toString(encoding);
-  return prime;
-};
-
-DiffieHellman.prototype.getGenerator = function(encoding) {
-  var generator = this._binding.getGenerator('buffer');
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding && encoding !== 'buffer')
-    generator = generator.toString(encoding);
-  return generator;
-};
-
-DiffieHellman.prototype.getPublicKey = function(encoding) {
-  var key = this._binding.getPublicKey('buffer');
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
-};
-
-DiffieHellman.prototype.getPrivateKey = function(encoding) {
-  var key = this._binding.getPrivateKey('buffer');
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
-};
-
-DiffieHellman.prototype.setPublicKey = function(key, encoding) {
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding === 'buffer')
-    encoding = null;
-  if (encoding || typeof key === 'string')
-    key = new Buffer(key, encoding);
-  this._binding.setPublicKey(key, 'buffer');
-  return this;
-};
-
-DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
-  encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding === 'buffer')
-    encoding = null;
-  if (encoding || typeof key === 'string')
-    key = new Buffer(key, encoding);
-  this._binding.setPrivateKey(key, 'buffer');
-  return this;
-};
-
 
 
 exports.DiffieHellmanGroup =
@@ -443,29 +362,104 @@ function DiffieHellmanGroup(name) {
   this._binding = new binding.DiffieHellmanGroup(name);
 }
 
+
 DiffieHellmanGroup.prototype.generateKeys =
-    DiffieHellman.prototype.generateKeys;
+    DiffieHellman.prototype.generateKeys =
+    dhGenerateKeys;
+
+function dhGenerateKeys(encoding) {
+  var keys = this._binding.generateKeys();
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  if (encoding && encoding !== 'buffer')
+    keys = keys.toString(encoding);
+  return keys;
+}
+
 
 DiffieHellmanGroup.prototype.computeSecret =
-    DiffieHellman.prototype.computeSecret;
+    DiffieHellman.prototype.computeSecret =
+    dhComputeSecret;
+
+function dhComputeSecret(key, inEnc, outEnc) {
+  inEnc = inEnc || exports.DEFAULT_ENCODING;
+  outEnc = outEnc || exports.DEFAULT_ENCODING;
+  var ret = this._binding.computeSecret(toBuf(key, inEnc));
+  if (outEnc && outEnc !== 'buffer')
+    ret = ret.toString(outEnc);
+  return ret;
+}
+
 
 DiffieHellmanGroup.prototype.getPrime =
-    DiffieHellman.prototype.getPrime;
+    DiffieHellman.prototype.getPrime =
+    dhGetPrime;
+
+function dhGetPrime(encoding) {
+  var prime = this._binding.getPrime();
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  if (encoding && encoding !== 'buffer')
+    prime = prime.toString(encoding);
+  return prime;
+}
+
 
 DiffieHellmanGroup.prototype.getGenerator =
-    DiffieHellman.prototype.getGenerator;
+    DiffieHellman.prototype.getGenerator =
+    dhGetGenerator;
+
+function dhGetGenerator(encoding) {
+  var generator = this._binding.getGenerator();
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  if (encoding && encoding !== 'buffer')
+    generator = generator.toString(encoding);
+  return generator;
+}
+
 
 DiffieHellmanGroup.prototype.getPublicKey =
-    DiffieHellman.prototype.getPublicKey;
+    DiffieHellman.prototype.getPublicKey =
+    dhGetPublicKey;
+
+function dhGetPublicKey(encoding) {
+  var key = this._binding.getPublicKey();
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  if (encoding && encoding !== 'buffer')
+    key = key.toString(encoding);
+  return key;
+}
+
 
 DiffieHellmanGroup.prototype.getPrivateKey =
-    DiffieHellman.prototype.getPrivateKey;
+    DiffieHellman.prototype.getPrivateKey =
+    dhGetPrivateKey;
+
+function dhGetPrivateKey(encoding) {
+  var key = this._binding.getPrivateKey();
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  if (encoding && encoding !== 'buffer')
+    key = key.toString(encoding);
+  return key;
+}
+
+
+DiffieHellman.prototype.setPublicKey = function(key, encoding) {
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  this._binding.setPublicKey(toBuf(key, encoding));
+  return this;
+};
+
+
+DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  this._binding.setPrivateKey(toBuf(key, encoding));
+  return this;
+};
+
+
 
 exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
-  if (typeof password === 'string')
-    password = new Buffer(password, 'binary');
-  if (typeof salt === 'string')
-    salt = new Buffer(salt, 'binary');
+  password = toBuf(password);
+  salt = toBuf(salt);
 
   if (exports.DEFAULT_ENCODING === 'buffer')
     return binding.PBKDF2(password, salt, iterations, keylen, callback);

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -19,6 +19,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Note: In 0.8 and before, crypto functions all defaulted to using
+// binary-encoded strings rather than buffers.
+
+exports.DEFAULT_ENCODING = 'buffer';
 
 try {
   var binding = process.binding('crypto');
@@ -137,15 +141,17 @@ function Hash(algorithm) {
 }
 
 Hash.prototype.update = function(data, encoding) {
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding === 'buffer')
     encoding = null;
-  if (encoding || typeof data === 'string')
+  if (typeof data === 'string')
     data = new Buffer(data, encoding);
   this._binding.update(data);
   return this;
 };
 
 Hash.prototype.digest = function(outputEncoding) {
+  outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
   var result = this._binding.digest('buffer');
   if (outputEncoding && outputEncoding !== 'buffer')
     result = result.toString(outputEncoding);
@@ -191,6 +197,8 @@ function Cipher(cipher, password) {
 }
 
 Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
+  inputEncoding = inputEncoding || exports.DEFAULT_ENCODING;
+  outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
   if (inputEncoding && inputEncoding !== 'buffer')
     data = new Buffer(data, inputEncoding);
 
@@ -205,6 +213,7 @@ Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
 };
 
 Cipher.prototype.final = function(outputEncoding) {
+  outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
   var ret = this._binding.final('buffer');
 
   if (outputEncoding && outputEncoding !== 'buffer') {
@@ -296,6 +305,7 @@ Sign.prototype.sign = function(key, encoding) {
   if (typeof key === 'string')
     key = new Buffer(key, 'binary');
 
+  encoding = encoding || exports.DEFAULT_ENCODING;
   var ret = this._binding.sign(key, 'buffer');
   if (encoding && encoding !== 'buffer')
     ret = ret.toString(encoding);
@@ -319,6 +329,7 @@ Verify.prototype.verify = function(object, signature, sigEncoding) {
   if (typeof object === 'string')
     object = new Buffer(object, 'binary');
 
+  sigEncoding = sigEncoding || exports.DEFAULT_ENCODING;
   if (sigEncoding === 'buffer')
     sigEncoding = null;
   if (sigEncoding || typeof signature === 'string')
@@ -336,9 +347,10 @@ function DiffieHellman(sizeOrKey, encoding) {
   if (!sizeOrKey)
     this._binding = new binding.DiffieHellman();
   else {
+    encoding = encoding || exports.DEFAULT_ENCODING;
     if (encoding === 'buffer')
       encoding = null;
-    if (encoding || typeof sizeOrKey === 'string')
+    if (typeof sizeOrKey === 'string')
       sizeOrKey = new Buffer(sizeOrKey, encoding);
     this._binding = new binding.DiffieHellman(sizeOrKey, 'buffer');
   }
@@ -346,12 +358,15 @@ function DiffieHellman(sizeOrKey, encoding) {
 
 DiffieHellman.prototype.generateKeys = function(encoding) {
   var keys = this._binding.generateKeys('buffer');
-  if (encoding)
+  encoding = encoding || exports.DEFAULT_ENCODING;
+  if (encoding && encoding !== 'buffer')
     keys = keys.toString(encoding);
   return keys;
 };
 
 DiffieHellman.prototype.computeSecret = function(key, inEnc, outEnc) {
+  inEnc = inEnc || exports.DEFAULT_ENCODING;
+  outEnc = outEnc || exports.DEFAULT_ENCODING;
   if (inEnc === 'buffer')
     inEnc = null;
   if (outEnc === 'buffer')
@@ -366,6 +381,7 @@ DiffieHellman.prototype.computeSecret = function(key, inEnc, outEnc) {
 
 DiffieHellman.prototype.getPrime = function(encoding) {
   var prime = this._binding.getPrime('buffer');
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     prime = prime.toString(encoding);
   return prime;
@@ -373,6 +389,7 @@ DiffieHellman.prototype.getPrime = function(encoding) {
 
 DiffieHellman.prototype.getGenerator = function(encoding) {
   var generator = this._binding.getGenerator('buffer');
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     generator = generator.toString(encoding);
   return generator;
@@ -380,6 +397,7 @@ DiffieHellman.prototype.getGenerator = function(encoding) {
 
 DiffieHellman.prototype.getPublicKey = function(encoding) {
   var key = this._binding.getPublicKey('buffer');
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     key = key.toString(encoding);
   return key;
@@ -387,12 +405,14 @@ DiffieHellman.prototype.getPublicKey = function(encoding) {
 
 DiffieHellman.prototype.getPrivateKey = function(encoding) {
   var key = this._binding.getPrivateKey('buffer');
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     key = key.toString(encoding);
   return key;
 };
 
 DiffieHellman.prototype.setPublicKey = function(key, encoding) {
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding === 'buffer')
     encoding = null;
   if (encoding || typeof key === 'string')
@@ -402,6 +422,7 @@ DiffieHellman.prototype.setPublicKey = function(key, encoding) {
 };
 
 DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
+  encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding === 'buffer')
     encoding = null;
   if (encoding || typeof key === 'string')
@@ -445,7 +466,22 @@ exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
     password = new Buffer(password, 'binary');
   if (typeof salt === 'string')
     salt = new Buffer(salt, 'binary');
-  return binding.PBKDF2(password, salt, iterations, keylen, callback);
+
+  if (exports.DEFAULT_ENCODING === 'buffer')
+    return binding.PBKDF2(password, salt, iterations, keylen, callback);
+
+  // at this point, we need to handle encodings.
+  var encoding = exports.DEFAULT_ENCODING;
+  if (callback) {
+    binding.PBKDF2(password, salt, iterations, keylen, function(er, ret) {
+      if (ret)
+        ret = ret.toString(encoding);
+      callback(er, ret);
+    });
+  } else {
+    var ret = binding.PBKDF2(password, salt, iterations, keylen);
+    return ret.toString(encoding);
+  }
 };
 
 exports.pbkdf2Sync = function(password, salt, iterations, keylen) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -23,14 +23,6 @@
 try {
   var binding = process.binding('crypto');
   var SecureContext = binding.SecureContext;
-  var Hmac = binding.Hmac;
-  var Hash = binding.Hash;
-  var Cipher = binding.Cipher;
-  var Decipher = binding.Decipher;
-  var Sign = binding.Sign;
-  var Verify = binding.Verify;
-  var DiffieHellman = binding.DiffieHellman;
-  var DiffieHellmanGroup = binding.DiffieHellmanGroup;
   var PBKDF2 = binding.PBKDF2;
   var randomBytes = binding.randomBytes;
   var pseudoRandomBytes = binding.pseudoRandomBytes;
@@ -42,6 +34,8 @@ try {
   var crypto = false;
 }
 
+var assert = require('assert');
+var StringDecoder = require('string_decoder').StringDecoder;
 
 function Credentials(secureProtocol, flags, context) {
   if (!(this instanceof Credentials)) {
@@ -129,64 +123,284 @@ exports.createCredentials = function(options, context) {
 };
 
 
-exports.Hash = Hash;
-exports.createHash = function(hash) {
-  return new Hash(hash);
+exports.createHash = exports.Hash = Hash;
+function Hash(algorithm) {
+  if (!(this instanceof Hash))
+    return new Hash(algorithm);
+  this._binding = new binding.Hash(algorithm);
+}
+
+Hash.prototype.update = function(data, encoding) {
+  if (encoding === 'buffer')
+    encoding = null;
+  if (encoding || typeof data === 'string')
+    data = new Buffer(data, encoding);
+  this._binding.update(data);
+  return this;
+};
+
+Hash.prototype.digest = function(outputEncoding) {
+  var result = this._binding.digest('buffer');
+  if (outputEncoding && outputEncoding !== 'buffer')
+    result = result.toString(outputEncoding);
+  return result;
 };
 
 
-exports.Hmac = Hmac;
-exports.createHmac = function(hmac, key) {
-  return (new Hmac).init(hmac, key);
+exports.createHmac = exports.Hmac = Hmac;
+
+function Hmac(hmac, key) {
+  if (!(this instanceof Hmac))
+    return new Hmac(hmac, key);
+  this._binding = new binding.Hmac();
+  this._binding.init(hmac, key);
 };
 
+Hmac.prototype.update = Hash.prototype.update;
+Hmac.prototype.digest = Hash.prototype.digest;
 
-exports.Cipher = Cipher;
-exports.createCipher = function(cipher, password) {
-  return (new Cipher).init(cipher, password);
+
+function getDecoder(decoder, encoding) {
+  decoder = decoder || new StringDecoder(encoding);
+  assert(decoder.encoding === encoding, 'Cannot change encoding');
+  return decoder;
+}
+
+
+exports.createCipher = exports.Cipher = Cipher;
+function Cipher(cipher, password) {
+  if (!(this instanceof Cipher))
+    return new Cipher(cipher, password);
+  this._binding = new binding.Cipher;
+  this._binding.init(cipher, password);
+  this._decoder = null;
 };
 
+Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
+  if (inputEncoding && inputEncoding !== 'buffer')
+    data = new Buffer(data, inputEncoding);
 
-exports.createCipheriv = function(cipher, key, iv) {
-  return (new Cipher).initiv(cipher, key, iv);
-};
+  var ret = this._binding.update(data, 'buffer', 'buffer');
 
-
-exports.Decipher = Decipher;
-exports.createDecipher = function(cipher, password) {
-  return (new Decipher).init(cipher, password);
-};
-
-
-exports.createDecipheriv = function(cipher, key, iv) {
-  return (new Decipher).initiv(cipher, key, iv);
-};
-
-
-exports.Sign = Sign;
-exports.createSign = function(algorithm) {
-  return (new Sign).init(algorithm);
-};
-
-exports.Verify = Verify;
-exports.createVerify = function(algorithm) {
-  return (new Verify).init(algorithm);
-};
-
-exports.DiffieHellman = DiffieHellman;
-exports.createDiffieHellman = function(size_or_key, enc) {
-  if (!size_or_key) {
-    return new DiffieHellman();
-  } else if (!enc) {
-    return new DiffieHellman(size_or_key);
-  } else {
-    return new DiffieHellman(size_or_key, enc);
+  if (outputEncoding && outputEncoding !== 'buffer') {
+    this._decoder = getDecoder(this._decoder, outputEncoding);
+    ret = this._decoder.write(ret);
   }
 
+  return ret;
 };
-exports.getDiffieHellman = function(group_name) {
-  return new DiffieHellmanGroup(group_name);
+
+Cipher.prototype.final = function(outputEncoding) {
+  var ret = this._binding.final('buffer');
+
+  if (outputEncoding && outputEncoding !== 'buffer') {
+    this._decoder = getDecoder(this._decoder, outputEncoding);
+    ret = this._decoder.write(ret);
+  }
+
+  return ret;
 };
+
+Cipher.prototype.setAutoPadding = function(ap) {
+  this._binding.setAutoPadding(ap);
+  return this;
+};
+
+
+
+exports.createCipheriv = exports.Cipheriv = Cipheriv;
+function Cipheriv(cipher, key, iv) {
+  if (!(this instanceof Cipheriv))
+    return new Cipheriv(cipher, key, iv);
+  this._binding = new binding.Cipher();
+  this._binding.initiv(cipher, key, iv);
+  this._decoder = null;
+}
+
+Cipheriv.prototype.update = Cipher.prototype.update;
+Cipheriv.prototype.final = Cipher.prototype.final;
+Cipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
+
+
+exports.createDecipher = exports.Decipher = Decipher;
+function Decipher(cipher, password) {
+  if (!(this instanceof Decipher))
+    return new Decipher(cipher, password);
+  this._binding = new binding.Decipher
+  this._binding.init(cipher, password);
+  this._decoder = null;
+};
+
+Decipher.prototype.update = Cipher.prototype.update;
+Decipher.prototype.final = Cipher.prototype.final;
+Decipher.prototype.finaltol = Cipher.prototype.final;
+Decipher.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
+
+
+exports.createDecipheriv = exports.Decipheriv = Decipheriv;
+function Decipheriv(cipher, key, iv) {
+  if (!(this instanceof Decipheriv))
+    return new Decipheriv(cipher, key, iv);
+  this._binding = new binding.Decipher;
+  this._binding.initiv(cipher, key, iv);
+  this._decoder = null;
+};
+
+Decipheriv.prototype.update = Cipher.prototype.update;
+Decipheriv.prototype.final = Cipher.prototype.final;
+Decipheriv.prototype.finaltol = Cipher.prototype.final;
+Decipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
+
+
+exports.createSign = exports.Sign = Sign;
+function Sign(algorithm) {
+  if (!(this instanceof Sign))
+    return new Sign(algorithm);
+  this._binding = new binding.Sign();
+  this._binding.init(algorithm);
+};
+
+Sign.prototype.update = Hash.prototype.update;
+
+Sign.prototype.sign = function(key, encoding) {
+  var ret = this._binding.sign(key, 'buffer');
+  if (encoding && encoding !== 'buffer')
+    ret = ret.toString(encoding);
+  return ret;
+};
+
+
+exports.createVerify = exports.Verify = Verify;
+function Verify(algorithm) {
+  if (!(this instanceof Verify))
+    return new Verify(algorithm);
+
+  this._binding = new binding.Verify;
+  this._binding.init(algorithm);
+}
+
+Verify.prototype.update = Hash.prototype.update;
+
+Verify.prototype.verify = function(object, signature, sigEncoding) {
+  if (sigEncoding === 'buffer')
+    sigEncoding = null;
+  if (sigEncoding || typeof signature === 'string')
+    signature = new Buffer(signature, sigEncoding);
+  return this._binding.verify(object, signature, 'buffer');
+};
+
+exports.createDiffieHellman = exports.DiffieHellman = DiffieHellman;
+
+function DiffieHellman(sizeOrKey, encoding) {
+  if (!(this instanceof DiffieHellman))
+    return new DiffieHellman(sizeOrKey, encoding);
+
+  if (!sizeOrKey)
+    this._binding = new binding.DiffieHellman();
+  else {
+    if (encoding === 'buffer')
+      encoding = null;
+    if (encoding || typeof sizeOrKey === 'string')
+      sizeOrKey = new Buffer(sizeOrKey, encoding);
+    this._binding = new binding.DiffieHellman(sizeOrKey, 'buffer');
+  }
+}
+
+DiffieHellman.prototype.generateKeys = function(encoding) {
+  var keys = this._binding.generateKeys('buffer');
+  if (encoding)
+    keys = keys.toString(encoding);
+  return keys;
+};
+
+DiffieHellman.prototype.computeSecret = function(key, inEnc, outEnc) {
+  if (inEnc === 'buffer')
+    inEnc = null;
+  if (outEnc === 'buffer')
+    outEnc = null;
+  if (inEnc || typeof key === 'string')
+    key = new Buffer(key, inEnc);
+  var ret = this._binding.computeSecret(key, 'buffer', 'buffer');
+  if (outEnc)
+    ret = ret.toString(outEnc);
+  return ret;
+};
+
+DiffieHellman.prototype.getPrime = function(encoding) {
+  var prime = this._binding.getPrime('buffer');
+  if (encoding && encoding !== 'buffer')
+    prime = prime.toString(encoding);
+  return prime;
+};
+
+DiffieHellman.prototype.getGenerator = function(encoding) {
+  var generator = this._binding.getGenerator('buffer');
+  if (encoding && encoding !== 'buffer')
+    generator = generator.toString(encoding);
+  return generator;
+};
+
+DiffieHellman.prototype.getPublicKey = function(encoding) {
+  var key = this._binding.getPublicKey('buffer');
+  if (encoding && encoding !== 'buffer')
+    key = key.toString(encoding);
+  return key;
+};
+
+DiffieHellman.prototype.getPrivateKey = function(encoding) {
+  var key = this._binding.getPrivateKey('buffer');
+  if (encoding && encoding !== 'buffer')
+    key = key.toString(encoding);
+  return key;
+};
+
+DiffieHellman.prototype.setPublicKey = function(key, encoding) {
+  if (encoding === 'buffer')
+    encoding = null;
+  if (encoding || typeof key === 'string')
+    key = new Buffer(key, encoding);
+  this._binding.setPublicKey(key, 'buffer');
+  return this;
+};
+
+DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
+  if (encoding === 'buffer')
+    encoding = null;
+  if (encoding || typeof key === 'string')
+    key = new Buffer(key, encoding);
+  this._binding.setPrivateKey(key, 'buffer');
+  return this;
+};
+
+
+
+exports.DiffieHellmanGroup =
+  exports.createDiffieHellmanGroup =
+  exports.getDiffieHellman = DiffieHellmanGroup;
+
+function DiffieHellmanGroup(name) {
+  if (!(this instanceof DiffieHellmanGroup))
+    return new DiffieHellmanGroup(name);
+  this._binding = new binding.DiffieHellmanGroup(name);
+};
+
+DiffieHellmanGroup.prototype.generateKeys =
+  DiffieHellman.prototype.generateKeys;
+
+DiffieHellmanGroup.prototype.computeSecret =
+  DiffieHellman.prototype.computeSecret;
+
+DiffieHellmanGroup.prototype.getPrime =
+  DiffieHellman.prototype.getPrime;
+
+DiffieHellmanGroup.prototype.getGenerator =
+  DiffieHellman.prototype.getGenerator;
+
+DiffieHellmanGroup.prototype.getPublicKey =
+  DiffieHellman.prototype.getPublicKey;
+
+DiffieHellmanGroup.prototype.getPrivateKey =
+  DiffieHellman.prototype.getPrivateKey;
 
 exports.pbkdf2 = PBKDF2;
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -23,7 +23,6 @@
 try {
   var binding = process.binding('crypto');
   var SecureContext = binding.SecureContext;
-  var PBKDF2 = binding.PBKDF2;
   var randomBytes = binding.randomBytes;
   var pseudoRandomBytes = binding.pseudoRandomBytes;
   var getCiphers = binding.getCiphers;
@@ -112,10 +111,17 @@ exports.createCredentials = function(options, context) {
   }
 
   if (options.pfx) {
-    if (options.passphrase) {
-      c.context.loadPKCS12(options.pfx, options.passphrase);
+    var pfx = options.pfx;
+    var passphrase = options.passphrase;
+    // legacy
+    if (typeof pfx === 'string')
+      pfx = new Buffer(pfx, 'binary');
+    if (passphrase && typeof passphrase === 'string')
+      passphrase = new Buffer(passphrase, 'binary');
+    if (passphrase) {
+      c.context.loadPKCS12(pfx, passphrase);
     } else {
-      c.context.loadPKCS12(options.pfx);
+      c.context.loadPKCS12(pfx);
     }
   }
 
@@ -153,8 +159,11 @@ function Hmac(hmac, key) {
   if (!(this instanceof Hmac))
     return new Hmac(hmac, key);
   this._binding = new binding.Hmac();
+  // legacy
+  if (typeof key === 'string')
+    key = new Buffer(key, 'binary');
   this._binding.init(hmac, key);
-};
+}
 
 Hmac.prototype.update = Hash.prototype.update;
 Hmac.prototype.digest = Hash.prototype.digest;
@@ -172,9 +181,14 @@ function Cipher(cipher, password) {
   if (!(this instanceof Cipher))
     return new Cipher(cipher, password);
   this._binding = new binding.Cipher;
+
+  // legacy.
+  if (typeof password === 'string')
+    password = new Buffer(password, 'binary');
+
   this._binding.init(cipher, password);
   this._decoder = null;
-};
+}
 
 Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
   if (inputEncoding && inputEncoding !== 'buffer')
@@ -212,6 +226,11 @@ exports.createCipheriv = exports.Cipheriv = Cipheriv;
 function Cipheriv(cipher, key, iv) {
   if (!(this instanceof Cipheriv))
     return new Cipheriv(cipher, key, iv);
+  // legacy
+  if (typeof key === 'string')
+    key = new Buffer(key, 'binary');
+  if (typeof iv === 'string')
+    iv = new Buffer(iv, 'binary');
   this._binding = new binding.Cipher();
   this._binding.initiv(cipher, key, iv);
   this._decoder = null;
@@ -226,10 +245,15 @@ exports.createDecipher = exports.Decipher = Decipher;
 function Decipher(cipher, password) {
   if (!(this instanceof Decipher))
     return new Decipher(cipher, password);
-  this._binding = new binding.Decipher
+
+  // legacy.
+  if (typeof password === 'string')
+    password = new Buffer(password, 'binary');
+
+  this._binding = new binding.Decipher;
   this._binding.init(cipher, password);
   this._decoder = null;
-};
+}
 
 Decipher.prototype.update = Cipher.prototype.update;
 Decipher.prototype.final = Cipher.prototype.final;
@@ -241,10 +265,15 @@ exports.createDecipheriv = exports.Decipheriv = Decipheriv;
 function Decipheriv(cipher, key, iv) {
   if (!(this instanceof Decipheriv))
     return new Decipheriv(cipher, key, iv);
+  // legacy
+  if (typeof key === 'string')
+    key = new Buffer(key, 'binary');
+  if (typeof iv === 'string')
+    iv = new Buffer(iv, 'binary');
   this._binding = new binding.Decipher;
   this._binding.initiv(cipher, key, iv);
   this._decoder = null;
-};
+}
 
 Decipheriv.prototype.update = Cipher.prototype.update;
 Decipheriv.prototype.final = Cipher.prototype.final;
@@ -258,11 +287,15 @@ function Sign(algorithm) {
     return new Sign(algorithm);
   this._binding = new binding.Sign();
   this._binding.init(algorithm);
-};
+}
 
 Sign.prototype.update = Hash.prototype.update;
 
 Sign.prototype.sign = function(key, encoding) {
+  // legacy.
+  if (typeof key === 'string')
+    key = new Buffer(key, 'binary');
+
   var ret = this._binding.sign(key, 'buffer');
   if (encoding && encoding !== 'buffer')
     ret = ret.toString(encoding);
@@ -282,10 +315,15 @@ function Verify(algorithm) {
 Verify.prototype.update = Hash.prototype.update;
 
 Verify.prototype.verify = function(object, signature, sigEncoding) {
+  // legacy.
+  if (typeof object === 'string')
+    object = new Buffer(object, 'binary');
+
   if (sigEncoding === 'buffer')
     sigEncoding = null;
   if (sigEncoding || typeof signature === 'string')
     signature = new Buffer(signature, sigEncoding);
+
   return this._binding.verify(object, signature, 'buffer');
 };
 
@@ -375,34 +413,45 @@ DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
 
 
 exports.DiffieHellmanGroup =
-  exports.createDiffieHellmanGroup =
-  exports.getDiffieHellman = DiffieHellmanGroup;
+    exports.createDiffieHellmanGroup =
+    exports.getDiffieHellman = DiffieHellmanGroup;
 
 function DiffieHellmanGroup(name) {
   if (!(this instanceof DiffieHellmanGroup))
     return new DiffieHellmanGroup(name);
   this._binding = new binding.DiffieHellmanGroup(name);
-};
+}
 
 DiffieHellmanGroup.prototype.generateKeys =
-  DiffieHellman.prototype.generateKeys;
+    DiffieHellman.prototype.generateKeys;
 
 DiffieHellmanGroup.prototype.computeSecret =
-  DiffieHellman.prototype.computeSecret;
+    DiffieHellman.prototype.computeSecret;
 
 DiffieHellmanGroup.prototype.getPrime =
-  DiffieHellman.prototype.getPrime;
+    DiffieHellman.prototype.getPrime;
 
 DiffieHellmanGroup.prototype.getGenerator =
-  DiffieHellman.prototype.getGenerator;
+    DiffieHellman.prototype.getGenerator;
 
 DiffieHellmanGroup.prototype.getPublicKey =
-  DiffieHellman.prototype.getPublicKey;
+    DiffieHellman.prototype.getPublicKey;
 
 DiffieHellmanGroup.prototype.getPrivateKey =
-  DiffieHellman.prototype.getPrivateKey;
+    DiffieHellman.prototype.getPrivateKey;
 
-exports.pbkdf2 = PBKDF2;
+exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
+  if (typeof password === 'string')
+    password = new Buffer(password, 'binary');
+  if (typeof salt === 'string')
+    salt = new Buffer(salt, 'binary');
+  return binding.PBKDF2(password, salt, iterations, keylen, callback);
+};
+
+exports.pbkdf2Sync = function(password, salt, iterations, keylen) {
+  return exports.pbkdf2(password, salt, iterations, keylen);
+};
+
 
 exports.randomBytes = randomBytes;
 exports.pseudoRandomBytes = pseudoRandomBytes;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1296,7 +1296,10 @@ exports.connect = function(/* [port, host], options, cb */) {
                             });
 
   if (options.session) {
-    pair.ssl.setSession(options.session);
+    var session = options.session;
+    if (typeof session === 'string')
+      session = new Buffer(session, 'binary');
+    pair.ssl.setSession(session);
   }
 
   var cleartext = pipe(pair, socket);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3602,13 +3602,7 @@ class DiffieHellman : public ObjectWrap {
 
     Local<Value> outString;
 
-    if (args.Length() > 2 && args[2]->IsString()) {
-      outString = EncodeWithEncoding(args[2], data, dataSize);
-    } else if (args.Length() > 1 && args[1]->IsString()) {
-      outString = EncodeWithEncoding(args[1], data, dataSize);
-    } else {
-      outString = Encode(data, dataSize, BUFFER);
-    }
+    outString = Encode(data, dataSize, BUFFER);
 
     delete[] data;
     return scope.Close(outString);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -286,7 +286,7 @@ static BIO* LoadBIO (Handle<Value> v) {
     String::Utf8Value s(v);
     r = BIO_write(bio, *s, s.length());
   } else if (Buffer::HasInstance(v)) {
-    char *buffer_data = Buffer::Data(v);
+    char* buffer_data = Buffer::Data(v);
     size_t buffer_length = Buffer::Length(v);
     r = BIO_write(bio, buffer_data, buffer_length);
   }
@@ -700,7 +700,7 @@ Handle<Value> SecureContext::LoadPKCS12(const Arguments& args) {
 
   if (!ret) {
     unsigned long err = ERR_get_error();
-    const char *str = ERR_reason_error_string(err);
+    const char* str = ERR_reason_error_string(err);
     return ThrowException(Exception::Error(String::New(str)));
   }
 
@@ -1047,7 +1047,7 @@ static int VerifyCallback(int preverify_ok, X509_STORE_CTX *ctx) {
 #ifdef OPENSSL_NPN_NEGOTIATED
 
 int Connection::AdvertiseNextProtoCallback_(SSL *s,
-                                            const unsigned char **data,
+                                            const unsigned char** data,
                                             unsigned int *len,
                                             void *arg) {
 
@@ -1066,7 +1066,7 @@ int Connection::AdvertiseNextProtoCallback_(SSL *s,
 }
 
 int Connection::SelectNextProtoCallback_(SSL *s,
-                             unsigned char **out, unsigned char *outlen,
+                             unsigned char** out, unsigned char* outlen,
                              const unsigned char* in,
                              unsigned int inlen, void *arg) {
   Connection *p = static_cast<Connection*> SSL_get_app_data(s);
@@ -1282,7 +1282,7 @@ Handle<Value> Connection::EncIn(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  char *buffer_data = Buffer::Data(args[0]);
+  char* buffer_data = Buffer::Data(args[0]);
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
@@ -1328,7 +1328,7 @@ Handle<Value> Connection::ClearOut(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  char *buffer_data = Buffer::Data(args[0]);
+  char* buffer_data = Buffer::Data(args[0]);
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
@@ -1400,7 +1400,7 @@ Handle<Value> Connection::EncOut(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  char *buffer_data = Buffer::Data(args[0]);
+  char* buffer_data = Buffer::Data(args[0]);
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
@@ -1439,7 +1439,7 @@ Handle<Value> Connection::ClearIn(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  char *buffer_data = Buffer::Data(args[0]);
+  char* buffer_data = Buffer::Data(args[0]);
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
@@ -1905,9 +1905,9 @@ Handle<Value> Connection::GetCurrentCipher(const Arguments& args) {
   c = SSL_get_current_cipher(ss->ssl_);
   if ( c == NULL ) return Undefined();
   Local<Object> info = Object::New();
-  const char *cipher_name = SSL_CIPHER_get_name(c);
+  const char* cipher_name = SSL_CIPHER_get_name(c);
   info->Set(name_symbol, String::New(cipher_name));
-  const char *cipher_version = SSL_CIPHER_get_version(c);
+  const char* cipher_version = SSL_CIPHER_get_version(c);
   info->Set(version_symbol, String::New(cipher_version));
   return scope.Close(info);
 }
@@ -1931,7 +1931,7 @@ Handle<Value> Connection::GetNegotiatedProto(const Arguments& args) {
   Connection *ss = Connection::Unwrap(args);
 
   if (ss->is_server_) {
-    const unsigned char *npn_proto;
+    const unsigned char* npn_proto;
     unsigned int npn_proto_len;
 
     SSL_get0_next_proto_negotiated(ss->ssl_, &npn_proto, &npn_proto_len);
@@ -2039,8 +2039,8 @@ class Cipher : public ObjectWrap {
       return false;
     }
     EVP_CipherInit_ex(&ctx, NULL, NULL,
-      (unsigned char *)key,
-      (unsigned char *)iv, true);
+      (unsigned char*)key,
+      (unsigned char*)iv, true);
     initialised_ = true;
     return true;
   }
@@ -2049,7 +2049,7 @@ class Cipher : public ObjectWrap {
   bool CipherInitIv(char* cipherType,
                     char* key,
                     int key_len,
-                    char *iv,
+                    char* iv,
                     int iv_len) {
     cipher = EVP_get_cipherbyname(cipherType);
     if(!cipher) {
@@ -2071,8 +2071,8 @@ class Cipher : public ObjectWrap {
       return false;
     }
     EVP_CipherInit_ex(&ctx, NULL, NULL,
-      (unsigned char *)key,
-      (unsigned char *)iv, true);
+      (unsigned char*)key,
+      (unsigned char*)iv, true);
     initialised_ = true;
     return true;
   }
@@ -2210,7 +2210,7 @@ class Cipher : public ObjectWrap {
 
     ASSERT_IS_BUFFER(args[0]);
 
-    unsigned char *out=0;
+    unsigned char* out=0;
     int out_len=0, r;
     char* buffer_data = Buffer::Data(args[0]);
     size_t buffer_length = Buffer::Length(args[0]);
@@ -2338,8 +2338,8 @@ class Decipher : public ObjectWrap {
       return false;
     }
     EVP_CipherInit_ex(&ctx, NULL, NULL,
-      (unsigned char *)key,
-      (unsigned char *)iv, false);
+      (unsigned char*)key,
+      (unsigned char*)iv, false);
     initialised_ = true;
     return true;
   }
@@ -2348,7 +2348,7 @@ class Decipher : public ObjectWrap {
   bool DecipherInitIv(char* cipherType,
                       char* key,
                       int key_len,
-                      char *iv,
+                      char* iv,
                       int iv_len) {
     cipher_ = EVP_get_cipherbyname(cipherType);
     if(!cipher_) {
@@ -2370,8 +2370,8 @@ class Decipher : public ObjectWrap {
       return false;
     }
     EVP_CipherInit_ex(&ctx, NULL, NULL,
-      (unsigned char *)key,
-      (unsigned char *)iv, false);
+      (unsigned char*)key,
+      (unsigned char*)iv, false);
     initialised_ = true;
     return true;
   }
@@ -2525,13 +2525,13 @@ class Decipher : public ObjectWrap {
     char* buf;
     // if alloc_buf then buf must be deleted later
     bool alloc_buf = false;
-    char *buffer_data = Buffer::Data(args[0]);
+    char* buffer_data = Buffer::Data(args[0]);
     size_t buffer_length = Buffer::Length(args[0]);
 
     buf = buffer_data;
     len = buffer_length;
 
-    unsigned char *out=0;
+    unsigned char* out=0;
     int out_len=0;
     int r = cipher->DecipherUpdate(buf, len, &out, &out_len);
 
@@ -2717,7 +2717,7 @@ class Hmac : public ObjectWrap {
 
     int r;
 
-    char *buffer_data = Buffer::Data(args[0]);
+    char* buffer_data = Buffer::Data(args[0]);
     size_t buffer_length = Buffer::Length(args[0]);
 
     r = hmac->HmacUpdate(buffer_data, buffer_length);
@@ -2832,7 +2832,7 @@ class Hash : public ObjectWrap {
 
     int r;
 
-    char *buffer_data = Buffer::Data(args[0]);
+    char* buffer_data = Buffer::Data(args[0]);
     size_t buffer_length = Buffer::Length(args[0]);
     r = hash->HashUpdate(buffer_data, buffer_length);
 
@@ -2984,7 +2984,7 @@ class Sign : public ObjectWrap {
 
     int r;
 
-    char *buffer_data = Buffer::Data(args[0]);
+    char* buffer_data = Buffer::Data(args[0]);
     size_t buffer_length = Buffer::Length(args[0]);
 
     r = sign->SignUpdate(buffer_data, buffer_length);
@@ -3195,7 +3195,7 @@ class Verify : public ObjectWrap {
 
     int r;
 
-    char *buffer_data = Buffer::Data(args[0]);
+    char* buffer_data = Buffer::Data(args[0]);
     size_t buffer_length = Buffer::Length(args[0]);
 
     r = verify->VerifyUpdate(buffer_data, buffer_length);
@@ -3236,7 +3236,7 @@ class Verify : public ObjectWrap {
     }
 
     unsigned char* hbuf = new unsigned char[hlen];
-    ssize_t hwritten = DecodeWrite((char *)hbuf, hlen, args[1], BINARY);
+    ssize_t hwritten = DecodeWrite((char*)hbuf, hlen, args[1], BINARY);
     assert(hwritten == hlen);
 
     int r=-1;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -41,9 +41,9 @@
 # define OPENSSL_CONST
 #endif
 
-#define ASSERT_IS_STRING_OR_BUFFER(val) \
-  if (!val->IsString() && !Buffer::HasInstance(val)) { \
-    return ThrowException(Exception::TypeError(String::New("Not a string or buffer"))); \
+#define ASSERT_IS_BUFFER(val) \
+  if (!Buffer::HasInstance(val)) { \
+    return ThrowException(Exception::TypeError(String::New("Not a buffer"))); \
   }
 
 static const char PUBLIC_KEY_PFX[] =  "-----BEGIN PUBLIC KEY-----";
@@ -657,9 +657,9 @@ Handle<Value> SecureContext::LoadPKCS12(const Arguments& args) {
   }
 
   if (args.Length() >= 2) {
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
+    ASSERT_IS_BUFFER(args[1]);
 
-    int passlen = DecodeBytes(args[1], BINARY);
+    int passlen = Buffer::Length(args[1]->ToObject());
     if (passlen < 0) {
       BIO_free(in);
       return ThrowException(Exception::TypeError(
@@ -1627,8 +1627,8 @@ Handle<Value> Connection::SetSession(const Arguments& args) {
     return ThrowException(exception);
   }
 
-  ASSERT_IS_STRING_OR_BUFFER(args[0]);
-  ssize_t slen = DecodeBytes(args[0], BINARY);
+  ASSERT_IS_BUFFER(args[0]);
+  ssize_t slen = Buffer::Length(args[0]->ToObject());
 
   if (slen < 0) {
     Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2005,137 +2005,6 @@ Handle<Value> Connection::SetSNICallback(const Arguments& args) {
 }
 #endif
 
-static void HexEncode(unsigned char *md_value,
-                      int md_len,
-                      char** md_hexdigest,
-                      int* md_hex_len) {
-  *md_hex_len = (2*(md_len));
-  *md_hexdigest = new char[*md_hex_len + 1];
-
-  char* buff = *md_hexdigest;
-  const int len = *md_hex_len;
-  for (int i = 0; i < len; i += 2) {
-    // nibble nibble
-    const int index = i / 2;
-    const char msb = (md_value[index] >> 4) & 0x0f;
-    const char lsb = md_value[index] & 0x0f;
-
-    buff[i] = (msb < 10) ? msb + '0' : (msb - 10) + 'a';
-    buff[i + 1] = (lsb < 10) ? lsb + '0' : (lsb - 10) + 'a';
-  }
-  // null terminator
-  buff[*md_hex_len] = '\0';
-}
-
-#define hex2i(c) ((c) <= '9' ? ((c) - '0') : (c) <= 'Z' ? ((c) - 'A' + 10) \
-                 : ((c) - 'a' + 10))
-
-static void HexDecode(unsigned char *input,
-                      int length,
-                      char** buf64,
-                      int* buf64_len) {
-  *buf64_len = (length/2);
-  *buf64 = new char[length/2 + 1];
-  char *b = *buf64;
-  for(int i = 0; i < length-1; i+=2) {
-    b[i/2]  = (hex2i(input[i])<<4) | (hex2i(input[i+1]));
-  }
-}
-
-
-void base64(unsigned char *input, int length, char** buf64, int* buf64_len) {
-  BIO *b64 = BIO_new(BIO_f_base64());
-  BIO *bmem = BIO_new(BIO_s_mem());
-  b64 = BIO_push(b64, bmem);
-  BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
-  int len = BIO_write(b64, input, length);
-  assert(len == length);
-  int r = BIO_flush(b64);
-  assert(r == 1);
-
-  BUF_MEM *bptr;
-  BIO_get_mem_ptr(b64, &bptr);
-
-  *buf64_len = bptr->length;
-  *buf64 = new char[*buf64_len+1];
-  memcpy(*buf64, bptr->data, *buf64_len);
-  char* b = *buf64;
-  b[*buf64_len] = 0;
-
-  BIO_free_all(b64);
-}
-
-
-void unbase64(unsigned char *input,
-               int length,
-               char** buffer,
-               int* buffer_len) {
-  BIO *b64, *bmem;
-  *buffer = new char[length];
-  memset(*buffer, 0, length);
-
-  b64 = BIO_new(BIO_f_base64());
-  BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
-  bmem = BIO_new_mem_buf(input, length);
-  bmem = BIO_push(b64, bmem);
-
-  *buffer_len = BIO_read(bmem, *buffer, length);
-  BIO_free_all(bmem);
-}
-
-
-// LengthWithoutIncompleteUtf8 from V8 d8-posix.cc
-// see http://v8.googlecode.com/svn/trunk/src/d8-posix.cc
-static int LengthWithoutIncompleteUtf8(char* buffer, int len) {
-  int answer = len;
-  // 1-byte encoding.
-  static const int kUtf8SingleByteMask = 0x80;
-  static const int kUtf8SingleByteValue = 0x00;
-  // 2-byte encoding.
-  static const int kUtf8TwoByteMask = 0xe0;
-  static const int kUtf8TwoByteValue = 0xc0;
-  // 3-byte encoding.
-  static const int kUtf8ThreeByteMask = 0xf0;
-  static const int kUtf8ThreeByteValue = 0xe0;
-  // 4-byte encoding.
-  static const int kUtf8FourByteMask = 0xf8;
-  static const int kUtf8FourByteValue = 0xf0;
-  // Subsequent bytes of a multi-byte encoding.
-  static const int kMultiByteMask = 0xc0;
-  static const int kMultiByteValue = 0x80;
-  int multi_byte_bytes_seen = 0;
-  while (answer > 0) {
-    int c = buffer[answer - 1];
-    // Ends in valid single-byte sequence?
-    if ((c & kUtf8SingleByteMask) == kUtf8SingleByteValue) return answer;
-    // Ends in one or more subsequent bytes of a multi-byte value?
-    if ((c & kMultiByteMask) == kMultiByteValue) {
-      multi_byte_bytes_seen++;
-      answer--;
-    } else {
-      if ((c & kUtf8TwoByteMask) == kUtf8TwoByteValue) {
-        if (multi_byte_bytes_seen >= 1) {
-          return answer + 2;
-        }
-        return answer - 1;
-      } else if ((c & kUtf8ThreeByteMask) == kUtf8ThreeByteValue) {
-        if (multi_byte_bytes_seen >= 2) {
-          return answer + 3;
-        }
-        return answer - 1;
-      } else if ((c & kUtf8FourByteMask) == kUtf8FourByteValue) {
-        if (multi_byte_bytes_seen >= 3) {
-          return answer + 4;
-        }
-        return answer - 1;
-      } else {
-        return answer;  // Malformed UTF-8.
-      }
-    }
-  }
-  return 0;
-}
-
 
 class Cipher : public ObjectWrap {
  public:
@@ -2252,8 +2121,6 @@ class Cipher : public ObjectWrap {
 
     Cipher *cipher = ObjectWrap::Unwrap<Cipher>(args.This());
 
-    cipher->incomplete_base64 = NULL;
-
     if (args.Length() <= 1
         || !args[0]->IsString()
         || !(args[1]->IsString() || Buffer::HasInstance(args[1])))
@@ -2262,8 +2129,8 @@ class Cipher : public ObjectWrap {
         "Must give cipher-type, key")));
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
-    ssize_t key_buf_len = DecodeBytes(args[1], BINARY);
+    ASSERT_IS_BUFFER(args[1]);
+    ssize_t key_buf_len = Buffer::Length(args[1]->ToObject());
 
     if (key_buf_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2293,7 +2160,6 @@ class Cipher : public ObjectWrap {
 
     HandleScope scope;
 
-    cipher->incomplete_base64 = NULL;
 
     if (args.Length() <= 2
         || !args[0]->IsString()
@@ -2304,16 +2170,16 @@ class Cipher : public ObjectWrap {
         "Must give cipher-type, key, and iv as argument")));
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
-    ssize_t key_len = DecodeBytes(args[1], BINARY);
+    ASSERT_IS_BUFFER(args[1]);
+    ssize_t key_len = Buffer::Length(args[1]->ToObject());
 
     if (key_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
       return ThrowException(exception);
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[2]);
-    ssize_t iv_len = DecodeBytes(args[2], BINARY);
+    ASSERT_IS_BUFFER(args[2]);
+    ssize_t iv_len = Buffer::Length(args[2]->ToObject());
 
     if (iv_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2347,31 +2213,15 @@ class Cipher : public ObjectWrap {
 
     HandleScope scope;
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-
-    enum encoding enc = ParseEncoding(args[1]);
-    ssize_t len = DecodeBytes(args[0], enc);
-
-    if (len < 0) {
-      Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
-      return ThrowException(exception);
-    }
+    ASSERT_IS_BUFFER(args[0]);
 
     unsigned char *out=0;
     int out_len=0, r;
-    if (Buffer::HasInstance(args[0])) {
-      Local<Object> buffer_obj = args[0]->ToObject();
-      char *buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
+    Local<Object> buffer_obj = args[0]->ToObject();
+    char *buffer_data = Buffer::Data(buffer_obj);
+    size_t buffer_length = Buffer::Length(buffer_obj);
 
-      r = cipher->CipherUpdate(buffer_data, buffer_length, &out, &out_len);
-    } else {
-      char* buf = new char[len];
-      ssize_t written = DecodeWrite(buf, len, args[0], enc);
-      assert(written == len);
-      r = cipher->CipherUpdate(buf, len,&out,&out_len);
-      delete [] buf;
-    }
+    r = cipher->CipherUpdate(buffer_data, buffer_length, &out, &out_len);
 
     if (!r) {
       delete [] out;
@@ -2380,50 +2230,7 @@ class Cipher : public ObjectWrap {
     }
 
     Local<Value> outString;
-    char* out_hexdigest;
-    int out_hex_len;
-    enum encoding out_enc = ParseEncoding(args[2], BINARY);
-    if (out_enc == HEX) {
-      // Hex encoding
-      HexEncode(out, out_len, &out_hexdigest, &out_hex_len);
-      outString = Encode(out_hexdigest, out_hex_len, BINARY);
-      delete [] out_hexdigest;
-    } else if (out_enc == BASE64) {
-      // Base64 encoding
-      // Check to see if we need to add in previous base64 overhang
-      if (cipher->incomplete_base64!=NULL){
-        unsigned char* complete_base64 = new unsigned char[out_len+cipher->incomplete_base64_len+1];
-        memcpy(complete_base64, cipher->incomplete_base64, cipher->incomplete_base64_len);
-        memcpy(&complete_base64[cipher->incomplete_base64_len], out, out_len);
-        delete [] out;
-
-        delete [] cipher->incomplete_base64;
-        cipher->incomplete_base64=NULL;
-
-        out=complete_base64;
-        out_len += cipher->incomplete_base64_len;
-      }
-
-      // Check to see if we need to trim base64 stream
-      if (out_len%3!=0){
-        cipher->incomplete_base64_len = out_len%3;
-        cipher->incomplete_base64 = new char[cipher->incomplete_base64_len+1];
-        memcpy(cipher->incomplete_base64,
-               &out[out_len-cipher->incomplete_base64_len],
-               cipher->incomplete_base64_len);
-        out_len -= cipher->incomplete_base64_len;
-        out[out_len]=0;
-      }
-
-      base64(out, out_len, &out_hexdigest, &out_hex_len);
-      outString = Encode(out_hexdigest, out_hex_len, BINARY);
-      delete [] out_hexdigest;
-    } else if (out_enc == BINARY || out_enc == BUFFER) {
-      outString = Encode(out, out_len, out_enc);
-    } else {
-      fprintf(stderr, "node-crypto : Cipher .update encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    outString = Encode(out, out_len, BUFFER);
 
     if (out) delete [] out;
 
@@ -2446,8 +2253,6 @@ class Cipher : public ObjectWrap {
 
     unsigned char* out_value = NULL;
     int out_len = -1;
-    char* out_hexdigest;
-    int out_hex_len;
     Local<Value> outString ;
 
     int r = cipher->CipherFinal(&out_value, &out_len);
@@ -2466,35 +2271,7 @@ class Cipher : public ObjectWrap {
       }
     }
 
-    enum encoding enc = ParseEncoding(args[0], BINARY);
-    if (enc == HEX) {
-      // Hex encoding
-      HexEncode(out_value, out_len, &out_hexdigest, &out_hex_len);
-      outString = Encode(out_hexdigest, out_hex_len, BINARY);
-      delete [] out_hexdigest;
-    } else if (enc == BASE64) {
-      // Check to see if we need to add in previous base64 overhang
-      if (cipher->incomplete_base64!=NULL){
-        unsigned char* complete_base64 = new unsigned char[out_len+cipher->incomplete_base64_len+1];
-        memcpy(complete_base64, cipher->incomplete_base64, cipher->incomplete_base64_len);
-        memcpy(&complete_base64[cipher->incomplete_base64_len], out_value, out_len);
-        delete [] out_value;
-
-        delete [] cipher->incomplete_base64;
-        cipher->incomplete_base64=NULL;
-
-        out_value=complete_base64;
-        out_len += cipher->incomplete_base64_len;
-      }
-      base64(out_value, out_len, &out_hexdigest, &out_hex_len);
-      outString = Encode(out_hexdigest, out_hex_len, BINARY);
-      delete [] out_hexdigest;
-    } else if (enc == BINARY || enc == BUFFER) {
-      outString = Encode(out_value, out_len, enc);
-    } else {
-      fprintf(stderr, "node-crypto : Cipher .final encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    outString = Encode(out_value, out_len, BUFFER);
 
     delete [] out_value;
     return scope.Close(outString);
@@ -2516,9 +2293,6 @@ class Cipher : public ObjectWrap {
   EVP_CIPHER_CTX ctx; /* coverity[member_decl] */
   const EVP_CIPHER *cipher; /* coverity[member_decl] */
   bool initialised_;
-  char* incomplete_base64; /* coverity[member_decl] */
-  int incomplete_base64_len; /* coverity[member_decl] */
-
 };
 
 
@@ -2660,9 +2434,6 @@ class Decipher : public ObjectWrap {
 
     HandleScope scope;
 
-    cipher->incomplete_utf8 = NULL;
-    cipher->incomplete_hex_flag = false;
-
     if (args.Length() <= 1
         || !args[0]->IsString()
         || !(args[1]->IsString() || Buffer::HasInstance(args[1])))
@@ -2671,8 +2442,8 @@ class Decipher : public ObjectWrap {
         "Must give cipher-type, key as argument")));
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
-    ssize_t key_len = DecodeBytes(args[1], BINARY);
+    ASSERT_IS_BUFFER(args[1]);
+    ssize_t key_len = Buffer::Length(args[1]->ToObject());
 
     if (key_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2701,9 +2472,6 @@ class Decipher : public ObjectWrap {
 
     HandleScope scope;
 
-    cipher->incomplete_utf8 = NULL;
-    cipher->incomplete_hex_flag = false;
-
     if (args.Length() <= 2
         || !args[0]->IsString()
         || !(args[1]->IsString() || Buffer::HasInstance(args[1]))
@@ -2713,16 +2481,16 @@ class Decipher : public ObjectWrap {
         "Must give cipher-type, key, and iv as argument")));
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
-    ssize_t key_len = DecodeBytes(args[1], BINARY);
+    ASSERT_IS_BUFFER(args[1]);
+    ssize_t key_len = Buffer::Length(args[1]->ToObject());
 
     if (key_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
       return ThrowException(exception);
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[2]);
-    ssize_t iv_len = DecodeBytes(args[2], BINARY);
+    ASSERT_IS_BUFFER(args[2]);
+    ssize_t iv_len = Buffer::Length(args[2]->ToObject());
 
     if (iv_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2756,79 +2524,19 @@ class Decipher : public ObjectWrap {
 
     Decipher *cipher = ObjectWrap::Unwrap<Decipher>(args.This());
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
+    ASSERT_IS_BUFFER(args[0]);
 
-    ssize_t len = DecodeBytes(args[0], BINARY);
-    if (len < 0) {
-        return ThrowException(Exception::Error(String::New(
-            "node`DecodeBytes() failed")));
-    }
+    ssize_t len;
 
     char* buf;
     // if alloc_buf then buf must be deleted later
     bool alloc_buf = false;
-    if (Buffer::HasInstance(args[0])) {
-      Local<Object> buffer_obj = args[0]->ToObject();
-      char *buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
+    Local<Object> buffer_obj = args[0]->ToObject();
+    char *buffer_data = Buffer::Data(buffer_obj);
+    size_t buffer_length = Buffer::Length(buffer_obj);
 
-      buf = buffer_data;
-      len = buffer_length;
-    } else {
-      alloc_buf = true;
-      buf = new char[len];
-      ssize_t written = DecodeWrite(buf, len, args[0], BINARY);
-      assert(written == len);
-    }
-
-    char* ciphertext;
-    int ciphertext_len;
-
-    enum encoding enc = ParseEncoding(args[1], BINARY);
-    if (enc == HEX) {
-      // Hex encoding
-      // Do we have a previous hex carry over?
-      if (cipher->incomplete_hex_flag) {
-        char* complete_hex = new char[len+2];
-        memcpy(complete_hex, &cipher->incomplete_hex, 1);
-        memcpy(complete_hex+1, buf, len);
-        if (alloc_buf) delete [] buf;
-        alloc_buf = true;
-        buf = complete_hex;
-        len += 1;
-      }
-      // Do we have an incomplete hex stream?
-      if ((len>0) && (len % 2 !=0)) {
-        len--;
-        cipher->incomplete_hex=buf[len];
-        cipher->incomplete_hex_flag=true;
-        buf[len]=0;
-      }
-      HexDecode((unsigned char*)buf, len, (char **)&ciphertext, &ciphertext_len);
-
-      if (alloc_buf) {
-        delete [] buf;
-      }
-      buf = ciphertext;
-      len = ciphertext_len;
-      alloc_buf = true;
-
-    } else if (enc == BASE64) {
-      unbase64((unsigned char*)buf, len, (char **)&ciphertext, &ciphertext_len);
-      if (alloc_buf) {
-        delete [] buf;
-      }
-      buf = ciphertext;
-      len = ciphertext_len;
-      alloc_buf = true;
-
-    } else if (enc == BINARY || enc == BUFFER) {
-      // Binary - do nothing
-
-    } else {
-      fprintf(stderr, "node-crypto : Decipher .update encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    buf = buffer_data;
+    len = buffer_length;
 
     unsigned char *out=0;
     int out_len=0;
@@ -2841,32 +2549,7 @@ class Decipher : public ObjectWrap {
     }
 
     Local<Value> outString;
-    enum encoding out_enc = ParseEncoding(args[2], BINARY);
-    if (out_enc == UTF8) {
-      // See if we have any overhang from last utf8 partial ending
-      if (cipher->incomplete_utf8!=NULL) {
-        char* complete_out = new char[cipher->incomplete_utf8_len + out_len];
-        memcpy(complete_out, cipher->incomplete_utf8, cipher->incomplete_utf8_len);
-        memcpy((char *)complete_out+cipher->incomplete_utf8_len, out, out_len);
-        delete [] out;
-
-        delete [] cipher->incomplete_utf8;
-        cipher->incomplete_utf8 = NULL;
-
-        out = (unsigned char*)complete_out;
-        out_len += cipher->incomplete_utf8_len;
-      }
-      // Check to see if we have a complete utf8 stream
-      int utf8_len = LengthWithoutIncompleteUtf8((char *)out, out_len);
-      if (utf8_len<out_len) { // We have an incomplete ut8 ending
-        cipher->incomplete_utf8_len = out_len-utf8_len;
-        cipher->incomplete_utf8 = new unsigned char[cipher->incomplete_utf8_len+1];
-        memcpy(cipher->incomplete_utf8, &out[utf8_len], cipher->incomplete_utf8_len);
-      }
-      outString = Encode(out, utf8_len, out_enc);
-    } else {
-      outString = Encode(out, out_len, out_enc);
-    }
+    outString = Encode(out, out_len, BUFFER);
 
     if (out) delete [] out;
 
@@ -2908,29 +2591,7 @@ class Decipher : public ObjectWrap {
       }
     }
 
-    if (args.Length() == 0 || !args[0]->IsString()) {
-      outString = Encode(out_value, out_len, BINARY);
-    } else {
-      enum encoding enc = ParseEncoding(args[0], BINARY);
-      if (enc == UTF8) {
-        // See if we have any overhang from last utf8 partial ending
-        if (cipher->incomplete_utf8!=NULL) {
-          char* complete_out = new char[cipher->incomplete_utf8_len + out_len];
-          memcpy(complete_out, cipher->incomplete_utf8, cipher->incomplete_utf8_len);
-          memcpy((char *)complete_out+cipher->incomplete_utf8_len, out_value, out_len);
-
-          delete [] cipher->incomplete_utf8;
-          cipher->incomplete_utf8=NULL;
-
-          outString = Encode(complete_out, cipher->incomplete_utf8_len+out_len, enc);
-          delete [] complete_out;
-        } else {
-          outString = Encode(out_value, out_len, enc);
-        }
-      } else {
-        outString = Encode(out_value, out_len, enc);
-      }
-    }
+    outString = Encode(out_value, out_len, BUFFER);
     delete [] out_value;
     return scope.Close(outString);
   }
@@ -2950,10 +2611,6 @@ class Decipher : public ObjectWrap {
   EVP_CIPHER_CTX ctx;
   const EVP_CIPHER *cipher_;
   bool initialised_;
-  unsigned char* incomplete_utf8;
-  int incomplete_utf8_len;
-  char incomplete_hex;
-  bool incomplete_hex_flag;
 };
 
 
@@ -3024,8 +2681,8 @@ class Hmac : public ObjectWrap {
         "Must give hashtype string as argument")));
     }
 
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
-    ssize_t len = DecodeBytes(args[1], BINARY);
+    ASSERT_IS_BUFFER(args[1]);
+    ssize_t len = Buffer::Length(args[1]->ToObject());
 
     if (len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -3064,30 +2721,15 @@ class Hmac : public ObjectWrap {
 
     HandleScope scope;
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-    enum encoding enc = ParseEncoding(args[1]);
-    ssize_t len = DecodeBytes(args[0], enc);
-
-    if (len < 0) {
-      Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
-      return ThrowException(exception);
-    }
+    ASSERT_IS_BUFFER(args[0]);
 
     int r;
 
-    if( Buffer::HasInstance(args[0])) {
-      Local<Object> buffer_obj = args[0]->ToObject();
-      char *buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
+    Local<Object> buffer_obj = args[0]->ToObject();
+    char *buffer_data = Buffer::Data(buffer_obj);
+    size_t buffer_length = Buffer::Length(buffer_obj);
 
-      r = hmac->HmacUpdate(buffer_data, buffer_length);
-    } else {
-      char* buf = new char[len];
-      ssize_t written = DecodeWrite(buf, len, args[0], enc);
-      assert(written == len);
-      r = hmac->HmacUpdate(buf, len);
-      delete [] buf;
-    }
+    r = hmac->HmacUpdate(buffer_data, buffer_length);
 
     if (!r) {
       Local<Value> exception = Exception::TypeError(String::New("HmacUpdate fail"));
@@ -3104,8 +2746,6 @@ class Hmac : public ObjectWrap {
 
     unsigned char* md_value = NULL;
     unsigned int md_len = 0;
-    char* md_hexdigest;
-    int md_hex_len;
     Local<Value> outString;
 
     int r = hmac->HmacDigest(&md_value, &md_len);
@@ -3114,22 +2754,8 @@ class Hmac : public ObjectWrap {
       md_len = 0;
     }
 
-    enum encoding enc = ParseEncoding(args[0], BINARY);
-    if (enc == HEX) {
-      // Hex encoding
-      HexEncode(md_value, md_len, &md_hexdigest, &md_hex_len);
-      outString = Encode(md_hexdigest, md_hex_len, BINARY);
-      delete [] md_hexdigest;
-    } else if (enc == BASE64) {
-      base64(md_value, md_len, &md_hexdigest, &md_hex_len);
-      outString = Encode(md_hexdigest, md_hex_len, BINARY);
-      delete [] md_hexdigest;
-    } else if (enc == BINARY || enc == BUFFER) {
-      outString = Encode(md_value, md_len, enc);
-    } else {
-      fprintf(stderr, "node-crypto : Hmac .digest encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    outString = Encode(md_value, md_len, BUFFER);
+
     delete [] md_value;
     return scope.Close(outString);
   }
@@ -3211,29 +2837,14 @@ class Hash : public ObjectWrap {
 
     Hash *hash = ObjectWrap::Unwrap<Hash>(args.This());
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-    enum encoding enc = ParseEncoding(args[1]);
-    ssize_t len = DecodeBytes(args[0], enc);
-
-    if (len < 0) {
-      Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
-      return ThrowException(exception);
-    }
+    ASSERT_IS_BUFFER(args[0]);
 
     int r;
 
-    if (Buffer::HasInstance(args[0])) {
-      Local<Object> buffer_obj = args[0]->ToObject();
-      char *buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
-      r = hash->HashUpdate(buffer_data, buffer_length);
-    } else {
-      char* buf = new char[len];
-      ssize_t written = DecodeWrite(buf, len, args[0], enc);
-      assert(written == len);
-      r = hash->HashUpdate(buf, len);
-      delete[] buf;
-    }
+    Local<Object> buffer_obj = args[0]->ToObject();
+    char *buffer_data = Buffer::Data(buffer_obj);
+    size_t buffer_length = Buffer::Length(buffer_obj);
+    r = hash->HashUpdate(buffer_data, buffer_length);
 
     if (!r) {
       Local<Value> exception = Exception::TypeError(String::New("HashUpdate fail"));
@@ -3261,26 +2872,7 @@ class Hash : public ObjectWrap {
 
     Local<Value> outString;
 
-    enum encoding enc = ParseEncoding(args[0], BINARY);
-    if (enc == HEX) {
-      // Hex encoding
-      char* md_hexdigest;
-      int md_hex_len;
-      HexEncode(md_value, md_len, &md_hexdigest, &md_hex_len);
-      outString = Encode(md_hexdigest, md_hex_len, BINARY);
-      delete [] md_hexdigest;
-    } else if (enc == BASE64) {
-      char* md_hexdigest;
-      int md_hex_len;
-      base64(md_value, md_len, &md_hexdigest, &md_hex_len);
-      outString = Encode(md_hexdigest, md_hex_len, BINARY);
-      delete [] md_hexdigest;
-    } else if (enc == BINARY || enc == BUFFER) {
-      outString = Encode(md_value, md_len, enc);
-    } else {
-      fprintf(stderr, "node-crypto : Hash .digest encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    outString = Encode(md_value, md_len, BUFFER);
 
     return scope.Close(outString);
   }
@@ -3398,30 +2990,15 @@ class Sign : public ObjectWrap {
 
     HandleScope scope;
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-    enum encoding enc = ParseEncoding(args[1]);
-    ssize_t len = DecodeBytes(args[0], enc);
-
-    if (len < 0) {
-      Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
-      return ThrowException(exception);
-    }
+    ASSERT_IS_BUFFER(args[0]);
 
     int r;
 
-    if (Buffer::HasInstance(args[0])) {
-      Local<Object> buffer_obj = args[0]->ToObject();
-      char *buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
+    Local<Object> buffer_obj = args[0]->ToObject();
+    char *buffer_data = Buffer::Data(buffer_obj);
+    size_t buffer_length = Buffer::Length(buffer_obj);
 
-      r = sign->SignUpdate(buffer_data, buffer_length);
-    } else {
-      char* buf = new char[len];
-      ssize_t written = DecodeWrite(buf, len, args[0], enc);
-      assert(written == len);
-      r = sign->SignUpdate(buf, len);
-      delete [] buf;
-    }
+    r = sign->SignUpdate(buffer_data, buffer_length);
 
     if (!r) {
       Local<Value> exception = Exception::TypeError(String::New("SignUpdate fail"));
@@ -3438,24 +3015,16 @@ class Sign : public ObjectWrap {
 
     unsigned char* md_value;
     unsigned int md_len;
-    char* md_hexdigest;
-    int md_hex_len;
     Local<Value> outString;
 
     md_len = 8192; // Maximum key size is 8192 bits
     md_value = new unsigned char[md_len];
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-    ssize_t len = DecodeBytes(args[0], BINARY);
-
-    if (len < 0) {
-      delete [] md_value;
-      Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
-      return ThrowException(exception);
-    }
+    ASSERT_IS_BUFFER(args[0]);
+    ssize_t len = Buffer::Length(args[0]->ToObject());
 
     char* buf = new char[len];
-    ssize_t written = DecodeWrite(buf, len, args[0], BINARY);
+    ssize_t written = DecodeWrite(buf, len, args[0], BUFFER);
     assert(written == len);
 
     int r = sign->SignFinal(&md_value, &md_len, buf, len);
@@ -3466,23 +3035,7 @@ class Sign : public ObjectWrap {
 
     delete [] buf;
 
-    enum encoding enc = ParseEncoding(args[1], BINARY);
-    if (enc == HEX) {
-      // Hex encoding
-      HexEncode(md_value, md_len, &md_hexdigest, &md_hex_len);
-      outString = Encode(md_hexdigest, md_hex_len, BINARY);
-      delete [] md_hexdigest;
-    } else if (enc == BASE64) {
-      base64(md_value, md_len, &md_hexdigest, &md_hex_len);
-      outString = Encode(md_hexdigest, md_hex_len, BINARY);
-      delete [] md_hexdigest;
-    } else if (enc == BINARY || enc == BUFFER) {
-      outString = Encode(md_value, md_len, enc);
-    } else {
-      outString = String::New("");
-      fprintf(stderr, "node-crypto : Sign .sign encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    outString = Encode(md_value, md_len, BUFFER);
 
     delete [] md_value;
     return scope.Close(outString);
@@ -3649,30 +3202,15 @@ class Verify : public ObjectWrap {
 
     Verify *verify = ObjectWrap::Unwrap<Verify>(args.This());
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-    enum encoding enc = ParseEncoding(args[1]);
-    ssize_t len = DecodeBytes(args[0], enc);
-
-    if (len < 0) {
-      Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
-      return ThrowException(exception);
-    }
+    ASSERT_IS_BUFFER(args[0]);
 
     int r;
 
-    if(Buffer::HasInstance(args[0])) {
-      Local<Object> buffer_obj = args[0]->ToObject();
-      char *buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
+    Local<Object> buffer_obj = args[0]->ToObject();
+    char *buffer_data = Buffer::Data(buffer_obj);
+    size_t buffer_length = Buffer::Length(buffer_obj);
 
-      r = verify->VerifyUpdate(buffer_data, buffer_length);
-    } else {
-      char* buf = new char[len];
-      ssize_t written = DecodeWrite(buf, len, args[0], enc);
-      assert(written == len);
-      r = verify->VerifyUpdate(buf, len);
-      delete [] buf;
-    }
+    r = verify->VerifyUpdate(buffer_data, buffer_length);
 
     if (!r) {
       Local<Value> exception = Exception::TypeError(String::New("VerifyUpdate fail"));
@@ -3688,8 +3226,8 @@ class Verify : public ObjectWrap {
 
     Verify *verify = ObjectWrap::Unwrap<Verify>(args.This());
 
-    ASSERT_IS_STRING_OR_BUFFER(args[0]);
-    ssize_t klen = DecodeBytes(args[0], BINARY);
+    ASSERT_IS_BUFFER(args[0]);
+    ssize_t klen = Buffer::Length(args[0]->ToObject());
 
     if (klen < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -3700,8 +3238,8 @@ class Verify : public ObjectWrap {
     ssize_t kwritten = DecodeWrite(kbuf, klen, args[0], BINARY);
     assert(kwritten == klen);
 
-    ASSERT_IS_STRING_OR_BUFFER(args[1]);
-    ssize_t hlen = DecodeBytes(args[1], BINARY);
+    ASSERT_IS_BUFFER(args[1]);
+    ssize_t hlen = Buffer::Length(args[1]->ToObject());
 
     if (hlen < 0) {
       delete [] kbuf;
@@ -3712,28 +3250,10 @@ class Verify : public ObjectWrap {
     unsigned char* hbuf = new unsigned char[hlen];
     ssize_t hwritten = DecodeWrite((char *)hbuf, hlen, args[1], BINARY);
     assert(hwritten == hlen);
-    unsigned char* dbuf;
-    int dlen;
 
     int r=-1;
 
-    enum encoding enc = ParseEncoding(args[2], BINARY);
-    if (enc == HEX) {
-      // Hex encoding
-      HexDecode(hbuf, hlen, (char **)&dbuf, &dlen);
-      r = verify->VerifyFinal(kbuf, klen, dbuf, dlen);
-      delete [] dbuf;
-    } else if (enc == BASE64) {
-      // Base64 encoding
-      unbase64(hbuf, hlen, (char **)&dbuf, &dlen);
-      r = verify->VerifyFinal(kbuf, klen, dbuf, dlen);
-      delete [] dbuf;
-    } else if (enc == BINARY || enc == BUFFER) {
-      r = verify->VerifyFinal(kbuf, klen, hbuf, hlen);
-    } else {
-      fprintf(stderr, "node-crypto : Verify .verify encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
+    r = verify->VerifyFinal(kbuf, klen, hbuf, hlen);
 
     delete [] kbuf;
     delete [] hbuf;
@@ -3864,30 +3384,10 @@ class DiffieHellman : public ObjectWrap {
       if (args[0]->IsInt32()) {
         initialized = diffieHellman->Init(args[0]->Int32Value());
       } else {
-        if (args[0]->IsString()) {
-          char* buf;
-          int len;
-          if (args.Length() > 1 && args[1]->IsString()) {
-            len = DecodeWithEncoding(args[0], args[1], &buf);
-          } else {
-            len = DecodeBinary(args[0], &buf);
-          }
-
-          if (len == -1) {
-            delete[] buf;
-            return ThrowException(Exception::Error(
-                  String::New("Invalid argument")));
-          } else {
-            initialized = diffieHellman->Init(
-                reinterpret_cast<unsigned char*>(buf), len);
-            delete[] buf;
-          }
-        } else if (Buffer::HasInstance(args[0])) {
-          Local<Object> buffer = args[0]->ToObject();
-          initialized = diffieHellman->Init(
-                  reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-                  Buffer::Length(buffer));
-        }
+        Local<Object> buffer = args[0]->ToObject();
+        initialized = diffieHellman->Init(
+                reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
+                Buffer::Length(buffer));
       }
     }
 
@@ -3924,11 +3424,7 @@ class DiffieHellman : public ObjectWrap {
     BN_bn2bin(diffieHellman->dh->pub_key,
         reinterpret_cast<unsigned char*>(data));
 
-    if (args.Length() > 0 && args[0]->IsString()) {
-      outString = EncodeWithEncoding(args[0], data, dataSize);
-    } else {
-      outString = Encode(data, dataSize, BINARY);
-    }
+    outString = Encode(data, dataSize, BUFFER);
     delete[] data;
 
     return scope.Close(outString);
@@ -3950,11 +3446,7 @@ class DiffieHellman : public ObjectWrap {
 
     Local<Value> outString;
 
-    if (args.Length() > 0 && args[0]->IsString()) {
-      outString = EncodeWithEncoding(args[0], data, dataSize);
-    } else {
-      outString = Encode(data, dataSize, BINARY);
-    }
+    outString = Encode(data, dataSize, BUFFER);
 
     delete[] data;
 
@@ -3977,11 +3469,7 @@ class DiffieHellman : public ObjectWrap {
 
     Local<Value> outString;
 
-    if (args.Length() > 0 && args[0]->IsString()) {
-      outString = EncodeWithEncoding(args[0], data, dataSize);
-    } else {
-      outString = Encode(data, dataSize, BINARY);
-    }
+    outString = Encode(data, dataSize, BUFFER);
 
     delete[] data;
 
@@ -4010,11 +3498,7 @@ class DiffieHellman : public ObjectWrap {
 
     Local<Value> outString;
 
-    if (args.Length() > 0 && args[0]->IsString()) {
-      outString = EncodeWithEncoding(args[0], data, dataSize);
-    } else {
-      outString = Encode(data, dataSize, BINARY);
-    }
+    outString = Encode(data, dataSize, BUFFER);
 
     delete[] data;
 
@@ -4043,11 +3527,7 @@ class DiffieHellman : public ObjectWrap {
 
     Local<Value> outString;
 
-    if (args.Length() > 0 && args[0]->IsString()) {
-      outString = EncodeWithEncoding(args[0], data, dataSize);
-    } else {
-      outString = Encode(data, dataSize, BINARY);
-    }
+    outString = Encode(data, dataSize, BUFFER);
 
     delete[] data;
 
@@ -4070,30 +3550,11 @@ class DiffieHellman : public ObjectWrap {
       return ThrowException(Exception::Error(
             String::New("First argument must be other party's public key")));
     } else {
-      if (args[0]->IsString()) {
-        char* buf;
-        int len;
-        if (args.Length() > 1) {
-          len = DecodeWithEncoding(args[0], args[1], &buf);
-        } else {
-          len = DecodeBinary(args[0], &buf);
-        }
-        if (len == -1) {
-          delete[] buf;
-          return ThrowException(Exception::Error(
-                String::New("Invalid argument")));
-        }
-        key = BN_bin2bn(reinterpret_cast<unsigned char*>(buf), len, 0);
-        delete[] buf;
-      } else if (Buffer::HasInstance(args[0])) {
-        Local<Object> buffer = args[0]->ToObject();
-        key = BN_bin2bn(
-          reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-          Buffer::Length(buffer), 0);
-      } else {
-        return ThrowException(Exception::Error(
-              String::New("First argument must be other party's public key")));
-      }
+      ASSERT_IS_BUFFER(args[0]);
+      Local<Object> buffer = args[0]->ToObject();
+      key = BN_bin2bn(
+        reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
+        Buffer::Length(buffer), 0);
     }
 
     int dataSize = DH_size(diffieHellman->dh);
@@ -4146,7 +3607,7 @@ class DiffieHellman : public ObjectWrap {
     } else if (args.Length() > 1 && args[1]->IsString()) {
       outString = EncodeWithEncoding(args[1], data, dataSize);
     } else {
-      outString = Encode(data, dataSize, BINARY);
+      outString = Encode(data, dataSize, BUFFER);
     }
 
     delete[] data;
@@ -4167,32 +3628,12 @@ class DiffieHellman : public ObjectWrap {
       return ThrowException(Exception::Error(
             String::New("First argument must be public key")));
     } else {
-      if (args[0]->IsString()) {
-        char* buf;
-        int len;
-        if (args.Length() > 1) {
-          len = DecodeWithEncoding(args[0], args[1], &buf);
-        } else {
-          len = DecodeBinary(args[0], &buf);
-        }
-        if (len == -1) {
-          delete[] buf;
-          return ThrowException(Exception::Error(
-                String::New("Invalid argument")));
-        }
-        diffieHellman->dh->pub_key =
-          BN_bin2bn(reinterpret_cast<unsigned char*>(buf), len, 0);
-        delete[] buf;
-      } else if (Buffer::HasInstance(args[0])) {
-        Local<Object> buffer = args[0]->ToObject();
-        diffieHellman->dh->pub_key =
-          BN_bin2bn(
-            reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-            Buffer::Length(buffer), 0);
-      } else {
-        return ThrowException(Exception::Error(
-              String::New("First argument must be public key")));
-      }
+      ASSERT_IS_BUFFER(args[0]);
+      Local<Object> buffer = args[0]->ToObject();
+      diffieHellman->dh->pub_key =
+        BN_bin2bn(
+          reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
+          Buffer::Length(buffer), 0);
     }
 
     return args.This();
@@ -4213,32 +3654,12 @@ class DiffieHellman : public ObjectWrap {
       return ThrowException(Exception::Error(
             String::New("First argument must be private key")));
     } else {
-      if (args[0]->IsString()) {
-        char* buf;
-        int len;
-        if (args.Length() > 1) {
-          len = DecodeWithEncoding(args[0], args[1], &buf);
-        } else {
-          len = DecodeBinary(args[0], &buf);
-        }
-        if (len == -1) {
-          delete[] buf;
-          return ThrowException(Exception::Error(
-                String::New("Invalid argument")));
-        }
-        diffieHellman->dh->priv_key =
-          BN_bin2bn(reinterpret_cast<unsigned char*>(buf), len, 0);
-        delete[] buf;
-      } else if (Buffer::HasInstance(args[0])) {
-        Local<Object> buffer = args[0]->ToObject();
-        diffieHellman->dh->priv_key =
-          BN_bin2bn(
-            reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-            Buffer::Length(buffer), 0);
-      } else {
-        return ThrowException(Exception::Error(
-              String::New("First argument must be private key")));
-      }
+      ASSERT_IS_BUFFER(args[0]);
+      Local<Object> buffer = args[0]->ToObject();
+      diffieHellman->dh->priv_key =
+        BN_bin2bn(
+          reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
+          Buffer::Length(buffer), 0);
     }
 
     return args.This();
@@ -4264,76 +3685,6 @@ class DiffieHellman : public ObjectWrap {
     if (codes & DH_UNABLE_TO_CHECK_GENERATOR) return false;
     if (codes & DH_NOT_SUITABLE_GENERATOR) return false;
     return true;
-  }
-
-  static int DecodeBinary(Handle<Value> str, char** buf) {
-    int len = DecodeBytes(str);
-    *buf = new char[len];
-    int written = DecodeWrite(*buf, len, str, BINARY);
-    if (written != len) {
-      return -1;
-    }
-    return len;
-  }
-
-  static int DecodeWithEncoding(Handle<Value> str, Handle<Value> encoding_v,
-      char** buf) {
-    int len = DecodeBinary(str, buf);
-    if (len == -1) {
-      return len;
-    }
-    enum encoding enc = ParseEncoding(encoding_v, (enum encoding) -1);
-    char* retbuf = 0;
-    int retlen;
-
-    if (enc == HEX) {
-      HexDecode((unsigned char*)*buf, len, &retbuf, &retlen);
-
-    } else if (enc == BASE64) {
-      unbase64((unsigned char*)*buf, len, &retbuf, &retlen);
-
-    } else if (enc == BINARY) {
-      // Binary - do nothing
-    } else {
-      fprintf(stderr, "node-crypto : Diffie-Hellman parameter encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
-
-    if (retbuf != 0) {
-      delete [] *buf;
-      *buf = retbuf;
-      len = retlen;
-    }
-
-    return len;
-  }
-
-  static Local<Value> EncodeWithEncoding(Handle<Value> encoding_v, char* buf,
-      int len) {
-    HandleScope scope;
-
-    Local<Value> outString;
-    enum encoding enc = ParseEncoding(encoding_v, (enum encoding) -1);
-    char* retbuf;
-    int retlen;
-
-    if (enc == HEX) {
-      // Hex encoding
-      HexEncode(reinterpret_cast<unsigned char*>(buf), len, &retbuf, &retlen);
-      outString = Encode(retbuf, retlen, BINARY);
-      delete [] retbuf;
-    } else if (enc == BASE64) {
-      base64(reinterpret_cast<unsigned char*>(buf), len, &retbuf, &retlen);
-      outString = Encode(retbuf, retlen, BINARY);
-      delete [] retbuf;
-    } else if (enc == BINARY || enc == BUFFER) {
-      outString = Encode(buf, len, enc);
-    } else {
-      fprintf(stderr, "node-crypto : Diffie-Hellman parameter encoding "
-                      "can be binary, buffer, hex or base64\n");
-    }
-
-    return scope.Close(outString);
   }
 
   bool initialised_;
@@ -4378,7 +3729,7 @@ void EIO_PBKDF2(uv_work_t* work_req) {
 void EIO_PBKDF2After(pbkdf2_req* req, Local<Value> argv[2]) {
   if (req->err) {
     argv[0] = Local<Value>::New(Undefined());
-    argv[1] = Encode(req->key, req->keylen, BINARY);
+    argv[1] = Encode(req->key, req->keylen, BUFFER);
     memset(req->key, 0, req->keylen);
   } else {
     argv[0] = Exception::Error(String::New("PBKDF2 error"));
@@ -4423,8 +3774,8 @@ Handle<Value> PBKDF2(const Arguments& args) {
     goto err;
   }
 
-  ASSERT_IS_STRING_OR_BUFFER(args[0]);
-  passlen = DecodeBytes(args[0], BINARY);
+  ASSERT_IS_BUFFER(args[0]);
+  passlen = Buffer::Length(args[0]->ToObject());
   if (passlen < 0) {
     type_error = "Bad password";
     goto err;
@@ -4434,8 +3785,8 @@ Handle<Value> PBKDF2(const Arguments& args) {
   pass_written = DecodeWrite(pass, passlen, args[0], BINARY);
   assert(pass_written == passlen);
 
-  ASSERT_IS_STRING_OR_BUFFER(args[1]);
-  saltlen = DecodeBytes(args[1], BINARY);
+  ASSERT_IS_BUFFER(args[1]);
+  saltlen = Buffer::Length(args[1]->ToObject());
   if (saltlen < 0) {
     type_error = "Bad salt";
     goto err;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -286,9 +286,8 @@ static BIO* LoadBIO (Handle<Value> v) {
     String::Utf8Value s(v);
     r = BIO_write(bio, *s, s.length());
   } else if (Buffer::HasInstance(v)) {
-    Local<Object> buffer_obj = v->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char *buffer_data = Buffer::Data(v);
+    size_t buffer_length = Buffer::Length(v);
     r = BIO_write(bio, buffer_data, buffer_length);
   }
 
@@ -659,7 +658,7 @@ Handle<Value> SecureContext::LoadPKCS12(const Arguments& args) {
   if (args.Length() >= 2) {
     ASSERT_IS_BUFFER(args[1]);
 
-    int passlen = Buffer::Length(args[1]->ToObject());
+    int passlen = Buffer::Length(args[1]);
     if (passlen < 0) {
       BIO_free(in);
       return ThrowException(Exception::TypeError(
@@ -1283,9 +1282,8 @@ Handle<Value> Connection::EncIn(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  Local<Object> buffer_obj = args[0]->ToObject();
-  char *buffer_data = Buffer::Data(buffer_obj);
-  size_t buffer_length = Buffer::Length(buffer_obj);
+  char *buffer_data = Buffer::Data(args[0]);
+  size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
   if (off >= buffer_length) {
@@ -1330,9 +1328,8 @@ Handle<Value> Connection::ClearOut(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  Local<Object> buffer_obj = args[0]->ToObject();
-  char *buffer_data = Buffer::Data(buffer_obj);
-  size_t buffer_length = Buffer::Length(buffer_obj);
+  char *buffer_data = Buffer::Data(args[0]);
+  size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
   if (off >= buffer_length) {
@@ -1403,9 +1400,8 @@ Handle<Value> Connection::EncOut(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  Local<Object> buffer_obj = args[0]->ToObject();
-  char *buffer_data = Buffer::Data(buffer_obj);
-  size_t buffer_length = Buffer::Length(buffer_obj);
+  char *buffer_data = Buffer::Data(args[0]);
+  size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
   if (off >= buffer_length) {
@@ -1443,9 +1439,8 @@ Handle<Value> Connection::ClearIn(const Arguments& args) {
           String::New("Second argument should be a buffer")));
   }
 
-  Local<Object> buffer_obj = args[0]->ToObject();
-  char *buffer_data = Buffer::Data(buffer_obj);
-  size_t buffer_length = Buffer::Length(buffer_obj);
+  char *buffer_data = Buffer::Data(args[0]);
+  size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
   if (off > buffer_length) {
@@ -1628,7 +1623,7 @@ Handle<Value> Connection::SetSession(const Arguments& args) {
   }
 
   ASSERT_IS_BUFFER(args[0]);
-  ssize_t slen = Buffer::Length(args[0]->ToObject());
+  ssize_t slen = Buffer::Length(args[0]);
 
   if (slen < 0) {
     Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2130,7 +2125,7 @@ class Cipher : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[1]);
-    ssize_t key_buf_len = Buffer::Length(args[1]->ToObject());
+    ssize_t key_buf_len = Buffer::Length(args[1]);
 
     if (key_buf_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2171,7 +2166,7 @@ class Cipher : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[1]);
-    ssize_t key_len = Buffer::Length(args[1]->ToObject());
+    ssize_t key_len = Buffer::Length(args[1]);
 
     if (key_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2179,7 +2174,7 @@ class Cipher : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[2]);
-    ssize_t iv_len = Buffer::Length(args[2]->ToObject());
+    ssize_t iv_len = Buffer::Length(args[2]);
 
     if (iv_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2217,9 +2212,8 @@ class Cipher : public ObjectWrap {
 
     unsigned char *out=0;
     int out_len=0, r;
-    Local<Object> buffer_obj = args[0]->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char* buffer_data = Buffer::Data(args[0]);
+    size_t buffer_length = Buffer::Length(args[0]);
 
     r = cipher->CipherUpdate(buffer_data, buffer_length, &out, &out_len);
 
@@ -2443,7 +2437,7 @@ class Decipher : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[1]);
-    ssize_t key_len = Buffer::Length(args[1]->ToObject());
+    ssize_t key_len = Buffer::Length(args[1]);
 
     if (key_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2482,7 +2476,7 @@ class Decipher : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[1]);
-    ssize_t key_len = Buffer::Length(args[1]->ToObject());
+    ssize_t key_len = Buffer::Length(args[1]);
 
     if (key_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2490,7 +2484,7 @@ class Decipher : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[2]);
-    ssize_t iv_len = Buffer::Length(args[2]->ToObject());
+    ssize_t iv_len = Buffer::Length(args[2]);
 
     if (iv_len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2531,9 +2525,8 @@ class Decipher : public ObjectWrap {
     char* buf;
     // if alloc_buf then buf must be deleted later
     bool alloc_buf = false;
-    Local<Object> buffer_obj = args[0]->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char *buffer_data = Buffer::Data(args[0]);
+    size_t buffer_length = Buffer::Length(args[0]);
 
     buf = buffer_data;
     len = buffer_length;
@@ -2682,7 +2675,7 @@ class Hmac : public ObjectWrap {
     }
 
     ASSERT_IS_BUFFER(args[1]);
-    ssize_t len = Buffer::Length(args[1]->ToObject());
+    ssize_t len = Buffer::Length(args[1]);
 
     if (len < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -2694,9 +2687,8 @@ class Hmac : public ObjectWrap {
     bool r;
 
     if( Buffer::HasInstance(args[1])) {
-      Local<Object> buffer_obj = args[1]->ToObject();
-      char* buffer_data = Buffer::Data(buffer_obj);
-      size_t buffer_length = Buffer::Length(buffer_obj);
+      char* buffer_data = Buffer::Data(args[1]);
+      size_t buffer_length = Buffer::Length(args[1]);
 
       r = hmac->HmacInit(*hashType, buffer_data, buffer_length);
     } else {
@@ -2725,9 +2717,8 @@ class Hmac : public ObjectWrap {
 
     int r;
 
-    Local<Object> buffer_obj = args[0]->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char *buffer_data = Buffer::Data(args[0]);
+    size_t buffer_length = Buffer::Length(args[0]);
 
     r = hmac->HmacUpdate(buffer_data, buffer_length);
 
@@ -2841,9 +2832,8 @@ class Hash : public ObjectWrap {
 
     int r;
 
-    Local<Object> buffer_obj = args[0]->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char *buffer_data = Buffer::Data(args[0]);
+    size_t buffer_length = Buffer::Length(args[0]);
     r = hash->HashUpdate(buffer_data, buffer_length);
 
     if (!r) {
@@ -2994,9 +2984,8 @@ class Sign : public ObjectWrap {
 
     int r;
 
-    Local<Object> buffer_obj = args[0]->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char *buffer_data = Buffer::Data(args[0]);
+    size_t buffer_length = Buffer::Length(args[0]);
 
     r = sign->SignUpdate(buffer_data, buffer_length);
 
@@ -3021,7 +3010,7 @@ class Sign : public ObjectWrap {
     md_value = new unsigned char[md_len];
 
     ASSERT_IS_BUFFER(args[0]);
-    ssize_t len = Buffer::Length(args[0]->ToObject());
+    ssize_t len = Buffer::Length(args[0]);
 
     char* buf = new char[len];
     ssize_t written = DecodeWrite(buf, len, args[0], BUFFER);
@@ -3206,9 +3195,8 @@ class Verify : public ObjectWrap {
 
     int r;
 
-    Local<Object> buffer_obj = args[0]->ToObject();
-    char *buffer_data = Buffer::Data(buffer_obj);
-    size_t buffer_length = Buffer::Length(buffer_obj);
+    char *buffer_data = Buffer::Data(args[0]);
+    size_t buffer_length = Buffer::Length(args[0]);
 
     r = verify->VerifyUpdate(buffer_data, buffer_length);
 
@@ -3227,7 +3215,7 @@ class Verify : public ObjectWrap {
     Verify *verify = ObjectWrap::Unwrap<Verify>(args.This());
 
     ASSERT_IS_BUFFER(args[0]);
-    ssize_t klen = Buffer::Length(args[0]->ToObject());
+    ssize_t klen = Buffer::Length(args[0]);
 
     if (klen < 0) {
       Local<Value> exception = Exception::TypeError(String::New("Bad argument"));
@@ -3239,7 +3227,7 @@ class Verify : public ObjectWrap {
     assert(kwritten == klen);
 
     ASSERT_IS_BUFFER(args[1]);
-    ssize_t hlen = Buffer::Length(args[1]->ToObject());
+    ssize_t hlen = Buffer::Length(args[1]);
 
     if (hlen < 0) {
       delete [] kbuf;
@@ -3384,10 +3372,9 @@ class DiffieHellman : public ObjectWrap {
       if (args[0]->IsInt32()) {
         initialized = diffieHellman->Init(args[0]->Int32Value());
       } else {
-        Local<Object> buffer = args[0]->ToObject();
         initialized = diffieHellman->Init(
-                reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-                Buffer::Length(buffer));
+                reinterpret_cast<unsigned char*>(Buffer::Data(args[0])),
+                Buffer::Length(args[0]));
       }
     }
 
@@ -3551,10 +3538,9 @@ class DiffieHellman : public ObjectWrap {
             String::New("First argument must be other party's public key")));
     } else {
       ASSERT_IS_BUFFER(args[0]);
-      Local<Object> buffer = args[0]->ToObject();
       key = BN_bin2bn(
-        reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-        Buffer::Length(buffer), 0);
+        reinterpret_cast<unsigned char*>(Buffer::Data(args[0])),
+        Buffer::Length(args[0]), 0);
     }
 
     int dataSize = DH_size(diffieHellman->dh);
@@ -3623,11 +3609,10 @@ class DiffieHellman : public ObjectWrap {
             String::New("First argument must be public key")));
     } else {
       ASSERT_IS_BUFFER(args[0]);
-      Local<Object> buffer = args[0]->ToObject();
       diffieHellman->dh->pub_key =
         BN_bin2bn(
-          reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-          Buffer::Length(buffer), 0);
+          reinterpret_cast<unsigned char*>(Buffer::Data(args[0])),
+          Buffer::Length(args[0]), 0);
     }
 
     return args.This();
@@ -3649,11 +3634,10 @@ class DiffieHellman : public ObjectWrap {
             String::New("First argument must be private key")));
     } else {
       ASSERT_IS_BUFFER(args[0]);
-      Local<Object> buffer = args[0]->ToObject();
       diffieHellman->dh->priv_key =
         BN_bin2bn(
-          reinterpret_cast<unsigned char*>(Buffer::Data(buffer)),
-          Buffer::Length(buffer), 0);
+          reinterpret_cast<unsigned char*>(Buffer::Data(args[0])),
+          Buffer::Length(args[0]), 0);
     }
 
     return args.This();
@@ -3769,7 +3753,7 @@ Handle<Value> PBKDF2(const Arguments& args) {
   }
 
   ASSERT_IS_BUFFER(args[0]);
-  passlen = Buffer::Length(args[0]->ToObject());
+  passlen = Buffer::Length(args[0]);
   if (passlen < 0) {
     type_error = "Bad password";
     goto err;
@@ -3780,7 +3764,7 @@ Handle<Value> PBKDF2(const Arguments& args) {
   assert(pass_written == passlen);
 
   ASSERT_IS_BUFFER(args[1]);
-  saltlen = Buffer::Length(args[1]->ToObject());
+  saltlen = Buffer::Length(args[1]);
   if (saltlen < 0) {
     type_error = "Bad salt";
     goto err;

--- a/test/simple/test-crypto-binary-default.js
+++ b/test/simple/test-crypto-binary-default.js
@@ -657,7 +657,7 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
-  var actual = crypto.pbkdf2(password, salt, iterations, keylen);
+  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen);
   assert.equal(actual, expected);
 
   crypto.pbkdf2(password, salt, iterations, keylen, function(err, actual) {

--- a/test/simple/test-crypto-binary-default.js
+++ b/test/simple/test-crypto-binary-default.js
@@ -19,7 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
+// This is the same as test/simple/test-crypto, but from before the shift
+// to use buffers by default.
 
 
 var common = require('../common');
@@ -32,7 +33,7 @@ try {
   process.exit();
 }
 
-crypto.DEFAULT_ENCODING = 'buffer';
+crypto.DEFAULT_ENCODING = 'binary';
 
 var fs = require('fs');
 var path = require('path');
@@ -378,16 +379,14 @@ assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
              '\u00bd\u008c', 'Test MD5 as binary');
 assert.equal(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
              'Test SHA256 as base64');
-assert.deepEqual(
-  a3,
-  new Buffer(
-    '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
-    '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
-    '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
-    '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
-    '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
-    'binary'),
-  'Test SHA512 as assumed buffer');
+
+assert.equal(a3, '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
+                 '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
+                 '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
+                 '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
+                 '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
+             'Test SHA512 as assumed binary');
+
 assert.deepEqual(a4,
                  new Buffer('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
                  'Test SHA1');
@@ -560,28 +559,14 @@ var privkey1 = dh1.getPrivateKey();
 dh3.setPublicKey(key1);
 dh3.setPrivateKey(privkey1);
 
-assert.deepEqual(dh1.getPrime(), dh3.getPrime());
-assert.deepEqual(dh1.getGenerator(), dh3.getGenerator());
-assert.deepEqual(dh1.getPublicKey(), dh3.getPublicKey());
-assert.deepEqual(dh1.getPrivateKey(), dh3.getPrivateKey());
+assert.equal(dh1.getPrime(), dh3.getPrime());
+assert.equal(dh1.getGenerator(), dh3.getGenerator());
+assert.equal(dh1.getPublicKey(), dh3.getPublicKey());
+assert.equal(dh1.getPrivateKey(), dh3.getPrivateKey());
 
 var secret3 = dh3.computeSecret(key2, 'hex', 'base64');
 
 assert.equal(secret1, secret3);
-
-assert.throws(function() {
-  dh3.computeSecret('');
-}, /key is too small/i);
-
-// Create a shared using a DH group.
-var alice = crypto.createDiffieHellmanGroup('modp5');
-var bob = crypto.createDiffieHellmanGroup('modp5');
-alice.generateKeys();
-bob.generateKeys();
-var aSecret = alice.computeSecret(bob.getPublicKey()).toString('hex');
-var bSecret = bob.computeSecret(alice.getPublicKey()).toString('hex');
-assert.equal(aSecret, bSecret);
-
 
 // https://github.com/joyent/node/issues/2338
 assert.throws(function() {
@@ -672,11 +657,11 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
-  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen);
-  assert.equal(actual.toString('binary'), expected);
+  var actual = crypto.pbkdf2(password, salt, iterations, keylen);
+  assert.equal(actual, expected);
 
   crypto.pbkdf2(password, salt, iterations, keylen, function(err, actual) {
-    assert.equal(actual.toString('binary'), expected);
+    assert.equal(actual, expected);
   });
 }
 
@@ -703,24 +688,3 @@ testPBKDF2('passwordPASSWORDpassword',
 testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
            '\x56\xfa\x6a\xa7\x55\x48\x09\x9d\xcc\x37\xd7\xf0\x34' +
            '\x25\xe0\xc3');
-
-function assertSorted(list) {
-  for (var i = 0, k = list.length - 1; i < k; ++i) {
-    var a = list[i + 0];
-    var b = list[i + 1];
-    assert(a <= b);
-  }
-}
-
-// Assume that we have at least AES256-SHA.
-assert.notEqual(0, crypto.getCiphers());
-assert.notEqual(-1, crypto.getCiphers().indexOf('AES256-SHA'));
-assertSorted(crypto.getCiphers());
-
-// Assert that we have sha and sha1 but not SHA and SHA1.
-assert.notEqual(0, crypto.getHashes());
-assert.notEqual(-1, crypto.getHashes().indexOf('sha1'));
-assert.notEqual(-1, crypto.getHashes().indexOf('sha'));
-assert.equal(-1, crypto.getHashes().indexOf('SHA1'));
-assert.equal(-1, crypto.getHashes().indexOf('SHA'));
-assertSorted(crypto.getHashes());

--- a/test/simple/test-crypto-ecb.js
+++ b/test/simple/test-crypto-ecb.js
@@ -32,6 +32,8 @@ try {
   process.exit();
 }
 
+crypto.DEFAULT_ENCODING = 'buffer';
+
 // Testing whether EVP_CipherInit_ex is functioning correctly.
 // Reference: bug#1997
 

--- a/test/simple/test-crypto-padding-aes256.js
+++ b/test/simple/test-crypto-padding-aes256.js
@@ -43,7 +43,7 @@ function aes256(decipherFinal) {
   function decrypt(val, pad) {
         var c = crypto.createDecipheriv('aes256', key, iv);
         c.setAutoPadding(pad);
-        return c.update(val, 'binary', 'binary') + c[decipherFinal]('utf8');
+        return c.update(val, 'binary', 'utf8') + c[decipherFinal]('utf8');
   }
 
   // echo 0123456789abcdef0123456789abcdef \

--- a/test/simple/test-crypto-padding-aes256.js
+++ b/test/simple/test-crypto-padding-aes256.js
@@ -29,6 +29,8 @@ try {
   process.exit();
 }
 
+crypto.DEFAULT_ENCODING = 'buffer';
+
 function aes256(decipherFinal) {
   var iv  = new Buffer('00000000000000000000000000000000', 'hex');
   var key = new Buffer('0123456789abcdef0123456789abcdef' +

--- a/test/simple/test-crypto-padding.js
+++ b/test/simple/test-crypto-padding.js
@@ -29,6 +29,8 @@ try {
   process.exit();
 }
 
+crypto.DEFAULT_ENCODING = 'buffer';
+
 
 /*
  * Input data

--- a/test/simple/test-crypto-random.js
+++ b/test/simple/test-crypto-random.js
@@ -29,6 +29,8 @@ try {
   process.exit();
 }
 
+crypto.DEFAULT_ENCODING = 'buffer';
+
 // bump, we register a lot of exit listeners
 process.setMaxListeners(256);
 

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -536,7 +536,7 @@ testCipher4(new Buffer('0123456789abcd0123456789'), new Buffer('12345678'));
 // update() should only take buffers / strings
 assert.throws(function() {
   crypto.createHash('sha1').update({foo: 'bar'});
-}, /string or buffer/);
+}, /buffer/);
 
 
 // Test Diffie-Hellman with two parties sharing a secret,
@@ -670,11 +670,11 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
-  var actual = crypto.pbkdf2(password, salt, iterations, keylen);
-  assert.equal(actual, expected);
+  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen);
+  assert.equal(actual.toString('binary'), expected);
 
   crypto.pbkdf2(password, salt, iterations, keylen, function(err, actual) {
-    assert.equal(actual, expected);
+    assert.equal(actual.toString('binary'), expected);
   });
 }
 

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -376,12 +376,16 @@ assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
              '\u00bd\u008c', 'Test MD5 as binary');
 assert.equal(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
              'Test SHA256 as base64');
-assert.equal(a3, '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
-                 '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
-                 '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
-                 '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
-                 '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
-             'Test SHA512 as assumed binary');
+assert.deepEqual(
+  a3,
+  new Buffer(
+    '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
+    '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
+    '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
+    '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
+    '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
+    'binary'),
+  'Test SHA512 as assumed buffer');
 assert.deepEqual(a4,
                  new Buffer('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
                  'Test SHA1');
@@ -554,10 +558,10 @@ var privkey1 = dh1.getPrivateKey();
 dh3.setPublicKey(key1);
 dh3.setPrivateKey(privkey1);
 
-assert.equal(dh1.getPrime(), dh3.getPrime());
-assert.equal(dh1.getGenerator(), dh3.getGenerator());
-assert.equal(dh1.getPublicKey(), dh3.getPublicKey());
-assert.equal(dh1.getPrivateKey(), dh3.getPrivateKey());
+assert.deepEqual(dh1.getPrime(), dh3.getPrime());
+assert.deepEqual(dh1.getGenerator(), dh3.getGenerator());
+assert.deepEqual(dh1.getPublicKey(), dh3.getPublicKey());
+assert.deepEqual(dh1.getPrivateKey(), dh3.getPrivateKey());
 
 var secret3 = dh3.computeSecret(key2, 'hex', 'base64');
 
@@ -566,6 +570,16 @@ assert.equal(secret1, secret3);
 assert.throws(function() {
   dh3.computeSecret('');
 }, /key is too small/i);
+
+// Create a shared using a DH group.
+var alice = crypto.createDiffieHellmanGroup('modp5');
+var bob = crypto.createDiffieHellmanGroup('modp5');
+alice.generateKeys();
+bob.generateKeys();
+var aSecret = alice.computeSecret(bob.getPublicKey()).toString('hex');
+var bSecret = bob.computeSecret(alice.getPublicKey()).toString('hex');
+assert.equal(aSecret, bSecret);
+
 
 // https://github.com/joyent/node/issues/2338
 assert.throws(function() {


### PR DESCRIPTION
Of course, the commits should be squashed, but I figured it might be good to see them split out, for easier reviewing in a more atomic way.

This makes the node crypto module default to using Buffers.  There is a flag that can be set to make it use 'binary' encoded strings by default, for ease of upgrading.  All of the buffer/string handling code is moved into JS, so it can use the same Buffer implementation as everything else.

It would be nice if the crypto functions used Buffers instead of SlowBuffers, but that's a much more involved change.
