### PR TITLE
http: close connection on 304 and chunked encoding

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -564,6 +564,22 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
     state.messageHeader += 'Date: ' + utcDate() + CRLF;
   }
 
+  // Force the connection to close when the response is a 304 Not Modified
+  // and the user has set a "Transfer-Encoding: chunked" header.
+  //
+  // RFC 2616 mandates that 304 responses MUST NOT have a body but node.js
+  // used to send out a zero chunk anyway to accommodate clients that don't
+  // have special handling for 304 responses.
+  //
+  // It was pointed out that this might confuse reverse proxies to the point
+  // of creating security liabilities, so suppress the zero chunk and force
+  // the connection to close.
+  if (this.statusCode === 304 && this.chunkedEncoding === true) {
+    debug('304 response should not use chunked encoding, closing connection.');
+    this.chunkedEncoding = false;
+    this.shouldKeepAlive = false;
+  }
+
   // keep-alive logic
   if (state.sentConnectionHeader === false) {
     var shouldSendKeepAlive = this.shouldKeepAlive &&

--- a/test/simple/test-http-chunked-304.js
+++ b/test/simple/test-http-chunked-304.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+
+// RFC 2616, section 10.3.5:
+//
+//   The 304 response MUST NOT contain a message-body, and thus is always
+//   terminated by the first empty line after the header fields.
+//
+// Verify that no empty chunk is sent when the user explicitly sets
+// a Transfer-Encoding header.
+var server = http.createServer(function(req, res) {
+  res.writeHead(304, { 'Transfer-Encoding': 'chunked' });
+  res.end();
+  server.close();
+});
+
+server.listen(common.PORT, function() {
+  var conn = net.createConnection(common.PORT, function() {
+    conn.write('GET / HTTP/1.1\r\n\r\n');
+
+    var resp = '';
+    conn.setEncoding('utf8');
+    conn.on('data', function(data) {
+      resp += data;
+    });
+
+    conn.on('end', common.mustCall(function() {
+      assert.equal(/^Connection: close\r\n$/m.test(resp), true);
+      assert.equal(/^0\r\n$/m.test(resp), false);
+    }));
+  });
+});


### PR DESCRIPTION
Force the connection to close when the response is a 304 Not Modified
and the user has set a "Transfer-Encoding: chunked" header.

RFC 2616 mandates that 304 responses MUST NOT have a body but node.js
used to send out a zero chunk anyway to accommodate clients that don't
have special handling for 304 responses.

It was pointed out that this might confuse reverse proxies to the point
of creating security liabilities, so suppress the zero chunk and force
the connection to close.

Suggested reviewers: @isaacs @pquerna
