### PR TITLE
Object streams + stream fixes

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -99,6 +99,9 @@ method. (See below.)
     resource.  Default=16kb
   * `encoding` {String} If specified, then buffers will be decoded to
     strings using the specified encoding.  Default=null
+  * `isObjectStream` {Boolean} Whether this stream should behave
+    as a stream of objects. Meaning that stream.read(n) returns
+    a single value instead of a Buffer of size n
 
 In classes that extend the Readable class, make sure to call the
 constructor so that the buffering settings can be properly

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -251,6 +251,8 @@ function onread(stream, er, chunk) {
         state.length += state.isObjectStream ? 1 : chunk.length;
       }
     }
+
+    console.log("ending", sync, state.length)
     // if we've ended and we have some data left, then emit
     // 'readable' now to make sure it gets picked up.
     if (!sync) {
@@ -262,7 +264,8 @@ function onread(stream, er, chunk) {
         }
       } else
         endReadable(stream);
-    }
+    } // else
+      // endReadable(stream);
     return;
   }
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -127,7 +127,7 @@ function howMuchToRead(n, state) {
     return 0;
 
   if (state.isObjectStream)
-    return 1;
+    return n === 0 ? 0 : 1;
 
   if (isNaN(n) || n === null)
     return state.length;
@@ -158,7 +158,7 @@ Readable.prototype.read = function(n) {
   n = howMuchToRead(n, state);
 
   // if we've ended, and we're now clear, then finish it up.
-  if (n === 0 && state.ended) {
+  if (n === 0 && state.buffer.length === 0 && state.ended) {
     endReadable(this);
     return null;
   }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -66,6 +66,11 @@ function ReadableState(options, stream) {
   this.needReadable = false;
   this.emittedReadable = false;
 
+
+  // isObjectStream flag. Used to make read(n) ignore n and to
+  // make all the buffer merging and length checks go away
+  this.isObjectStream = options.isObjectStream || false;
+
   // when piping, we only care about 'readable' events that happen
   // after read()ing all the bytes and not getting any pushback.
   this.ranOut = false;
@@ -234,7 +239,7 @@ function onread(stream, er, chunk) {
   var state = stream._readableState;
   var sync = state.sync;
 
-  if (!Buffer.isBuffer(chunk) && 'string' !== typeof chunk)
+  if (!Buffer.isBuffer(chunk) && 'string' !== typeof chunk && chunk != null)
     state.isObjectStream = true;
 
   state.reading = false;
@@ -252,7 +257,6 @@ function onread(stream, er, chunk) {
       }
     }
 
-    console.log("ending", sync, state.length)
     // if we've ended and we have some data left, then emit
     // 'readable' now to make sure it gets picked up.
     if (!sync) {
@@ -264,8 +268,8 @@ function onread(stream, er, chunk) {
         }
       } else
         endReadable(stream);
-    } // else
-      // endReadable(stream);
+    } else
+      endReadable(stream);
     return;
   }
 
@@ -367,8 +371,10 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     // specific writer, then it would cause it to never start
     // flowing again.
     // So, if this is awaiting a drain, then we just call it now.
-    // If we don't know, then assume that we are waiting for one.
-    if (!dest._writableState || dest._writableState.needDrain)
+    // If we don't know, then assume that we are not
+    // waiting for one. If we don't know it's the writer's
+    // responsibility to manage drain state.
+    if (dest._writableState && dest._writableState.needDrain)
       ondrain();
   }
 
@@ -496,6 +502,7 @@ Readable.prototype.unpipe = function(dest) {
     state.pipes = null;
     state.pipesCount = 0;
     this.removeListener('readable', pipeOnReadable);
+    state.flowing = false;
     if (dest)
       dest.emit('unpipe', this);
     return this;
@@ -510,6 +517,7 @@ Readable.prototype.unpipe = function(dest) {
     state.pipes = null;
     state.pipesCount = 0;
     this.removeListener('readable', pipeOnReadable);
+    state.flowing = false;
 
     for (var i = 0; i < len; i++)
       dests[i].emit('unpipe', this);

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -220,7 +220,7 @@ Readable.prototype.read = function(n) {
   else
     ret = null;
 
-  if (ret === null || ret.length === 0) {
+  if (ret === null || (!state.isObjectStream && ret.length === 0)) {
     state.needReadable = true;
     n = 0;
   }
@@ -246,7 +246,7 @@ function onread(stream, er, chunk) {
   if (er)
     return stream.emit('error', er);
 
-  if (!chunk || (!state.isObjectStream && !chunk.length)) {
+  if (chunk == null || (!state.isObjectStream && !chunk.length)) {
     // eof
     state.ended = true;
     if (state.decoder) {
@@ -277,7 +277,7 @@ function onread(stream, er, chunk) {
     chunk = state.decoder.write(chunk);
 
   // update the buffer info.
-  if (chunk) {
+  if (chunk || state.isObjectStream) {
     state.length += state.isObjectStream ? 1 : chunk.length;
     state.buffer.push(chunk);
   }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -121,6 +121,9 @@ function howMuchToRead(n, state) {
   if (state.length === 0 && state.ended)
     return 0;
 
+  if (state.isObjectStream)
+    return 1;
+
   if (isNaN(n) || n === null)
     return state.length;
 
@@ -208,7 +211,7 @@ Readable.prototype.read = function(n) {
 
   var ret;
   if (n > 0)
-    ret = fromList(n, state.buffer, state.length, !!state.decoder);
+    ret = fromList(n, state.buffer, state.length, !!state.decoder, state);
   else
     ret = null;
 
@@ -231,18 +234,21 @@ function onread(stream, er, chunk) {
   var state = stream._readableState;
   var sync = state.sync;
 
+  if (!Buffer.isBuffer(chunk) && 'string' !== typeof chunk)
+    state.isObjectStream = true;
+
   state.reading = false;
   if (er)
     return stream.emit('error', er);
 
-  if (!chunk || !chunk.length) {
+  if (!chunk || (!state.isObjectStream && !chunk.length)) {
     // eof
     state.ended = true;
     if (state.decoder) {
       chunk = state.decoder.end();
       if (chunk && chunk.length) {
         state.buffer.push(chunk);
-        state.length += chunk.length;
+        state.length += state.isObjectStream ? 1 : chunk.length;
       }
     }
     // if we've ended and we have some data left, then emit
@@ -265,7 +271,7 @@ function onread(stream, er, chunk) {
 
   // update the buffer info.
   if (chunk) {
-    state.length += chunk.length;
+    state.length += state.isObjectStream ? 1 : chunk.length;
     state.buffer.push(chunk);
   }
 
@@ -665,7 +671,7 @@ Readable._fromList = fromList;
 
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.
-function fromList(n, list, length, stringMode) {
+function fromList(n, list, length, stringMode, state) {
   var ret;
 
   // nothing in the list, definitely empty.
@@ -675,6 +681,8 @@ function fromList(n, list, length, stringMode) {
 
   if (length === 0)
     ret = null;
+  else if (state && state.isObjectStream)
+    ret = list.shift();
   else if (!n || n >= length) {
     // read it all, truncate the array.
     if (stringMode)

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -239,8 +239,11 @@ function onread(stream, er, chunk) {
   var state = stream._readableState;
   var sync = state.sync;
 
-  if (!Buffer.isBuffer(chunk) && 'string' !== typeof chunk && chunk != null)
+  if (!Buffer.isBuffer(chunk) && 'string' !== typeof chunk && chunk != null) {
     state.isObjectStream = true;
+    state.length = state.buffer.length;
+    state.decoder = null;
+  }
 
   state.reading = false;
   if (er)

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -131,7 +131,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     return;
   }
 
-  if (typeof chunk !== "string" && !Buffer.isBuffer(chunk))
+  if (typeof chunk !== 'string' && !Buffer.isBuffer(chunk))
     state.isObjectStream = true;
 
   var l = chunk.length;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -45,6 +45,10 @@ function WritableState(options, stream) {
   // default to pushing everything out as fast as possible.
   this.lowWaterMark = options.lowWaterMark || 0;
 
+  // object stream flag to indicate whether or not this stream
+  // contains buffers or objects.
+  this.isObjectStream = options.isObjectStream || false;
+
   // cast to ints.
   this.lowWaterMark = ~~this.lowWaterMark;
   this.highWaterMark = ~~this.highWaterMark;
@@ -127,15 +131,20 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     return;
   }
 
+  if (typeof chunk !== "string" && !Buffer.isBuffer(chunk))
+    state.isObjectStream = true;
+
   var l = chunk.length;
-  if (false === state.decodeStrings)
-    chunk = [chunk, encoding || 'utf8'];
-  else if (typeof chunk === 'string' || encoding) {
-    chunk = new Buffer(chunk + '', encoding);
-    l = chunk.length;
+  if (!state.isObjectStream) {
+    if (false === state.decodeStrings)
+      chunk = [chunk, encoding || 'utf8'];
+    else if (typeof chunk === 'string' || encoding) {
+      chunk = new Buffer(chunk + '', encoding);
+      l = chunk.length;
+    }
   }
 
-  state.length += l;
+  state.length += state.isObjectStream ? 1 : l;
 
   var ret = state.length < state.highWaterMark;
   if (ret === false)
@@ -185,7 +194,7 @@ function onwrite(stream, er) {
     stream.emit('error', er);
     return;
   }
-  state.length -= l;
+  state.length -= state.isObjectStream ? 1 : l;
 
   if (cb) {
     // Don't call the cb until the next tick if we're in sync mode.

--- a/test/simple/test-stream2-basic.js
+++ b/test/simple/test-stream2-basic.js
@@ -400,6 +400,36 @@ test('back pressure respected', function (t) {
     assert.equal(expected.length, 0);
     t.end();
   };
+});
+
+test('read(0) for ended streams', function (t) {
+  var r = new R();
+  var written = false;
+  var ended = false;
+  r._read = function () {};
+
+  r.push(new Buffer("foo"));
+  r.push(null);
+
+  var v = r.read(0);
+
+  assert.equal(v, null);
+
+  var w = new R();
+
+  w.write = function (buffer) {
+    written = true;
+    assert.equal(ended, false);
+    assert.equal(buffer.toString(), "foo")
+  };
+
+  w.end = function () {
+    ended = true;
+    assert.equal(written, true);
+    t.end();
+  };
+
+  r.pipe(w);
 })
 
 test('sync _read ending', function (t) {

--- a/test/simple/test-stream2-objects.js
+++ b/test/simple/test-stream2-objects.js
@@ -67,14 +67,32 @@ test('can read objects from stream', function (t) {
   var r = new Readable();
   r.push({ one: "1" });
   r.push({ two: "2" });
-  r._read = noop
+  r._read = noop;
+
+  var v1 = r.read();
+  var v2 = r.read();
+  var v3 = r.read();
+
+  assert.deepEqual(v1, { one: "1" });
+  assert.deepEqual(v2, { two: "2" });
+  assert.deepEqual(v3, null);
+
+  t.end();
+})
+
+test('can pipe objects into stream', function (t) {
+  var r = new Readable();
+  r.push({ one: "1" });
+  r.push({ two: "2" });
+  r.push(null);
+  r._read = noop;
 
   r.pipe(toArray(function (list) {
     assert.deepEqual(list, [
       { one: "1" },
       { two: "2" }
     ]);
-  }));
 
-  t.end();
+    t.end();
+  }));
 });

--- a/test/simple/test-stream2-objects.js
+++ b/test/simple/test-stream2-objects.js
@@ -122,25 +122,57 @@ test('read(n) is ignored', function (t) {
   t.end();
 });
 
-// test('can read objects from _read (sync)', function (t) {
-//   var r = new Readable();
-//   var list = [{ one: "1"}, { two: "2" }];
-//   r._read = function (n, cb) {
-//     var item = list.shift()
-//     console.log("ITEM", item)
-//     cb(null, item || null)
-//   };
+test('can read objects from _read (sync)', function (t) {
+  var r = new Readable();
+  var list = [{ one: "1"}, { two: "2" }];
+  r._read = function (n, cb) {
+    var item = list.shift()
+    cb(null, item || null)
+  };
 
-//   r.on("end", function () {
-//     console.log("ENDED");
-//   })
+  r.pipe(toArray(function (list) {
+    assert.deepEqual(list, [
+      { one: "1" },
+      { two: "2" }
+    ]);
 
-//   r.pipe(toArray(function (list) {
-//     assert.deepEqual(list, [
-//       { one: "1" },
-//       { two: "2" }
-//     ]);
+    t.end();
+  }));
+});
 
-//     t.end();
-//   }));
-// })
+test('can read objects from _read (async)', function (t) {
+  var r = new Readable();
+  var list = [{ one: "1"}, { two: "2" }];
+  r._read = function (n, cb) {
+    var item = list.shift()
+    process.nextTick(function () {
+      cb(null, item || null)
+    });
+  };
+
+  r.pipe(toArray(function (list) {
+    assert.deepEqual(list, [
+      { one: "1" },
+      { two: "2" }
+    ]);
+
+    t.end();
+  }));
+});
+
+test('can read strings as objects', function (t) {
+  var r = new Readable({
+    isObjectStream: true
+  });
+  var list = ["one", "two", "three"];
+  list.forEach(function (str) {
+    r.push(str);
+  });
+  r.push(null);
+
+  r.pipe(toArray(function (array) {
+    assert.deepEqual(array, list)
+
+    t.end();
+  }));
+});

--- a/test/simple/test-stream2-objects.js
+++ b/test/simple/test-stream2-objects.js
@@ -1,0 +1,80 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var common = require('../common.js')
+var Readable = require('_stream_readable');
+var assert = require('assert');
+
+// tiny node-tap lookalike.
+var tests = [];
+function test(name, fn) {
+  tests.push([name, fn]);
+}
+
+function run() {
+  var next = tests.shift();
+  if (!next)
+    return console.error('ok');
+
+  var name = next[0];
+  var fn = next[1];
+  console.log('# %s', name);
+  fn({
+    same: assert.deepEqual,
+    equal: assert.equal,
+    end: run
+  });
+}
+
+process.nextTick(run);
+
+function toArray(callback) {
+  var stream = new Readable();
+  var list = [];
+  stream.write = function (chunk) {
+    list.push(chunk);
+  };
+
+  stream.end = function () {
+    callback(list);
+  };
+
+  return stream;
+}
+
+function noop() {}
+
+test('can read objects from stream', function (t) {
+  var r = new Readable();
+  r.push({ one: "1" });
+  r.push({ two: "2" });
+  r._read = noop
+
+  r.pipe(toArray(function (list) {
+    assert.deepEqual(list, [
+      { one: "1" },
+      { two: "2" }
+    ]);
+  }));
+
+  t.end();
+});

--- a/test/simple/test-stream2-objects.js
+++ b/test/simple/test-stream2-objects.js
@@ -342,9 +342,55 @@ test('low watermark push', function (t) {
 });
 
 test('stream of buffers converted to object halfway through', function (t) {
-  t.end();
+  var r = new Readable()
+  r._read = noop
+
+  r.push(new Buffer("fus"));
+  r.push(new Buffer("do"));
+  r.push(new Buffer("rah"));
+
+  var str = r.read(4);
+
+  assert.equal(str, "fusd");
+
+  r.push({ foo: "bar" });
+  r.push(null);
+
+  r.pipe(toArray(function (list) {
+    assert.deepEqual(list, [
+      new Buffer("o"),
+      new Buffer("rah"),
+      { foo: "bar"}
+    ]);
+
+    t.end();
+  }));
 });
 
 test('stream of strings converted to objects halfway through', function (t) {
-  t.end();
+  var r = new Readable({
+    encoding: "utf8"
+  })
+  r._read = noop
+
+  r.push("fus");
+  r.push("do");
+  r.push("rah");
+
+  var str = r.read(4);
+
+  assert.equal(str, "fusd");
+
+  r.push({ foo: "bar" });
+  r.push(null);
+
+  r.pipe(toArray(function (list) {
+    assert.deepEqual(list, [
+      "o",
+      "rah",
+      { foo: "bar"}
+    ]);
+
+    t.end();
+  }));
 });

--- a/test/simple/test-stream2-readable-from-list.js
+++ b/test/simple/test-stream2-readable-from-list.js
@@ -25,7 +25,10 @@ var fromList = require('_stream_readable')._fromList;
 
 // tiny node-tap lookalike.
 var tests = [];
+var count = 0;
+
 function test(name, fn) {
+  count++;
   tests.push([name, fn]);
 }
 
@@ -40,9 +43,17 @@ function run() {
   fn({
     same: assert.deepEqual,
     equal: assert.equal,
-    end: run
+    end: function () {
+      count--;
+      run();
+    }
   });
 }
+
+// ensure all tests have run
+process.on("exit", function () {
+  assert.equal(count, 0);
+});
 
 process.nextTick(run);
 

--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -26,7 +26,10 @@ var Transform = require('_stream_transform');
 
 // tiny node-tap lookalike.
 var tests = [];
+var count = 0;
+
 function test(name, fn) {
+  count++;
   tests.push([name, fn]);
 }
 
@@ -41,9 +44,17 @@ function run() {
   fn({
     same: assert.deepEqual,
     equal: assert.equal,
-    end: run
+    end: function () {
+      count--;
+      run();
+    }
   });
 }
+
+// ensure all tests have run
+process.on("exit", function () {
+  assert.equal(count, 0);
+});
 
 process.nextTick(run);
 

--- a/test/simple/test-stream2-writable.js
+++ b/test/simple/test-stream2-writable.js
@@ -48,28 +48,35 @@ for (var i = 0; i < chunks.length; i++) {
 
 // tiny node-tap lookalike.
 var tests = [];
+var count = 0;
+
 function test(name, fn) {
+  count++;
   tests.push([name, fn]);
 }
 
 function run() {
   var next = tests.shift();
   if (!next)
-    return console.log('ok');
+    return console.error('ok');
 
   var name = next[0];
   var fn = next[1];
-
-  if (!fn)
-    return run();
-
   console.log('# %s', name);
   fn({
     same: assert.deepEqual,
     equal: assert.equal,
-    end: run
+    end: function () {
+      count--;
+      run();
+    }
   });
 }
+
+// ensure all tests have run
+process.on("exit", function () {
+  assert.equal(count, 0);
+});
 
 process.nextTick(run);
 


### PR DESCRIPTION
Support for having streams of "objects" which means user land modules can use `_read`, `_write`, `push` and all the buffering / back pressure logic isaacs has done in streams2 in their streams of objects.

This adds the `isObjectStream` boolean to options to switch a stream into an object stream. The object stream semantics are different, namely:
- `read()` always returns a single object. the `n` argument is ignored.
- `push(item)` pushes a single object onto the stream's internal buffer
- `cb(null, item)` in `_read` pushes a single object onto the stream's internal buffer.

If internal `onread` is ever called with something that is not a `Buffer`, `string`, `null` or `undefined` it will switch a normal stream into object stream mode.
## Bonus bug fixes

The tests for streams2 didn't tell you if they ran successfully so I added a counter to the tiny tap-like test function to ensure all tests actually ran. this found some bugs.

Specifically the drainState counter could become negative if a writable stream was unpiped and we didn't know whether it needed drain so we just did it anyway. If the drainState counter is negative then either pipe is broken or backpressure is not respected, a test has been added to ensure backpressure is respected.

Another bug was unpipe did not set `state.flowing = false` so the pipe was broken since pipe would not start flow and the readable listener which started flow was removed.

Another bug was we forgot to call `endReadable` when `_read(null, null)` was called synchronously.

All the tests pass
