### PR TITLE
WINDOWS: Fix perfctr crash on Windows XP and Windows Server 2003

### DIFF
--- a/src/node_win32_perfctr_provider.cc
+++ b/src/node_win32_perfctr_provider.cc
@@ -172,6 +172,13 @@ void InitPerfCountersWin32() {
     ZeroMemory(&providerContext, sizeof(providerContext));
     providerContext.ContextSize = sizeof(providerContext);
 
+    if (!perfctr_startProvider ||
+        !perfctr_setCounterSetInfo ||
+        !perfctr_createInstance) {
+      NodeCounterProvider = NULL;
+      return;
+    }
+
     status = perfctr_startProvider(&NodeCounterSetGuid,
                                    &providerContext,
                                    &NodeCounterProvider);


### PR DESCRIPTION
fixes #4462
