### PR TITLE
http: remove unused variable

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -27,8 +27,6 @@ var EventEmitter = require('events').EventEmitter;
 var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;
 var assert = require('assert').ok;
-var END_OF_FILE = {};
-
 
 var debug;
 if (process.env.NODE_DEBUG && /http/.test(process.env.NODE_DEBUG)) {


### PR DESCRIPTION
The module variable `END_OF_FILE` was no longer needed from 1d369317.
