### PR TITLE
doc: Add callback parameter to dgram socket.bind() and describe more details of bind()

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -108,19 +108,34 @@ a packet might travel, and that generally sending a datagram greater than
 the (receiver) `MTU` won't work (the packet gets silently dropped, without
 informing the source that the data did not reach its intended recipient).
 
-### dgram.bind(port, [address])
+### dgram.bind(port, [address], [callback])
 
 * `port` Integer
 * `address` String, Optional
+* `callback` Function with no parameters, Optional. Callback when binding is 
+done.
 
 For UDP sockets, listen for datagrams on a named `port` and optional `address`. If
 `address` is not specified, the OS will try to listen on all addresses.
+After binding is done, an "listening" event is emitted and the `callback`(if specified) 
+is called. Specifying both an "listening" event listener and `callback` is not 
+harmful but not very useful.
+
+A bound datagram socket keeps the node process running to receive datagrams.
+
+If binding fails, an "error" event is generated. In rare case (e.g. binding a 
+closed socket), an `Error` may be thrown by this method.
 
 Example of a UDP server listening on port 41234:
 
     var dgram = require("dgram");
 
     var server = dgram.createSocket("udp4");
+
+    server.on("error", function (err) {
+      console.log("server error:\n" + err.stack);
+      server.close();
+    });
 
     server.on("message", function (msg, rinfo) {
       console.log("server got: " + msg + " from " +


### PR DESCRIPTION
Add callback parameter to dgram socket.bind() method;
Describe events and errors of bind();
Add error handling to the exmaple code.
