### PR TITLE
Added debugging information to man page and help

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -158,12 +158,16 @@ breakpoint)
 ## Advanced Usage
 
 The V8 debugger can be enabled and accessed either by starting Node with
-the `--debug` command-line flag or by signaling an existing Node process
-with `SIGUSR1`.
+the `--debug` or `--debug-brk` command-line flags or by signaling an existing
+Node process with `SIGUSR1`.
+
+The difference between `--debug` and `--debug-brk` is that `--debug-brk` will
+wait until a debugger has connected between running the script. This is useful
+for short living processes i.e. scripts rather than server processes.
 
 Once a process has been set in debug mode with this it can be connected to
 with the node debugger. Either connect to the `pid` or the URI to the debugger.
 The syntax is:
 
 * `node debug -p <pid>` - Connects to the process via the `pid`
-* `node debug <URI> - Connects to the process via the URI such as localhost:5858
+* `node debug <URI>` - Connects to the process via the URI such as localhost:5858

--- a/doc/node.1
+++ b/doc/node.1
@@ -29,6 +29,17 @@ node \- Server-side JavaScript
 [
 .I arguments
 ]
+.br
+.B node debug
+[
+.B \-e
+.I command
+|
+.I script.js
+]
+[
+.I arguments
+]
 
 Execute without arguments to start the REPL.
 
@@ -61,6 +72,16 @@ and servers.
   --v8-options           print v8 command line options
 
   --max-stack-size=val   set max v8 stack size (bytes)
+
+  --debug                enable remote debugging on port 5858
+                         useful for long-running scripts
+
+  --debug-brk            enable remote debugging on port 5858
+                         and break on first line. Useful for
+                         short-running scripts
+
+  debug                  run the script and start a command
+                         line debugger
 
 
 .SH ENVIRONMENT VARIABLES

--- a/src/node.cc
+++ b/src/node.cc
@@ -2527,6 +2527,13 @@ static void PrintHelp() {
          "  --trace-deprecation  show stack traces on deprecations\n"
          "  --v8-options         print v8 command line options\n"
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
+         "  --debug              enable remote debugging on port 5858\n"
+         "                       useful for long-running scripts\n"
+         "  --debug-brk          enable remote debugging on port 5858\n"
+         "                       and break on first line. Useful for\n"
+         "                       short-running scripts\n"
+         "  debug                run the script and start a command\n"
+         "                       line debugger\n"
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32


### PR DESCRIPTION
The man page for node and the help text when running node -h are now displaying
information about the --debug, --debug-brk and debug options.

Especially --debug and debug is important to distinguish since they look so
similar.
