### PR TITLE
stream2: fix to emit end event on http.ClientResponse

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -155,6 +155,11 @@ function parserOnMessageComplete() {
     // For upgraded connections, also emit this after parser.execute
     stream._readableState.onread(null, null);
 
+  if (!stream._readableState.endEmitted && !parser.incoming._pendings.length) {
+    // For emit end event
+    stream._readableState.onread(null, null);
+  }
+
   if (parser.socket.readable) {
     // force to read the next incoming message
     socket.resume();

--- a/test/simple/test-stream2-httpclient-response-end.js
+++ b/test/simple/test-stream2-httpclient-response-end.js
@@ -1,0 +1,52 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var assert = require('assert');
+var http = require('http');
+var msg = 'Hello';
+var readable_event = false;
+var end_event = false;
+var server = http.createServer(function(req, res) {
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.end(msg);
+}).listen(common.PORT, function() {
+  http.get({port: common.PORT}, function(res) {
+    var data = '';
+    res.on('readable', function() {
+      console.log('readable event');
+      readable_event = true;
+      data += res.read();
+    });
+    res.on('end', function() {
+      console.log('end event');
+      end_event = true;
+      assert.strictEqual(msg, data);
+      server.close();
+    });
+  });
+});
+
+process.on('exit', function() {
+  assert(readable_event);
+  assert(end_event);
+});
+


### PR DESCRIPTION
An end event on http.ClientResponse is not emitted in stream2 because only `res.resume()` is performed after readable event. ' test-stream2-httpclient-response-end.js' fails due to timeout.
 It seems to be necessary to execute `stream._readableState.onread(null, null)` explicitly again  like `http.clientResponse._emitEnd()` in `parserOnMessageComplete`.
I wonder if it is the right fix for stream2 but the test works fine.
