### PR TITLE
doc: fix typo in setPrivateKey function signature

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -366,7 +366,7 @@ Sets the Diffie-Hellman public key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is
 expected.
 
-### diffieHellman.setPrivateKey(public_key, [encoding])
+### diffieHellman.setPrivateKey(private_key, [encoding])
 
 Sets the Diffie-Hellman private key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is


### PR DESCRIPTION
setPrivateKey documentation lists public_key as input parameter while instead a private_key is expected.
