### PR TITLE
events: Fix typos in code comment

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -139,8 +139,8 @@ EventEmitter.prototype.addListener = function(type, listener) {
 
   if (!this._events) this._events = {};
 
-  // To avoid recursion in the case that type == "newListeners"! Before
-  // adding it to the listeners, first emit "newListeners".
+  // To avoid recursion in the case that type == "newListener"! Before
+  // adding it to the listeners, first emit "newListener".
   if (this._events.newListener) {
     this.emit('newListener', type, typeof listener.listener === 'function' ?
               listener.listener : listener);


### PR DESCRIPTION
- `newListeners` -> `newListener`
