### PR TITLE
dns: make error message match errno

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -28,12 +28,13 @@ function errnoException(errorno, syscall) {
   // TODO make this more compatible with ErrnoException from src/node.cc
   // Once all of Node is using this function the ErrnoException from
   // src/node.cc should be removed.
-  var e = new Error(syscall + ' ' + errorno);
 
   // For backwards compatibility. libuv returns ENOENT on NXDOMAIN.
   if (errorno == 'ENOENT') {
     errorno = 'ENOTFOUND';
   }
+
+  var e = new Error(syscall + ' ' + errorno);
 
   e.errno = e.code = errorno;
   e.syscall = syscall;

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -308,6 +308,7 @@ TEST(function test_lookup_failure(done) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, dns.NOTFOUND);
     assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.ok(!/ENOENT/.test(err.message));
 
     done();
   });


### PR DESCRIPTION
There is a case where an error message coming from dns has `ENOENT`, but the errno is `ENOTFOUND`. This commit, correctly sets the error message to also contain `ENOTFOUND`.

reproduce:

``` javascript
require('dns').lookup('does.not.exist', 4, function(err) {
  console.log(err.message, err.errno)
})
```
