### PR TITLE
domain: Don't expose uncaughtException implementation details

### DIFF
--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -27,11 +27,11 @@ Any time an Error object is routed through a domain, a few extra fields
 are added to it.
 
 * `error.domain` The domain that first handled the error.
-* `error.domain_emitter` The event emitter that emitted an 'error' event
+* `error.domainEmitter` The event emitter that emitted an 'error' event
   with the error object.
-* `error.domain_bound` The callback function which was bound to the
+* `error.domainBound` The callback function which was bound to the
   domain, and passed an error as its first argument.
-* `error.domain_thrown` A boolean indicating whether the error was
+* `error.domainThrown` A boolean indicating whether the error was
   thrown, emitted, or passed to a bound callback function.
 
 ## Implicit Binding

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -46,27 +46,6 @@ exports._stack = stack;
 exports.active = null;
 
 
-// loading this file the first time sets up the global
-// uncaughtException handler.
-process.on('uncaughtException', uncaughtHandler);
-
-function uncaughtHandler(er) {
-  // if there's an active domain, then handle this there.
-  // Note that if this error emission throws, then it'll just crash.
-  if (exports.active && !exports.active._disposed) {
-    util._extend(er, {
-      domain: exports.active,
-      domain_thrown: true
-    });
-    exports.active.emit('error', er);
-    if (exports.active) exports.active.exit();
-  } else if (process.listeners('uncaughtException').length === 1) {
-    // if there are other handlers, then they'll take care of it.
-    // but if not, then we need to crash now.
-    throw er;
-  }
-}
-
 inherits(Domain, EventEmitter);
 
 function Domain() {

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -140,8 +140,8 @@ Domain.prototype.bind = function(cb, interceptError) {
         (arguments[0] instanceof Error)) {
       var er = arguments[0];
       util._extend(er, {
-        domain_bound: cb,
-        domain_thrown: false,
+        domainBound: cb,
+        domainThrown: false,
         domain: self
       });
       self.emit('error', er);

--- a/lib/events.js
+++ b/lib/events.js
@@ -58,9 +58,9 @@ EventEmitter.prototype.emit = function(type) {
     {
       if (this.domain) {
         var er = arguments[1];
-        er.domain_emitter = this;
+        er.domainEmitter = this;
         er.domain = this.domain;
-        er.domain_thrown = false;
+        er.domainThrown = false;
         this.domain.emit('error', er);
         return false;
       }

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -86,23 +86,28 @@ function insert(item, msecs) {
 
           if (!first._onTimeout) continue;
 
-          // v0.4 compatibility: if the timer callback throws and the user's
-          // uncaughtException handler ignores the exception, other timers that
-          // expire on this tick should still run. If #2582 goes through, this
-          // hack should be removed.
+          // v0.4 compatibility: if the timer callback throws and the
+          // domain or uncaughtException handler ignore the exception,
+          // other timers that expire on this tick should still run.
           //
           // https://github.com/joyent/node/issues/2631
-          if (first.domain) {
-            if (first.domain._disposed) continue;
-            first.domain.enter();
-          }
+          var domain = first.domain;
+          if (domain && domain._disposed) continue;
           try {
+            if (domain)
+              domain.enter();
+            var threw = true;
             first._onTimeout();
-          } catch (e) {
-            if (!process.listeners('uncaughtException').length) throw e;
-            process.emit('uncaughtException', e);
+            if (domain)
+              domain.exit();
+            threw = false;
+          } finally {
+            if (threw) {
+              process.nextTick(function() {
+                list.ontimeout();
+              });
+            }
           }
-          if (first.domain) first.domain.exit();
         }
       }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -110,9 +110,7 @@ static Persistent<String> rss_symbol;
 static Persistent<String> heap_total_symbol;
 static Persistent<String> heap_used_symbol;
 
-static Persistent<String> listeners_symbol;
-static Persistent<String> uncaught_exception_symbol;
-static Persistent<String> emit_symbol;
+static Persistent<String> fatal_exception_symbol;
 
 static Persistent<Function> process_makeCallback;
 
@@ -1883,47 +1881,36 @@ static void OnFatalError(const char* location, const char* message) {
 void FatalException(TryCatch &try_catch) {
   HandleScope scope;
 
-  if (listeners_symbol.IsEmpty()) {
-    listeners_symbol = NODE_PSYMBOL("listeners");
-    uncaught_exception_symbol = NODE_PSYMBOL("uncaughtException");
-    emit_symbol = NODE_PSYMBOL("emit");
-  }
+  if (fatal_exception_symbol.IsEmpty())
+    fatal_exception_symbol = NODE_PSYMBOL("_fatalException");
 
-  Local<Value> listeners_v = process->Get(listeners_symbol);
-  assert(listeners_v->IsFunction());
+  Local<Value> fatal_v = process->Get(fatal_exception_symbol);
 
-  Local<Function> listeners = Local<Function>::Cast(listeners_v);
-
-  Local<String> uncaught_exception_symbol_l = Local<String>::New(uncaught_exception_symbol);
-  Local<Value> argv[1] = { uncaught_exception_symbol_l  };
-  Local<Value> ret = listeners->Call(process, 1, argv);
-
-  assert(ret->IsArray());
-
-  Local<Array> listener_array = Local<Array>::Cast(ret);
-
-  uint32_t length = listener_array->Length();
-  // Report and exit if process has no "uncaughtException" listener
-  if (length == 0) {
+  if (!fatal_v->IsFunction()) {
+    // failed before the process._fatalException function was added!
+    // this is probably pretty bad.  Nothing to do but report and exit.
     ReportException(try_catch, true);
     exit(1);
   }
 
-  // Otherwise fire the process "uncaughtException" event
-  Local<Value> emit_v = process->Get(emit_symbol);
-  assert(emit_v->IsFunction());
-
-  Local<Function> emit = Local<Function>::Cast(emit_v);
+  Local<Function> fatal_f = Local<Function>::Cast(fatal_v);
 
   Local<Value> error = try_catch.Exception();
-  Local<Value> event_argv[2] = { uncaught_exception_symbol_l, error };
+  Local<Value> argv[1] = { error };
 
-  TryCatch event_try_catch;
-  emit->Call(process, 2, event_argv);
+  TryCatch fatal_try_catch;
 
-  if (event_try_catch.HasCaught()) {
-    // the uncaught exception event threw, so we must exit.
-    ReportException(event_try_catch, true);
+  // this will return true if the JS layer handled it, false otherwise
+  Local<Value> caught = fatal_f->Call(process, ARRAY_SIZE(argv), argv);
+
+  if (fatal_try_catch.HasCaught()) {
+    // the fatal exception function threw, so we must exit
+    ReportException(fatal_try_catch, true);
+    exit(1);
+  }
+
+  if (false == caught->BooleanValue()) {
+    ReportException(try_catch, true);
     exit(1);
   }
 }

--- a/src/node.js
+++ b/src/node.js
@@ -231,7 +231,7 @@
           return true;
 
         er.domain = domain;
-        er.domain_thrown = true;
+        er.domainThrown = true;
         // wrap this in a try/catch so we don't get infinite throwing
         try {
           caught = domain.emit('error', er);

--- a/src/node.js
+++ b/src/node.js
@@ -234,6 +234,14 @@
         er.domainThrown = true;
         // wrap this in a try/catch so we don't get infinite throwing
         try {
+          // One of three things will happen here.
+          //
+          // 1. There is a handler, caught = true
+          // 2. There is no handler, caught = false
+          // 3. It throws, caught = false
+          //
+          // If caught is false after this, then there's no need to exit()
+          // the domain, because we're going to crash the process anyway.
           caught = domain.emit('error', er);
           domain.exit();
         } catch (er2) {

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+process.nextTick(function() {
+  process.nextTick(function() {
+    process.nextTick(function() {
+      process.nextTick(function() {
+        undefined_reference_error_maker;
+      });
+    });
+  });
+});

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -1,0 +1,6 @@
+*test*message*nexttick_throw.js:*
+        undefined_reference_error_maker;
+        ^
+ReferenceError: undefined_reference_error_maker is not defined
+    at *test*message*nexttick_throw.js:*:*
+    at process._tickCallback (node.js:*:*)

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -1,0 +1,27 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+setTimeout(function() {
+  undefined_reference_error_maker;
+});

--- a/test/message/timeout_throw.out
+++ b/test/message/timeout_throw.out
@@ -1,0 +1,7 @@
+*test*message*timeout_throw.js:*
+  undefined_reference_error_maker;
+  ^
+ReferenceError: undefined_reference_error_maker is not defined
+    at null._onTimeout (*test*message*timeout_throw.js:*:*)
+    at Timer.list.ontimeout (timers.js:*:*)
+    at process._makeCallback (node.js:*:*)

--- a/test/simple/test-domain-implicit-fs.js
+++ b/test/simple/test-domain-implicit-fs.js
@@ -36,8 +36,8 @@ d.on('error', function(er) {
   console.error('caught', er);
 
   assert.strictEqual(er.domain, d);
-  assert.strictEqual(er.domain_thrown, true);
-  assert.ok(!er.domain_emitter);
+  assert.strictEqual(er.domainThrown, true);
+  assert.ok(!er.domainEmitter);
   assert.strictEqual(er.code, 'ENOENT');
   assert.ok(/\bthis file does not exist\b/i.test(er.path));
   assert.strictEqual(typeof er.errno, 'number');

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -26,14 +26,15 @@ var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var events = require('events');
+var fs = require('fs');
 var caught = 0;
-var expectCaught = 8;
+var expectCaught = 0;
 
 var d = new domain.Domain();
 var e = new events.EventEmitter();
 
 d.on('error', function(er) {
-  console.error('caught', er);
+  console.error('caught', er && (er.message || er));
 
   var er_message = er.message;
   var er_path = er.path
@@ -110,24 +111,58 @@ d.on('error', function(er) {
       break;
 
     default:
-      console.error('unexpected error, throwing %j', er.message);
+      console.error('unexpected error, throwing %j', er.message || er);
       throw er;
   }
 
   caught++;
 });
 
+
+
 process.on('exit', function() {
-  console.error('exit');
-  assert.equal(caught, expectCaught);
+  console.error('exit', caught, expectCaught);
+  assert.equal(caught, expectCaught, 'caught the expected number of errors');
   console.log('ok');
 });
+
+
+// catch thrown errors no matter how many times we enter the event loop
+// this only uses implicit binding, except for the first function
+// passed to d.run().  The rest are implicitly bound by virtue of being
+// set up while in the scope of the d domain.
+d.run(function() {
+  process.nextTick(function() {
+    var i = setInterval(function () {
+      clearInterval(i);
+      setTimeout(function() {
+        fs.stat('this file does not exist', function(er, stat) {
+          // uh oh!  stat isn't set!
+          // pretty common error.
+          console.log(stat.isDirectory());
+        });
+      });
+    });
+  });
+});
+expectCaught++;
+
+
+
+// implicit addition of a timer created within a domain-bound context.
+d.run(function() {
+  setTimeout(function() {
+    throw new Error('implicit timer');
+  });
+});
+expectCaught++;
 
 
 
 // Event emitters added to the domain have their errors routed.
 d.add(e);
 e.emit('error', new Error('emitted'));
+expectCaught++;
 
 
 
@@ -141,6 +176,9 @@ function fn(er) {
 
 var bound = d.intercept(fn);
 bound(new Error('bound'));
+expectCaught++;
+
+
 
 // intercepted should never pass first argument to callback
 function fn2(data) {
@@ -169,36 +207,16 @@ function thrower() {
   throw new Error('thrown');
 }
 setTimeout(d.bind(thrower), 100);
+expectCaught++;
 
 
 
 // Pass an intercepted function to an fs operation that fails.
-var fs = require('fs');
 fs.open('this file does not exist', 'r', d.intercept(function(er) {
   console.error('should not get here!', er);
   throw new Error('should not get here!');
 }, true));
-
-
-
-// catch thrown errors no matter how many times we enter the event loop
-// this only uses implicit binding, except for the first function
-// passed to d.run().  The rest are implicitly bound by virtue of being
-// set up while in the scope of the d domain.
-d.run(function() {
-  process.nextTick(function() {
-    var i = setInterval(function () {
-      clearInterval(i);
-      setTimeout(function() {
-        fs.stat('this file does not exist', function(er, stat) {
-          // uh oh!  stat isn't set!
-          // pretty common error.
-          console.log(stat.isDirectory());
-        });
-      });
-    });
-  });
-});
+expectCaught++;
 
 
 
@@ -213,15 +231,8 @@ setTimeout(function() {
   // escape from the domain, but implicit is still bound to it.
   implicit.emit('error', new Error('implicit'));
 }, 10);
+expectCaught++;
 
-
-
-// implicit addition of a timer created within a domain-bound context.
-d.run(function() {
-  setTimeout(function() {
-    throw new Error('implicit timer');
-  });
-});
 
 var result = d.run(function () {
   return 'return value';
@@ -231,3 +242,4 @@ assert.equal(result, 'return value');
 
 var fst = fs.createReadStream('stream for nonexistent file')
 d.add(fst)
+expectCaught++;

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -53,28 +53,28 @@ d.on('error', function(er) {
   switch (er_message) {
     case 'emitted':
       assert.equal(er.domain, d);
-      assert.equal(er.domain_emitter, e);
-      assert.equal(er.domain_thrown, false);
+      assert.equal(er.domainEmitter, e);
+      assert.equal(er.domainThrown, false);
       break;
 
     case 'bound':
-      assert.ok(!er.domain_emitter);
+      assert.ok(!er.domainEmitter);
       assert.equal(er.domain, d);
-      assert.equal(er.domain_bound, fn);
-      assert.equal(er.domain_thrown, false);
+      assert.equal(er.domainBound, fn);
+      assert.equal(er.domainThrown, false);
       break;
 
     case 'thrown':
-      assert.ok(!er.domain_emitter);
+      assert.ok(!er.domainEmitter);
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, true);
+      assert.equal(er.domainThrown, true);
       break;
 
     case "ENOENT, open 'this file does not exist'":
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, false);
-      assert.equal(typeof er.domain_bound, 'function');
-      assert.ok(!er.domain_emitter);
+      assert.equal(er.domainThrown, false);
+      assert.equal(typeof er.domainBound, 'function');
+      assert.ok(!er.domainEmitter);
       assert.equal(er.code, 'ENOENT');
       assert.equal(er_path, 'this file does not exist');
       assert.equal(typeof er.errno, 'number');
@@ -85,33 +85,33 @@ d.on('error', function(er) {
       assert.equal(er.code, 'ENOENT');
       assert.equal(er_path, 'stream for nonexistent file');
       assert.equal(er.domain, d);
-      assert.equal(er.domain_emitter, fst);
-      assert.ok(!er.domain_bound);
-      assert.equal(er.domain_thrown, false);
+      assert.equal(er.domainEmitter, fst);
+      assert.ok(!er.domainBound);
+      assert.equal(er.domainThrown, false);
       break;
 
     case 'implicit':
-      assert.equal(er.domain_emitter, implicit);
+      assert.equal(er.domainEmitter, implicit);
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, false);
-      assert.ok(!er.domain_bound);
+      assert.equal(er.domainThrown, false);
+      assert.ok(!er.domainBound);
       break;
 
     case 'implicit timer':
       assert.equal(er.domain, d);
-      assert.equal(er.domain_thrown, true);
-      assert.ok(!er.domain_emitter);
-      assert.ok(!er.domain_bound);
+      assert.equal(er.domainThrown, true);
+      assert.ok(!er.domainEmitter);
+      assert.ok(!er.domainBound);
       break;
 
     case 'Cannot call method \'isDirectory\' of undefined':
       assert.equal(er.domain, d);
-      assert.ok(!er.domain_emitter);
-      assert.ok(!er.domain_bound);
+      assert.ok(!er.domainEmitter);
+      assert.ok(!er.domainBound);
       break;
 
     default:
-      console.error('unexpected error, throwing %j', er.message || er);
+      console.error('unexpected error, throwing %j', er.message, er);
       throw er;
   }
 


### PR DESCRIPTION
This also makes a bunch of other kludges a bit nicer, and gives domains first-class status an an error handling mechanism.

Bonus: use camelCase instead of snake_case.  Mixing the two can have disastrously confusing results.

![](http://www.freakingnews.com/pictures/60500/Poisonous-Camel-Snake--60626.jpg)
