### PR TITLE
path: fix bugs related to paths with trailing slashes

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -290,7 +290,17 @@ if (isWindows) {
   // 'root' is just a slash, or nothing.
   var splitPathRe =
       /^(\/?)([\s\S]+\/(?!$)|\/)?((?:\.{1,2}$|[\s\S]+?)?(\.[^.\/]*)?)$/;
+  var trailingSlash = /\/+$/;
   var splitPath = function(filename) {
+
+    // removes trailing slashes before spliting the path
+    var tail = trailingSlash.exec(filename);
+    if (tail) {
+      if (tail.index === 0) return ['/', '', '', ''];
+
+      filename = filename.slice(0, tail.index);
+    }
+
     var result = splitPathRe.exec(filename);
     return [result[1] || '', result[2] || '', result[3] || '', result[4] || ''];
   };

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -30,6 +30,11 @@ var f = __filename;
 
 assert.equal(path.basename(f), 'test-path.js');
 assert.equal(path.basename(f, '.js'), 'test-path');
+assert.equal(path.basename('/dir/basename.ext'), 'basename.ext');
+assert.equal(path.basename('/basename.ext'), 'basename.ext');
+assert.equal(path.basename('basename.ext'), 'basename.ext');
+assert.equal(path.basename('basename.ext/'), 'basename.ext');
+assert.equal(path.basename('basename.ext//'), 'basename.ext');
 
 // POSIX filenames may include control characters
 // c.f. http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html
@@ -47,6 +52,7 @@ assert.equal(path.dirname('/a/b/'), '/a');
 assert.equal(path.dirname('/a/b'), '/a');
 assert.equal(path.dirname('/a'), '/');
 assert.equal(path.dirname('/'), '/');
+assert.equal(path.dirname('////'), '/');
 
 if (isWindows) {
   assert.equal(path.dirname('c:\\'), 'c:\\');
@@ -114,7 +120,8 @@ assert.equal(path.extname('..file..'), '.');
 assert.equal(path.extname('...'), '.');
 assert.equal(path.extname('...ext'), '.ext');
 assert.equal(path.extname('....'), '.');
-assert.equal(path.extname('file.ext/'), '');
+assert.equal(path.extname('file.ext/'), '.ext');
+assert.equal(path.extname('file.ext//'), '.ext');
 
 if (isWindows) {
   // On windows, backspace is a path separator.


### PR DESCRIPTION
Fix issue #4520

After look more closely at the `splitPath` code `path.basename` wasn't the only method there was (or would be) wrong.
- `path.extname('/file.ext/')`returned `''` (empty string). It now returns `.ext`
- `path.dirname('////')` returned `//`, it now returns '/'.
- `path.basename('/file.ext/')` returned `file.ext/`, it now returns `file.ext`.

This should be tested on windows as well, I have a license but I have never managed to compile node on windows properly. Could someone else test this?

Note: originally I had hoped to simply fix the `splitPathRe` regexp, but matching a not-fixed number of `/` at multiply positions did quickly become complicated.

/cc @bnoordhuis 
