### PR TITLE
[don't merge yet] 1.5x speed up setTimeout()

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -50,10 +50,10 @@ var lists = {};
 // the main function - creates lists on demand and the watchers associated
 // with them.
 function insert(item, msecs) {
-  item._idleStart = Date.now();
-  item._idleTimeout = msecs;
-
   if (msecs < 0) return;
+
+  if (!item._idleStart) item._idleStart = Date.now();
+  item._idleTimeout = msecs;
 
   var list;
 
@@ -155,7 +155,7 @@ exports.active = function(item) {
     if (!list || L.isEmpty(list)) {
       insert(item, msecs);
     } else {
-      item._idleStart = Date.now();
+      if (!item._idleStart) item._idleStart = Date.now();
       L.append(list, item);
     }
   }
@@ -248,12 +248,12 @@ var Timeout = function(after) {
   this._idleTimeout = after;
   this._idlePrev = this;
   this._idleNext = this;
-  this._when = Date.now() + after;
+  this._idleStart = Date.now();
 };
 
 Timeout.prototype.unref = function() {
   if (!this._handle) {
-    var delay = this._when - Date.now();
+    var delay = this._idleStart + this._idleTimeout - Date.now();
     if (delay < 0) delay = 0;
     exports.unenroll(this);
     this._handle = new Timer();


### PR DESCRIPTION
Main points are:
1. Do not set Timeout._when property at all -> less memory footprint.
2. Set Timeout._idleStart in the constructor due to this recommendations: http://s3.mrale.ph/nodecamp.eu/#55
3. Do not re-calculate Timeout._idleStart when it is set already.
4. Do not modify item in insert() when msecs < 0

This is not about timers accuracy. It's just about the time setTimeout() call take.

<a href="https://github.com/joyent/node/blob/master/benchmark/settimeout.js">Benchmark</a> results are the following:
node 0.8.12 + timers.js from 0.9.2:

```
wait...
smaller is better
startup: 11257
done: 999
```

node 0.8.12 + optimized timers.js from 0.9.2:

```
wait...
smaller is better
startup: 7610
done: 999
```

node 0.9.2 reproduces these results as well.
