### PR TITLE
domain: speed up domain.create

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -70,7 +70,7 @@ function uncaughtHandler(er) {
 inherits(Domain, EventEmitter);
 
 function Domain() {
-  EventEmitter.apply(this);
+  EventEmitter.call(this);
 
   this.members = [];
 }


### PR DESCRIPTION
Use `EventEmitter.call` instead of `EventEmitter.apply` because of performance.

benchmark is here: https://gist.github.com/4389306

Before:

```
source:
function Domain() {
  EventEmitter.apply(this);

  this.members = [];
}
- 1227 ms
```

After:

```
source:
function Domain() {
  EventEmitter.call(this);

  this.members = [];
}
- 865 ms
```
