### PR TITLE
console: Support formatting options in trace()

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -85,12 +85,12 @@ Console.prototype.timeEnd = function(label) {
 };
 
 
-Console.prototype.trace = function(label) {
+Console.prototype.trace = function() {
   // TODO probably can to do this better with V8's debug object once that is
   // exposed.
   var err = new Error;
   err.name = 'Trace';
-  err.message = label || '';
+  err.message = util.format.apply(this, arguments);
   Error.captureStackTrace(err, arguments.callee);
   this.error(err.stack);
 };

--- a/test/simple/test-console.js
+++ b/test/simple/test-console.js
@@ -43,13 +43,17 @@ console.log('foo', 'bar');
 console.log('%s %s', 'foo', 'bar', 'hop');
 console.log({slashes: '\\\\'});
 
+console._stderr = process.stdout;
+console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
+
 global.process.stdout.write = stdout_write;
+
 assert.equal('foo\n', strings.shift());
 assert.equal('foo bar\n', strings.shift());
 assert.equal('foo bar hop\n', strings.shift());
 assert.equal("{ slashes: '\\\\\\\\' }\n", strings.shift());
-
-process.stderr.write('hello world');
+assert.equal('Trace: This is a {"formatted":"trace"} 10 foo',
+             strings.shift().split('\n').shift());
 
 assert.throws(function () {
   console.timeEnd('no such label');


### PR DESCRIPTION
Especially handy when swapping out `console.error` with `console.trace` while debugging.
