### PR TITLE
node_os.cc: CPU time values must be Numbers not Integers

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -124,15 +124,15 @@ static Handle<Value> GetCPUInfo(const Arguments& args) {
   for (i = 0; i < count; i++) {
     Local<Object> times_info = Object::New();
     times_info->Set(String::New("user"),
-      Integer::New(cpu_infos[i].cpu_times.user));
+      Number::New(cpu_infos[i].cpu_times.user));
     times_info->Set(String::New("nice"),
-      Integer::New(cpu_infos[i].cpu_times.nice));
+      Number::New(cpu_infos[i].cpu_times.nice));
     times_info->Set(String::New("sys"),
-      Integer::New(cpu_infos[i].cpu_times.sys));
+      Number::New(cpu_infos[i].cpu_times.sys));
     times_info->Set(String::New("idle"),
-      Integer::New(cpu_infos[i].cpu_times.idle));
+      Number::New(cpu_infos[i].cpu_times.idle));
     times_info->Set(String::New("irq"),
-      Integer::New(cpu_infos[i].cpu_times.irq));
+      Number::New(cpu_infos[i].cpu_times.irq));
 
     Local<Object> cpu_info = Object::New();
     cpu_info->Set(String::New("model"), String::New(cpu_infos[i].model));


### PR DESCRIPTION
as they can be too large for Integers on 32 bit platforms

This causes them to wrap resulting in large negative values.

This request is mildly associated with another one I'm about to make for libuv: it's not dependent on that one but there are related issues in libuv.  The branch tfeb.cpu-fix has both sets of fixes for node in though some of them belong to libuv in reality.
