### PR TITLE
fix ETIMEDOUT node.js crash

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -785,6 +785,10 @@ function errnoException(errorno, syscall) {
   // TODO make this more compatible with ErrnoException from src/node.cc
   // Once all of Node is using this function the ErrnoException from
   // src/node.cc should be removed.
+  if ((typeof errorno === "undefined")||(typeof syscall === "undefined")){
+    var e = new Error("Uncaught, unspecified 'error' event.");
+    return e;
+  }
   var e = new Error(syscall + ' ' + errorno);
   e.errno = e.code = errorno;
   e.syscall = syscall;


### PR DESCRIPTION
I use node.js to send a lot of get requests with fixed request/sec rate
sometimes node.js crash with

events.js:66
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: connect ETIMEDOUT
    at errnoException (net.js:769:11)
    at Object.afterConnect [as oncomplete](net.js:760:19)

because ETIMEDOUT not recognised in js code 
i am fixed that
