### PR TITLE
streams2: net.Socket stalls on large read()

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -147,6 +147,13 @@ Readable.prototype.read = function(n) {
   if (typeof n !== 'number' || n > 0)
     state.emittedReadable = false;
 
+  // Caller wants to read huge buffers, but has not increased highWaterMark
+  // correctly.  This can cause push oriented streams like net.Socket to
+  // deadlock. Automatically increase the highWaterMark to avoid this
+  // condition.
+  if (n > state.highWaterMark)
+    state.highWaterMark = n;
+
   n = howMuchToRead(n, state);
 
   // if we've ended, and we're now clear, then finish it up.

--- a/test/simple/test-net-large-read.js
+++ b/test/simple/test-net-large-read.js
@@ -1,0 +1,117 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common.js');
+var net = require('net');
+
+// tiny node-tap lookalike.
+var tests = [];
+function test(name, fn) {
+  tests.push([name, fn]);
+}
+
+function run() {
+  var next = tests.shift();
+  if (!next)
+    return console.error('ok');
+
+  var name = next[0];
+  var fn = next[1];
+  console.log('# %s', name);
+  fn({
+    same: assert.deepEqual,
+    equal: assert.equal,
+    end: run
+  });
+}
+
+process.nextTick(run);
+
+/////
+
+test('large read', function(t) {
+  var testLength = 1024*1024;
+
+  var server = net.createServer();
+  server.on('connection', function(socketIn) {
+    readFlow(socketIn, testLength, function(data) {
+      assert.notEqual(data, null);
+      assert.equal(data.length, testLength);
+
+      server.close();
+      socketIn.end();
+
+      t.end();
+    });
+  });
+
+  server.listen(0, '127.0.0.1', function() {
+    var port = server.address().port;
+
+    var socketOut = new net.Socket();
+    socketOut.connect(port, '127.0.0.1', function() {
+      socketOut.write(new Buffer(testLength), function() {
+        socketOut.end();
+      });
+    });
+  });
+});
+
+test('late large read', function(t) {
+  var testLength = 1024*1024;
+
+  var server = net.createServer();
+  server.on('connection', function(socketIn) {
+    setTimeout(function() {
+      readFlow(socketIn, testLength, function(data) {
+        assert.notEqual(data, null);
+        assert.equal(data.length, testLength);
+
+        server.close();
+        socketIn.end();
+
+        t.end();
+      });
+    }, 2000);
+  });
+
+  server.listen(0, '127.0.0.1', function() {
+    var port = server.address().port;
+
+    var socketOut = new net.Socket();
+    socketOut.connect(port, '127.0.0.1', function() {
+      socketOut.write(new Buffer(testLength), function() {
+        socketOut.end();
+      });
+    });
+  });
+});
+
+function readFlow(readable, length, callback) {
+  var res = readable.read(length);
+  if (res) {
+    callback(res);
+    return;
+  }
+
+  readable.once('readable', readFlow.bind(null, readable, length, callback));
+}


### PR DESCRIPTION
Currently, if you attempt to perform a read() on a net.Socket for a buffer larger than
its highWaterMark the stream will stall.

This occurs because `onread()` in `lib/net.js` issues the `'readable'` event via its call
to `Readable.push()` prior to calling the underlying `readStop()` function.  This means
that the client will get the event, attempt another `read()` which is its one chance to
restart a stopped stream, and then the stream will be stopped.  The end result is a stall.

While it is possible to workaround this problem by setting the `highWaterMark` to the
size of the largest buffer you wish to read, not all net.Socket instances are created by
client code.  In particular, net.Socket objects returned by net.Server do not provide the
opportunity to set a `highWaterMark`.

This pull request provides a simple, albeit perhaps not ideal, solution.  When `read()`
is called on a Readable object with size parameter larger than the `highWaterMark`,
then automatically increase the `highWaterMark` to match.

An alternative would be to duplicate the `highWaterMark` logic in the net.Socket `onread()`
function so that the stream could be stopped prior to issuing the `'readable'` event
via the `push()` function.  This would then allow the client code to restart the stream by
calling `read()` again.

I'm interested to know if there are better or more correct ways to deal with this issue.

Thank you.
