### PR TITLE
build: disable to use thin archive

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -163,6 +163,11 @@
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-pthread', ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
         'ldflags': [ '-pthread', '-rdynamic' ],
+        'target_conditions': [
+          ['_type=="static_library"', {
+            'standalone_static_library': 1, # disable thin archive which needs binutils >= 2.19
+          }],
+        ],
         'conditions': [
           [ 'target_arch=="ia32"', {
             'cflags': [ '-m32' ],


### PR DESCRIPTION
Updated gyp uses thin archive by using  `ar crsT` and causes build failures in old systems such as CentOS5.8 and SmartOS on node-ninja.com 
thin archive needs binutils >= 2.19. So it is better to disable thin archive for supporting old ar even if static libraries are linked within a local build.
