### PR TITLE
EventEmitter handles an object has 'handleEvent' property like DOM Event

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -120,21 +120,36 @@ EventEmitter.prototype.emit = function() {
 
     var listeners = handler.slice();
     for (var i = 0, l = listeners.length; i < l; i++) {
-      listeners[i].apply(this, args);
+      if (typeof listeners[i] === 'function')
+        listeners[i].apply(this, args);
+      else if (typeof listeners[i] === 'object' && 'handleEvent' in listeners[i])
+        listeners[i].handleEvent.call(listeners[i], type, args);
     }
     if (this.domain && this !== PROCESS) {
       this.domain.exit();
     }
     return true;
 
+  } else if (typeof handler === 'object' && 'handleEvent' in handler) {
+    var l = arguments.length;
+    var args = new Array(l - 1);
+    for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+    handler.handleEvent.call(handler, type, args);
+
+    if (this.domain && this !== PROCESS) {
+      this.domain.exit();
+    }
+    return true;
   } else {
     return false;
   }
 };
 
 EventEmitter.prototype.addListener = function(type, listener) {
-  if ('function' !== typeof listener) {
-    throw new Error('addListener only takes instances of Function');
+  if ('function' !== typeof listener &&
+      !('object' === typeof listener && 'handleEvent' in listener))
+  {
+    throw new Error('addListener only takes instances of Function or Object has "handleEvent"');
   }
 
   if (!this._events) this._events = {};
@@ -185,15 +200,24 @@ EventEmitter.prototype.addListener = function(type, listener) {
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 EventEmitter.prototype.once = function(type, listener) {
-  if ('function' !== typeof listener) {
-    throw new Error('.once only takes instances of Function');
+  if ('function' !== typeof listener &&
+      !('object' === typeof listener && 'handleEvent' in listener))
+  {
+    throw new Error('.once only takes instances of Function or Object has "handleEvent"');
   }
-
-  var self = this;
-  function g() {
-    self.removeListener(type, g);
-    listener.apply(this, arguments);
-  };
+  var self = this,
+      g;
+  if ('function' === typeof listener) {
+    g = function g() {
+      self.removeListener(type, g);
+      listener.apply(this, arguments);
+    };
+  } else if ('object' === typeof listener && 'handleEvent' in listener) {
+    g = function g() {
+      self.removeListener(type, g);
+      listener.handleEvent(type, Array.prototype.slice.call(arguments));
+    };
+  }
 
   g.listener = listener;
   self.on(type, g);
@@ -203,8 +227,10 @@ EventEmitter.prototype.once = function(type, listener) {
 
 // emits a 'removeListener' event iff the listener was removed
 EventEmitter.prototype.removeListener = function(type, listener) {
-  if ('function' !== typeof listener) {
-    throw new Error('removeListener only takes instances of Function');
+  if ('function' !== typeof listener &&
+      !('object' === typeof listener && 'handleEvent' in listener))
+  {
+    throw new Error('removeListener only takes instances of Function or Object has "handleEvent"');
   }
 
   // does not use listeners(), so no side effect of creating _events[type]

--- a/test/simple/test-event-emitter-add-listeners-hendleEvent.js
+++ b/test/simple/test-event-emitter-add-listeners-hendleEvent.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var e = new events.EventEmitter();
+
+var handler = {
+  name: 'handler',
+  num: 0,
+  handleEvent: function (type, args) {
+    console.log('handler called: ' + ++this.num);
+    assert.equal('hello', type);
+    assert.deepEqual(['a', 'b'], args);
+    assert.equal('handler', this.name);
+  }
+};
+
+console.log('start: EventEmitter-handleEvent tests');
+
+e.on('newListener', function(event, listener) {
+  console.log('newListener:', event);
+});
+e.on('hello', handler);
+e.once('hello', handler);
+
+e.emit('hello', 'a', 'b');
+e.emit('hello', 'a', 'b');
+
+process.on('exit', function() {
+  assert.equal(3, handler.num);
+});
+


### PR DESCRIPTION
This patch allows addListener an object has `handleEvent` method for binding the current execution context to the object.

example:

```
var events = require("events");
var e = new event.EventEmitter();
var handler = {
  name: "handler",
  handleEvent: function(type, args) {
    console.log(type, this.name);
  }
};
e.on("hello", handler);
e.emit("hello");
```
