### PR TITLE
url: Housekeeping

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -342,58 +342,72 @@ function urlFormat(obj) {
 }
 
 Url.prototype.format = function() {
-  var auth = this.auth || '';
-  if (auth) {
-    auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ':');
-    auth += '@';
-  }
-
-  var protocol = this.protocol || '',
-      pathname = this.pathname || '',
-      hash = this.hash || '',
-      host = false,
-      query = '';
-
-  if (this.host) {
-    host = auth + this.host;
-  } else if (this.hostname) {
-    host = auth + (this.hostname.indexOf(':') === -1 ?
-        this.hostname :
-        '[' + this.hostname + ']');
-    if (this.port) {
-      host += ':' + this.port;
+  var url = '';
+  
+  if (this.protocol) {
+    url += this.protocol;
+    if (this.protocol.substr(-1) !== ':') {
+      url += ':';
     }
   }
 
-  if (this.query && typeof this.query === 'object' &&
-      Object.keys(this.query).length) {
-    query = querystring.stringify(this.query);
-  }
-
-  var search = this.search || (query && ('?' + query)) || '';
-
-  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
+  var hasHost = !!this.host || !!this.hostname;
+  var addSlashes = this.slashes ||
+      (!this.protocol || slashedProtocol[this.protocol]) && hasHost;
 
   // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
   // unless they had them to begin with.
-  if (this.slashes ||
-      (!protocol || slashedProtocol[protocol]) && host !== false) {
-    host = '//' + (host || '');
-    if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
-  } else if (!host) {
-    host = '';
+  if (addSlashes) {
+    url += '//';
   }
 
-  if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
-  if (search && search.charAt(0) !== '?') search = '?' + search;
+  if (hastHost) {
+    if (this.auth) {
+      url += encodeURIComponent(auth).replace(/%3A/i, ':');
+      url += "@";
+    }
 
-  pathname = pathname.replace(/[?#]/g, function(match) {
-    return encodeURIComponent(match);
-  });
-  search = search.replace('#', '%23');
+    if (this.host){
+      url += this.host;
+    } else {
+      // this.hostname exists
+      if (this.hostname.indexOf(':') === -1) {
+        url += this.hostname;
+      } else {
+        url += "[" + this.hostname + "]";
+      }
 
-  return protocol + host + pathname + search + hash;
+      if (this.port) {
+        url += ':' + this.port;
+      }
+    }
+  }
+
+  if (this.pathname) {
+    if (addSlashes && this.pathname.charAt(0) !== '/') {
+      url += '/';
+    }
+    url += this.pathname.replace(/[?#]/g, encodeURIComponent);
+  }
+
+  if (this.search) {
+    if (this.search.charAt(0) !== '?') {
+      url += '?';
+    }
+    url += this.search.replace('#', '%23');
+  } else if (this.query && typeof this.query === 'object' &&
+      Object.keys(this.query).length) {
+    url += '?' + querystring.stringify(this.query).replace('#', '%23');
+  }
+
+  if (this.hash) {
+    if (this.hash.charAt(0) !== '#') {
+      url += '#';
+    }
+    url += this.hash;
+  }
+
+  return url;
 };
 
 function urlResolve(source, relative) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -267,7 +267,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // strip [ and ] from the hostname
     // the host field still retains them, though
     if (ipv6Hostname) {
-      this.hostname = this.hostname.slice(1, -2);
+      this.hostname = this.hostname.slice(1, -1);
       if (rest[0] !== '/') {
         rest = '/' + rest;
       }
@@ -361,9 +361,9 @@ Url.prototype.format = function() {
     url += '//';
   }
 
-  if (hastHost) {
+  if (hasHost) {
     if (this.auth) {
-      url += encodeURIComponent(auth).replace(/%3A/i, ':');
+      url += encodeURIComponent(this.auth).replace(/%3A/i, ':');
       url += "@";
     }
 
@@ -620,7 +620,7 @@ Url.prototype.resolveObject = function(relative) {
   var up = 0;
   for (var i = srcPath.length; i >= 0; i--) {
     last = srcPath[i];
-    if (last == '.') {
+    if (last === '.') {
       srcPath.splice(i, 1);
     } else if (last === '..') {
       srcPath.splice(i, 1);

--- a/lib/url.js
+++ b/lib/url.js
@@ -46,8 +46,8 @@ function Url() {
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-var protocolPattern = /^([a-z0-9.+-]+:)/i,
-    portPattern = /:[0-9]*$/,
+var protocolPattern = /^[a-z\d.+-]+:/i,
+    portPattern = /:\d*$/,
 
     // RFC 2396: characters reserved for delimiting URLs.
     // We actually just auto-escape these.
@@ -66,8 +66,8 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
       .concat(unwise).concat(autoEscape),
     nonAuthChars = ['/', '@', '?', '#'].concat(delims),
     hostnameMaxLen = 255,
-    hostnamePartPattern = /^[a-z0-9A-Z_-]{0,63}$/,
-    hostnamePartStart = /^([a-z0-9A-Z_-]{0,63})(.*)$/,
+    hostnamePartPattern = /^[\w-]{0,63}$/,
+    hostnamePartStart = /^([\w-]{0,63})(.*)$/,
     // protocols that can allow "unsafe" and "unwise" chars.
     unsafeProtocol = {
       'javascript': true,
@@ -106,7 +106,7 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     querystring = require('querystring');
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (url && typeof(url) === 'object' && url instanceof Url) return url;
+  if (url && typeof url === 'object' && url instanceof Url) return url;
 
   var u = new Url;
   u.parse(url, parseQueryString, slashesDenoteHost);
@@ -136,7 +136,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // user@server is *always* interpreted as a hostname, and url
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
+  if (slashesDenoteHost || proto || /^\/\/[^@\/]+@[^@\/]+/.test(rest)) {
     var slashes = rest.substr(0, 2) === '//';
     if (slashes && !(proto && hostlessProtocol[proto])) {
       rest = rest.substr(2);
@@ -156,19 +156,17 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // URLs are obnoxious.
     var atSign = rest.indexOf('@');
     if (atSign !== -1) {
-      var auth = rest.slice(0, atSign);
+      var auth = rest.substr(0, atSign);
 
       // there *may be* an auth
-      var hasAuth = true;
-      for (var i = 0, l = nonAuthChars.length; i < l; i++) {
-        if (auth.indexOf(nonAuthChars[i]) !== -1) {
-          // not a valid auth.  Something like http://foo.com/bar@baz/
-          hasAuth = false;
-          break;
+      addAuth: {
+        for (var i = 0, l = nonAuthChars.length; i < l; i++) {
+          if (auth.indexOf(nonAuthChars[i]) !== -1) {
+            // not a valid auth.  Something like http://foo.com/bar@baz/
+            break addAuth;
+          }
         }
-      }
-
-      if (hasAuth) {
+  
         // pluck off the auth portion.
         this.auth = decodeURIComponent(auth);
         rest = rest.substr(atSign + 1);
@@ -204,11 +202,11 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 
     // validate a little.
     if (!ipv6Hostname) {
-      var hostparts = this.hostname.split(/\./);
+      var hostparts = this.hostname.split(".");
       for (var i = 0, l = hostparts.length; i < l; i++) {
         var part = hostparts[i];
         if (!part) continue;
-        if (!part.match(hostnamePartPattern)) {
+        if (!hostnamePartPattern.test(part)) {
           var newpart = '';
           for (var j = 0, k = part.length; j < k; j++) {
             if (part.charCodeAt(j) > 127) {
@@ -221,7 +219,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
             }
           }
           // we test again with ASCII char only
-          if (!newpart.match(hostnamePartPattern)) {
+          if (!hostnamePartPattern.test(newpart)) {
             var validParts = hostparts.slice(0, i);
             var notHost = hostparts.slice(i + 1);
             var bit = part.match(hostnamePartStart);
@@ -255,7 +253,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       var newOut = [];
       for (var i = 0; i < domainArray.length; ++i) {
         var s = domainArray[i];
-        newOut.push(s.match(/[^A-Za-z0-9_-]/) ?
+        newOut.push(/[^\w-]/.test(s) ?
             'xn--' + punycode.encode(s) : s);
       }
       this.hostname = newOut.join('.');
@@ -269,7 +267,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // strip [ and ] from the hostname
     // the host field still retains them, though
     if (ipv6Hostname) {
-      this.hostname = this.hostname.substr(1, this.hostname.length - 2);
+      this.hostname = this.hostname.slice(1, -2);
       if (rest[0] !== '/') {
         rest = '/' + rest;
       }
@@ -299,7 +297,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   if (hash !== -1) {
     // got a fragment string.
     this.hash = rest.substr(hash);
-    rest = rest.slice(0, hash);
+    rest = rest.substr(0, hash);
   }
   var qm = rest.indexOf('?');
   if (qm !== -1) {
@@ -308,7 +306,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     if (parseQueryString) {
       this.query = querystring.parse(this.query);
     }
-    rest = rest.slice(0, qm);
+    rest = rest.substr(0, qm);
   } else if (parseQueryString) {
     // no query string, but parseQueryString still requested
     this.search = '';
@@ -338,7 +336,7 @@ function urlFormat(obj) {
   // If it's an obj, this is a no-op.
   // this way, you can call url_format() on strings
   // to clean up potentially wonky urls.
-  if (typeof(obj) === 'string') obj = urlParse(obj);
+  if (typeof obj === 'string') obj = urlParse(obj);
   if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
   return obj.format();
 }

--- a/lib/url.js
+++ b/lib/url.js
@@ -548,10 +548,12 @@ Url.prototype.resolveObject = function(relative) {
 
   if (isRelAbs) {
     // it's absolute.
-    result.host = (relative.host || relative.host === '') ?
-                  relative.host : result.host;
-    result.hostname = (relative.hostname || relative.hostname === '') ?
-                      relative.hostname : result.hostname;
+    if (typeof relative.host === "string" || relative.host) {
+      result.host = relative.host;
+    }
+    if (typeof relative.hostname === "string" || relative.hostname) {
+      result.hostname = relative.hostname;
+    }
     result.search = relative.search;
     result.query = relative.query;
     srcPath = relPath;
@@ -559,9 +561,11 @@ Url.prototype.resolveObject = function(relative) {
   } else if (relPath.length) {
     // it's relative
     // throw away the existing file, and take the new path instead.
-    if (!srcPath) srcPath = [];
-    srcPath.pop();
-    srcPath = srcPath.concat(relPath);
+    if (!srcPath) srcPath = relPath;
+    else {
+      srcPath.pop();
+      srcPath = srcPath.concat(relPath);
+    }
     result.search = relative.search;
     result.query = relative.query;
   } else if (relative.search !== null && relative.search !== undefined) {
@@ -573,9 +577,8 @@ Url.prototype.resolveObject = function(relative) {
       //occationaly the auth can get stuck only in host
       //this especialy happens in cases like
       //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-      var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                       result.host.split('@') : false;
-      if (authInHost) {
+      if (result.host && result.host.indexOf('@') > 0) {
+        var authInHost = result.host.split('@', 2);
         result.auth = authInHost.shift();
         result.host = result.hostname = authInHost.shift();
       }
@@ -584,8 +587,7 @@ Url.prototype.resolveObject = function(relative) {
     result.query = relative.query;
     //to support http.request
     if (result.pathname !== null || result.search !== null) {
-      result.path = (result.pathname ? result.pathname : '') +
-                    (result.search ? result.search : '');
+      result.path = (result.pathname || '') + (result.search || '');
     }
     result.href = result.format();
     return result;
@@ -650,8 +652,8 @@ Url.prototype.resolveObject = function(relative) {
 
   // put the host back
   if (psychotic) {
-    result.hostname = result.host = isAbsolute ? '' :
-                                    srcPath.length ? srcPath.shift() : '';
+    result.hostname = result.host = isAbsolute || !srcPath.length ?
+                                    '' : srcPath.shift();
     //occationaly the auth can get stuck only in host
     //this especialy happens in cases like
     //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
@@ -678,8 +680,7 @@ Url.prototype.resolveObject = function(relative) {
 
   //to support request.http
   if (result.pathname !== null || result.search !== null) {
-    result.path = (result.pathname ? result.pathname : '') +
-                  (result.search ? result.search : '');
+    result.path = (result.pathname || '') + (result.search || '');
   }
   result.auth = relative.auth || result.auth;
   result.slashes = result.slashes || relative.slashes;
@@ -695,7 +696,7 @@ Url.prototype.parseHost = function() {
     if (port !== ':') {
       this.port = port.substr(1);
     }
-    host = host.substr(0, host.length - port.length);
+    host = host.slice(0, -port.length);
   }
   if (host) this.hostname = host;
 };


### PR DESCRIPTION
**Contents:**
- rearranged Url.prototype.format (same as #3291, just without the regression and including all updates)
- use appropriate string functions (eg. use `RegExp#test` instead of `.match`, prefer calling `.split` with a string when it's possible)
- simplified parts of Url.prototype.resolveObject
- simplified regexps
- use a labeled block instead of a bool for auth data

**Results:**

A [quick test](https://gist.github.com/8c07e29b75ee1875b950) shows consistent speedups. All tests in [simple/test-url.js](https://github.com/joyent/node/blob/54d293da560a86e48b302c0ef219ac6e38a9a1e9/test/simple/test-url.js) pass. Plus, the code is (at least in my opinion) a bit more readable.
