### PR TITLE
Buffer assertion fix

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -582,15 +582,27 @@ Buffer.prototype.asciiWrite = function(string, offset) {
   return this.write(string, offset, 'ascii');
 };
 
+
+/*
+ * Simple checks that verify the argument types and that the read doesn't
+ * overflow beyond the buffer.
+ */
+function verifyReadArguments(buffer, offset, isBigEndian, overflow) {
+  assert.ok(Number.isFinite(offset),
+      'missing or incorrect offset');
+
+  assert.ok(typeof (isBigEndian) == 'boolean',
+      'missing or invalid endian');
+
+  assert.ok(offset + overflow < buffer.length,
+      'trying to read beyond buffer length');
+}
+
 Buffer.prototype.readUInt8 = function(offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, true, 0);
   }
 
   return buffer[offset];
@@ -601,14 +613,7 @@ function readUInt16(buffer, offset, isBigEndian, noAssert) {
 
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 1 < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, isBigEndian, 1);
   }
 
   if (isBigEndian) {
@@ -634,14 +639,7 @@ function readUInt32(buffer, offset, isBigEndian, noAssert) {
   var val = 0;
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 3 < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, isBigEndian, 3);
   }
 
   if (isBigEndian) {
@@ -718,11 +716,7 @@ Buffer.prototype.readInt8 = function(offset, noAssert) {
   var neg;
 
   if (!noAssert) {
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, true, 0);
   }
 
   neg = buffer[offset] & 0x80;
@@ -737,14 +731,7 @@ function readInt16(buffer, offset, isBigEndian, noAssert) {
   var neg, val;
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 1 < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, isBigEndian, 1);
   }
 
   val = readUInt16(buffer, offset, isBigEndian, noAssert);
@@ -768,14 +755,7 @@ function readInt32(buffer, offset, isBigEndian, noAssert) {
   var neg, val;
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 3 < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, isBigEndian, 3);
   }
 
   val = readUInt32(buffer, offset, isBigEndian, noAssert);
@@ -797,11 +777,7 @@ Buffer.prototype.readInt32BE = function(offset, noAssert) {
 
 function readFloat(buffer, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(offset + 3 < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, isBigEndian, 3);
   }
 
   return require('buffer_ieee754').readIEEE754(buffer, offset, isBigEndian,
@@ -818,11 +794,7 @@ Buffer.prototype.readFloatBE = function(offset, noAssert) {
 
 function readDouble(buffer, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(offset + 7 < buffer.length,
-        'Trying to read beyond buffer length');
+    verifyReadArguments(buffer, offset, isBigEndian, 7);
   }
 
   return require('buffer_ieee754').readIEEE754(buffer, offset, isBigEndian,

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -586,8 +586,8 @@ Buffer.prototype.readUInt8 = function(offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset < buffer.length,
         'Trying to read beyond buffer length');
@@ -604,8 +604,8 @@ function readUInt16(buffer, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 1 < buffer.length,
         'Trying to read beyond buffer length');
@@ -637,8 +637,8 @@ function readUInt32(buffer, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 3 < buffer.length,
         'Trying to read beyond buffer length');
@@ -718,8 +718,8 @@ Buffer.prototype.readInt8 = function(offset, noAssert) {
   var neg;
 
   if (!noAssert) {
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset < buffer.length,
         'Trying to read beyond buffer length');
@@ -740,8 +740,8 @@ function readInt16(buffer, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 1 < buffer.length,
         'Trying to read beyond buffer length');
@@ -771,8 +771,8 @@ function readInt32(buffer, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 3 < buffer.length,
         'Trying to read beyond buffer length');
@@ -866,8 +866,8 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
     assert.ok(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset < buffer.length,
         'trying to write beyond buffer length');
@@ -886,8 +886,8 @@ function writeUInt16(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 1 < buffer.length,
         'trying to write beyond buffer length');
@@ -920,8 +920,8 @@ function writeUInt32(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 3 < buffer.length,
         'trying to write beyond buffer length');
@@ -1018,8 +1018,8 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
     assert.ok(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset < buffer.length,
         'Trying to write beyond buffer length');
@@ -1042,8 +1042,8 @@ function writeInt16(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 1 < buffer.length,
         'Trying to write beyond buffer length');
@@ -1074,8 +1074,8 @@ function writeInt32(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 3 < buffer.length,
         'Trying to write beyond buffer length');
@@ -1106,8 +1106,8 @@ function writeFloat(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 3 < buffer.length,
         'Trying to write beyond buffer length');
@@ -1135,8 +1135,8 @@ function writeDouble(buffer, value, offset, isBigEndian, noAssert) {
     assert.ok(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
-        'missing offset');
+    assert.ok(Number.isFinite(offset),
+        'missing or incorrect offset');
 
     assert.ok(offset + 7 < buffer.length,
         'Trying to write beyond buffer length');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -839,40 +839,52 @@ Buffer.prototype.readDoubleBE = function(offset, noAssert) {
 
 
 /*
- * We have to make sure that the value is a valid integer. This means that it is
- * non-negative. It has no fractional component and that it does not exceed the
- * maximum allowed value.
- *
- *      value           The number to check for validity
- *
- *      max             The maximum value
+ * Every write method has a set of mostly standard arguments. These are easy
+ * to verify in a single location for simplicity. The two basic types of
+ * checks performed are if the argument types are correct and if writing the
+ * value will overflow the buffer.
  */
-function verifuint(value, max) {
+function verifyWriteArguments(buffer, value, offset, isBigEndian, overflow) {
   assert.ok(typeof (value) == 'number',
       'cannot write a non-number as a number');
 
-  assert.ok(value >= 0,
-      'specified a negative value for writing an unsigned value');
+  assert.ok(Number.isFinite(offset),
+      'missing or incorrect offset');
 
-  assert.ok(value <= max, 'value is larger than maximum value for type');
+  assert.ok(typeof (isBigEndian) == 'boolean',
+      'missing or invalid endian');
 
-  assert.ok(Math.floor(value) === value, 'value has a fractional component');
+  assert.ok(offset + overflow < buffer.length,
+      'trying to write beyond buffer length');
 }
+
+/*
+ * Verify that value to be writing falls withing the size boundries of
+ * each write method.
+ */
+function verifySize(value, max, min) {
+  assert.ok(value <= max, 'value larger than maximum allowed size');
+
+  assert.ok(value >= min, 'value smaller than minimum allowed size');
+}
+
+/*
+ * Simple check for fractional component
+ */
+function verifyInt(value) {
+  assert.ok((value % 1) === 0, 'value has fractional component');
+}
+
 
 Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, true, 0);
 
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
+    verifySize(value, 0xff, 0);
 
-    assert.ok(offset < buffer.length,
-        'trying to write beyond buffer length');
-
-    verifuint(value, 0xff);
+    verifyInt(value);
   }
 
   buffer[offset] = value;
@@ -880,19 +892,11 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
 
 function writeUInt16(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, isBigEndian, 1);
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
+    verifySize(value, 0xffff, 0);
 
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 1 < buffer.length,
-        'trying to write beyond buffer length');
-
-    verifuint(value, 0xffff);
+    verifyInt(value);
   }
 
   if (isBigEndian) {
@@ -914,19 +918,11 @@ Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
 
 function writeUInt32(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, isBigEndian, 3);
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
+    verifySize(value, 0xffffffff, 0);
 
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 3 < buffer.length,
-        'trying to write beyond buffer length');
-
-    verifuint(value, 0xffffffff);
+    verifyInt(value);
   }
 
   if (isBigEndian) {
@@ -988,43 +984,15 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
  * hacky, but it should work and get the job done which is our goal here.
  */
 
-/*
- * A series of checks to make sure we actually have a signed 32-bit number
- */
-function verifsint(value, max, min) {
-  assert.ok(typeof (value) == 'number',
-      'cannot write a non-number as a number');
-
-  assert.ok(value <= max, 'value larger than maximum allowed value');
-
-  assert.ok(value >= min, 'value smaller than minimum allowed value');
-
-  assert.ok(Math.floor(value) === value, 'value has a fractional component');
-}
-
-function verifIEEE754(value, max, min) {
-  assert.ok(typeof (value) == 'number',
-      'cannot write a non-number as a number');
-
-  assert.ok(value <= max, 'value larger than maximum allowed value');
-
-  assert.ok(value >= min, 'value smaller than minimum allowed value');
-}
-
 Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, true, 0);
 
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
+    verifySize(value, 0x7f, -0x80);
 
-    assert.ok(offset < buffer.length,
-        'Trying to write beyond buffer length');
-
-    verifsint(value, 0x7f, -0x80);
+    verifyInt(value);
   }
 
   if (value >= 0) {
@@ -1036,19 +1004,11 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
 
 function writeInt16(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, isBigEndian, 1);
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
+    verifySize(value, 0x7fff, -0x8000);
 
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 1 < buffer.length,
-        'Trying to write beyond buffer length');
-
-    verifsint(value, 0x7fff, -0x8000);
+    verifyInt(value);
   }
 
   if (value >= 0) {
@@ -1068,19 +1028,11 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
 
 function writeInt32(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, isBigEndian, 3);
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
+    verifySize(value, 0x7fffffff, -0x80000000);
 
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 3 < buffer.length,
-        'Trying to write beyond buffer length');
-
-    verifsint(value, 0x7fffffff, -0x80000000);
+    verifyInt(value);
   }
 
   if (value >= 0) {
@@ -1100,19 +1052,9 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
 
 function writeFloat(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, isBigEndian, 3);
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 3 < buffer.length,
-        'Trying to write beyond buffer length');
-
-    verifIEEE754(value, 3.4028234663852886e+38, -3.4028234663852886e+38);
+    verifySize(value, 3.4028234663852886e+38, -3.4028234663852886e+38);
   }
 
   require('buffer_ieee754').writeIEEE754(buffer, value, offset, isBigEndian,
@@ -1129,19 +1071,9 @@ Buffer.prototype.writeFloatBE = function(value, offset, noAssert) {
 
 function writeDouble(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
-        'missing value');
+    verifyWriteArguments(buffer, value, offset, isBigEndian, 7);
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
-        'missing or invalid endian');
-
-    assert.ok(Number.isFinite(offset),
-        'missing or incorrect offset');
-
-    assert.ok(offset + 7 < buffer.length,
-        'Trying to write beyond buffer length');
-
-    verifIEEE754(value, 1.7976931348623157E+308, -1.7976931348623157E+308);
+    verifySize(value, 1.7976931348623157E+308, -1.7976931348623157E+308);
   }
 
   require('buffer_ieee754').writeIEEE754(buffer, value, offset, isBigEndian,

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -735,6 +735,15 @@ var b = Buffer('xxx');
 a.write('aaaaaaaa', 'base64');
 assert.equal(b.toString(), 'xxx');
 
+// Be verbose on all incorrect offset values
+var a = Buffer(2);
+assert.throws(function() {
+  a.writeUInt8(1, -Infinity)
+}, 'missing or incorrect offset');
+assert.throws(function() {
+  a.readUInt8(-Infinity);
+}, 'missing or incorrect offset');
+
 // issue GH-3416
 Buffer(Buffer(0), 0, 0);
 


### PR DESCRIPTION
The first commit adds a check to write at offset `-Infinity`.

The second consolidates write assert checks into a set of 3 functions. This also removes a few duplicate checks that existed.

The third consolidates and fixes the assert checks for the read methods.

If the seconds and third commits are too much of a change, just cherry-pick the first.

These changes currently conflict with master. I can port the patch if needed.
