### PR TITLE
Fix hardfloat detection

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -163,7 +163,7 @@
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'cflags': [ '-Wall', '-pthread', ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
-        'ldflags': [ '-pthread', '-rdynamic' ],
+        'ldflags': [ '-pthread' ],
         'conditions': [
           [ 'target_arch=="ia32"', {
             'cflags': [ '-m32' ],

--- a/deps/v8/build/common.gypi
+++ b/deps/v8/build/common.gypi
@@ -29,6 +29,7 @@
 
 {
   'variables': {
+    'arm_neon%': 1,
     'use_system_v8%': 0,
     'msvs_use_common_release': 0,
     'gcc_version%': 'unknown',

--- a/deps/v8/src/platform-linux.cc
+++ b/deps/v8/src/platform-linux.cc
@@ -170,7 +170,7 @@ bool OS::ArmCpuHasFeature(CpuFeature feature) {
 // calling this will return 1.0 and otherwise 0.0.
 static void ArmUsingHardFloatHelper() {
   asm("mov r0, #0":::"r0");
-#if defined(__VFP_FP__) && !defined(__SOFTFP__)
+#if defined(__ARM_PCS_VFP) && !defined(__SOFTFP__)
   // Load 0x3ff00000 into r1 using instructions available in both ARM
   // and Thumb mode.
   asm("mov r1, #3":::"r1");
@@ -195,7 +195,7 @@ static void ArmUsingHardFloatHelper() {
 #else
   asm("vmov d0, r0, r1");
 #endif  // __thumb__
-#endif  // defined(__VFP_FP__) && !defined(__SOFTFP__)
+#endif  // defined(__ARM_PCS_VFP) && !defined(__SOFTFP__)
   asm("mov r1, #0":::"r1");
 }
 


### PR DESCRIPTION
gcc has a builtin define to denote hard abi when in use, e.g. when
using -mfloat-abi=hard it will define `__ARM_PCS_VFP` to 1 and therefore
we should check that to determine which calling convention is in use
and not `__VFP_FP__` which merely indicates presence of VFP unit

The fix has been provided by Khem Raj raj.khem@gmail.com

Updated to v0.8 branch and resubmitted by Jason Kridner jdk@ti.com

Upstream-Status: Forwarded
