### PR TITLE
Colorize documentation stability indices

### DIFF
--- a/doc/api/documentation.markdown
+++ b/doc/api/documentation.markdown
@@ -31,32 +31,46 @@ proven, and so relied upon, that they are unlikely to ever change at
 all.  Others are brand new and experimental, or known to be hazardous
 and in the process of being redesigned.
 
-The notices look like this:
-
-    Stability: 1 Experimental
-
 The stability indices are as follows:
 
-* **0 - Deprecated**  This feature is known to be problematic, and changes are
+```
+Stability: 0 - Deprecated
+This feature is known to be problematic, and changes are
 planned.  Do not rely on it.  Use of the feature may cause warnings.  Backwards
 compatibility should not be expected.
+```
 
-* **1 - Experimental**  This feature was introduced recently, and may change
+```
+Stability: 1 - Experimental
+This feature was introduced recently, and may change
 or be removed in future versions.  Please try it out and provide feedback.
 If it addresses a use-case that is important to you, tell the node core team.
+```
 
-* **2 - Unstable**  The API is in the process of settling, but has not yet had
+```
+Stability: 2 - Unstable
+The API is in the process of settling, but has not yet had
 sufficient real-world testing to be considered stable. Backwards-compatibility
 will be maintained if reasonable.
+```
 
-* **3 - Stable**  The API has proven satisfactory, but cleanup in the underlying
+```
+Stability: 3 - Stable
+The API has proven satisfactory, but cleanup in the underlying
 code may cause minor changes.  Backwards-compatibility is guaranteed.
+```
 
-* **4 - API Frozen**  This API has been tested extensively in production and is
+```
+Stability: 4 - API Frozen
+This API has been tested extensively in production and is
 unlikely to ever have to change.
+```
 
-* **5 - Locked**  Unless serious bugs are found, this code will not ever
+```
+Stability: 5 - API Locked
+Unless serious bugs are found, this code will not ever
 change.  Please do not suggest changes in this area; they will be refused.
+```
 
 ## JSON Output
 

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -67,6 +67,30 @@ code a:hover {
   margin: 0;
 }
 
+.api_stability_0 {
+  border-color: #D60027;
+}
+
+.api_stability_1 {
+  border-color: #EC5315;
+}
+
+.api_stability_2 {
+  border-color: #FFD700;
+}
+
+.api_stability_3 {
+  border-color: #AEC516;
+}
+
+.api_stability_4 {
+  border-color: #009431;
+}
+
+.api_stability_5 {
+  border-color: #0084B6;
+}
+
 ul.plain {
   list-style: none;
 }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -69,6 +69,11 @@ function parseLists(input) {
   var output = [];
   output.links = input.links;
   input.forEach(function(tok) {
+    if (tok.type === 'code' && tok.text.match(/Stability:.*/g)) {
+      tok.text = parseAPIHeader(tok.text);
+      output.push({ type: 'html', text: tok.text });
+      return;
+    }
     if (state === null) {
       if (tok.type === 'heading') {
         state = 'AFTERHEADING';
@@ -122,6 +127,11 @@ function parseListItem(text) {
   return text;
 }
 
+function parseAPIHeader(text) {
+  text = text.replace(/(.*:)\s(\d)([\s\S]*)/,
+                      '<pre class="api_stability_$2">$1 $2$3</pre>');
+  return text;
+}
 
 // section is just the first heading
 function getSection(lexed) {


### PR DESCRIPTION
As @shtylman noted in #3898, API stability headers are easy to overlook. This change gives the headers a corresponding css class added at doc generation time. I initially started to do this with the updated version of https://github.com/chjj/marked, but it turns out updating the markdown parser wasn't necessary (the highlight cb in the latest version did not work as expected).

The docs can be previewed here: http://st-luke.github.com/node/documentation.html
