### PR TITLE
REPL .1+.2 fails -- the fix to https://github.com/joyent/node/issues/4268 was not complete

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -206,7 +206,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (cmd && cmd.charAt(0) === '.' && cmd != parseFloat(cmd)) {
+    if (cmd && cmd.charAt(0) === '.' && isNaN(parseFloat(cmd))) {
       var matches = cmd.match(/^(\.[^\s]+)\s*(.*)$/);
       var keyword = matches && matches[1];
       var rest = matches && matches[2];

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -122,6 +122,9 @@ function error_test() {
     // Floating point numbers are not interpreted as REPL commands.
     { client: client_unix, send: '.1234',
       expect: '0.1234' },
+    // Floating point numbers are not interpreted as REPL commands, part 2
+		{ client: client_unix, send: '.1+.1',
+      expect: '0.2' },
     // Can parse valid JSON
     { client: client_unix, send: 'JSON.parse(\'{"valid": "json"}\');',
       expect: '{ valid: \'json\' }'},


### PR DESCRIPTION
```
.1+.2
```

The original fix in https://github.com/bnoordhuis/node/commit/b6e989759bfcfdc00d9d4b5a3b32d31ea29838c0 only worked for a single float (and not for an arbitrary expression).
