### PR TITLE
TypedArrays is not a module, it is attached to the global object.

### DIFF
--- a/src/node_extensions.h
+++ b/src/node_extensions.h
@@ -22,7 +22,6 @@
 
 NODE_EXT_LIST_START
 NODE_EXT_LIST_ITEM(node_buffer)
-NODE_EXT_LIST_ITEM(node_typed_array)
 #if HAVE_OPENSSL
 NODE_EXT_LIST_ITEM(node_crypto)
 #endif

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -846,5 +846,3 @@ int SizeOfArrayElementForType(v8::ExternalArrayType type) {
 }
 
 }  // namespace v8_typed_array
-
-NODE_MODULE(node_typed_array, v8_typed_array::AttachBindings)


### PR DESCRIPTION
Don't register it with Node's module system.
