### PR TITLE
build: fix default dtrace flag on Linux

### DIFF
--- a/configure
+++ b/configure
@@ -134,7 +134,7 @@ parser.add_option("--shared-zlib-libname",
 parser.add_option("--with-dtrace",
     action="store_true",
     dest="with_dtrace",
-    help="Build with DTrace (default is true on supported systems)")
+    help="Build with DTrace (default is true on sunos)")
 
 parser.add_option("--without-dtrace",
     action="store_true",
@@ -384,7 +384,7 @@ def configure_node(o):
   # SunOS, and we haven't implemented it.)
   if sys.platform.startswith('sunos'):
     o['variables']['node_use_dtrace'] = b(not options.without_dtrace)
-  elif sys.platform.startswith('linux'):
+  elif sys.platform.startswith('linux') and options.with_dtrace:
     o['variables']['node_use_dtrace'] = 'false'
     o['variables']['node_use_systemtap'] = b(not options.without_dtrace)
     if options.systemtap_includes:
@@ -394,6 +394,7 @@ def configure_node(o):
        'DTrace is currently only supported on SunOS or Linux systems.')
   else:
     o['variables']['node_use_dtrace'] = 'false'
+    o['variables']['node_use_systemtap'] = 'false'
 
   if options.no_ifaddrs:
     o['defines'] += ['SUNOS_NO_IFADDRS']

--- a/configure
+++ b/configure
@@ -384,9 +384,9 @@ def configure_node(o):
   # SunOS, and we haven't implemented it.)
   if sys.platform.startswith('sunos'):
     o['variables']['node_use_dtrace'] = b(not options.without_dtrace)
-  elif sys.platform.startswith('linux') and options.with_dtrace:
+  elif sys.platform.startswith('linux'):
     o['variables']['node_use_dtrace'] = 'false'
-    o['variables']['node_use_systemtap'] = b(not options.without_dtrace)
+    o['variables']['node_use_systemtap'] = b(options.with_dtrace)
     if options.systemtap_includes:
       o['include_dirs'] += [options.systemtap_includes]
   elif b(options.with_dtrace) == 'true':


### PR DESCRIPTION
06810b29fae7c549c3a016f2faa3cf6b444a1149 cause a build failure on Linux which has no DTrace.
DTrace on Linux should not be enabled by default but needs explicitly with --with-dtrace option flag in configure.
