### PR TITLE
REPL: fix floating point number parsing

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -206,7 +206,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (cmd && cmd.charAt(0) === '.' && cmd != parseFloat(cmd)) {
+    if (cmd && cmd.charAt(0) === '.' && isNaN(parseFloat(cmd))) {
       var matches = cmd.match(/^(\.[^\s]+)\s*(.*)$/);
       var keyword = matches && matches[1];
       var rest = matches && matches[2];

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -122,6 +122,9 @@ function error_test() {
     // Floating point numbers are not interpreted as REPL commands.
     { client: client_unix, send: '.1234',
       expect: '0.1234' },
+    // Floating point expressions are not interpreted as REPL commands
+		{ client: client_unix, send: '.1+.1',
+      expect: '0.2' },
     // Can parse valid JSON
     { client: client_unix, send: 'JSON.parse(\'{"valid": "json"}\');',
       expect: '{ valid: \'json\' }'},


### PR DESCRIPTION
In JS, the expression ".1" is a floating point number.  Issue 4268 concerns the
REPL interpreting floating point numbers that lead with a "." as keywords.  The
original bugfix worked for this specific case but not for the general case:

```
var x = [
    .1,
    .2,
    .3
];
```

The attached change and test (`.1+.1` should be `.2`) fix the bug.
