### PR TITLE
doc: Improved example of process.hrtime()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -418,15 +418,15 @@ You may pass in the result of a previous call to `process.hrtime()` to get
 a diff reading, useful for benchmarks and measuring intervals:
 
     var time = process.hrtime();
-    // [ 1800216, 927643717 ]
+    // [ 1800216, 25 ]
 
     setTimeout(function () {
       var diff = process.hrtime(time);
-      // [ 1, 6962306 ]
+      // [ 1, 552 ]
 
-      console.log('benchmark took %d seconds and %d nanoseconds',
-                  diff[0], diff[1]);
-      // benchmark took 1 seconds and 6962306 nanoseconds
+      console.log('benchmark took %d nanoseconds',
+                  diff[0] * 1000000000 + diff[1]);
+      // benchmark took 1000000527 nanoseconds
     }, 1000);
 
 [EventEmitter]: events.html#events_class_events_eventemitter


### PR DESCRIPTION
The example clarifies now that diff[0] \* 1000000000 + diff[1] equals the result in nanoseconds.

See [here](/joyent/node/pull/4498) for further discussion.
