### PR TITLE
Move symbol caching to Load().

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2374,6 +2374,9 @@ static void SignalExit(int signal) {
 
 
 void Load(Handle<Object> process_l) {
+  process_symbol = NODE_PSYMBOL("process");
+  domain_symbol = NODE_PSYMBOL("domain");
+
   // Compile, execute the src/node.js file. (Which was included as static C
   // string in node_natives.h. 'natve_node' is the string containing that
   // source code.)
@@ -2982,9 +2985,6 @@ int Start(int argc, char *argv[]) {
     // Create the one and only Context.
     Persistent<Context> context = Context::New();
     Context::Scope context_scope(context);
-
-    process_symbol = NODE_PSYMBOL("process");
-    domain_symbol = NODE_PSYMBOL("domain");
 
     // Use original argv, as we're just copying values out of it.
     Handle<Object> process_l = SetupProcessObject(argc, argv);


### PR DESCRIPTION
Start() is meant to be a helper, but not a requirement for embedders of Node.  Load() is exported and meant to be where setup happens, so move the symbol caching (added in 636add246ca78be5c374cfd951c76de7f1010fb9) into Load.
