### PR TITLE
make repl compatible with domains

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -114,7 +114,13 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     } catch (e) {
       err = e;
     }
-    cb(err, result);
+    if (err && process.domain) {
+      process.domain.emit('error', err);
+      process.domain.exit();
+    }
+    else {
+      cb(err, result);
+    }
   };
 
   if (!input && !output) {

--- a/test/simple/test-repl-domain.js
+++ b/test/simple/test-repl-domain.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var util   = require('util');
+var repl   = require('repl');
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function(data) {
+    var self = this;
+    data.forEach(function(line) {
+      self.emit('data', line + '\n');
+    });
+  }
+}
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function() {};
+ArrayStream.prototype.write = function() {};
+
+var putIn = new ArrayStream();
+var testMe = repl.start('', putIn);
+
+putIn.write = function(data) {
+  // Don't use assert for this because the domain might catch it, and
+  // give a false negative.  Don't throw, just print and exit.
+  if (data === 'OK\n') {
+      console.log('ok');
+  }
+  else {
+      console.error(data);
+      process.exit(1);
+  }
+};
+
+putIn.run([
+  'require("domain").create().on("error", function () { console.log("OK") })'
+  + '.run(function () { throw new Error("threw") })'
+]);


### PR DESCRIPTION
The try/catch in repl.js keeps any active domain from catching the
error.  Since the domain may not even be enterd until the code is run,
it's not possible to avoid the try/catch, so emit on the domain when an
error is thrown.

Originally discovered in the comments under PR #4570
