### PR TITLE
events: Use assigned variable instead of `arguments`

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -48,8 +48,7 @@ EventEmitter.prototype.setMaxListeners = function(n) {
 // non-global reference, for speed.
 var PROCESS;
 
-EventEmitter.prototype.emit = function() {
-  var type = arguments[0];
+EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events || !this._events.error ||


### PR DESCRIPTION
Always `arguments[0]` is used when `EventEmitter#emit` called.
Using assigned variable is faster than `arguments[0]`.

---

Benchmark: https://gist.github.com/4249528

```
arguments[0]:
  731 ms
assigned variable:
  12 ms
```
