### PR TITLE
Do not cache stdout or stderr when there is no callback

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -586,21 +586,23 @@ exports.execFile = function(file /* args, options, callback */) {
   child.stdout.setEncoding(options.encoding);
   child.stderr.setEncoding(options.encoding);
 
-  child.stdout.addListener('data', function(chunk) {
-    stdout += chunk;
-    if (stdout.length > options.maxBuffer) {
-      err = new Error('stdout maxBuffer exceeded.');
-      kill();
-    }
-  });
+  if (callback) {
+    child.stdout.addListener('data', function(chunk) {
+      stdout += chunk;
+      if (stdout.length > options.maxBuffer) {
+        err = new Error('stdout maxBuffer exceeded.');
+        kill();
+      }
+    });
 
-  child.stderr.addListener('data', function(chunk) {
-    stderr += chunk;
-    if (stderr.length > options.maxBuffer) {
-      err = new Error('stderr maxBuffer exceeded.');
-      kill();
-    }
-  });
+    child.stderr.addListener('data', function(chunk) {
+      stderr += chunk;
+      if (stderr.length > options.maxBuffer) {
+        err = new Error('stderr maxBuffer exceeded.');
+        kill();
+      }
+    });
+  }
 
   child.addListener('close', exithandler);
   child.addListener('error', errorhandler);


### PR DESCRIPTION
Sometimes we need to stream output of exec, there could be large amount of data. We use "event" instead of "callback" on this situation, but still limited by cache of stdout.
