### PR TITLE
net: fix bufferSize include writableStream length

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -316,7 +316,7 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 Object.defineProperty(Socket.prototype, 'bufferSize', {
   get: function() {
     if (this._handle) {
-      return this._handle.writeQueueSize;
+      return this._handle.writeQueueSize + this._writableState.length;
     }
   }
 });

--- a/test/simple/test-net-buffersize.js
+++ b/test/simple/test-net-buffersize.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var iter = 10;
+
+var server = net.createServer(function(socket) {
+  socket.on('readable', function() {
+    socket.read();
+  });
+
+  socket.on('end', function() {
+    server.close();
+  });
+});
+
+server.listen(common.PORT, function() {
+  var client = net.connect(common.PORT);
+
+  client.on('finish', function() {
+    assert.strictEqual(client.bufferSize, 0);
+  });
+
+  for (var i = 1; i < iter; i++) {
+    client.write('a');
+    assert.strictEqual(client.bufferSize, i);
+  }
+
+  client.end();
+});


### PR DESCRIPTION
socket.bufferSize missed to include the length of internal buffers in writableStream.
Testing results are shown below.

```
var net = require('net');

var server = net.createServer(function(socket) {
  socket.on('readable', function() {
    socket.read();
  });
  socket.on('end', function() {
    server.close();
  });
});
server.listen(1234, function() {
  var client = net.connect(1234);
  client.on('finish', function() {
    console.log('finish: socket.bufferSize=' + client.bufferSize);
  });
  for(var i = 1; i < 10; i++) {
    client.write('a');
    console.log(i + ': socket.bufferSize= ' + client.bufferSize);
  }
  client.end();
});
```

node-v0.9.5,

```
1: socket.bufferSize= 0
2: socket.bufferSize= 0
3: socket.bufferSize= 0
4: socket.bufferSize= 0
5: socket.bufferSize= 0
6: socket.bufferSize= 0
7: socket.bufferSize= 0
8: socket.bufferSize= 0
9: socket.bufferSize= 0
finish: socket.bufferSize=0
```

after this commit,

```
1: socket.bufferSize= 1
2: socket.bufferSize= 2
3: socket.bufferSize= 3
4: socket.bufferSize= 4
5: socket.bufferSize= 5
6: socket.bufferSize= 6
7: socket.bufferSize= 7
8: socket.bufferSize= 8
9: socket.bufferSize= 9
finish: socket.bufferSize=0
```
