### PR TITLE
Support ARM arch for makefile `binary` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,11 @@ endif
 ifeq ($(DESTCPU),x64)
 ARCH=x64
 else
+ifeq ($(DESTCPU),arm)
+ARCH=arm
+else
 ARCH=x86
+endif
 endif
 TARNAME=node-$(VERSION)
 TARBALL=$(TARNAME).tar.gz


### PR DESCRIPTION
Makefile for creating release binary packages currently only checks for x64, and if not assumes x86. As node also supports arm architectures, it should set ARCH variable correctly. Further work may be necessary to distinguish between the variants (e.g. neon, vfp, vfp3, etc.), but at least this patch makes sure that ARM tarballs can't get confused with x86 ones.
