### PR TITLE
Cluster module cluster.settings typo.

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -101,7 +101,7 @@ the worker pool for your application's needs.
     (Default=`false`)
 
 All settings set by the `.setupMaster` is stored in this settings object.
-This object is not supposed to be change or set manually, by you.
+This object is not supposed to be changed or set manually, by you.
 
 ## cluster.isMaster
 


### PR DESCRIPTION
Fixing a small typo in the cluster.settings documentation.
