### PR TITLE
https: seed up function to create https connection

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -57,26 +57,24 @@ exports.createServer = function(opts, requestListener) {
 
 // HTTPS agents.
 
-function createConnection(/* [port, host, options] */) {
-  var options = {};
-
-  if (typeof arguments[0] === 'object') {
-    options = arguments[0];
-  } else if (typeof arguments[1] === 'object') {
-    options = arguments[1];
-    options.port = arguments[0];
-  } else if (typeof arguments[2] === 'object') {
-    options = arguments[2];
-    options.port = arguments[0];
-    options.host = arguments[1];
+function createConnection(port, host, options) {
+  if (typeof port === 'object') {
+    options = port;
+  } else if (typeof host === 'object') {
+    options = host;
+  } else if (typeof options === 'object') {
+    options = options;
   } else {
-    if (typeof arguments[0] === 'number') {
-      options.port = arguments[0];
-    }
-    if (typeof arguments[1] === 'string') {
-      options.host = arguments[1];
-    }
+    options = {};
   }
+
+  if (typeof port === 'number') {
+    options.port = port;
+  }
+  if (typeof host === 'string') {
+    options.host = host;
+  }
+
   return tls.connect(options);
 }
 


### PR DESCRIPTION
Stop using `arguments` for performance and readability.

benchmark is here: https://gist.github.com/4395584

Before

```
* createConnection(port, host, options) - 380 ms
* createConnection(port, options) - 359 ms
* createConnection(options) - 315 ms
* createConnection(port) - 2680 ms
* createConnection(port, host) - 1836 ms
```

After

```
* createConnection(port, host, options) - 268 ms
* createConnection(port, options) - 302 ms
* createConnection(options) - 281 ms
* createConnection(port) - 788 ms
* createConnection(port, host) - 843 ms
```
