### PR TITLE
doc: reflect hostname v. host preference in examples

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -512,7 +512,7 @@ upload a file with a POST request, then write to the `ClientRequest` object.
 Example:
 
     var options = {
-      host: 'www.google.com',
+      hostname: 'www.google.com',
       port: 80,
       path: '/upload',
       method: 'POST'
@@ -601,7 +601,7 @@ pool you can do something along the lines of:
 
 Alternatively, you could just opt out of pooling entirely using `agent:false`:
 
-    http.get({host:'localhost', port:80, path:'/', agent:false}, function (res) {
+    http.get({hostname:'localhost', port:80, path:'/', agent:false}, function (res) {
       // Do stuff
     })
 
@@ -726,7 +726,7 @@ A client server pair that show you how to listen for the `connect` event.
       // make a request to a tunneling proxy
       var options = {
         port: 1337,
-        host: '127.0.0.1',
+        hostname: '127.0.0.1',
         method: 'CONNECT',
         path: 'www.google.com:80'
       };
@@ -783,7 +783,7 @@ A client server pair that show you how to listen for the `upgrade` event.
       // make a request
       var options = {
         port: 1337,
-        host: '127.0.0.1',
+        hostname: '127.0.0.1',
         headers: {
           'Connection': 'Upgrade',
           'Upgrade': 'websocket'

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -71,7 +71,7 @@ Example:
     var https = require('https');
 
     var options = {
-      host: 'encrypted.google.com',
+      hostname: 'encrypted.google.com',
       port: 443,
       path: '/',
       method: 'GET'
@@ -137,7 +137,7 @@ In order to specify these options, use a custom `Agent`.
 Example:
 
     var options = {
-      host: 'encrypted.google.com',
+      hostname: 'encrypted.google.com',
       port: 443,
       path: '/',
       method: 'GET',
@@ -155,7 +155,7 @@ Or does not use an `Agent`.
 Example:
 
     var options = {
-      host: 'encrypted.google.com',
+      hostname: 'encrypted.google.com',
       port: 443,
       path: '/',
       method: 'GET',


### PR DESCRIPTION
The documentation for http.request and https.request states that
`hostname` is preferred over `host` so the code examples should
use that option name.
