### PR TITLE
Fix Issue 4331

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -192,10 +192,10 @@ SlowBuffer.prototype.slice = function(start, end) {
 
 function coerce(length) {
   // Coerce length to a number (possibly NaN), round up
-  // in case it's fractional (e.g. 123.456) then do a
-  // double negate to coerce a NaN to 0. Easy, right?
-  length = ~~Math.ceil(+length);
-  return length < 0 ? 0 : length;
+  // in case it's fractional (e.g. 123.456). Since NaN
+  // comparisons are always false, use to return zero.
+  length = Math.ceil(+length);
+  return length > 0 ? length : 0;
 }
 
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -737,3 +737,11 @@ assert.equal(b.toString(), 'xxx');
 
 // issue GH-3416
 Buffer(Buffer(0), 0, 0);
+
+// issue GH-4331
+assert.throws(function() {
+  new Buffer(0xFFFFFFFF);
+}, RangeError);
+assert.throws(function() {
+  new Buffer(0xFFFFFFFFF);
+}, TypeError);


### PR DESCRIPTION
Using double negate forces values into 32bit space. Because of this
Math.ceil needs to be used. Since NaN comparisons are always false, use
that to our advantage to return 0 if it is.

Also added two tests to verify the changes.
