### PR TITLE
fs: pool size coincide with ReadStream bufferSize

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1559,7 +1559,6 @@ function WriteStream(path, options) {
 
   // a little bit bigger buffer and water marks by default
   options = util._extend({
-    bufferSize: 64 * 1024,
     lowWaterMark: 16 * 1024,
     highWaterMark: 64 * 1024
   }, options || {});

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -38,7 +38,6 @@ var Readable = Stream.Readable;
 var Writable = Stream.Writable;
 
 var kMinPoolSpace = 128;
-var kPoolSize = 40 * 1024;
 
 var O_APPEND = constants.O_APPEND || 0;
 var O_CREAT = constants.O_CREAT || 0;
@@ -1370,8 +1369,8 @@ fs.realpath = function realpath(p, cache, cb) {
 
 var pool;
 
-function allocNewPool() {
-  pool = new Buffer(kPoolSize);
+function allocNewPool(poolSize) {
+  pool = new Buffer(poolSize);
   pool.used = 0;
 }
 
@@ -1468,7 +1467,7 @@ ReadStream.prototype._read = function(n, cb) {
     // discard the old pool. Can't add to the free list because
     // users might have refernces to slices on it.
     pool = null;
-    allocNewPool();
+    allocNewPool(this._readableState.bufferSize);
   }
 
   // Grab another reference to the pool in the case that while we're


### PR DESCRIPTION
pool size of file reading in ReadableStream was statically set 40k. It can be adjustable with a bufferSize option for performace tuning of file read.
Benchmarking results in reading/writing file stream of 100Mbyte are below.

```
//  fs_stream_bench.js
var fs = require('fs');
var infile = '/home/ohtsu/tmp/100M.file';
var outfile = infile + '.out';
var kB = 1024;
var bufferSizeList = [2 * 64 * kB, 3 * 64 * kB, 4 * 64 * kB, 5 * 64 * kB];

function fsStreamBench(bufferSize) {
  var option = {};
  if (bufferSize) option.bufferSize = bufferSize;
  if (fs.existsSync(outfile)) fs.unlinkSync(outfile);

  var rstream = fs.createReadStream(infile, option);
  var wstream = fs.createWriteStream(outfile);

  var start = Date.now();
  rstream.pipe(wstream);

  wstream.on('finish', function() {
    var bufSize = rstream._readableState.bufferSize;
    console.log('bufferSize:', bufSize, ', time:', Date.now() - start);
    if (bufferSizeList.length) fsStreamBench(bufferSizeList.shift());
  });
}

fsStreamBench();
```

```
# node-v0.9.5
> ./node ~/tmp/fs_stream_bench.js
bufferSize: 65536 , time: 307
bufferSize: 131072 , time: 287
bufferSize: 196608 , time: 274
bufferSize: 262144 , time: 277
bufferSize: 327680 , time: 320

# after this commit
> ./node ~/tmp/fs_stream_bench.js
bufferSize: 65536 , time: 255
bufferSize: 131072 , time: 196
bufferSize: 196608 , time: 156
bufferSize: 262144 , time: 170
bufferSize: 327680 , time: 139
```

And another commit to remove unsed bufferSize option in WriteStream was added.
