### PR TITLE
module: Throw an error when require() isn't called with a string

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -277,6 +277,10 @@ Module._load = function(request, parent, isMain) {
     debug('Module._load REQUEST  ' + (request) + ' parent: ' + parent.id);
   }
 
+  if (typeof request !== 'string') {
+    throw new TypeError('require() must be called with a string!');
+  }
+
   var filename = Module._resolveFilename(request, parent);
 
   var cachedModule = Module._cache[filename];


### PR DESCRIPTION
fixes #4541
