### PR TITLE
path: Stop warning from jslint

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -82,7 +82,7 @@ if (isWindows) {
 
   var normalizeUNCRoot = function(device) {
     return '\\\\' + device.replace(/^[\\\/]+/, '').replace(/[\\\/]+/g, '\\');
-  }
+  };
 
   // path.resolve([from ...], to)
   // windows version


### PR DESCRIPTION
`make jslint` shows the following warning: 

```
node/lib/path.js:85:(0011) Missing semicolon after function assigned to a variable
```
