### PR TITLE
http: Emit all socket errors on the request object

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1777,7 +1777,15 @@ function connectionListener(socket) {
   }
 
   socket.addListener('error', function(e) {
-    self.emit('clientError', e, this);
+    // if we have a request, then emit the error there
+    // otherwise just emit a clientError on the server
+    // destroy the socket either way, though
+    if (parser.incoming)
+      parser.incoming.emit('error', e);
+    else
+      self.emit('clientError', e, this);
+
+    socket.destroy();
   });
 
   socket.ondata = function(d, start, end) {

--- a/test/simple/test-http-blank-header.js
+++ b/test/simple/test-http-blank-header.js
@@ -34,8 +34,12 @@ var server = http.createServer(function(req, res) {
   assert.deepEqual({
     host: 'mapdevel.trolologames.ru:443',
     origin: 'http://mapdevel.trolologames.ru',
-    cookie: ''
+    cookie: '',
+    'content-length': '12'
   }, req.headers);
+
+  req.setEncoding('utf8');
+  req.on('data', console.error);
 });
 
 
@@ -44,16 +48,13 @@ server.listen(common.PORT, function() {
 
   c.on('connect', function() {
     common.error('client wrote message');
-    c.write('GET /blah HTTP/1.1\r\n' +
-            'Host: mapdevel.trolologames.ru:443\r\n' +
-            'Cookie:\r\n' +
-            'Origin: http://mapdevel.trolologames.ru\r\n' +
-            '\r\n\r\nhello world'
+    c.end('GET /blah HTTP/1.1\r\n' +
+          'Host: mapdevel.trolologames.ru:443\r\n' +
+          'Cookie:\r\n' +
+          'Origin: http://mapdevel.trolologames.ru\r\n' +
+          'Content-Length: 12\r\n' +
+          '\r\nhello, world'
     );
-  });
-
-  c.on('end', function() {
-    c.end();
   });
 
   c.on('close', function() {


### PR DESCRIPTION
This fixes #3945

The potential hazard is that anyone who doesn't add a `req.on('error', handler)` in their http server is now vulnerable to a DoS attack.  Perhaps we should check for a `req.listeners('error').length` before emitting on the request?

/cc @bnoordhuis @piscisaureus
