### PR TITLE
Any expression starting with float should not be treated as keyword

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -206,7 +206,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (cmd && cmd.charAt(0) === '.' && cmd != parseFloat(cmd)) {
+    if (cmd && cmd.charAt(0) === '.' && isNaN(parseFloat(cmd))) {
       var matches = cmd.match(/^(\.[^\s]+)\s*(.*)$/);
       var keyword = matches && matches[1];
       var rest = matches && matches[2];

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -122,6 +122,9 @@ function error_test() {
     // Floating point numbers are not interpreted as REPL commands.
     { client: client_unix, send: '.1234',
       expect: '0.1234' },
+    // Expressions staring with floating point numbers are not interpreted as REPL commands as well.
+    { client: client_unix, send: '.2 + .2',
+      expect: '0.4' },
     // Can parse valid JSON
     { client: client_unix, send: 'JSON.parse(\'{"valid": "json"}\');',
       expect: '{ valid: \'json\' }'},


### PR DESCRIPTION
Issue #4268 covers not all possible use cases: all expressions starting with floating points should not be treated as keyword
