### PR TITLE
tls: delete useless removeListener call

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1321,7 +1321,6 @@ function pipe(pair, socket) {
 
   function onclose() {
     socket.removeListener('error', onerror);
-    socket.removeListener('end', onclose);
     socket.removeListener('timeout', ontimeout);
   }
 


### PR DESCRIPTION
onclose was never attached to 'end' so this call to remove this listener
is useless.  Delete it.
