### PR TITLE
fix bug in node_crypto.cc

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -890,9 +890,9 @@ int Connection::HandleBIOError(BIO *bio, const char* func, int rv) {
 }
 
 
-int Connection::HandleSSLError(const char* func, int rv, bool zeroIsAnError) {
+int Connection::HandleSSLError(const char* func, int rv, ZeroStatus zs) {
   if (rv > 0) return rv;
-  if ((rv == 0) && !zeroIsAnError) return rv;
+  if ((rv == 0) && (zs == kZeroIsNotAnError)) return rv;
 
   int err = SSL_get_error(ssl_, rv);
 
@@ -1349,17 +1349,17 @@ Handle<Value> Connection::ClearOut(const Arguments& args) {
 
     if (ss->is_server_) {
       rv = SSL_accept(ss->ssl_);
-      ss->HandleSSLError("SSL_accept:ClearOut", rv);
+      ss->HandleSSLError("SSL_accept:ClearOut", rv, kZeroIsAnError);
     } else {
       rv = SSL_connect(ss->ssl_);
-      ss->HandleSSLError("SSL_connect:ClearOut", rv);
+      ss->HandleSSLError("SSL_connect:ClearOut", rv, kZeroIsAnError);
     }
 
     if (rv < 0) return scope.Close(Integer::New(rv));
   }
 
   int bytes_read = SSL_read(ss->ssl_, buffer_data + off, len);
-  ss->HandleSSLError("SSL_read:ClearOut", bytes_read, false);
+  ss->HandleSSLError("SSL_read:ClearOut", bytes_read, kZeroIsNotAnError);
   ss->SetShutdownFlags();
 
   return scope.Close(Integer::New(bytes_read));
@@ -1459,10 +1459,10 @@ Handle<Value> Connection::ClearIn(const Arguments& args) {
     int rv;
     if (ss->is_server_) {
       rv = SSL_accept(ss->ssl_);
-      ss->HandleSSLError("SSL_accept:ClearIn", rv);
+      ss->HandleSSLError("SSL_accept:ClearIn", rv, kZeroIsAnError);
     } else {
       rv = SSL_connect(ss->ssl_);
-      ss->HandleSSLError("SSL_connect:ClearIn", rv);
+      ss->HandleSSLError("SSL_connect:ClearIn", rv, kZeroIsAnError);
     }
 
     if (rv < 0) return scope.Close(Integer::New(rv));
@@ -1470,7 +1470,7 @@ Handle<Value> Connection::ClearIn(const Arguments& args) {
 
   int bytes_written = SSL_write(ss->ssl_, buffer_data + off, len);
 
-  ss->HandleSSLError("SSL_write:ClearIn", bytes_written);
+  ss->HandleSSLError("SSL_write:ClearIn", bytes_written, kZeroIsAnError);
   ss->SetShutdownFlags();
 
   return scope.Close(Integer::New(bytes_written));
@@ -1698,10 +1698,10 @@ Handle<Value> Connection::Start(const Arguments& args) {
     int rv;
     if (ss->is_server_) {
       rv = SSL_accept(ss->ssl_);
-      ss->HandleSSLError("SSL_accept:Start", rv);
+      ss->HandleSSLError("SSL_accept:Start", rv, kZeroIsAnError);
     } else {
       rv = SSL_connect(ss->ssl_);
-      ss->HandleSSLError("SSL_connect:Start", rv);
+      ss->HandleSSLError("SSL_connect:Start", rv, kZeroIsAnError);
     }
 
     return scope.Close(Integer::New(rv));
@@ -1718,20 +1718,7 @@ Handle<Value> Connection::Shutdown(const Arguments& args) {
 
   if (ss->ssl_ == NULL) return False();
   int rv = SSL_shutdown(ss->ssl_);
-
-  if (rv == 0) {
-    // from http://openssl.org/docs/ssl/SSL_shutdown.html:
-    //
-    //    The shutdown is not yet finished. Call SSL_shutdown() for a second time, 
-    //    if a bidirectional shutdown shall be performed. The output of SSL_get_error(3) 
-    //    may be misleading, as an erroneous SSL_ERROR_SYSCALL may be flagged even though 
-    //    no error occurred.
-    //
-    // Do we need bidirectional shutdown? I guess "yes", but someone more experienced should make decision. 
-    rv = SSL_shutdown(ss->ssl_);
-  } 
-
-  ss->HandleSSLError("SSL_shutdown", rv, false);
+  ss->HandleSSLError("SSL_shutdown", rv, kZeroIsNotAnError);
   ss->SetShutdownFlags();
 
   return scope.Close(Integer::New(rv));

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -214,7 +214,7 @@ class Connection : ObjectWrap {
 #endif
 
   int HandleBIOError(BIO *bio, const char* func, int rv);
-  int HandleSSLError(const char* func, int rv);
+  int HandleSSLError(const char* func, int rv, bool zeroIsAnError = true);
 
   void ClearError();
   void SetShutdownFlags();

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -214,7 +214,13 @@ class Connection : ObjectWrap {
 #endif
 
   int HandleBIOError(BIO *bio, const char* func, int rv);
-  int HandleSSLError(const char* func, int rv, bool zeroIsAnError = true);
+
+  enum ZeroStatus {
+    kZeroIsNotAnError,
+    kZeroIsAnError
+  };
+
+  int HandleSSLError(const char* func, int rv, ZeroStatus zs);
 
   void ClearError();
   void SetShutdownFlags();


### PR DESCRIPTION
Fixed problem: 

1) OpenSSL contains errors in thread-specific errors stacks. Becouse of asynchronous nature of nodejs, all nodejs connections share the same errors stack. So, if you didn't process error (and clean stack) in one connection, you will surprisingly get it in another one.

2) Function SSL_get_error can not work correctly if before apropriate SSL/TLS call errors stack was not empty (see http://openssl.org/docs/ssl/SSL_get_error.html )

3) Your version of HandleSSLError always interpret zero as a non-error code. For SSL_accept, SSL_connect and SS_write it is not true (see http://openssl.org/docs/ssl/SSL_connect.html ).  Apropriate errors were never processed and another connection got them.

4) And see comment about SSL_shutdown in my code.
