### PR TITLE
5-50% speed up setTimeout()

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -249,6 +249,7 @@ var Timeout = function(after) {
   this._idlePrev = this;
   this._idleNext = this;
   this._idleStart = null;
+  this._onTimeout = null;
 };
 
 Timeout.prototype.unref = function() {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -248,12 +248,13 @@ var Timeout = function(after) {
   this._idleTimeout = after;
   this._idlePrev = this;
   this._idleNext = this;
-  this._when = Date.now() + after;
+  this._idleStart = null;
 };
 
 Timeout.prototype.unref = function() {
   if (!this._handle) {
-    var delay = this._when - Date.now();
+    if (!this._idleStart) this._idleStart = Date.now();
+    var delay = this._idleStart + this._idleTimeout - Date.now();
     if (delay < 0) delay = 0;
     exports.unenroll(this);
     this._handle = new Timer();

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -254,8 +254,9 @@ var Timeout = function(after) {
 
 Timeout.prototype.unref = function() {
   if (!this._handle) {
-    if (!this._idleStart) this._idleStart = Date.now();
-    var delay = this._idleStart + this._idleTimeout - Date.now();
+    var now = Date.now();
+    if (!this._idleStart) this._idleStart = now;
+    var delay = this._idleStart + this._idleTimeout - now;
     if (delay < 0) delay = 0;
     exports.unenroll(this);
     this._handle = new Timer();


### PR DESCRIPTION
Main points are:
1. Do not set Timeout._when property at all -> save a relatively slow Date.now() call & smaller memory footprint.
2. Set Timeout._idleStart and Timeout._onTimeout in the constructor due to these recommendations: http://s3.mrale.ph/nodecamp.eu/#55. Many runs of benchmark/settimeout.js verify this gives about 1-2% gain too.

<a href="https://github.com/joyent/node/blob/master/benchmark/settimeout.js">Benchmark</a> results are the following:
node 0.8.12 + timers.js from 0.9.2:

```
wait...
smaller is better
startup: 11257
done: 999
```

node 0.8.12 + optimized timers.js from 0.9.2:

```
wait...
smaller is better
startup: 7610
done: 999
```

node 0.9.2 reproduces these results as well.
