### PR TITLE
Updates to TypedArrays to match spec. Edit

### DIFF
--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -131,7 +131,7 @@ class ArrayBuffer {
 
   static v8::Handle<v8::Value> slice(const v8::Arguments& args) {
     if (args.Length() < 1)
-       return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     unsigned int length =
         args.This()->Get(v8::String::New("byteLength"))->Uint32Value();
@@ -602,7 +602,7 @@ class DataView {
       return ThrowTypeError("Constructor cannot be called as a function.");
 
     if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     if (!args[0]->IsObject())
       return ThrowError("Object must be an ArrayBuffer.");
@@ -616,16 +616,16 @@ class DataView {
     unsigned int byte_offset = args[1]->Uint32Value();
 
     if (args[1]->Int32Value() < 0 || byte_offset >= byte_length)
-      return ThrowRangeError("byteOffset out of range.");
+      return ThrowRangeError("Size is too large (or is negative).");
 
     if (!args[2]->IsUndefined()) {
       if (args[2]->Int32Value() < 0)
-        return ThrowRangeError("byteLength out of range.");
+        return ThrowRangeError("Size is too large (or is negative).");
       unsigned int new_byte_length = args[2]->Uint32Value();
       if (new_byte_length > byte_length)
-        return ThrowRangeError("byteLength out of range.");
+        return ThrowRangeError("Size is too large (or is negative).");
       if (byte_offset + new_byte_length > byte_length)
-        return ThrowRangeError("byteOffset/byteLength out of range.");
+        return ThrowRangeError("Size is too large (or is negative).");
       byte_length = new_byte_length;
     } else {
       // Adjust the original byte_length from total length to length to end.
@@ -654,7 +654,7 @@ class DataView {
   template <typename T>
   static v8::Handle<v8::Value> getGeneric(const v8::Arguments& args) {
     if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     unsigned int index = args[0]->Uint32Value();
     bool little_endian = args[1]->BooleanValue();
@@ -666,7 +666,7 @@ class DataView {
 
     // TODO(deanm): integer overflow.
     if (index + sizeof(T) > static_cast<unsigned int>(size))
-      return ThrowError("Index out of range.");
+      return ThrowError("IndexSizeError: DOM Exception 1");
 
     void* ptr = reinterpret_cast<char*>(
         args.This()->GetIndexedPropertiesExternalArrayData()) + index;
@@ -687,7 +687,7 @@ class DataView {
   template <typename T>
   static v8::Handle<v8::Value> setGeneric(const v8::Arguments& args) {
     if (args.Length() < 2)
-      return ThrowError("Wrong number of arguments.");
+      return ThrowTypeError("Not enough arguments");
 
     unsigned int index = args[0]->Int32Value();
     bool little_endian = args[2]->BooleanValue();
@@ -699,7 +699,7 @@ class DataView {
 
     // TODO(deanm): integer overflow.
     if (index + sizeof(T) > static_cast<unsigned int>(size))
-      return ThrowError("Index out of range.");
+      return ThrowError("IndexSizeError: DOM Exception 1");
 
     void* ptr = reinterpret_cast<char*>(
         args.This()->GetIndexedPropertiesExternalArrayData()) + index;

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -217,7 +217,6 @@ class TypedArray {
     v8::Local<v8::Signature> default_signature = v8::Signature::New(ft_cache);
 
     static BatchedMethods methods[] = {
-      { "get", &TypedArray<TBytes, TEAType>::get },
       { "set", &TypedArray<TBytes, TEAType>::set },
       { "slice", &TypedArray<TBytes, TEAType>::subarray },
       { "subarray", &TypedArray<TBytes, TEAType>::subarray },
@@ -348,16 +347,6 @@ class TypedArray {
                      (v8::PropertyAttribute)(v8::ReadOnly|v8::DontDelete));
 
     return args.This();
-  }
-
-  static v8::Handle<v8::Value> get(const v8::Arguments& args) {
-    if (args.Length() < 1)
-      return ThrowError("Wrong number of arguments.");
-
-    if (args[0]->IsNumber())
-      return args.This()->Get(args[0]->Uint32Value());
-
-    return v8::Undefined();
   }
 
   static v8::Handle<v8::Value> set(const v8::Arguments& args) {

--- a/src/v8_typed_array.cc
+++ b/src/v8_typed_array.cc
@@ -424,11 +424,11 @@ class TypedArray {
 
     if (begin < 0) begin = length + begin;
     if (begin < 0) begin = 0;
-    if ((unsigned)begin > length) begin = length;
+    if (static_cast<unsigned int>(begin) > length) begin = length;
 
     if (end < 0) end = length + end;
     if (end < 0) end = 0;
-    if ((unsigned)end > length) end = length;
+    if (static_cast<unsigned int>(end) > length) end = length;
 
     if (begin > end) begin = end;
 
@@ -664,7 +664,8 @@ class DataView {
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
 
-    if (index + sizeof(T) > (unsigned)size)  // TODO(deanm): integer overflow.
+    // TODO(deanm): integer overflow.
+    if (index + sizeof(T) > static_cast<unsigned int>(size))
       return ThrowError("Index out of range.");
 
     void* ptr = reinterpret_cast<char*>(
@@ -696,7 +697,8 @@ class DataView {
     int size = args.This()->GetIndexedPropertiesExternalArrayDataLength() *
                element_size;
 
-    if (index + sizeof(T) > (unsigned)size)  // TODO(deanm): integer overflow.
+    // TODO(deanm): integer overflow.
+    if (index + sizeof(T) > static_cast<unsigned int>(size))
       return ThrowError("Index out of range.");
 
     void* ptr = reinterpret_cast<char*>(

--- a/test/simple/test-typed-arrays.js
+++ b/test/simple/test-typed-arrays.js
@@ -153,13 +153,13 @@ sub[1] = 0x34;
 assert.equal(uint8[2], 0x12);
 assert.equal(uint8[3], 0x34);
 
-// test .set(index, value), .set(arr, offset) and .get(index)
+// test .set(index, value), .set(arr, offset)
 uint8.set(1, 0x09);
 uint8.set([0x0a, 0x0b], 2);
 
-assert.equal(uint8.get(1), 0x09);
-assert.equal(uint8.get(2), 0x0a);
-assert.equal(uint8.get(3), 0x0b);
+assert.equal(uint8[1], 0x09);
+assert.equal(uint8[2], 0x0a);
+assert.equal(uint8[3], 0x0b);
 
 // test clamped array
 var uint8c = new Uint8ClampedArray(buffer);

--- a/test/simple/test-typed-arrays.js
+++ b/test/simple/test-typed-arrays.js
@@ -154,7 +154,7 @@ assert.equal(uint8[2], 0x12);
 assert.equal(uint8[3], 0x34);
 
 // test .set(index, value), .set(arr, offset)
-uint8.set(1, 0x09);
+uint8[1] = 0x09;
 uint8.set([0x0a, 0x0b], 2);
 
 assert.equal(uint8[1], 0x09);
@@ -169,8 +169,8 @@ uint8c[1] = 257;
 assert.equal(uint8c[0], 0);
 assert.equal(uint8c[1], 255);
 
-uint8c.set(0, -10);
-uint8c.set(1, 260);
+uint8c[0] = -10;
+uint8c[1] = 260;
 
 assert.equal(uint8c[0], 0);
 assert.equal(uint8c[1], 255);


### PR DESCRIPTION
This is a re-request of https://github.com/joyent/node/pull/4442

These again are a few effective reverts of previous changes by Mikael Bourges-Sevenier to the TypedArrays code. I believe it was caused by a misreading of the spec, where get() and set() methods are defined as getters/setters ([] and []= operators). By removing these and updating a few exception strings the TypedArray implementation now fully passes the following related WebKit tests:

array-buffer-crash.html
array-buffer-view-crash-when-reassigned.html
array-buffer-view-crash.html
array-constructor.html
array-get-and-set-method-removal.html
array-get-out-of-bounds.html
array-override-set.html
array-set-invalid-arguments.html
array-set-out-of-bounds.html
array-set-with-offset.html
array-setters.html
array-unit-tests.html
dfg-float32array.js
dfg-int16array.js
dfg-int32array-overflow-values.js
dfg-int32array.js
dfg-int8array.js
dfg-uint16array.js
dfg-uint32array-overflow-values.js
dfg-uint32array.js
dfg-uint8array.js
dfg-uint8clampedarray.js
