### PR TITLE
Use close event instead of exit in child_process example.

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -298,7 +298,7 @@ Example: A very elaborate way to run 'ps ax | grep ssh'
       console.log('ps stderr: ' + data);
     });
 
-    ps.on('exit', function (code) {
+    ps.on('close', function (code) {
       if (code !== 0) {
         console.log('ps process exited with code ' + code);
       }
@@ -313,7 +313,7 @@ Example: A very elaborate way to run 'ps ax | grep ssh'
       console.log('grep stderr: ' + data);
     });
 
-    grep.on('exit', function (code) {
+    grep.on('close', function (code) {
       if (code !== 0) {
         console.log('grep process exited with code ' + code);
       }


### PR DESCRIPTION
Node doesn't guarantee that all the data will be read from the 'ps' before its
'exit' event is called, so the example is misleading.

(I suppose this really should be rewritten to use streams2, but this is at least an incremental improvement. I found a real bug in my code today that was modeled after this example and assuming that 'exit' came after all stdout 'data'.)
