### PR TITLE
Improved note on process.hrtime()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -522,9 +522,10 @@ Number of seconds Node has been running.
 ## process.hrtime()
 
 Returns the current high-resolution real time in a `[seconds, nanoseconds]`
-tuple Array. It is relative to an arbitrary time in the past. It is not
-related to the time of day and therefore not subject to clock drift. The
-primary use is for measuring performance between intervals.
+tuple Array with the sum of both being the overall result. It is relative
+to an arbitrary time in the past. It is not related to the time of day and
+therefore not subject to clock drift. The primary use is for measuring
+performance between intervals.
 
 You may pass in the result of a previous call to `process.hrtime()` to get
 a diff reading, useful for benchmarks and measuring intervals:


### PR DESCRIPTION
I just had trouble understanding [process.hrtime()](http://nodejs.org/api/process.html#process_process_hrtime). I thought `process.hrtime()` returns the time in two units, seconds and nanoseconds. It took me some time to figure out that `time[0] * 1000000000 + time[1]` is actually the overall result in nanoseconds.

You may correct me if my English is bad, but please add a note on this. Don't want others to do the same mistake :smile: 
