### PR TITLE
duplicate variable initialization in IncomingMessage

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -283,7 +283,6 @@ function IncomingMessage(socket) {
   // XXX This implementation is kind of all over the place
   // When the parser emits body chunks, they go in this list.
   // _read() pulls them out, and when it finds EOF, it ends.
-  this._pendings = [];
 
   this.socket = socket;
   this.connection = socket;


### PR DESCRIPTION
IncomingMessage function contained duplicate initialization
of this._pendings. Line with one of those expressions has been
removed.
