### PR TITLE
Timers can false start 1ms earlier than needed

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -76,7 +76,7 @@ function insert(item, msecs) {
       var first;
       while (first = L.peek(list)) {
         var diff = now - first._idleStart;
-        if (diff + 1 < msecs) {
+        if (diff < msecs) {
           list.start(msecs - diff, 0);
           debug(msecs + ' list wait because diff is ' + diff);
           return;

--- a/test/simple/test-timers-ordering.js
+++ b/test/simple/test-timers-ordering.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var i;
+
+var N = 30;
+
+var last_i = 0;
+var last_ts = 0;
+var start = Date.now();
+
+var f = function(i) {
+  if (i <= N) {
+    // check order
+    assert.equal(i, last_i + 1, 'order is broken: ' + i + ' != ' + last_i + ' + 1');
+    last_i = i;
+
+    // check that this iteration is fired at least 1ms later than the previous
+    var now = Date.now();
+    console.log(i, now);
+    assert(now >= last_ts + 1, 'current ts ' + now + ' < prev ts ' + last_ts + ' + 1');
+    last_ts = now;
+
+    // schedule next iteration
+    setTimeout(f, 1, i + 1);
+  }
+};
+f(1);


### PR DESCRIPTION
( Related issue: https://github.com/joyent/node/issues/534 )

@bnoordhuis , you actually introduced another bug in https://github.com/joyent/node/commit/82e9da9

Lets say:

```
var _idleStart = 0;
var msecs = 1000;
var now = 999;
var diff = now - _idleStart;
console.log('diff', diff);
if (diff + 1 < msecs) {
  console.log('schedule for', msecs - diff, 'ms more');
} else {
  console.log('immediate exec');
}
```

Outputs

```
diff 999
immediate exec
```

which is definitely wrong.

There is a complete test for this bug. You can include into node/test/simple:

``` javascript
var common = require('../common');
var assert = require('assert');
var i;

var N = 30;

var last_i = 0;
var last_ts = 0;
var start = Date.now();

var f = function(i) {
  if (i <= N) {
    // check order
    assert(i == last_i + 1, 'iteration order is broken on ' + i + 'th iteration, prev is ' + last_i);
    last_i = i;

    // check that this iteration has been fired at leat 1ms later than the previous
    var now = Date.now();
    console.log(i, now);
    assert(now >= last_ts + 1, 'iteration has been fired within the same ms as the previous on ' + i + 'th iteration');
    last_ts = now;

    // schedule next iteration
    setTimeout(f, 1, i + 1);
  }
}
f(1);
```

it fails on the current master:

```
1 1351075317097
2 1351075317103
3 1351075317106
4 1351075317106

timers.js:102
            if (!process.listeners('uncaughtException').length) throw e;
                                                                      ^
AssertionError: iteration has been fired within the same ms as the previous on 4th iteration
    at f (/home/wicked/Alawar/node/test/simple/test-next-tick-ordering3.js:41:5)
    at exports.setTimeout.timer._onTimeout (timers.js:195:16)
    at Timer.list.ontimeout (timers.js:100:19)
    at process.startup.processMakeCallback.process._makeCallback (node.js:248:20)
```

If I revert the https://github.com/joyent/node/commit/82e9da9 , the test passes.
