### PR TITLE
Remove duplicate assertion tests

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1015,15 +1015,6 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
-
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
-
-    assert.ok(offset < buffer.length,
-        'Trying to write beyond buffer length');
-
     verifsint(value, 0x7f, -0x80);
   }
 
@@ -1036,18 +1027,6 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
 
 function writeInt16(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
-
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
-
-    assert.ok(offset + 1 < buffer.length,
-        'Trying to write beyond buffer length');
-
     verifsint(value, 0x7fff, -0x8000);
   }
 
@@ -1068,18 +1047,6 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
 
 function writeInt32(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
-
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
-
-    assert.ok(offset + 3 < buffer.length,
-        'Trying to write beyond buffer length');
-
     verifsint(value, 0x7fffffff, -0x80000000);
   }
 


### PR DESCRIPTION
Many assertion tests are duplicated in buffer.js. These few could be
easily removed and still have all tests pass.
