### PR TITLE
2 patches to speed up http with streams2

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -410,10 +410,21 @@ IncomingMessage.prototype._addHeaderLine = function(field, value) {
 // Call this instead of resume() if we want to just
 // dump all the data to /dev/null
 IncomingMessage.prototype._dump = function() {
+  if (this._dumped)
+    return;
+
   this._dumped = true;
   this.socket.parser.incoming = null;
-  this.push(null);
+  this.readable = false;
   readStart(this.socket);
+
+  var stream = this;
+  var state = stream._readableState;
+  if (!state.endEmitted) {
+    process.nextTick(function() {
+      stream.emit('end');
+    });
+  }
 };
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -158,6 +158,7 @@ function Socket(options) {
 
   initSocketHandle(this);
 
+  this._connecting = false;
   this._pendingWrite = null;
 
   // handle strings directly


### PR DESCRIPTION
The first initializes the `Socket._connecting` member in the constructor.

The second inlines the logic in the `IncomingMessage._dump` method.

These two changes bring the streams2 performance up to par with streams1 on Darwin.  However, it's still lagging behind on SmartOS and Linux, though this is an improvement.
