### PR TITLE
Fix dropped html tag

### DIFF
--- a/doc/download/index.html
+++ b/doc/download/index.html
@@ -118,7 +118,7 @@
             <tr>
               <th>SunOS Binaries (.tar.gz)</th>
               <td><a href="http://nodejs.org/dist/__VERSION__/node-__VERSION__-sunos-x86.tar.gz">32-bit</a></td>
-              <td><a href="http://nodejs.org/dist/__VERSION__/node-__VERSION__-sunos-x64.tar.gz">64-bit</a</td>
+              <td><a href="http://nodejs.org/dist/__VERSION__/node-__VERSION__-sunos-x64.tar.gz">64-bit</a></td>
             </tr>
 
             <tr>


### PR DESCRIPTION
In doc/download/index.html, there are an incomplete html tag.
Though there is no problem in rendering html, it is more precise.
