### PR TITLE
Support building Node.JS with http_parser and c-ares shared libraries

### DIFF
--- a/configure
+++ b/configure
@@ -124,6 +124,26 @@ parser.add_option("--shared-zlib-libname",
     dest="shared_zlib_libname",
     help="Alternative lib name to link to (default: 'z')")
 
+parser.add_option("--shared-http-parser",
+    action="store_true",
+    dest="shared_http_parser",
+    help="Link to a shared http_parser DLL instead of static linking")
+
+parser.add_option("--shared-http-parser-includes",
+    action="store",
+    dest="shared_http_parser_includes",
+    help="Directory containing http_parser header files")
+
+parser.add_option("--shared-http-parser-libpath",
+    action="store",
+    dest="shared_http_parser_libpath",
+    help="A directory to search for the shared http_parser DLL")
+
+parser.add_option("--shared-http-parser-libname",
+    action="store",
+    dest="shared_http_parser_libname",
+    help="Alternative lib name to link to (default: 'http_parser')")
+
 parser.add_option("--with-dtrace",
     action="store_true",
     dest="with_dtrace",
@@ -400,6 +420,20 @@ def configure_libz(o):
     o['include_dirs'] += [options.shared_zlib_includes]
 
 
+def configure_http_parser(o):
+    o['variables']['node_shared_http_parser'] = b(options.shared_http_parser)
+
+    # assume shared http_parser if one of these is set?
+    if options.shared_http_parser_libpath:
+        o['libraries'] += ['-L%s' % options.shared_http_parser_libpath]
+    if options.shared_http_parser_libname:
+        o['libraries'] += ['-l%s' % options.shared_http_parser_libname]
+    elif options.shared_http_parser:
+        o['libraries'] += ['-lhttp_parser']
+    if options.shared_http_parser_includes:
+        o['include_dirs'] += [options.shared_http_parser_includes]
+
+
 def configure_v8(o):
   o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
   o['variables']['node_shared_v8'] = b(options.shared_v8)
@@ -453,6 +487,7 @@ output = {
 
 configure_node(output)
 configure_libz(output)
+configure_http_parser(output)
 configure_v8(output)
 configure_openssl(output)
 

--- a/configure
+++ b/configure
@@ -144,6 +144,26 @@ parser.add_option("--shared-http-parser-libname",
     dest="shared_http_parser_libname",
     help="Alternative lib name to link to (default: 'http_parser')")
 
+parser.add_option("--shared-cares",
+    action="store_true",
+    dest="shared_cares",
+    help="Link to a shared cares DLL instead of static linking")
+
+parser.add_option("--shared-cares-includes",
+    action="store",
+    dest="shared_cares_includes",
+    help="Directory containing cares header files")
+
+parser.add_option("--shared-cares-libpath",
+    action="store",
+    dest="shared_cares_libpath",
+    help="A directory to search for the shared cares DLL")
+
+parser.add_option("--shared-cares-libname",
+    action="store",
+    dest="shared_cares_libname",
+    help="Alternative lib name to link to (default: 'cares')")
+
 parser.add_option("--with-dtrace",
     action="store_true",
     dest="with_dtrace",
@@ -434,6 +454,20 @@ def configure_http_parser(o):
         o['include_dirs'] += [options.shared_http_parser_includes]
 
 
+def configure_cares(o):
+    o['variables']['node_shared_cares'] = b(options.shared_cares)
+
+    # assume shared cares if one of these is set?
+    if options.shared_cares_libpath:
+        o['libraries'] += ['-L%s' % options.shared_cares_libpath]
+    if options.shared_cares_libname:
+        o['libraries'] += ['-l%s' % options.shared_cares_libname]
+    elif options.shared_cares:
+        o['libraries'] += ['-lcares']
+    if options.shared_cares_includes:
+        o['include_dirs'] += [options.shared_cares_includes]
+
+
 def configure_v8(o):
   o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
   o['variables']['node_shared_v8'] = b(options.shared_v8)
@@ -488,6 +522,7 @@ output = {
 configure_node(output)
 configure_libz(output)
 configure_http_parser(output)
+configure_cares(output)
 configure_v8(output)
 configure_openssl(output)
 

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -299,6 +299,7 @@ An example of the possible output looks like:
        { host_arch: 'x64',
          node_install_npm: 'true',
          node_prefix: '',
+         node_shared_cares: 'false',
          node_shared_http_parser: 'false',
          node_shared_v8: 'false',
          node_shared_zlib: 'false',

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -299,6 +299,7 @@ An example of the possible output looks like:
        { host_arch: 'x64',
          node_install_npm: 'true',
          node_prefix: '',
+         node_shared_http_parser: 'false',
          node_shared_v8: 'false',
          node_shared_zlib: 'false',
          node_use_dtrace: 'false',

--- a/node.gyp
+++ b/node.gyp
@@ -9,6 +9,7 @@
     'node_shared_v8%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
+    'node_shared_cares%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'library_files': [
@@ -58,7 +59,6 @@
       'type': 'executable',
 
       'dependencies': [
-        'deps/cares/cares.gyp:cares',
         'deps/uv/uv.gyp:libuv',
         'node_js2c#host',
       ],
@@ -194,6 +194,10 @@
 
         [ 'node_shared_http_parser=="false"', {
           'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
+        }],
+
+        [ 'node_shared_cares=="false"', {
+          'dependencies': [ 'deps/cares/cares.gyp:cares' ],
         }],
 
         [ 'OS=="win"', {

--- a/node.gyp
+++ b/node.gyp
@@ -8,6 +8,7 @@
     'node_use_etw%': 'false',
     'node_shared_v8%': 'false',
     'node_shared_zlib%': 'false',
+    'node_shared_http_parser%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'library_files': [
@@ -58,7 +59,6 @@
 
       'dependencies': [
         'deps/cares/cares.gyp:cares',
-        'deps/http_parser/http_parser.gyp:http_parser',
         'deps/uv/uv.gyp:libuv',
         'node_js2c#host',
       ],
@@ -190,6 +190,10 @@
 
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
+        }],
+
+        [ 'node_shared_http_parser=="false"', {
+          'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
         }],
 
         [ 'OS=="win"', {


### PR DESCRIPTION
Some distributions such as Fedora ship http_parser as a shared library in order to simplify pushing out security updates (only the package containing the shared library needs to be updated, rather than all packages compiling it statically). With this patch, Node.JS can be linked against the system library instead of the bundled copy.

Update: also give c-ares the same treatment
