### PR TITLE
Fixes to TypedArrays and rearranging for compatibility with Plask

### DIFF
--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -33,25 +33,6 @@ using node::ThrowRangeError;
 using node::ThrowTypeError;
 using node::ThrowError;
 
-int SizeOfArrayElementForType(v8::ExternalArrayType type) {
-  switch (type) {
-    case v8::kExternalByteArray:
-    case v8::kExternalUnsignedByteArray:
-      return 1;
-    case v8::kExternalShortArray:
-    case v8::kExternalUnsignedShortArray:
-      return 2;
-    case v8::kExternalIntArray:
-    case v8::kExternalUnsignedIntArray:
-    case v8::kExternalFloatArray:
-      return 4;
-    case v8::kExternalDoubleArray:
-      return 8;
-    default:
-      return 0;
-  }
-}
-
 struct BatchedMethods {
   const char* name;
   v8::Handle<v8::Value> (*func)(const v8::Arguments& args);
@@ -90,7 +71,7 @@ class ArrayBuffer {
     v8::Object* obj = v8::Object::Cast(*value);
 
     void* ptr = obj->GetIndexedPropertiesExternalArrayData();
-    int element_size = SizeOfArrayElementForType(
+    int element_size = v8_typed_array::SizeOfArrayElementForType(
         obj->GetIndexedPropertiesExternalArrayDataType());
     int size =
         obj->GetIndexedPropertiesExternalArrayDataLength() * element_size;
@@ -714,7 +695,7 @@ class DataView {
     unsigned int index = args[0]->Uint32Value();
     bool little_endian = args[1]->BooleanValue();
     // TODO(deanm): All of these things should be cacheable.
-    int element_size = SizeOfArrayElementForType(
+    int element_size = v8_typed_array::SizeOfArrayElementForType(
         args.This()->GetIndexedPropertiesExternalArrayDataType());
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
@@ -734,7 +715,7 @@ class DataView {
     unsigned int index = args[0]->Int32Value();
     bool little_endian = args[2]->BooleanValue();
     // TODO(deanm): All of these things should be cacheable.
-    int element_size = SizeOfArrayElementForType(
+    int element_size = v8_typed_array::SizeOfArrayElementForType(
         args.This()->GetIndexedPropertiesExternalArrayDataType());
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
@@ -842,6 +823,25 @@ void AttachBindings(v8::Handle<v8::Object> obj) {
            Float64Array::GetTemplate()->GetFunction());
   obj->Set(v8::String::New("DataView"),
            DataView::GetTemplate()->GetFunction());
+}
+
+int SizeOfArrayElementForType(v8::ExternalArrayType type) {
+  switch (type) {
+    case v8::kExternalByteArray:
+    case v8::kExternalUnsignedByteArray:
+      return 1;
+    case v8::kExternalShortArray:
+    case v8::kExternalUnsignedShortArray:
+      return 2;
+    case v8::kExternalIntArray:
+    case v8::kExternalUnsignedIntArray:
+    case v8::kExternalFloatArray:
+      return 4;
+    case v8::kExternalDoubleArray:
+      return 8;
+    default:
+      return 0;
+  }
 }
 
 }  // namespace v8_typed_array

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -829,6 +829,7 @@ int SizeOfArrayElementForType(v8::ExternalArrayType type) {
   switch (type) {
     case v8::kExternalByteArray:
     case v8::kExternalUnsignedByteArray:
+    case v8::kExternalPixelArray:
       return 1;
     case v8::kExternalShortArray:
     case v8::kExternalUnsignedShortArray:

--- a/src/v8_typed_array.h
+++ b/src/v8_typed_array.h
@@ -28,6 +28,8 @@ namespace v8_typed_array {
 
 void AttachBindings(v8::Handle<v8::Object> obj);
 
+int SizeOfArrayElementForType(v8::ExternalArrayType type);
+
 }  // namespace v8_typed_array
 
 #endif  // V8_TYPED_ARRAY_H_


### PR DESCRIPTION
I am trying to get Node's v8_typed_arrays closer to my upstream copy.  This means a few fixes in both directions and moving back to exporting SizeOfArrayElementForType which is required for Plask's WebGL implementation.
