### PR TITLE
doc: tls: rejectUnauthorized defaults to true after 35607f3a

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1043,13 +1043,13 @@ SecurePair.prototype.error = function() {
 //   If true clients whose certificates are invalid for any reason will not
 //   be allowed to make connections. If false, they will simply be marked as
 //   unauthorized but secure communication will continue. By default this is
-//   false.
+//   true.
 //
 //
 //
 // Options:
 // - requestCert. Send verify request. Default to false.
-// - rejectUnauthorized. Boolean, default to false.
+// - rejectUnauthorized. Boolean, default to true.
 // - key. string.
 // - cert: string.
 // - ca: string or array of strings.


### PR DESCRIPTION
On a side note, making a tls connection to servers without a valid certificates crashes node master.

Assertion failed: (!!(events & UV__IO_READ) ^ !!(events & UV__IO_WRITE)), function uv__stream_io, file ../deps/uv/src/unix/stream.c, line 1037.
Abort trap: 6
