### PR TITLE
Fixing extra boolean conversion in assert

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -119,7 +119,7 @@ assert.fail = fail;
 // assert.strictEqual(true, guard, message_opt);.
 
 function ok(value, message) {
-  if (!!!value) fail(value, true, message, '==', assert.ok);
+  if (!value) fail(value, true, message, '==', assert.ok);
 }
 assert.ok = ok;
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -448,6 +448,6 @@ if (isWindows) {
   };
 } else {
   exports._makeLong = function(path) {
-    return path;
+    return exports.resolve(path);
   };
 }

--- a/lib/path.js
+++ b/lib/path.js
@@ -448,6 +448,6 @@ if (isWindows) {
   };
 } else {
   exports._makeLong = function(path) {
-    return exports.resolve(path);
+    return path;
   };
 }


### PR DESCRIPTION
This should result in a very minor performance improvement as there will be 2 less boolean conversions being performed.  For this situation, when checking if the expression is false, the extra boolean conversion is not needed as the falsiness will be handled with the single boolean conversion.
