### PR TITLE
repl: add 'domain' to automatic loading libs

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -68,7 +68,7 @@ module.paths = require('module')._nodeModulePaths(module.filename);
 exports.writer = util.inspect;
 
 exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
-  'crypto', 'dgram', 'dns', 'events', 'fs', 'http', 'https', 'net',
+  'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net',
   'os', 'path', 'punycode', 'querystring', 'readline', 'repl',
   'string_decoder', 'tls', 'tty', 'url', 'util', 'vm', 'zlib'];
 


### PR DESCRIPTION
`domain` should be a member of automatic loading libs in `repl`.
