### PR TITLE
tweak `assert` uses

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -27,7 +27,6 @@ module.exports = Writable;
 Writable.WritableState = WritableState;
 
 var util = require('util');
-var assert = require('assert');
 var Stream = require('stream');
 
 util.inherits(Writable, Stream);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var SlowBuffer = process.binding('buffer').SlowBuffer;
-var assert = require('assert');
+var assert = require('assert').ok;
 
 exports.INSPECT_MAX_BYTES = 50;
 
@@ -614,10 +614,10 @@ Buffer.prototype.readUInt8 = function(offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset < buffer.length,
+    assert(offset < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -629,13 +629,13 @@ function readUInt16(buffer, offset, isBigEndian, noAssert) {
 
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 1 < buffer.length,
+    assert(offset + 1 < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -662,13 +662,13 @@ function readUInt32(buffer, offset, isBigEndian, noAssert) {
   var val = 0;
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 3 < buffer.length,
+    assert(offset + 3 < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -746,10 +746,10 @@ Buffer.prototype.readInt8 = function(offset, noAssert) {
   var neg;
 
   if (!noAssert) {
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset < buffer.length,
+    assert(offset < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -765,13 +765,13 @@ function readInt16(buffer, offset, isBigEndian, noAssert) {
   var neg, val;
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 1 < buffer.length,
+    assert(offset + 1 < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -796,13 +796,13 @@ function readInt32(buffer, offset, isBigEndian, noAssert) {
   var neg, val;
 
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 3 < buffer.length,
+    assert(offset + 3 < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -825,10 +825,10 @@ Buffer.prototype.readInt32BE = function(offset, noAssert) {
 
 function readFloat(buffer, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset + 3 < buffer.length,
+    assert(offset + 3 < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -846,10 +846,10 @@ Buffer.prototype.readFloatBE = function(offset, noAssert) {
 
 function readDouble(buffer, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset + 7 < buffer.length,
+    assert(offset + 7 < buffer.length,
         'Trying to read beyond buffer length');
   }
 
@@ -876,28 +876,28 @@ Buffer.prototype.readDoubleBE = function(offset, noAssert) {
  *      max             The maximum value
  */
 function verifuint(value, max) {
-  assert.ok(typeof (value) == 'number',
+  assert(typeof (value) == 'number',
       'cannot write a non-number as a number');
 
-  assert.ok(value >= 0,
+  assert(value >= 0,
       'specified a negative value for writing an unsigned value');
 
-  assert.ok(value <= max, 'value is larger than maximum value for type');
+  assert(value <= max, 'value is larger than maximum value for type');
 
-  assert.ok(Math.floor(value) === value, 'value has a fractional component');
+  assert(Math.floor(value) === value, 'value has a fractional component');
 }
 
 Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   var buffer = this;
 
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
+    assert(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset < buffer.length,
+    assert(offset < buffer.length,
         'trying to write beyond buffer length');
 
     verifuint(value, 0xff);
@@ -908,16 +908,16 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
 
 function writeUInt16(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
+    assert(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 1 < buffer.length,
+    assert(offset + 1 < buffer.length,
         'trying to write beyond buffer length');
 
     verifuint(value, 0xffff);
@@ -942,16 +942,16 @@ Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
 
 function writeUInt32(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
+    assert(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 3 < buffer.length,
+    assert(offset + 3 < buffer.length,
         'trying to write beyond buffer length');
 
     verifuint(value, 0xffffffff);
@@ -1020,27 +1020,27 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
  * A series of checks to make sure we actually have a signed 32-bit number
  */
 function verifsint(value, max, min) {
-  assert.ok(typeof (value) == 'number',
+  assert(typeof (value) == 'number',
       'cannot write a non-number as a number');
 
-  assert.ok(value <= max, 'value larger than maximum allowed value');
+  assert(value <= max, 'value larger than maximum allowed value');
 
-  assert.ok(value >= min, 'value smaller than minimum allowed value');
+  assert(value >= min, 'value smaller than minimum allowed value');
 
-  assert.ok(Math.floor(value) === value, 'value has a fractional component');
+  assert(Math.floor(value) === value, 'value has a fractional component');
 }
 
 function verifyIEEE754(value, max, min) {
-  assert.ok(typeof (value) == 'number',
+  assert(typeof (value) == 'number',
       'cannot write a non-number as a number');
 
   if (isNaN(value) || value === Infinity || value === -Infinity) {
     return;
   }
 
-  assert.ok(value <= max, 'value larger than maximum allowed value');
+  assert(value <= max, 'value larger than maximum allowed value');
 
-  assert.ok(value >= min, 'value smaller than minimum allowed value');
+  assert(value >= min, 'value smaller than minimum allowed value');
 }
 
 Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
@@ -1099,16 +1099,16 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
 
 function writeFloat(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
+    assert(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 3 < buffer.length,
+    assert(offset + 3 < buffer.length,
         'Trying to write beyond buffer length');
 
     verifyIEEE754(value, 3.4028234663852886e+38, -3.4028234663852886e+38);
@@ -1128,16 +1128,16 @@ Buffer.prototype.writeFloatBE = function(value, offset, noAssert) {
 
 function writeDouble(buffer, value, offset, isBigEndian, noAssert) {
   if (!noAssert) {
-    assert.ok(value !== undefined && value !== null,
+    assert(value !== undefined && value !== null,
         'missing value');
 
-    assert.ok(typeof (isBigEndian) === 'boolean',
+    assert(typeof (isBigEndian) === 'boolean',
         'missing or invalid endian');
 
-    assert.ok(offset !== undefined && offset !== null,
+    assert(offset !== undefined && offset !== null,
         'missing offset');
 
-    assert.ok(offset + 7 < buffer.length,
+    assert(offset + 7 < buffer.length,
         'Trying to write beyond buffer length');
 
     verifyIEEE754(value, 1.7976931348623157E+308, -1.7976931348623157E+308);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var assert = require('assert');
+var assert = require('assert').ok;
 var fork = require('child_process').fork;
 var net = require('net');
 var EventEmitter = require('events').EventEmitter;

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -54,7 +54,7 @@ function toBuf(str, encoding) {
 }
 
 
-var assert = require('assert');
+var assert = require('assert').ok;
 var StringDecoder = require('string_decoder').StringDecoder;
 
 function Credentials(secureProtocol, flags, context) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -23,7 +23,7 @@ var events = require('events');
 var stream = require('stream');
 var timers = require('timers');
 var util = require('util');
-var assert = require('assert');
+var assert = require('assert').ok;
 var cares = process.binding('cares_wrap');
 var cluster;
 
@@ -680,7 +680,7 @@ function connect(self, address, port, addressType, localAddress) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
 
-  assert.ok(self._connecting);
+  assert(self._connecting);
 
   if (localAddress) {
     var r;
@@ -817,7 +817,7 @@ function afterConnect(status, handle, req, readable, writable) {
 
   debug('afterConnect');
 
-  assert.ok(self._connecting);
+  assert(self._connecting);
   self._connecting = false;
 
   if (status == 0) {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var assert = require('assert');
 var inherits = require('util').inherits;
 var net = require('net');
 var TTY = process.binding('tty_wrap').TTY;


### PR DESCRIPTION
for consistency, use `assert.ok` instead of just `assert`; remove useless assert requires
