### PR TITLE
repl: remove 'repl' from automatic loading libs

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -69,7 +69,7 @@ exports.writer = util.inspect;
 
 exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
   'crypto', 'dgram', 'dns', 'events', 'fs', 'http', 'https', 'net',
-  'os', 'path', 'punycode', 'querystring', 'readline', 'repl',
+  'os', 'path', 'punycode', 'querystring', 'readline',
   'string_decoder', 'tls', 'tty', 'url', 'util', 'vm', 'zlib'];
 
 


### PR DESCRIPTION
In repl, calling `repl` **twice** shows the following message:

```
> repl // repl loaded
{...}
> repl
A different "repl" already exists globally
```

Because `require('repl')` doesn't use cache of `require`, it always creates a new object when `require('repl')` is called.
- https://github.com/joyent/node/blob/v0.8/lib/module.js#L287-L294

I might be able to treat `'repl'` special in repl.
But I think that `require('repl')` in repl is a rarely case.
(if it required, everyone can call `var repl = require('repl')` in manually.)

Threrfore I remove `'repl'` from automatic loading libs.
