### PR TITLE
buffer: remove float write range checks

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -626,7 +626,7 @@ complement signed integer into `buffer`.
 * `noAssert` Boolean, Optional, Default: false
 
 Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid 32 bit float.
+format. Note, behavior is unspecified if `value` is not a 32 bit float.
 
 Set `noAssert` to true to skip validation of `value` and `offset`. This means
 that `value` may be too large for the specific function and `offset` may be


### PR DESCRIPTION
Removed range checks when writing float values, and removed a few
includes and defines. Also updated api docs to reflect that invalid 32
bit float values will be allowed to overflow to `+/-Infinity` or `0`.

@piscisaureus I think this addresses everything we discussed.

As a side, currently on my machine (since 22b84e6) when compiling with clang 3.2 for ia32 the operations `writeFloatLE|BE` and `writeDoubleLE|BE` write signaling NaNs. While on x64 with clang 3.2 and x64/ia32 with gcc 4.7 write quiet NaNs. So under that condition, two tests will fail. Right now I'm considering this a non-issue.
