### PR TITLE
Fixing path._makeLong to have consistent behavior across platforms

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -448,6 +448,6 @@ if (isWindows) {
   };
 } else {
   exports._makeLong = function(path) {
-    return path;
+    return exports.resolve(path);
   };
 }


### PR DESCRIPTION
On windows functions that depend on path._makeLong (like readdir) resolve relative paths.  This PR updates the_makeLong export to have consistent behavior.
