### PR TITLE
net: Allow socket end before connect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -191,7 +191,7 @@ function onSocketFinish() {
   debug('oSF: not ended, call shutdown()');
 
   // otherwise, just shutdown, or destroy() if not possible
-  if (!this._handle.shutdown)
+  if (!this._handle || !this._handle.shutdown)
     return this.destroy();
 
   var shutdownReq = this._handle.shutdown();


### PR DESCRIPTION
Fix a bug where .end on a socket before calling .connect will
throw an error.

Closes #4463
