### PR TITLE
always empty domain stack when handling exceptions

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -243,7 +243,14 @@
           // If caught is false after this, then there's no need to exit()
           // the domain, because we're going to crash the process anyway.
           caught = domain.emit('error', er);
-          domain.exit();
+
+          // Exit all domains on the stack.  Uncaught exceptions end the
+          // current tick and no domains should be left on the stack between
+          // ticks.  Since a domain exists, this require will not be loading
+          // it for the first time and should be safe.
+          var domain_module = NativeModule.require('domain');
+          domain_module._stack.length = 0;
+          domain_module.active = process.domain = null;
         } catch (er2) {
           caught = false;
         }

--- a/test/simple/test-domain-nested.js
+++ b/test/simple/test-domain-nested.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Make sure that the nested domains don't cause the domain stack to grow
+
+var assert = require('assert');
+var domain = require('domain');
+
+process.on('exit', function(c) {
+  assert.equal(domain._stack.length, 0);
+});
+
+domain.create().run(function() {
+  domain.create().run(function() {
+    domain.create().run(function() {
+      domain.create().on("error", function(e) {
+          // Don't need to do anything here
+      }).run(function() {
+        throw new Error("died")
+      })
+    })
+  })
+})


### PR DESCRIPTION
Re-filing PR #4557 based against master

Make domains a little safer by avoiding potentially unbounded stack bloat

The following code will cause the stack to grow:

```
var d = require("domain");

setTimeout(function() {
    console.log('domain stack length is now ' + d._stack.length);
}, 100);

d.create().run(function() {
    d.create().run(function() {
        d.create().run(function() {
            d.create().on("error", function(e) {
                console.log("caught " + e)
            }).run(function() {
                    throw new Error("died")
            })
        })
    })
})
```
