### PR TITLE
events: Use null assignment instead of deleting property

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -226,7 +226,7 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     if (position < 0) return this;
     list.splice(position, 1);
     if (list.length == 0)
-      delete this._events[type];
+      this._events[type] = null;
 
     if (this._events.removeListener) {
       this.emit('removeListener', type, listener);
@@ -234,7 +234,7 @@ EventEmitter.prototype.removeListener = function(type, listener) {
   } else if (list === listener ||
              (list.listener && list.listener === listener))
   {
-    delete this._events[type];
+    this._events[type] = null;
 
     if (this._events.removeListener) {
       this.emit('removeListener', type, listener);


### PR DESCRIPTION
There is the following difference between the way of removing listeners.
- `removeLisner` use deleting property
  - https://github.com/joyent/node/blob/master/lib/events.js#L229
  - https://github.com/joyent/node/blob/master/lib/events.js#L237
- `removeAllListeners` use null assignment
  - https://github.com/joyent/node/blob/master/lib/events.js#L255
  - https://github.com/joyent/node/blob/master/lib/events.js#L280

I think this difference has no particular meaning.

So, I modified to use null assignment because it is faster than deleting property.

---

benchmark: https://gist.github.com/4238204

```
null assignment(`obj[key] = null`):
  94 ms
deleting property(`delete obj[key]`):
  4274 ms
```

This PR is from #4390
