### PR TITLE
Add bytesWritten proxy property to CryptoStream

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -413,6 +413,15 @@ gets high.
 The number of concurrent connections on the server.
 
 
+## Class: CryptoStream
+
+This is an encrypted stream.
+
+### cryptoStream.bytesWritten
+
+A proxy to the underlying socket's bytesWritten accessor, this will return
+the total bytes written to the socket, *including the TLS overhead*.
+
 ## Class: tls.CleartextStream
 
 This is a stream on top of the *Encrypted* stream that makes it possible to

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -334,6 +334,9 @@ CryptoStream.prototype.setKeepAlive = function(enable, initialDelay) {
   if (this.socket) this.socket.setKeepAlive(enable, initialDelay);
 };
 
+CryptoStream.prototype.__defineGetter__('bytesWritten', function() {
+  return this.socket ? this.socket.bytesWritten : 0;
+});
 
 CryptoStream.prototype.setEncoding = function(encoding) {
   var StringDecoder = require('string_decoder').StringDecoder; // lazy load
@@ -685,10 +688,6 @@ CleartextStream.prototype.__defineGetter__('remoteAddress', function() {
 
 CleartextStream.prototype.__defineGetter__('remotePort', function() {
   return this.socket && this.socket.remotePort;
-});
-
-CleartextStream.prototype.__defineGetter__('bytesWritten', function() {
-  return this.socket && this.socket.bytesWritten;
 });
 
 function EncryptedStream(pair) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -687,6 +687,9 @@ CleartextStream.prototype.__defineGetter__('remotePort', function() {
   return this.socket && this.socket.remotePort;
 });
 
+CleartextStream.prototype.__defineGetter__('bytesWritten', function() {
+  return this.socket && this.socket.bytesWritten;
+});
 
 function EncryptedStream(pair) {
   CryptoStream.call(this, pair);

--- a/test/simple/test-http-byteswritten.js
+++ b/test/simple/test-http-byteswritten.js
@@ -19,36 +19,25 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var http = require('http');
-var https = require('https');
-
-var options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
-};
 
 var body = 'hello world\n';
 
-var httpsServer = https.createServer(options, function(req, res) {
+var httpServer = http.createServer(function(req, res) {
   req.on('end', function() {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end(body);
     assert(typeof(req.connection.bytesWritten) !== undefined);
     assert(req.connection.bytesWritten > 0);
   });
-  httpsServer.close(); 
+  httpServer.close(); 
 });
 
-httpsServer.listen(common.PORT + 1, function() {
-  var req = https.request({ port: common.PORT + 1 }, function(res) {
+httpServer.listen(common.PORT, function() {
+  var req = http.request({ port: common.PORT }, function(res) {
   });
   req.end();
 });

--- a/test/simple/test-https-byteswritten.js
+++ b/test/simple/test-https-byteswritten.js
@@ -1,0 +1,79 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) {
+  console.error('Skipping because node compiled without OpenSSL.');
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+
+var fs = require('fs');
+
+var http = require('http');
+var https = require('https');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var body = 'hello world\n';
+
+// Try first with http server
+
+var server_http = http.createServer(function(req, res) {
+  req.on('end', function() {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(body);
+    assert( req.connection.bytesWritten );
+  });
+});
+
+server_http.listen(common.PORT, function() {
+  var req = http.request({ port: common.PORT }, function(res) {
+    res.on('end', function() {
+      server_http.close(); 
+    });
+  });
+  req.end();
+});
+
+
+// Now try with HTTPS
+
+var server_https = https.createServer(options, function(req, res) {
+  req.on('end', function() {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(body);
+    assert( req.connection.bytesWritten );
+  });
+});
+
+server_https.listen(common.PORT + 1, function() {
+  var req = https.request({ port: common.PORT + 1 }, function(res) {
+    res.on('end', function() {
+      server_https.close(); 
+    });
+  });
+  req.end();
+});


### PR DESCRIPTION
This adds a bytesWritten proxy to CryptoStream that returns the bytesWritten
from the underlying socket, including the TLS overhead.  This should make
the connection objects in http and https requests more of a work-alike.

See #4650 for discussion.
