### PR TITLE
streams: set listener first, emit 'data' later

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -511,12 +511,14 @@ Readable.prototype.unpipe = function(dest) {
 // This is *not* part of the new readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.on = function(ev, fn) {
+  var res = Stream.prototype.on.call(this, ev, fn);
+
   // https://github.com/isaacs/readable-stream/issues/16
   // if we're already flowing, then no need to set up data events.
   if (ev === 'data' && !this._readableState.flowing)
     emitDataEvents(this);
 
-  return Stream.prototype.on.call(this, ev, fn);
+  return res;
 };
 Readable.prototype.addListener = Readable.prototype.on;
 

--- a/test/simple/test-stream2-compatibility.js
+++ b/test/simple/test-stream2-compatibility.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var common = require('../common.js');
+var R = require('_stream_readable');
+var assert = require('assert');
+
+var util = require('util');
+var EE = require('events').EventEmitter;
+
+var ondataCalled = 0;
+
+function TestReader() {
+  R.apply(this);
+  this._buffer = new Buffer(100);
+  this._buffer.fill('x');
+
+  this.on('data', function() {
+    ondataCalled++;
+  });
+}
+
+util.inherits(TestReader, R);
+
+TestReader.prototype._read = function(n, cb) {
+  cb(null, this._buffer);
+  this._buffer = new Buffer(0);
+};
+
+var reader = new TestReader();
+assert.equal(ondataCalled, 1);


### PR DESCRIPTION
When switching into compatibility mode by setting `data` event listener,
`_read()` method will be called immediately. If method implementation
invokes callback in the same tick - all emitted `data` events will be
discarded, because `data` listener wasn't set yet.

/cc @isaacs
