### PR TITLE
Updates to TypedArrays to match spec.

### DIFF
--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -33,25 +33,6 @@ using node::ThrowRangeError;
 using node::ThrowTypeError;
 using node::ThrowError;
 
-int SizeOfArrayElementForType(v8::ExternalArrayType type) {
-  switch (type) {
-    case v8::kExternalByteArray:
-    case v8::kExternalUnsignedByteArray:
-      return 1;
-    case v8::kExternalShortArray:
-    case v8::kExternalUnsignedShortArray:
-      return 2;
-    case v8::kExternalIntArray:
-    case v8::kExternalUnsignedIntArray:
-    case v8::kExternalFloatArray:
-      return 4;
-    case v8::kExternalDoubleArray:
-      return 8;
-    default:
-      return 0;
-  }
-}
-
 struct BatchedMethods {
   const char* name;
   v8::Handle<v8::Value> (*func)(const v8::Arguments& args);
@@ -90,7 +71,7 @@ class ArrayBuffer {
     v8::Object* obj = v8::Object::Cast(*value);
 
     void* ptr = obj->GetIndexedPropertiesExternalArrayData();
-    int element_size = SizeOfArrayElementForType(
+    int element_size = v8_typed_array::SizeOfArrayElementForType(
         obj->GetIndexedPropertiesExternalArrayDataType());
     int size =
         obj->GetIndexedPropertiesExternalArrayDataLength() * element_size;
@@ -714,7 +695,7 @@ class DataView {
     unsigned int index = args[0]->Uint32Value();
     bool little_endian = args[1]->BooleanValue();
     // TODO(deanm): All of these things should be cacheable.
-    int element_size = SizeOfArrayElementForType(
+    int element_size = v8_typed_array::SizeOfArrayElementForType(
         args.This()->GetIndexedPropertiesExternalArrayDataType());
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
@@ -734,7 +715,7 @@ class DataView {
     unsigned int index = args[0]->Int32Value();
     bool little_endian = args[2]->BooleanValue();
     // TODO(deanm): All of these things should be cacheable.
-    int element_size = SizeOfArrayElementForType(
+    int element_size = v8_typed_array::SizeOfArrayElementForType(
         args.This()->GetIndexedPropertiesExternalArrayDataType());
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
@@ -842,6 +823,25 @@ void AttachBindings(v8::Handle<v8::Object> obj) {
            Float64Array::GetTemplate()->GetFunction());
   obj->Set(v8::String::New("DataView"),
            DataView::GetTemplate()->GetFunction());
+}
+
+int SizeOfArrayElementForType(v8::ExternalArrayType type) {
+  switch (type) {
+    case v8::kExternalByteArray:
+    case v8::kExternalUnsignedByteArray:
+      return 1;
+    case v8::kExternalShortArray:
+    case v8::kExternalUnsignedShortArray:
+      return 2;
+    case v8::kExternalIntArray:
+    case v8::kExternalUnsignedIntArray:
+    case v8::kExternalFloatArray:
+      return 4;
+    case v8::kExternalDoubleArray:
+      return 8;
+    default:
+      return 0;
+  }
 }
 
 }  // namespace v8_typed_array

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -829,6 +829,7 @@ int SizeOfArrayElementForType(v8::ExternalArrayType type) {
   switch (type) {
     case v8::kExternalByteArray:
     case v8::kExternalUnsignedByteArray:
+    case v8::kExternalPixelArray:
       return 1;
     case v8::kExternalShortArray:
     case v8::kExternalUnsignedShortArray:

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -326,65 +326,61 @@ class TypedArray {
 
   static v8::Handle<v8::Value> set(const v8::Arguments& args) {
     if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
-    //if (!args[0]->IsObject())
-    //  return ThrowTypeError("Type error.");
+    if (!args[0]->IsObject())
+      return ThrowTypeError("Invalid argument");
 
-    if (args[0]->IsNumber()) {  // index, <type> value
-      args.This()->Set(args[0]->Uint32Value(), args[1]);
-    } else if (args[0]->IsObject()) {
-      v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(args[0]);
+    v8::Handle<v8::Object> obj = v8::Handle<v8::Object>::Cast(args[0]);
 
-      if (TypedArray<TBytes, TEAType>::HasInstance(obj)) {  // ArrayBufferView.
-        if (args[1]->Int32Value() < 0)
-          return ThrowRangeError("Offset may not be negative.");
+    if (TypedArray<TBytes, TEAType>::HasInstance(obj)) {  // ArrayBufferView.
+      if (args[1]->Int32Value() < 0)
+        return ThrowRangeError("Offset may not be negative.");
 
-        unsigned int offset = args[1]->Uint32Value();
-        unsigned int src_length =
-            obj->Get(v8::String::New("length"))->Uint32Value();
-        unsigned int dst_length =
-            args.This()->Get(v8::String::New("length"))->Uint32Value();
-        if (offset > dst_length)
-          return ThrowRangeError("Offset out of range.");
+      unsigned int offset = args[1]->Uint32Value();
+      unsigned int src_length =
+          obj->Get(v8::String::New("length"))->Uint32Value();
+      unsigned int dst_length =
+          args.This()->Get(v8::String::New("length"))->Uint32Value();
+      if (offset > dst_length)
+        return ThrowRangeError("Offset out of range.");
 
-        if (src_length > dst_length - offset)
-          return ThrowRangeError("Offset/length out of range.");
+      if (src_length > dst_length - offset)
+        return ThrowRangeError("Index is out of range.");
 
-        // We don't want to get the buffer pointer, because that means we'll have
-        // to just do the calculations for byteOffset / byteLength again.
-        // Instead just use the pointer on the external array data.
-        void* src_ptr = obj->GetIndexedPropertiesExternalArrayData();
-        void* dst_ptr = args.This()->GetIndexedPropertiesExternalArrayData();
+      // We don't want to get the buffer pointer, because that means we'll have
+      // to just do the calculations for byteOffset / byteLength again.
+      // Instead just use the pointer on the external array data.
+      void* src_ptr = obj->GetIndexedPropertiesExternalArrayData();
+      void* dst_ptr = args.This()->GetIndexedPropertiesExternalArrayData();
 
-        // From the spec:
-        // If the input array is a TypedArray, the two arrays may use the same
-        // underlying ArrayBuffer. In this situation, setting the values takes
-        // place as if all the data is first copied into a temporary buffer that
-        // does not overlap either of the arrays, and then the data from the
-        // temporary buffer is copied into the current array.
-        memmove(reinterpret_cast<char*>(dst_ptr) + offset * TBytes, src_ptr,
-            src_length * TBytes);
-      } else {  // type[]
-        if (args[1]->Int32Value() < 0)
-          return ThrowRangeError("Offset may not be negative.");
+      // From the spec:
+      // If the input array is a TypedArray, the two arrays may use the same
+      // underlying ArrayBuffer. In this situation, setting the values takes
+      // place as if all the data is first copied into a temporary buffer that
+      // does not overlap either of the arrays, and then the data from the
+      // temporary buffer is copied into the current array.
+      memmove(reinterpret_cast<char*>(dst_ptr) + offset * TBytes, src_ptr,
+          src_length * TBytes);
+    } else {  // type[]
+      if (args[1]->Int32Value() < 0)
+        return ThrowRangeError("Offset may not be negative.");
 
-        unsigned int src_length =
-            obj->Get(v8::String::New("length"))->Uint32Value();
-        unsigned int dst_length =
-            args.This()->Get(v8::String::New("length"))->Uint32Value();
-        unsigned int offset = args[1]->Uint32Value();
+      unsigned int src_length =
+          obj->Get(v8::String::New("length"))->Uint32Value();
+      unsigned int dst_length =
+          args.This()->Get(v8::String::New("length"))->Uint32Value();
+      unsigned int offset = args[1]->Uint32Value();
 
-        if (offset > dst_length)
-          return ThrowRangeError("Offset out of range.");
+      if (offset > dst_length)
+        return ThrowRangeError("Offset out of range.");
 
-        if (src_length > dst_length - offset)
-          return ThrowRangeError("Offset/length out of range.");
+      if (src_length > dst_length - offset)
+        return ThrowRangeError("Index is out of range.");
 
-        for (uint32_t i = 0; i < src_length; ++i) {
-          // Use the v8 setter to deal with typing.  Maybe slow?
-          args.This()->Set(i + offset, obj->Get(i));
-        }
+      for (uint32_t i = 0; i < src_length; ++i) {
+        // Use the v8 setter to deal with typing.  Maybe slow?
+        args.This()->Set(i + offset, obj->Get(i));
       }
     }
 

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -399,11 +399,11 @@ class TypedArray {
 
     if (begin < 0) begin = length + begin;
     if (begin < 0) begin = 0;
-    if ((unsigned)begin > length) begin = length;
+    if (static_cast<unsigned int>(begin) > length) begin = length;
 
     if (end < 0) end = length + end;
     if (end < 0) end = 0;
-    if ((unsigned)end > length) end = length;
+    if (static_cast<unsigned int>(end) > length) end = length;
 
     if (begin > end) begin = end;
 
@@ -685,7 +685,8 @@ class DataView {
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
 
-    if (index + sizeof(T) > (unsigned)size)  // TODO(deanm): integer overflow.
+    // TODO(deanm): integer overflow.
+    if (index + sizeof(T) > static_cast<unsigned int>(size))
       return ThrowError("Index out of range.");
 
     void* ptr = args.This()->GetIndexedPropertiesExternalArrayData();
@@ -705,7 +706,8 @@ class DataView {
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
 
-    if (index + sizeof(T) > (unsigned)size)  // TODO(deanm): integer overflow.
+    // TODO(deanm): integer overflow.
+    if (index + sizeof(T) > static_cast<unsigned int>(size))
       return ThrowError("Index out of range.");
 
     void* ptr = args.This()->GetIndexedPropertiesExternalArrayData();

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -192,7 +192,6 @@ class TypedArray {
     v8::Local<v8::Signature> default_signature = v8::Signature::New(ft_cache);
 
     static BatchedMethods methods[] = {
-      { "get", &TypedArray<TBytes, TEAType>::get },
       { "set", &TypedArray<TBytes, TEAType>::set },
       { "slice", &TypedArray<TBytes, TEAType>::subarray },
       { "subarray", &TypedArray<TBytes, TEAType>::subarray },
@@ -323,16 +322,6 @@ class TypedArray {
                      (v8::PropertyAttribute)(v8::ReadOnly|v8::DontDelete));
 
     return args.This();
-  }
-
-  static v8::Handle<v8::Value> get(const v8::Arguments& args) {
-    if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
-
-    if (args[0]->IsNumber())
-      return args.This()->Get(args[0]->Uint32Value());
-
-    return v8::Undefined();
   }
 
   static v8::Handle<v8::Value> set(const v8::Arguments& args) {

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -130,7 +130,7 @@ class ArrayBuffer {
 
   static v8::Handle<v8::Value> slice(const v8::Arguments& args) {
     if (args.Length() < 1)
-       return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     unsigned int length =
         args.This()->Get(v8::String::New("byteLength"))->Uint32Value();
@@ -594,7 +594,7 @@ class DataView {
       return ThrowTypeError("Constructor cannot be called as a function.");
 
     if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     if (!args[0]->IsObject())
       return ThrowError("Object must be an ArrayBuffer.");
@@ -608,16 +608,16 @@ class DataView {
     unsigned int byte_offset = args[1]->Uint32Value();
 
     if (args[1]->Int32Value() < 0 || byte_offset >= byte_length)
-      return ThrowRangeError("byteOffset out of range.");
+      return ThrowRangeError("Size is too large (or is negative).");
 
     if (!args[2]->IsUndefined()) {
       if (args[2]->Int32Value() < 0)
-        return ThrowRangeError("byteLength out of range.");
+        return ThrowRangeError("Size is too large (or is negative).");
       unsigned int new_byte_length = args[2]->Uint32Value();
       if (new_byte_length > byte_length)
-        return ThrowRangeError("byteLength out of range.");
+        return ThrowRangeError("Size is too large (or is negative).");
       if (byte_offset + new_byte_length > byte_length)
-        return ThrowRangeError("byteOffset/byteLength out of range.");
+        return ThrowRangeError("Size is too large (or is negative).");
       byte_length = new_byte_length;
     } else {
       // Adjust the original byte_length from total length to length to end.
@@ -675,7 +675,7 @@ class DataView {
   template <typename T>
   static v8::Handle<v8::Value> getGeneric(const v8::Arguments& args) {
     if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     unsigned int index = args[0]->Uint32Value();
     bool little_endian = args[1]->BooleanValue();
@@ -687,7 +687,7 @@ class DataView {
 
     // TODO(deanm): integer overflow.
     if (index + sizeof(T) > static_cast<unsigned int>(size))
-      return ThrowError("Index out of range.");
+      return ThrowError("IndexSizeError: DOM Exception 1");
 
     void* ptr = args.This()->GetIndexedPropertiesExternalArrayData();
     return cTypeToValue<T>(getValue<T>(ptr, index, !little_endian));
@@ -696,7 +696,7 @@ class DataView {
   template <typename T>
   static v8::Handle<v8::Value> setGeneric(const v8::Arguments& args) {
     if (args.Length() < 2)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     unsigned int index = args[0]->Int32Value();
     bool little_endian = args[2]->BooleanValue();
@@ -708,7 +708,7 @@ class DataView {
 
     // TODO(deanm): integer overflow.
     if (index + sizeof(T) > static_cast<unsigned int>(size))
-      return ThrowError("Index out of range.");
+      return ThrowError("IndexSizeError: DOM Exception 1");
 
     void* ptr = args.This()->GetIndexedPropertiesExternalArrayData();
     setValue<T>(ptr, index, valueToCType<T>(args[1]), !little_endian);

--- a/src/v8_typed_array.h
+++ b/src/v8_typed_array.h
@@ -28,6 +28,8 @@ namespace v8_typed_array {
 
 void AttachBindings(v8::Handle<v8::Object> obj);
 
+int SizeOfArrayElementForType(v8::ExternalArrayType type);
+
 }  // namespace v8_typed_array
 
 #endif  // V8_TYPED_ARRAY_H_

--- a/test/simple/test-typed-arrays.js
+++ b/test/simple/test-typed-arrays.js
@@ -153,13 +153,13 @@ sub[1] = 0x34;
 assert.equal(uint8[2], 0x12);
 assert.equal(uint8[3], 0x34);
 
-// test .set(index, value), .set(arr, offset) and .get(index)
+// test .set(index, value), .set(arr, offset)
 uint8.set(1, 0x09);
 uint8.set([0x0a, 0x0b], 2);
 
-assert.equal(uint8.get(1), 0x09);
-assert.equal(uint8.get(2), 0x0a);
-assert.equal(uint8.get(3), 0x0b);
+assert.equal(uint8[1], 0x09);
+assert.equal(uint8[2], 0x0a);
+assert.equal(uint8[3], 0x0b);
 
 // test clamped array
 var uint8c = new Uint8ClampedArray(buffer);

--- a/test/simple/test-typed-arrays.js
+++ b/test/simple/test-typed-arrays.js
@@ -154,7 +154,7 @@ assert.equal(uint8[2], 0x12);
 assert.equal(uint8[3], 0x34);
 
 // test .set(index, value), .set(arr, offset)
-uint8.set(1, 0x09);
+uint8[1] = 0x09;
 uint8.set([0x0a, 0x0b], 2);
 
 assert.equal(uint8[1], 0x09);
@@ -169,8 +169,8 @@ uint8c[1] = 257;
 assert.equal(uint8c[0], 0);
 assert.equal(uint8c[1], 255);
 
-uint8c.set(0, -10);
-uint8c.set(1, 260);
+uint8c[0] = -10;
+uint8c[1] = 260;
 
 assert.equal(uint8c[0], 0);
 assert.equal(uint8c[1], 255);


### PR DESCRIPTION
These again are a few effective reverts of previous changes by Mikael Bourges-Sevenier to the TypedArrays code.  I believe it was caused by a misreading of the spec, where get() and set() methods are defined as getters/setters ([] and []= operators).  By removing these and updating a few exception strings the TypedArray implementation now fully passes the following related WebKit tests:

array-buffer-crash.html
array-buffer-view-crash-when-reassigned.html
array-buffer-view-crash.html
array-constructor.html
array-get-and-set-method-removal.html
array-get-out-of-bounds.html
array-override-set.html
array-set-invalid-arguments.html
array-set-out-of-bounds.html
array-set-with-offset.html
array-setters.html
array-unit-tests.html
dfg-float32array.js
dfg-int16array.js
dfg-int32array-overflow-values.js
dfg-int32array.js
dfg-int8array.js
dfg-uint16array.js
dfg-uint32array-overflow-values.js
dfg-uint32array.js
dfg-uint8array.js
dfg-uint8clampedarray.js
