### PR TITLE
repl: handle async error in repl

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -47,6 +47,7 @@ var vm = require('vm');
 var path = require('path');
 var fs = require('fs');
 var rl = require('readline');
+var domain = require('domain');
 var Console = require('console').Console;
 var EventEmitter = require('events').EventEmitter;
 
@@ -199,6 +200,13 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     self.displayPrompt();
   });
 
+  var replDomain = domain.create();
+  replDomain.on('error', function(e) {
+    self.outputStream.write((e.stack || e) + '\n');
+    self.bufferedCommand = '';
+    self.displayPrompt();
+  });
+
   rli.on('line', function(cmd) {
     sawSIGINT = false;
     var skipCatchall = false;
@@ -245,21 +253,24 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
       // First we attempt to eval as expression with parens.
       // This catches '{a : 1}' properly.
-      self.eval('(' + evalCmd + ')',
-                self.context,
-                'repl',
-                function(e, ret) {
-            if (e && !isSyntaxError(e)) return finish(e);
 
-            if (typeof ret === 'function' &&
-                /^[\r\n\s]*function/.test(evalCmd) ||
-                e) {
-              // Now as statement without parens.
-              self.eval(evalCmd, self.context, 'repl', finish);
-            } else {
-              finish(null, ret);
-            }
-          });
+      replDomain.run(function() {
+        self.eval('(' + evalCmd + ')',
+                  self.context,
+                  'repl',
+                  function(e, ret) {
+                    if (e && !isSyntaxError(e)) return finish(e);
+
+                    if (typeof ret === 'function' &&
+                        /^[\r\n\s]*function/.test(evalCmd) ||
+                        e) {
+                      // Now as statement without parens.
+                      self.eval(evalCmd, self.context, 'repl', finish);
+                    } else {
+                      finish(null, ret);
+                    }
+                  });
+      });
 
     } else {
       finish(null);

--- a/test/simple/test-repl-handle-async-error.js
+++ b/test/simple/test-repl-handle-async-error.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var util = require('util');
+var repl = require('repl');
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function (data) {
+    var self = this;
+    data.forEach(function (line) {
+      self.emit('data', line + '\n');
+    });
+  }
+}
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function () {};
+ArrayStream.prototype.write = function () {};
+
+var putIn = new ArrayStream;
+var testMe = repl.start('', putIn, null, false);
+
+var handled = false;
+
+putIn.write = function(data) {
+  if (/Error: Async error thrown./.test(data)) {
+    handled = true;
+  }
+};
+putIn.run(['process.nextTick(function() { throw new Error("Async error thrown."); })']);
+
+process.on('exit', function() {
+  assert.equal(handled, true);
+});


### PR DESCRIPTION
I think `repl` should handle any error thrown.
But now async errors are unhandled in `repl`. 

When async error thrown, process is exited with status `1`.

``` sh
$ node
> process.nextTick(function() { throw new Error(); });
> 
repl:1
process.nextTick(function() { throw new Error(); });
                                    ^
Error
    at repl:1:37
    at process._tickCallback (node.js:386:13)
    at process._makeCallback (node.js:304:15)
```

I supported async error handling.
