### PR TITLE
Use "Node.js" notation instead of "node.js"

### DIFF
--- a/doc/about/index.html
+++ b/doc/about/index.html
@@ -10,7 +10,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
   <body class="alt int" id="about">
     <div id="intro" class="interior">

--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -12,7 +12,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
 
   <body class="int" id="community">

--- a/doc/download/index.html
+++ b/doc/download/index.html
@@ -10,7 +10,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
   <body class="int" id="download-page">
     <div id="intro" class="interior">

--- a/doc/index.html
+++ b/doc/index.html
@@ -10,7 +10,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
   <body id="front">
     <div id="intro">

--- a/doc/logos/index.html
+++ b/doc/logos/index.html
@@ -10,7 +10,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
   <body class="int" id="logos">
     <div id="intro" class="interior">


### PR DESCRIPTION
According to https://github.com/joyent/node/wiki/FAQ,
"Node.js" is the correct capitalization.

It would be better to follow the guideline in the title
of html documents.

Other than this "node.js" notation is used in some places.
As there may be room for discussion to change all of them,
this patch has left them untouched.
