### PR TITLE
Initial buffer_ieee754 Micro Optimizations

### DIFF
--- a/lib/buffer_ieee754.js
+++ b/lib/buffer_ieee754.js
@@ -30,6 +30,8 @@
 //
 // Modifications to writeIEEE754 to support negative zeroes made by Brian White
 
+const RTFIX = Math.pow(2, -24) - Math.pow(2, -77);
+
 exports.readIEEE754 = function(buffer, offset, isBE, mLen, nBytes) {
   var e, m,
       eLen = nBytes * 8 - mLen - 1,
@@ -64,46 +66,40 @@ exports.readIEEE754 = function(buffer, offset, isBE, mLen, nBytes) {
 };
 
 exports.writeIEEE754 = function(buffer, value, offset, isBE, mLen, nBytes) {
-  var e, m, c,
+  var m,
       eLen = nBytes * 8 - mLen - 1,
       eMax = (1 << eLen) - 1,
       eBias = eMax >> 1,
-      rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0),
+      rt = mLen === 23 ? RTFIX : 0,
       i = isBE ? (nBytes - 1) : 0,
       d = isBE ? -1 : 1,
-      s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0;
+      s = value < 0 || (value === 0 && 1 / value < 0) ? (value = -value, 1) : 0,
+      e = Math.floor(Math.log(value) / Math.LN2),
+      c = Math.pow(2, -e);
 
-  value = Math.abs(value);
-
-  if (isNaN(value) || value === Infinity) {
-    m = isNaN(value) ? 1 : 0;
-    e = eMax;
+  if (value * c < 1) {
+    e--;
+    c *= 2;
+  }
+  if (e + eBias >= 1) {
+    value += rt / c;
   } else {
-    e = Math.floor(Math.log(value) / Math.LN2);
-    if (value * (c = Math.pow(2, -e)) < 1) {
-      e--;
-      c *= 2;
-    }
-    if (e + eBias >= 1) {
-      value += rt / c;
-    } else {
-      value += rt * Math.pow(2, 1 - eBias);
-    }
-    if (value * c >= 2) {
-      e++;
-      c /= 2;
-    }
+    value += rt * Math.pow(2, 1 - eBias);
+  }
+  if (value * c >= 2) {
+    e++;
+    c /= 2;
+  }
 
-    if (e + eBias >= eMax) {
-      m = 0;
-      e = eMax;
-    } else if (e + eBias >= 1) {
-      m = (value * c - 1) * Math.pow(2, mLen);
-      e = e + eBias;
-    } else {
-      m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
-      e = 0;
-    }
+  if (e + eBias >= eMax) {
+    m = 0;
+    e = eMax;
+  } else if (e + eBias >= 1) {
+    m = (value * c - 1) * Math.pow(2, mLen);
+    e = e + eBias;
+  } else {
+    m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
+    e = 0;
   }
 
   for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8);


### PR DESCRIPTION
Attempting to bring writeIEEE754 performance closer to that of
DataView's setFloat32. These few small changes increase performance by
about 20%. They include:
- Removal of isNaN() checks. Arguments are controlled, so no need for
  that check.
- Variable rt wasn't caching a static result. Added that as constant at
  top of script.
- Inlined the absolute assignation of value.
- Assigned more values at beginning because of previous.
