### PR TITLE
`./config --debug`: node's .default_configuration should be 'Debug' for debug binary, 'Release' for release binary

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -332,6 +332,7 @@
           'inputs': [
             '<@(library_files)',
             './config.gypi',
+            'src/natives_macros.py',
           ],
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/node_natives.h',
@@ -349,6 +350,8 @@
             }]
           ],
               'action': [
+                'env',
+                'BUILDTYPE=$(BUILDTYPE)',
                 '<(python)',
                 'tools/js2c.py',
                 '<@(_outputs)',

--- a/src/natives_macros.py
+++ b/src/natives_macros.py
@@ -1,0 +1,5 @@
+# This file is used by tools/js2c.py to preprocess the files in lib/
+
+# Replace BUILDTYPE(x) with the current build type
+# Note: x must be specified, but can be anything.
+python macro BUILDTYPE(x) = repr(os.environ["BUILDTYPE"]);

--- a/src/node.js
+++ b/src/node.js
@@ -235,6 +235,7 @@
       if (value === 'false') return false;
       return value;
     });
+    process.config.target_defaults.default_configuration = BUILDTYPE('');
   };
 
   startup.processMakeCallback = function() {


### PR DESCRIPTION
NodeJS from Git, configured with (among other things)  `./configure --debug`, builds both a Debug and a Release build of node.
`make install` installs the Release build, but `node -e 'console.log(process.config.target_defaults.default_configuration)'` still gives "Debug" when using the Release build node binary.

From what I've found, this causes node-gyp to build Debug versions of addons unless '-r' option is specified.
This causes problem when `npm install` builds these addons as dependencies, since no way to specify '-r' option to node-gyp. Not all entry scripts are designed to deal with path to the Debug build of the addon, so using these modules will fail.

Wouldn't it be much more logical to have process.config.target_defaults.default_configuration be:
- 'Release' for out/Release/node (and the binary installed with `make install`)
  and
- 'Debug` for out/Debug/node

?
