### PR TITLE
buffer: speed up base64 encoding by 20%

### DIFF
--- a/benchmark/buffer-base64-encode.js
+++ b/benchmark/buffer-base64-encode.js
@@ -1,0 +1,27 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var N = 64*1024*1024
+var b = Buffer(N);
+var s = '';
+for (var i = 0; i < 256; ++i) s += String.fromCharCode(i);
+for (var i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
+for (var i = 0; i < 32; ++i) b.toString('base64');


### PR DESCRIPTION
Remove a lot of branches from the inner loop. Speeds up buf.toString('base64') by about 20%.

Before:

```
$ time out/Release/node benchmark/buffer-base64-encode.js
real    0m6.607s
user    0m5.508s
sys     0m1.088s
```

After:

```
$ time out/Release/node benchmark/buffer-base64-encode.js
real    0m5.520s
user    0m4.520s
sys     0m0.992s
```

Reviewers: @indutny @piscisaureus
