### PR TITLE
doc: tls: added path property to tls.connect

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -229,6 +229,9 @@ Creates a new client connection to the given `port` and `host` (old API) or
     creating a new socket. If this option is specified, `host` and `port`
     are ignored.
 
+  - `path`: Creates unix socket connection to path. If this option is
+    specified, `host` and `port` are ignored.
+
   - `pfx`: A string or `Buffer` containing the private key, certificate and
     CA certs of the server in PFX or PKCS12 format.
 


### PR DESCRIPTION
In tls.connect a unix socket connection to a path may be made in recent versions of node by specifying the value for the path property.
