### PR TITLE
Add TAP output to the test runner

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -220,6 +220,29 @@ class DotsProgressIndicator(SimpleProgressIndicator):
       sys.stdout.write('.')
       sys.stdout.flush()
 
+class TapProgressIndicator(SimpleProgressIndicator):
+
+  def Starting(self):
+    print '1..%i' % len(self.cases)
+    self._done = 0
+
+  def AboutToRun(self, case):
+    pass
+
+  def HasRun(self, output):
+    self._done += 1
+    command = basename(output.command[1])
+    if output.UnexpectedOutput():
+      print 'not ok %i - %s' % (self._done, command)
+      for l in output.output.stderr.split(os.linesep):
+        print '#' + l
+      for l in output.output.stdout.split(os.linesep):
+        print '#' + l
+    else:
+      print 'ok %i - %s' % (self._done, command)
+
+  def Done(self):
+    pass
 
 class CompactProgressIndicator(ProgressIndicator):
 
@@ -311,6 +334,7 @@ PROGRESS_INDICATORS = {
   'verbose': VerboseProgressIndicator,
   'dots': DotsProgressIndicator,
   'color': ColorProgressIndicator,
+  'tap': TapProgressIndicator,
   'mono': MonochromeProgressIndicator
 }
 
@@ -1140,7 +1164,7 @@ def BuildOptions():
   result.add_option("-S", dest="scons_flags", help="Flag to pass through to scons",
       default=[], action="append")
   result.add_option("-p", "--progress",
-      help="The style of progress indicator (verbose, dots, color, mono)",
+      help="The style of progress indicator (verbose, dots, color, mono, tap)",
       choices=PROGRESS_INDICATORS.keys(), default="mono")
   result.add_option("--no-build", help="Don't build requirements",
       default=True, action="store_true")


### PR DESCRIPTION
This adds --progress=tap to the test runner such that it produces TAP compliant output
