### PR TITLE
net: initialize TCPWrap when receiving socket

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -139,6 +139,10 @@ function Socket(options) {
   stream.Duplex.call(this, options);
 
   if (options.handle) {
+    // Initialize TCPWrap and PipeWrap
+    process.binding('tcp_wrap');
+    process.binding('pipe_wrap');
+
     this._handle = options.handle; // private
   } else if (typeof options.fd !== 'undefined') {
     this._handle = createPipe();

--- a/test/simple/test-cluster-net-send.js
+++ b/test/simple/test-cluster-net-send.js
@@ -1,0 +1,67 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fork = require('child_process').fork;
+var net = require('net');
+
+if (process.argv[2] !== 'child') {
+  console.error('[%d] master', process.pid);
+
+  var worker = fork(__filename, ['child']);
+  var called = false;
+
+  worker.once('message', function(msg, handle) {
+    assert.equal(msg, 'handle');
+    assert.ok(handle);
+    worker.send('got');
+
+    handle.on('data', function(data) {
+      called = true;
+      assert.equal(data.toString(), 'hello');
+      worker.kill();
+    });
+  });
+
+  process.once('exit', function() {
+    assert.ok(called);
+  });
+} else {
+  console.error('[%d] worker', process.pid);
+
+  var server = net.createServer(function(c) {
+    process.once('message', function(msg) {
+      assert.equal(msg, 'got');
+      c.end('hello');
+    });
+  });
+  server.listen(common.PORT, function() {
+    var socket = net.connect(common.PORT, '127.0.0.1', function() {
+      process.send('handle', socket);
+    });
+  });
+
+  process.on('disconnect', function() {
+    process.exit();
+    server.close();
+  });
+}


### PR DESCRIPTION
TCPWrap::Initialize() and PipeWrap::Initialize() should be called before
any data will be read from received socket. But, because of lazy
initialization of these bindings, Initialize() method isn't called.

Init bindings manually upon socket receiving.

See #4669

/cc @bnoordhuis
