### PR TITLE
doc: modify documentation style about 'Stability: 5'

### DIFF
--- a/doc/api/documentation.markdown
+++ b/doc/api/documentation.markdown
@@ -67,7 +67,7 @@ unlikely to ever have to change.
 ```
 
 ```
-Stability: 5 - API Locked
+Stability: 5 - Locked
 Unless serious bugs are found, this code will not ever
 change.  Please do not suggest changes in this area; they will be refused.
 ```


### PR DESCRIPTION
'Stability: 5' is described as 'Locked' not as 'API Locked'
in other documents.

For example:
- [`/doc/api/assert.markdown`](https://github.com/joyent/node/blob/master/doc/api/assert.markdown)
- [`/doc/api/util.markdown`](https://github.com/joyent/node/blob/master/doc/api/util.markdown)

This word was injected in 192192a0.
