### PR TITLE
build: allow to specify custom tags (v0.9)

### DIFF
--- a/configure
+++ b/configure
@@ -265,6 +265,11 @@ parser.add_option("--xcode",
     dest="use_xcode",
     help="Generate build files for use with xcode")
 
+parser.add_option("--tag",
+    action="store",
+    dest="tag",
+    help="Custom build tag")
+
 (options, args) = parser.parse_args()
 
 
@@ -489,6 +494,8 @@ def configure_node(o):
     raise Exception('Performance counter is only supported on Windows.')
   else:
     o['variables']['node_use_perfctr'] = 'false'
+
+  o['variables']['node_tag'] = options.tag or ''
 
 
 def configure_libz(o):

--- a/node.gyp
+++ b/node.gyp
@@ -140,6 +140,7 @@
         'NODE_WANT_INTERNALS=1',
         'ARCH="<(target_arch)"',
         'PLATFORM="<(OS)"',
+        'NODE_TAG="<(node_tag)"',
       ],
 
       'conditions': [

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -25,6 +25,11 @@
 #define NODE_MAJOR_VERSION 0
 #define NODE_MINOR_VERSION 9
 #define NODE_PATCH_VERSION 4
+
+#ifndef NODE_TAG
+#  define NODE_TAG ""
+#endif
+
 #define NODE_VERSION_IS_RELEASE 0
 
 #ifndef NODE_STRINGIFY
@@ -35,11 +40,13 @@
 #if NODE_VERSION_IS_RELEASE
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_PATCH_VERSION)
+                              NODE_STRINGIFY(NODE_PATCH_VERSION)     \
+                              NODE_TAG
 #else
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_PATCH_VERSION) "-pre"
+                              NODE_STRINGIFY(NODE_PATCH_VERSION)     \
+                              NODE_TAG "-pre"
 #endif
 
 #define NODE_VERSION "v" NODE_VERSION_STRING


### PR DESCRIPTION
When building custom `node` versions (e.g., floating features/fixes from
different versions) it's often useful to specify a custom tag which
easily identifies build when invoking `node -v`.

Introduce a way to specify this tag in `node_version.h` file or by
running `./configure --tag="<tag>"`. Insert it right after the patch
version (and before `-pre`, if build is not a release).

Conflicts:
    configure
    src/node_version.h
