### PR TITLE
enable DEAD_CODE_STRIPPING for node target on mac

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -211,6 +211,9 @@
           'defines!': [
             'PLATFORM="mac"',
           ],
+          'xcode_settings': {
+            'DEAD_CODE_STRIPPING': 'YES',
+          },
           'defines': [
             # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
             'PLATFORM="darwin"',


### PR DESCRIPTION
Before enabling the node binary is 10MB after it's 8.7MB

Even though most people don't care about binary size I don't think there's much harm enabling this. It does need further testing on systems where people use more binary modules to make sure it hasn't removed portions that things may currently rely on.

/cc @isaacs and @tootallnate
