### PR TITLE
stream: speed up instantiation of readable stream

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -91,7 +91,7 @@ function Readable(options) {
   // legacy
   this.readable = true;
 
-  Stream.apply(this);
+  Stream.call(this);
 }
 
 // backwards compatibility.


### PR DESCRIPTION
Use `Stream.call` instead of `Stream.apply`.

benchmark is here: https://gist.github.com/4389641

Before:

```
*   Stream.apply(this); - 959 ms
```

After:

```
*   Stream.call(this); - 901 ms
```
