### PR TITLE
Convert TypedArray's TypeName implementation to template specialization

### DIFF
--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -169,6 +169,30 @@ static bool checkAlignment(size_t val, unsigned int bytes) {
   return (val & (bytes - 1)) == 0;  // Handles bytes == 0.
 }
 
+template <v8::ExternalArrayType TEAType>
+struct TEANameTrait {
+  static const char* const name;
+};
+
+template <> const char* const
+    TEANameTrait<v8::kExternalByteArray>::name = "Int8Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalUnsignedByteArray>::name = "Uint8Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalPixelArray>::name = "Uint8ClampedArray";
+template <> const char* const
+    TEANameTrait<v8::kExternalShortArray>::name = "Int16Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalUnsignedShortArray>::name = "Uint16Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalIntArray>::name = "Int32Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalUnsignedIntArray>::name = "Uint32Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalFloatArray>::name = "Float32Array";
+template <> const char* const
+    TEANameTrait<v8::kExternalDoubleArray>::name = "Float64Array";
+
 template <unsigned int TBytes, v8::ExternalArrayType TEAType>
 class TypedArray {
  public:
@@ -180,7 +204,7 @@ class TypedArray {
     v8::HandleScope scope;
     ft_cache = v8::Persistent<v8::FunctionTemplate>::New(
         v8::FunctionTemplate::New(&TypedArray<TBytes, TEAType>::V8New));
-    ft_cache->SetClassName(v8::String::New(TypeName()));
+    ft_cache->SetClassName(v8::String::New(TEANameTrait<TEAType>::name));
     v8::Local<v8::ObjectTemplate> instance = ft_cache->InstanceTemplate();
     instance->SetInternalFieldCount(0);
 
@@ -432,23 +456,6 @@ class TypedArray {
         v8::Integer::New(end - begin)};
     return TypedArray<TBytes, TEAType>::GetTemplate()->
         GetFunction()->NewInstance(3, argv);
-  }
-
-  static const char* TypeName() {
-    switch (TEAType) {
-      case v8::kExternalByteArray: return "Int8Array";
-      case v8::kExternalUnsignedByteArray: return "Uint8Array";
-      case v8::kExternalShortArray: return "Int16Array";
-      case v8::kExternalUnsignedShortArray: return "Uint16Array";
-      case v8::kExternalIntArray: return "Int32Array";
-      case v8::kExternalUnsignedIntArray: return "Uint32Array";
-      case v8::kExternalFloatArray: return "Float32Array";
-      case v8::kExternalDoubleArray: return "Float64Array";
-      case v8::kExternalPixelArray: return "Uint8ClampedArray";
-    }
-    abort();
-    // Please the compiler
-    return "";
   }
 };
 


### PR DESCRIPTION
This has the added advantage of compile-time error if you add a new type without adding the string, and gets rid of the runtime abort() / return "" please the compiler stuff.  I think for GCC it will produce the same code as before, I tested that it compiles on MSVC and I reckon it should produce either the same or better code.
