### PR TITLE
document child_process.spawn option, windowsVerbatimArguments

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -249,6 +249,8 @@ there is no IPC channel keeping it alive. When calling this method the
   * `customFds` {Array} **Deprecated** File descriptors for the child to use
     for stdio.  (See below)
   * `env` {Object} Environment key-value pairs
+  * `windowsVerbatimArguments` {Boolean} Disable unix-like argument formatting and 
+    instead use only spaces to separate provided arguments.
   * `detached` {Boolean} The child will be a process group leader.  (See below)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)


### PR DESCRIPTION
initial attempt at documenting child_process.spawn's `windowsVerbatimArguments` option

...I know, I know, no topic branch. I blame the github online editor for not having that capability.  I'm on my cr48 right now and don't have a git client accessible.
