### PR TITLE
piped stream w/dst err listener should not throw

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -74,16 +74,26 @@ Stream.prototype.pipe = function(dest, options) {
     if (typeof dest.destroy === 'function') dest.destroy();
   }
 
+  // on a source error, cleanup then emit to dest if any dst err listeners
+  function onsrcerror(er) {
+    cleanup();
+    if (dest.listeners('error').length !== 0) {
+      dest.emit('error', er); // now emit err to downstream
+    } else if (this.listeners('error').length === 0) {
+      throw er; // Unhandled stream error in pipe
+    }
+  }
+
   // don't leave dangling pipes when there are errors.
-  function onerror(er) {
+  function ondsterror(er) {
     cleanup();
     if (this.listeners('error').length === 0) {
       throw er; // Unhandled stream error in pipe.
     }
   }
 
-  source.on('error', onerror);
-  dest.on('error', onerror);
+  source.on('error', onsrcerror);
+  dest.on('error', ondsterror);
 
   // remove all the event listeners that were added.
   function cleanup() {
@@ -93,8 +103,8 @@ Stream.prototype.pipe = function(dest, options) {
     source.removeListener('end', onend);
     source.removeListener('close', onclose);
 
-    source.removeListener('error', onerror);
-    dest.removeListener('error', onerror);
+    source.removeListener('error', onsrcerror);
+    dest.removeListener('error', ondsterror);
 
     source.removeListener('end', cleanup);
     source.removeListener('close', cleanup);

--- a/test/simple/test-stream-pipe-error-handling.js
+++ b/test/simple/test-stream-pipe-error-handling.js
@@ -39,6 +39,22 @@ var Stream = require('stream').Stream;
   assert.strictEqual(gotErr, err);
 })();
 
+(function testErrorDestListenerCatches() {
+  var source = new Stream();
+  var dest = new Stream();
+
+  source.pipe(dest);
+
+  var gotErr = null;
+  dest.on('error', function(err) {
+    gotErr = err;
+  });
+
+  var err = new Error('This stream turned into bacon.');
+  source.emit('error', err);
+  assert.strictEqual(gotErr, err);
+})();
+
 (function testErrorWithoutListenerThrows() {
   var source = new Stream();
   var dest = new Stream();


### PR DESCRIPTION
### Not proceeding with this pull request due to risk and alternatives, see last comment for details

Add failing test for the following premise:

A piped stream should not throw an error if there is an `error`
listener on the pipe destination, so that error handling is
propagated through all of the pipes to the end where it can
be handled in one place.

So rather than having to do handle errors in each intermediate
stream as it is currently

``` javascript
rstream
  .on('error', handleErr)
  .pipe(foo)
  .on('error', handleErr)
  .pipe(bar)
  .on('error', handleErr);
```

we can simply handle these in one place at the end of the pipe
chain

``` javascript
rstream
  .pipe(foo)
  .pipe(bar)
  .on('error', handleErr);
```

If destination error handler exists
then we should forward to the destination error handler,
otherwise if no src error handler either, then throw error.

Also for errors originating on the destination, do not 
propagate back up, only forward.
