### PR TITLE
let gyp choose msvs version - VS2012 support

### DIFF
--- a/configure
+++ b/configure
@@ -495,7 +495,7 @@ write('config.mk',
 if options.use_ninja:
   gyp_args = ['-f', 'ninja']
 elif os.name == 'nt':
-  gyp_args = ['-f', 'msvs', '-G', 'msvs_version=2010']
+  gyp_args = ['-f', 'msvs', '-G', 'msvs_version=auto']
 elif options.dest_os:
   gyp_args = ['-f', 'make-' + options.dest_os]
 else:


### PR DESCRIPTION
With this patch node can be compiled with VS2012. Can someone test on a VS2010 system to assure that gyp chooses well the version?

Thank you.
