### PR TITLE
Fix build with gcc 4.7.0 on sunos: use -pthreads

### DIFF
--- a/wscript
+++ b/wscript
@@ -424,11 +424,7 @@ def configure(conf):
 
   conf.define("HAVE_CONFIG_H", 1)
 
-  if sys.platform.startswith("sunos"):
-    conf.env.append_value ('CCFLAGS', '-threads')
-    conf.env.append_value ('CXXFLAGS', '-threads')
-    #conf.env.append_value ('LINKFLAGS', ' -threads')
-  elif not sys.platform.startswith("cygwin") and not sys.platform.startswith("win32"):
+  if not sys.platform.startswith("cygwin") and not sys.platform.startswith("win32"):
     threadflags='-pthread'
     conf.env.append_value ('CCFLAGS', threadflags)
     conf.env.append_value ('CXXFLAGS', threadflags)


### PR DESCRIPTION
Specifically I'm testing on a recent smartos.  With this recent gcc
version at least the "-threads" option is an HPPA-only option. The use
of '-threads' for sunos builds dates back to
https://github.com/joyent/node/commit/4279725d790b5b23e89e4ff90cff2c03be21635d

I know that a new v0.4 build isn't planned, but this would help those stuck deploying old v0.4-only services to a new sunos box.
