### PR TITLE
tls, https: add tls handshake timeout

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -120,6 +120,12 @@ automatically set as a listener for the [secureConnection][] event.  The
     acceptable cipher. Unfortunately, `AES256-SHA` is a CBC cipher and therefore
     susceptible to BEAST attacks. Do *not* use it.
 
+  - `handshakeTimeout`: Abort the connection if the SSL/TLS handshake does not
+    finish in this many milliseconds. The default is 120 seconds.
+
+    A `'clientError'` is emitted on the `tls.Server` object whenever a handshake
+    times out.
+
   - `honorCipherOrder` : When choosing a cipher, use the server's preferences
     instead of the client preferences.
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1115,6 +1115,12 @@ function Server(/* [options], listener */) {
     sessionIdContext: self.sessionIdContext
   });
 
+  var timeout = options.handshakeTimeout || (120 * 1000);
+
+  if (typeof timeout !== 'number') {
+    throw new TypeError('handshakeTimeout must be a number');
+  }
+
   // constructor call
   net.Server.call(this, function(socket) {
     var creds = crypto.createCredentials(null, sharedCreds.context);
@@ -1132,7 +1138,17 @@ function Server(/* [options], listener */) {
     var cleartext = pipe(pair, socket);
     cleartext._controlReleased = false;
 
-    pair.on('secure', function() {
+    function listener() {
+      pair.emit('error', new Error('TLS handshake timeout'));
+    }
+
+    if (timeout > 0) {
+      socket.setTimeout(timeout, listener);
+    }
+
+    pair.once('secure', function() {
+      socket.setTimeout(0, listener);
+
       pair.cleartext.authorized = false;
       pair.cleartext.npnProtocol = pair.npnProtocol;
       pair.cleartext.servername = pair.servername;

--- a/test/simple/test-https-timeout-server-2.js
+++ b/test/simple/test-https-timeout-server-2.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) process.exit();
+
+var common = require('../common');
+var assert = require('assert');
+var https = require('https');
+var net = require('net');
+var tls = require('tls');
+var fs = require('fs');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var server = https.createServer(options, assert.fail);
+
+server.on('secureConnection', function(cleartext) {
+  cleartext.setTimeout(50, function() {
+    cleartext.destroy();
+    server.close();
+  });
+});
+
+server.listen(common.PORT, function() {
+  tls.connect({
+    host: '127.0.0.1',
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
+});

--- a/test/simple/test-https-timeout-server.js
+++ b/test/simple/test-https-timeout-server.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) process.exit();
+
+var common = require('../common');
+var assert = require('assert');
+var https = require('https');
+var net = require('net');
+var tls = require('tls');
+var fs = require('fs');
+
+var clientErrors = 0;
+
+process.on('exit', function() {
+  assert.equal(clientErrors, 1);
+});
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  handshakeTimeout: 50
+};
+
+var server = https.createServer(options, assert.fail);
+
+server.on('clientError', function(err, conn) {
+  // Don't hesitate to update the asserts if the internal structure of
+  // the cleartext object ever changes. We're checking that the https.Server
+  // has closed the client connection.
+  assert.equal(conn._secureEstablished, false);
+  assert.equal(conn._doneFlag, true);
+  assert.equal(conn.ssl, null);
+  server.close();
+  clientErrors++;
+});
+
+server.listen(common.PORT, function() {
+  net.connect({ host: '127.0.0.1', port: common.PORT });
+});

--- a/test/simple/test-tls-timeout-server-2.js
+++ b/test/simple/test-tls-timeout-server-2.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) process.exit();
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var server = tls.createServer(options, function(cleartext) {
+  cleartext.setTimeout(50, function() {
+    cleartext.destroy();
+    server.close();
+  });
+});
+
+server.listen(common.PORT, function() {
+  tls.connect({
+    host: '127.0.0.1',
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
+});

--- a/test/simple/test-tls-timeout-server.js
+++ b/test/simple/test-tls-timeout-server.js
@@ -1,0 +1,52 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) process.exit();
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var tls = require('tls');
+var fs = require('fs');
+
+var clientErrors = 0;
+
+process.on('exit', function() {
+  assert.equal(clientErrors, 1);
+});
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  handshakeTimeout: 50
+};
+
+var server = tls.createServer(options, assert.fail);
+
+server.on('clientError', function(err, conn) {
+  conn.destroy();
+  server.close();
+  clientErrors++;
+});
+
+server.listen(common.PORT, function() {
+  net.connect({ host: '127.0.0.1', port: common.PORT });
+});


### PR DESCRIPTION
Don't allow connections to stall indefinitely if the SSL/TLS handshake does
not complete.

Adds a new tls.Server and https.Server configuration option, handshakeTimeout.

Fixes #4355.

Reviewers: @indutny @piscisaureus?
