### PR TITLE
repl: make built-in modules available by default

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -338,12 +338,8 @@ REPLServer.prototype.createContext = function() {
       },
       // allow the creation of other globals with this name
       set: function(val){
-        Object.defineProperty(context, name, {
-          value: val,
-          configurable: true,
-          writable: true,
-          enumerable: true
-        });
+        delete context[name];
+        context[name] = val;
       },
       configurable: true
     });

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -218,16 +218,6 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       }
     }
 
-    // Check if a builtin module name was used and then include it
-    // if there's no conflict.
-    if (!(cmd in self.context) && exports._builtinLibs.indexOf(cmd) !== -1) {
-      var lib = require(cmd);
-      self.context._ = self.context[cmd] = lib;
-      self.outputStream.write(self.writer(lib) + '\n');
-      self.displayPrompt();
-      return;
-    }
-
     if (!skipCatchall) {
       var evalCmd = self.bufferedCommand + cmd + '\n';
 
@@ -336,6 +326,28 @@ REPLServer.prototype.createContext = function() {
 
   this.lines = [];
   this.lines.level = [];
+
+  // make built-in modules available directly
+  // (loaded lazily)
+  exports._builtinLibs.forEach(function(name){
+    Object.defineProperty(context, name, {
+      get: function(){
+        var lib = require(name);
+        context._ = context[name] = lib;
+        return lib;
+      },
+      // allow the creation of other globals with this name
+      set: function(val){
+        Object.defineProperty(context, name, {
+          value: val,
+          configurable: true,
+          writable: true,
+          enumerable: true
+        });
+      },
+      configurable: true
+    });
+  });
 
   return context;
 };

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -172,7 +172,11 @@ function error_test() {
     { client: client_unix, send: '(function () {\n\nreturn 1;\n})()',
       expect: '1' },
     { client: client_unix, send: '{\n\na: 1\n}',
-      expect: '{ a: 1 }' }
+      expect: '{ a: 1 }' },
+    { client: client_unix, send: 'url.format("http://google.com")',
+      expect: 'http://google.com/' },
+    { client: client_unix, send: 'var path = 42; path',
+      expect: '42' }
   ]);
 }
 


### PR DESCRIPTION
Previously:

``` js
> fs
> fs.readdirSync()
```

Now:

``` js
> fs.readdirSync()
```

The modules are still lazy-loaded, but without the need of a direct reference.
