### PR TITLE
Fix avoid apps from retaining references to the upgrade head and large s...

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1484,7 +1484,9 @@ function socketOnData(d, start, end) {
     parser.finish();
 
     // This is start + byteParsed
-    var bodyHead = d.slice(start + bytesParsed, end);
+    //Apps that hang on to bodyHead can lead to large slab buffer retention
+    var bodyHead = new Buffer(end - start - bytesParsed);
+    d.copy(bodyHead,0,start + bytesParsed, end); 
 
     var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
     if (req.listeners(eventName).length) {
@@ -1834,7 +1836,9 @@ function connectionListener(socket) {
       freeParser(parser, req);
 
       // This is start + byteParsed
-      var bodyHead = d.slice(start + bytesParsed, end);
+      //Apps that hang on to bodyHead can lead to large slab buffer retention
+      var bodyHead = new Buffer(end - start - bytesParsed);
+      d.copy(bodyHead,0,start + bytesParsed, end); 
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
       if (self.listeners(eventName).length) {


### PR DESCRIPTION
For consideration, at the very least to raise awareness to apps handling buffers from node core.

Please see https://github.com/jmatthewsr-ms/node-slab-memory-issues for an explanation.  Three modules are identified that suffer from high memory usage by retaining a reference to the upgrade head data.
