### PR TITLE
expose the process global through require('process');

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -1,0 +1,24 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// for now just expose the global process object
+module.exports = process;

--- a/node.gyp
+++ b/node.gyp
@@ -40,6 +40,7 @@
       'lib/net.js',
       'lib/os.js',
       'lib/path.js',
+      'lib/process.js',
       'lib/punycode.js',
       'lib/querystring.js',
       'lib/readline.js',


### PR DESCRIPTION
This was done for the node specific buffer module a long time ago,
however process was left as a global. This allows the use of process via
a require so that going forward this can become the practice for
obtaining the process info much like buffer global was phased out.

see #4487 for some more comments on the topic.
