### PR TITLE
Document that os.cpus() returns times in milliseconds, not ticks

### DIFF
--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -52,7 +52,7 @@ Returns the amount of free system memory in bytes.
 
 ## os.cpus()
 
-Returns an array of objects containing information about each CPU/core installed: model, speed (in MHz), and times (an object containing the number of CPU ticks spent in: user, nice, sys, idle, and irq).
+Returns an array of objects containing information about each CPU/core installed: model, speed (in MHz), and times (an object containing the number of milliseconds the CPU/core spent in: user, nice, sys, idle, and irq).
 
 Example inspection of os.cpus:
 


### PR DESCRIPTION
This is purely a documentation change, and corresponds to a pull request for libuv I sent a few minutes ago: most platforms are already doing this, the pull request changes the linux and solaris ports (I don't know what the AIX port does).

Note this is a change to the documentation of an API marked "frozen": however it changes the documentation to be closer to what actually happens.  However it won't be strictly true until the libuv code is merged into node proper.
