### PR TITLE
Update tools/install.py

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
 import errno
-import json
+
+try:
+  import json
+except ImportError:
+  import simplejson as json
+    
 import os
 import re
 import shutil


### PR DESCRIPTION
Make tools/install.py work with python 2.5

2.5 is still fairly widespread and does not include a json lib as
standard. Most python folk will have simplejson if they are in that
boat.

In general it seems a bit tricky to solve this perfectly...
