### PR TITLE
Define MAP_ANONYMOUS to MAP_ANON if not defined

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -33,6 +33,9 @@
 # include <sys/mman.h>  // mmap
 # include <unistd.h>    // sysconf
 # include <stdio.h>     // perror
+# ifndef MAP_ANONYMOUS
+#  define MAP_ANONYMOUS MAP_ANON
+# endif
 #endif
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))


### PR DESCRIPTION
2433ec8 breaks OS X.  This fixes it.

Review plz, @bnoordhuis
