### PR TITLE
Protect against HTTP response splitting

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -698,7 +698,11 @@ OutgoingMessage.prototype._renderHeaders = function() {
   var keys = Object.keys(this._headers);
   for (var i = 0, l = keys.length; i < l; i++) {
     var key = keys[i];
-    headers[this._headerNames[key]] = this._headers[key];
+    var value = this._headers[key];
+    /* protect against HTTP response splitting: */
+    if(value.indexOf("\r") == -1 && value.indexOf("\n") == -1) {
+      headers[this._headerNames[key]] = value;
+    }
   }
   return headers;
 };


### PR DESCRIPTION
The HTTP module is currently vulnerable to response splitting attacks.

Here's an example:

``` javascript
var http = require("http"),
    url  = require("url");

http.createServer(function (req, res) {
  var queryData = url.parse(req.url, true).query;
  res.writeHead(302, { "Location": queryData.redirect });
  res.end();
}).listen(1337, "127.0.0.1");
```

An attacker can split the response by passing `%0d%0a` in the query string in order to inject their own headers/body.

Here's a PoC link: http://127.0.0.1:1337/?redirect=%0d%0aContent-Length:%2033%0d%0a%0d%0a%3Ch1%3E%3Cmarquee%3Eowned%3C/marquee%3E%3C/h1%3E
