### PR TITLE
Fix typo in Hash.digest note

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -110,7 +110,7 @@ Calculates the digest of all of the passed data to be hashed.  The
 `encoding` can be `'hex'`, `'binary'` or `'base64'`.  If no encoding
 is provided, then a buffer is returned.
 
-Note: `hash` object can not be used after `digest()` method been
+Note: `hash` object can not be used after `digest()` method has been
 called.
 
 


### PR DESCRIPTION
Added the word 'has' to the sentence.
