### PR TITLE
events: Use null assignment instead of deleting property

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -222,11 +222,11 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     if (position < 0) return this;
     list.splice(position, 1);
     if (list.length == 0)
-      delete this._events[type];
+      this._events[type] = null;
   } else if (list === listener ||
              (list.listener && list.listener === listener))
   {
-    delete this._events[type];
+    this._events[type] = null;
   }
 
   return this;


### PR DESCRIPTION
There is the following difference between the way of removing listeners.
- `removeLisner` use deleting property
  - https://github.com/joyent/node/blob/v0.8/lib/events.js#L225
  - https://github.com/joyent/node/blob/v0.8/lib/events.js#L229
- `removeAllListeners` use null assignment
  - https://github.com/joyent/node/blob/v0.8/lib/events.js#L242

I think this difference has no particular meaning.

So, I use null assignment because it is 20 ~ 40 times faster than deleting property.
