### PR TITLE
Update lib/http.js

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1195,7 +1195,7 @@ function ClientRequest(options, cb) {
   var self = this;
   OutgoingMessage.call(self);
 
-  self.agent = options.agent === undefined ? globalAgent : options.agent;
+  self.agent = options.agent === undefined ? exports.globalAgent : options.agent;
 
   var defaultPort = options.defaultPort || 80;
 


### PR DESCRIPTION
can't not setup a global http/https agent by this:
http.globalAgent = new SomeAgent()
because the default agent will always be the original agent object
so that has to pass the agent ref everytime use http api
change the 'globalAgent' to 'exports.globalAgent' will make globalAgent 
more flexable with not changing the default behaver
