### PR TITLE
v8dbg_* symbols not available when NodeJS is statically linked with V8

### DIFF
--- a/deps/v8/src/v8.cc
+++ b/deps/v8/src/v8.cc
@@ -44,6 +44,10 @@
 #include "serialize.h"
 #include "store-buffer.h"
 
+#if defined(POSTMORTEM_SUPPORT)
+#include <debug-support.h>
+#endif
+
 namespace v8 {
 namespace internal {
 

--- a/deps/v8/tools/gyp/v8.gyp
+++ b/deps/v8/tools/gyp/v8.gyp
@@ -744,8 +744,14 @@
               ],
             }],
             ['v8_postmortem_support=="true"', {
+              'defines': [
+                'POSTMORTEM_SUPPORT'
+              ],
+              'include_dirs': [
+                '<(SHARED_INTERMEDIATE_DIR)'
+              ],
               'sources': [
-                '<(SHARED_INTERMEDIATE_DIR)/debug-support.cc',
+                '<(SHARED_INTERMEDIATE_DIR)/debug-support.h',
               ],
               'dependencies': ['postmortem-metadata']
             }],
@@ -841,7 +847,7 @@
                   '<@(heapobject_files)',
                 ],
                 'outputs': [
-                  '<(SHARED_INTERMEDIATE_DIR)/debug-support.cc',
+                  '<(SHARED_INTERMEDIATE_DIR)/debug-support.h',
                 ],
                 'action': [
                   'python',


### PR DESCRIPTION
When NodeJS is statically linked with libv8_base.a, which is the default, I've found that the v8dbg_\* debug symbols generated by `deps/v8/tools/gen-postmortem-metadata.py` are not included in the node binaries. This makes debugging with GDB or writing DTrace or SystemTap probes more difficult than needed (see `tools/genv8constants.py`).

After some hunting around, I found that while debug-support.cc is being generated and compiled, the `debug-support.o` object file is never linked into the node binaries. This is because the linker decides that nothing in the node binary actually uses anything defined in `debug-support.o`, and skips the object file entirely.

I've found a surprisingly trivial fix: instead of a C++ file, create a header file instead, then #include it somewhere which is certainly going to get linked into node.

Any comments and suggestions are very welcome.

Tested with gdb and SystemTap

```
$ gdb out/Debug/node
[...]
(gdb) p v8dbg_SmiTagMask
$1 = 1
```

```
# stap -e 'probe process.function("main") { printf("%s: %s(%d)\n", pp(), execname(), pid()); printf("v8dbg_SmiTagMask = %d\n", @var("v8dbg_SmiTagMask@v8.cc")) }' -c out/Debug/node
process("/home/miki/vcs/git/node/out/Debug/node").function("main@../src/node_main.cc:64"): node(10908)
v8dbg_SmiTagMask = 1
```
