### PR TITLE
Update http docs with http.IncomingMessage.

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -56,7 +56,7 @@ This is an [EventEmitter][] with the following events:
 
 Emitted each time there is a request. Note that there may be multiple requests
 per connection (in the case of keep-alive connections).
- `request` is an instance of `http.ServerRequest` and `response` is
+ `request` is an instance of `http.IncomingMessage` and `response` is
  an instance of `http.ServerResponse`
 
 ### Event: 'connection'
@@ -186,133 +186,6 @@ Stops the server from accepting new connections.  See [net.Server.close()][].
 
 Limits maximum incoming headers count, equal to 1000 by default. If set to 0 -
 no limit will be applied.
-
-
-## Class: http.ServerRequest
-
-This object is created internally by a HTTP server -- not by
-the user -- and passed as the first argument to a `'request'` listener.
-
-The request implements the [Readable Stream][] interface. This is an
-[EventEmitter][] with the following events:
-
-### Event: 'data'
-
-`function (chunk) { }`
-
-Emitted when a piece of the message body is received. The chunk is a string if
-an encoding has been set with `request.setEncoding()`, otherwise it's a
-[Buffer][].
-
-Note that the __data will be lost__ if there is no listener when a
-`ServerRequest` emits a `'data'` event.
-
-### Event: 'end'
-
-`function () { }`
-
-Emitted exactly once for each request. After that, no more `'data'` events
-will be emitted on the request.
-
-### Event: 'close'
-
-`function () { }`
-
-Indicates that the underlaying connection was terminated before
-`response.end()` was called or able to flush.
-
-Just like `'end'`, this event occurs only once per request, and no more `'data'`
-events will fire afterwards.
-
-Note: `'close'` can fire after `'end'`, but not vice versa.
-
-### request.method
-
-The request method as a string. Read only. Example:
-`'GET'`, `'DELETE'`.
-
-
-### request.url
-
-Request URL string. This contains only the URL that is
-present in the actual HTTP request. If the request is:
-
-    GET /status?name=ryan HTTP/1.1\r\n
-    Accept: text/plain\r\n
-    \r\n
-
-Then `request.url` will be:
-
-    '/status?name=ryan'
-
-If you would like to parse the URL into its parts, you can use
-`require('url').parse(request.url)`.  Example:
-
-    node> require('url').parse('/status?name=ryan')
-    { href: '/status?name=ryan',
-      search: '?name=ryan',
-      query: 'name=ryan',
-      pathname: '/status' }
-
-If you would like to extract the params from the query string,
-you can use the `require('querystring').parse` function, or pass
-`true` as the second argument to `require('url').parse`.  Example:
-
-    node> require('url').parse('/status?name=ryan', true)
-    { href: '/status?name=ryan',
-      search: '?name=ryan',
-      query: { name: 'ryan' },
-      pathname: '/status' }
-
-
-
-### request.headers
-
-Read only map of header names and values. Header names are lower-cased.
-Example:
-
-    // Prints something like:
-    //
-    // { 'user-agent': 'curl/7.22.0',
-    //   host: '127.0.0.1:8000',
-    //   accept: '*/*' }
-    console.log(request.headers);
-
-
-### request.trailers
-
-Read only; HTTP trailers (if present). Only populated after the 'end' event.
-
-### request.httpVersion
-
-The HTTP protocol version as a string. Read only. Examples:
-`'1.1'`, `'1.0'`.
-Also `request.httpVersionMajor` is the first integer and
-`request.httpVersionMinor` is the second.
-
-
-### request.setEncoding([encoding])
-
-Set the encoding for the request body. See [stream.setEncoding()][] for more
-information.
-
-### request.pause()
-
-Pauses request from emitting events.  Useful to throttle back an upload.
-
-
-### request.resume()
-
-Resumes a paused request.
-
-### request.connection
-
-The `net.Socket` object associated with the connection.
-
-
-With HTTPS support, use request.connection.verifyPeer() and
-request.connection.getPeerCertificate() to obtain the client's
-authentication details.
 
 
 
@@ -637,7 +510,7 @@ data chunk or when closing the connection.
 To get the response, add a listener for `'response'` to the request object.
 `'response'` will be emitted from the request object when the response
 headers have been received.  The `'response'` event is executed with one
-argument which is an instance of `http.ClientResponse`.
+argument which is an instance of `http.IncomingMessage`.
 
 During the `'response'` event, one can add listeners to the
 response object; particularly to listen for the `'data'` event. Note that
@@ -674,7 +547,7 @@ The request implements the [Writable Stream][] interface. This is an
 `function (response) { }`
 
 Emitted when a response is received to this request. This event is emitted only
-once. The `response` argument will be an instance of `http.ClientResponse`.
+once. The `response` argument will be an instance of `http.IncomingMessage`.
 
 Options:
 
@@ -850,24 +723,26 @@ Once a socket is assigned to this request and is connected
 Once a socket is assigned to this request and is connected
 [socket.setKeepAlive()][] will be called.
 
-## http.ClientResponse
 
-This object is created when making a request with `http.request()`. It is
-passed to the `'response'` event of the request object.
+## http.IncomingMessage
 
-The response implements the [Readable Stream][] interface. This is an
+An `IncomingMessage` object is created by `http.Server` or `http.ClientRequest`
+and passed as the first argument to the `'request'` and `'response'` event
+respectively. It may be used to access response status, headers and data.
+
+It implements the [Readable Stream][] interface. `http.IncomingMessage` is an
 [EventEmitter][] with the following events:
-
 
 ### Event: 'data'
 
 `function (chunk) { }`
 
-Emitted when a piece of the message body is received.
+Emitted when a piece of the message body is received. The chunk is a string if
+an encoding has been set with `message.setEncoding()`, otherwise it's
+a [Buffer][].
 
 Note that the __data will be lost__ if there is no listener when a
-`ClientResponse` emits a `'data'` event.
-
+`IncomingMessage` emits a `'data'` event.
 
 ### Event: 'end'
 
@@ -875,7 +750,6 @@ Note that the __data will be lost__ if there is no listener when a
 
 Emitted exactly once for each response. After that, no more `'data'` events
 will be emitted on the response.
-
 
 ### Event: 'close'
 
@@ -890,38 +764,103 @@ event for more information.
 
 Note: `'close'` can fire after `'end'`, but not vice versa.
 
+### message.httpVersion
 
-### response.statusCode
+In case of server request, the HTTP version sent by the client. In the case of
+client response, the HTTP version of the connected-to server.
+Probably either `'1.1'` or `'1.0'`.
 
-The 3-digit HTTP response status code. E.G. `404`.
-
-### response.httpVersion
-
-The HTTP version of the connected-to server. Probably either
-`'1.1'` or `'1.0'`.
 Also `response.httpVersionMajor` is the first integer and
 `response.httpVersionMinor` is the second.
 
-### response.headers
+### message.headers
 
-The response headers object.
+The request/response headers object.
 
-### response.trailers
+Read only map of header names and values. Header names are lower-cased.
+Example:
 
-The response trailers object. Only populated after the 'end' event.
+    // Prints something like:
+    //
+    // { 'user-agent': 'curl/7.22.0',
+    //   host: '127.0.0.1:8000',
+    //   accept: '*/*' }
+    console.log(request.headers);
 
-### response.setEncoding([encoding])
+### message.trailers
 
-Set the encoding for the response body. See [stream.setEncoding()][] for more
+The request/response trailers object. Only populated after the 'end' event.
+
+### message.setEncoding([encoding])
+
+Set the encoding for data emitted by the `'data'` event. See [stream.setEncoding()][] for more
 information.
 
-### response.pause()
+Should be set before any `'data'` events have been emitted.
 
-Pauses response from emitting events.  Useful to throttle back a download.
+### message.pause()
 
-### response.resume()
+Pauses request/response from emitting events.  Useful to throttle back a download.
 
-Resumes a paused response.
+### message.resume()
+
+Resumes a paused request/response.
+
+### message.method
+
+**Only valid for request obtained from `http.Server`.**
+
+The request method as a string. Read only. Example:
+`'GET'`, `'DELETE'`.
+
+### message.url
+
+**Only valid for request obtained from `http.Server`.**
+
+Request URL string. This contains only the URL that is
+present in the actual HTTP request. If the request is:
+
+    GET /status?name=ryan HTTP/1.1\r\n
+    Accept: text/plain\r\n
+    \r\n
+
+Then `request.url` will be:
+
+    '/status?name=ryan'
+
+If you would like to parse the URL into its parts, you can use
+`require('url').parse(request.url)`.  Example:
+
+    node> require('url').parse('/status?name=ryan')
+    { href: '/status?name=ryan',
+      search: '?name=ryan',
+      query: 'name=ryan',
+      pathname: '/status' }
+
+If you would like to extract the params from the query string,
+you can use the `require('querystring').parse` function, or pass
+`true` as the second argument to `require('url').parse`.  Example:
+
+    node> require('url').parse('/status?name=ryan', true)
+    { href: '/status?name=ryan',
+      search: '?name=ryan',
+      query: { name: 'ryan' },
+      pathname: '/status' }
+
+### message.statusCode
+
+**Only valid for response obtained from `http.ClientRequest`.**
+
+The 3-digit HTTP response status code. E.G. `404`.
+
+### message.socket
+
+The `net.Socket` object associated with the connection.
+
+With HTTPS support, use request.connection.verifyPeer() and
+request.connection.getPeerCertificate() to obtain the client's
+authentication details.
+
 
 [Agent]: #http_class_http_agent
 ['checkContinue']: #http_event_checkcontinue
@@ -929,7 +868,7 @@ Resumes a paused response.
 [EventEmitter]: events.html#events_class_events_eventemitter
 [global Agent]: #http_http_globalagent
 [http.request()]: #http_http_request_options_callback
-[http.ServerRequest]: #http_class_http_serverrequest
+[http.IncomingMessage]: #http_class_http_incomingmessage
 ['listening']: net.html#net_event_listening
 [net.Server.close()]: net.html#net_server_close_callback
 [net.Server.listen(path)]: net.html#net_server_listen_path_callback


### PR DESCRIPTION
http.ServerRequest and http.ClientResponse are merged into http.IncomingMessage
which has fields for both, and acts as a Readable Stream and EventEmitter.

Fixes #3851.
