### PR TITLE
Test simple/test-child-process-fork2.js will never pass

### DIFF
--- a/test/simple/test-child-process-fork2.js
+++ b/test/simple/test-child-process-fork2.js
@@ -68,6 +68,6 @@ n.on('message', function(m) {
 
 process.on('exit', function() {
   assert.equal(10, socketCloses);
-  assert.ok(messageCount > 1);
+  assert.ok(messageCount >= 1);
 });
 


### PR DESCRIPTION
One message is sent from parent to a child so by the time it reaches the assertion check, messageCount = 1 and assert(1 > 1) will always fail.

Modified check to assert(messageCount >= 1) instead and verified locally.
