### PR TITLE
Readable.prototype.push(chunk | null)

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -611,16 +611,11 @@ Readable.prototype.wrap = function(stream) {
     state.ended = true;
     if (state.decoder) {
       var chunk = state.decoder.end();
-      if (chunk && chunk.length) {
-        state.buffer.push(chunk);
-        state.length += chunk.length;
-      }
+      if (chunk && chunk.length)
+        self.push(chunk);
     }
 
-    if (state.length > 0)
-      self.emit('readable');
-    else
-      endReadable(self);
+    self.push(null);
   });
 
   stream.on('data', function(chunk) {
@@ -629,12 +624,8 @@ Readable.prototype.wrap = function(stream) {
     if (!chunk || !chunk.length)
       return;
 
-    state.buffer.push(chunk);
-    state.length += chunk.length;
-    self.emit('readable');
-
-    // if not consumed, then pause the stream.
-    if (state.length > state.lowWaterMark && !paused) {
+    var ret = self.push(chunk);
+    if (!ret) {
       paused = true;
       stream.pause();
     }
@@ -657,40 +648,13 @@ Readable.prototype.wrap = function(stream) {
     stream.on(ev, self.emit.bind(self, ev));
   });
 
-  // consume some bytes.  if not all is consumed, then
-  // pause the underlying stream.
-  this.read = function(n) {
-    if (state.length === 0) {
-      state.needReadable = true;
-      return null;
-    }
-
-    if (isNaN(n) || n <= 0)
-      n = state.length;
-
-    if (n > state.length) {
-      if (!state.ended) {
-        state.needReadable = true;
-        return null;
-      } else
-        n = state.length;
-    }
-
-    var ret = fromList(n, state.buffer, state.length, !!state.decoder);
-    state.length -= n;
-
-    if (state.length === 0 && !state.ended)
-      state.needReadable = true;
-
-    if (state.length <= state.lowWaterMark && paused) {
+  // when we try to consume some more bytes, simply unpause the
+  // underlying stream.
+  self._read = function(n, cb) {
+    if (paused) {
       stream.resume();
       paused = false;
     }
-
-    if (state.length === 0 && state.ended)
-      endReadable(this);
-
-    return ret;
   };
 };
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -94,6 +94,21 @@ function Readable(options) {
   Stream.call(this);
 }
 
+// Manually shove something into the read() buffer.
+// This returns true if the highWaterMark has not been hit yet,
+// similar to how Writable.write() returns true if you should
+// write() some more.
+Readable.prototype.push = function(chunk) {
+  var rs = this._readableState;
+  rs.onread(null, chunk);
+
+  // if it's past the high water mark, we can push in some more.
+  // Also, if it's still within the lowWaterMark, we can stand some
+  // more bytes.  This is to work around cases where hwm=0 and
+  // lwm=0, such as the repl.
+  return rs.length < rs.highWaterMark || rs.length <= rs.lowWaterMark;
+};
+
 // backwards compatibility.
 Readable.prototype.setEncoding = function(enc) {
   if (!StringDecoder)

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -75,7 +75,7 @@ function TransformState(stream) {
   this.transforming = false;
   this.pendingReadCb = null;
   this.output = function(chunk) {
-    stream._output(chunk);
+    stream.push(chunk);
   };
 }
 
@@ -148,9 +148,6 @@ Transform.prototype._read = function(n, readcb) {
   var rs = this._readableState;
   var ts = this._transformState;
 
-  if (ts.pendingReadCb)
-    throw new Error('_read while _read already in progress');
-
   ts.pendingReadCb = readcb;
 
   // if there's nothing pending, then we just wait.
@@ -173,31 +170,6 @@ Transform.prototype._read = function(n, readcb) {
   });
 };
 
-Transform.prototype._output = function(chunk) {
-  if (!chunk || !chunk.length)
-    return;
-
-  // if we've got a pending readcb, then just call that,
-  // and let Readable take care of it.  If not, then we fill
-  // the readable buffer ourselves, and emit whatever's needed.
-  var ts = this._transformState;
-  var readcb = ts.pendingReadCb;
-  if (readcb) {
-    ts.pendingReadCb = null;
-    readcb(null, chunk);
-    return;
-  }
-
-  // otherwise, it's up to us to fill the rs buffer.
-  var rs = this._readableState;
-  var len = rs.length;
-  rs.buffer.push(chunk);
-  rs.length += chunk.length;
-  if (rs.needReadable) {
-    rs.needReadable = false;
-    this.emit('readable');
-  }
-};
 
 function done(stream, er) {
   if (er)
@@ -215,17 +187,5 @@ function done(stream, er) {
   if (ts.transforming)
     throw new Error('calling transform done when still transforming');
 
-  // if we were waiting on a read, let them know that it isn't coming.
-  var readcb = ts.pendingReadCb;
-  if (readcb)
-    return readcb();
-
-  rs.ended = true;
-  // we may have gotten a 'null' read before, and since there is
-  // no more data coming from the writable side, we need to emit
-  // now so that the consumer knows to pick up the tail bits.
-  if (rs.length && rs.needReadable)
-    stream.emit('readable');
-  else if (rs.length === 0)
-    stream.emit('end');
+  return stream.push(null);
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -122,17 +122,15 @@ function parserOnBody(b, start, len) {
   if (!stream)
     return;
 
-  var rs = stream._readableState;
   var socket = stream.socket;
 
   // pretend this was the result of a stream._read call.
-  if (len > 0) {
+  if (len > 0 && !stream._dumped) {
     var slice = b.slice(start, start + len);
-    rs.onread(null, slice);
+    var ret = stream.push(slice);
+    if (!ret)
+      socket.pause();
   }
-
-  if (rs.length >= rs.highWaterMark)
-    socket.pause();
 }
 
 function parserOnMessageComplete() {
@@ -155,14 +153,12 @@ function parserOnMessageComplete() {
 
     if (!stream.upgrade)
       // For upgraded connections, also emit this after parser.execute
-      stream._readableState.onread(null, null);
+      stream.push(null);
   }
 
-  if (stream &&
-      !stream._readableState.endEmitted &&
-      !parser.incoming._pendings.length) {
+  if (stream && !parser.incoming._pendings.length) {
     // For emit end event
-    stream._readableState.onread(null, null);
+    stream.push(null);
   }
 
   if (parser.socket.readable) {
@@ -402,7 +398,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
 IncomingMessage.prototype._dump = function() {
   this._dumped = true;
   this.socket.parser.incoming = null;
-  this._readableState.onread(null, null);
+  this.push(null);
   this.socket.resume();
 };
 
@@ -1363,7 +1359,7 @@ function socketCloseListener() {
     res.on('end', function() {
       res.emit('close');
     });
-    res._readableState.onread(null, null);
+    res.push(null);
   } else if (!req.res && !req._hadError) {
     // This socket error fired before we started to
     // receive a response. The error needs to

--- a/lib/http.js
+++ b/lib/http.js
@@ -35,6 +35,16 @@ if (process.env.NODE_DEBUG && /http/.test(process.env.NODE_DEBUG)) {
   debug = function() { };
 }
 
+function readStart(socket) {
+  if (!socket || !socket._handle || !socket._handle.readStart) return;
+  socket._handle.readStart();
+}
+
+function readStop(socket) {
+  if (!socket || !socket._handle || !socket._handle.readStop) return;
+  socket._handle.readStop();
+}
+
 // Only called in the slow case where slow means
 // that the request headers were either fragmented
 // across multiple TCP packets or too large to be
@@ -129,7 +139,7 @@ function parserOnBody(b, start, len) {
     var slice = b.slice(start, start + len);
     var ret = stream.push(slice);
     if (!ret)
-      socket.pause();
+      readStop(socket);
   }
 }
 
@@ -163,7 +173,7 @@ function parserOnMessageComplete() {
 
   if (parser.socket.readable) {
     // force to read the next incoming message
-    parser.socket.resume();
+    readStart(parser.socket);
   }
 }
 
@@ -325,7 +335,7 @@ IncomingMessage.prototype._read = function(n, callback) {
   if (!this.socket.readable)
     return callback(null, null);
   else
-    this.socket.resume();
+    readStart(this.socket);
 };
 
 
@@ -399,7 +409,7 @@ IncomingMessage.prototype._dump = function() {
   this._dumped = true;
   this.socket.parser.incoming = null;
   this.push(null);
-  this.socket.resume();
+  readStart(this.socket);
 };
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -472,10 +472,11 @@ function onread(buffer, offset, length) {
     self.bytesRead += length;
 
     // Optimization: emit the original buffer with end points
+    var ret = true;
     if (self.ondata) self.ondata(buffer, offset, end);
-    else self._readableState.onread(null, buffer.slice(offset, end));
+    else ret = self.push(buffer.slice(offset, end));
 
-    if (handle.reading && !self._readableState.reading) {
+    if (handle.reading && !ret) {
       handle.reading = false;
       debug('readStop');
       var r = handle.readStop();
@@ -492,7 +493,7 @@ function onread(buffer, offset, length) {
     if (self.onend) self.once('end', self.onend);
 
     // send a null to the _read cb to signal the end of data.
-    self._readableState.onread(null, null);
+    self.push(null);
 
     // internal end event so that we know that the actual socket
     // is no longer readable, and we can start the shutdown

--- a/test/simple/test-stream2-push.js
+++ b/test/simple/test-stream2-push.js
@@ -1,0 +1,139 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var stream = require('stream');
+var Readable = stream.Readable;
+var Writable = stream.Writable;
+var assert = require('assert');
+
+var util = require('util');
+var EE = require('events').EventEmitter;
+
+
+// a mock thing a bit like the net.Socket/tcp_wrap.handle interaction
+
+var stream = new Readable({
+  lowWaterMark: 0,
+  highWaterMark: 16,
+  encoding: 'utf8'
+});
+
+var source = new EE;
+
+stream._read = function() {
+  console.error('stream._read');
+  readStart();
+};
+
+var ended = false;
+stream.on('end', function() {
+  ended = true;
+});
+
+source.on('data', function(chunk) {
+  var ret = stream.push(chunk);
+  console.error('data', stream._readableState.length);
+  if (!ret)
+    readStop();
+});
+
+source.on('end', function() {
+  stream.push(null);
+});
+
+var reading = false;
+
+function readStart() {
+  console.error('readStart');
+  reading = true;
+}
+
+function readStop() {
+  console.error('readStop');
+  reading = false;
+  process.nextTick(function() {
+    var r = stream.read();
+    if (r !== null)
+      writer.write(r);
+  });
+}
+
+var writer = new Writable({
+  decodeStrings: false
+});
+
+var written = [];
+
+var expectWritten =
+  [ 'asdfgasdfgasdfgasdfg',
+    'asdfgasdfgasdfgasdfg',
+    'asdfgasdfgasdfgasdfg',
+    'asdfgasdfgasdfgasdfg',
+    'asdfgasdfgasdfgasdfg',
+    'asdfgasdfgasdfgasdfg' ];
+
+writer._write = function(chunk, cb) {
+  console.error('WRITE %s', chunk[0]);
+  written.push(chunk[0]);
+  process.nextTick(cb);
+};
+
+writer.on('finish', finish);
+
+
+// now emit some chunks.
+
+var chunk = "asdfg";
+
+var set = 0;
+readStart();
+data();
+function data() {
+  assert(reading);
+  source.emit('data', chunk);
+  assert(reading);
+  source.emit('data', chunk);
+  assert(reading);
+  source.emit('data', chunk);
+  assert(reading);
+  source.emit('data', chunk);
+  assert(!reading);
+  if (set++ < 5)
+    setTimeout(data, 10);
+  else
+    end();
+}
+
+function finish() {
+  console.error('finish');
+  assert.deepEqual(written, expectWritten);
+  console.log('ok');
+}
+
+function end() {
+  source.emit('end');
+  assert(!reading);
+  writer.end(stream.read());
+  setTimeout(function() {
+    assert(ended);
+  });
+}

--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -215,35 +215,40 @@ test('passthrough event emission', function(t) {
   var i = 0;
 
   pt.write(new Buffer('foog'));
+
+  console.error('need emit 0');
   pt.write(new Buffer('bark'));
+
+  console.error('should have emitted readable now 1 === %d', emits);
+  t.equal(emits, 1);
 
   t.equal(pt.read(5).toString(), 'foogb');
   t.equal(pt.read(5) + '', 'null');
 
-  console.error('need emit 0');
+  console.error('need emit 1');
 
   pt.write(new Buffer('bazy'));
   console.error('should have emitted, but not again');
   pt.write(new Buffer('kuel'));
 
-  console.error('should have emitted readable now 1 === %d', emits);
-  t.equal(emits, 1);
+  console.error('should have emitted readable now 2 === %d', emits);
+  t.equal(emits, 2);
 
   t.equal(pt.read(5).toString(), 'arkba');
   t.equal(pt.read(5).toString(), 'zykue');
   t.equal(pt.read(5), null);
 
-  console.error('need emit 1');
+  console.error('need emit 2');
 
   pt.end();
 
-  t.equal(emits, 2);
+  t.equal(emits, 3);
 
   t.equal(pt.read(5).toString(), 'l');
   t.equal(pt.read(5), null);
 
   console.error('should not have emitted again');
-  t.equal(emits, 2);
+  t.equal(emits, 3);
   t.end();
 });
 
@@ -256,25 +261,28 @@ test('passthrough event emission reordered', function(t) {
   });
 
   pt.write(new Buffer('foog'));
+  console.error('need emit 0');
   pt.write(new Buffer('bark'));
+  console.error('should have emitted readable now 1 === %d', emits);
+  t.equal(emits, 1);
 
   t.equal(pt.read(5).toString(), 'foogb');
   t.equal(pt.read(5), null);
 
-  console.error('need emit 0');
+  console.error('need emit 1');
   pt.once('readable', function() {
     t.equal(pt.read(5).toString(), 'arkba');
 
     t.equal(pt.read(5), null);
 
-    console.error('need emit 1');
+    console.error('need emit 2');
     pt.once('readable', function() {
       t.equal(pt.read(5).toString(), 'zykue');
       t.equal(pt.read(5), null);
       pt.once('readable', function() {
         t.equal(pt.read(5).toString(), 'l');
         t.equal(pt.read(5), null);
-        t.equal(emits, 3);
+        t.equal(emits, 4);
         t.end();
       });
       pt.end();


### PR DESCRIPTION
This adds a `readable.push()` method to explicitly injecting chunks of data (or `null` or empty buffer/string for `EOF`) onto the readable stream's read() queue.

This is useful in cases where the data source is a "pushy" source, such as a streams1 style stream or the tcp_wrap net.Socket handles.

Also, this means that the http/net interaction can avoid switching the net socket into old mode.
