### PR TITLE
repl: fix how to module requiring in code comment

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -22,7 +22,7 @@
 /* A repl library that you can include in your own code to get a runtime
  * interface to your program.
  *
- *   var repl = require("/repl.js");
+ *   var repl = require("repl");
  *   // start repl on stdin
  *   repl.start("prompt> ");
  *


### PR DESCRIPTION
This module requiring style is old.
This API has been changed in Node 0.1.16 726865af.
