### PR TITLE
Fix Windows build error.

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -253,8 +253,11 @@
             {
               'action_name': 'node_etw',
               'inputs': [ 'src/res/node_etw_provider.man' ],
-              'outputs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
-              'action': [ 'mc <@(_inputs) -h <@(_outputs) -r <@(_outputs)' ]
+              'outputs': [
+                '<(SHARED_INTERMEDIATE_DIR)/node_etw_provider.rc',
+                '<(SHARED_INTERMEDIATE_DIR)/node_etw_provider.h',
+              ],
+              'action': [ 'mc <@(_inputs) -h <(SHARED_INTERMEDIATE_DIR) -r <(SHARED_INTERMEDIATE_DIR)' ]
             }
           ]
         } ]


### PR DESCRIPTION
The gyp target node_etw didn't list its output dependencies. This
was causing virgin builds to fail with a "failed to open file for
write" error.

With this corrected outputs list, gyp reliably pre-creates
required output directories.
