### PR TITLE
readline: make \r\n emit one 'line' event

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -303,7 +303,7 @@ Interface.prototype._normalWrite = function(b) {
   }
   if (string.indexOf('\n') !== -1) {
     // got one or more newlines; process into "line" events
-    var lines = string.split('\n');
+    var lines = string.split(/\r?\n/);
     // either '' or (concievably) the unfinished portion of the next line
     string = lines.pop();
     this._line_buffer = string;
@@ -758,6 +758,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         this._moveCursor(+1);
         break;
 
+      case 'return':  // carriage return, i.e. \r
       case 'home':
         this._moveCursor(-Infinity);
         break;
@@ -885,8 +886,12 @@ function emitKey(stream, s) {
 
   key.sequence = s;
 
-  if (s === '\r' || s === '\n') {
-    // enter
+  if (s === '\r') {
+    // carriage return
+    key.name = 'return';
+
+  } else if (s === '\n') {
+    // enter, should have been called linefeed
     key.name = 'enter';
 
   } else if (s === '\t') {

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -113,6 +113,19 @@ FakeInput.prototype.end = function() {};
   assert.equal(callCount, expectedLines.length - 1);
   rli.close();
 
+  // \r\n should emit one line event, not two
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
+  expectedLines = ['foo', 'bar', 'baz', 'bat'];
+  callCount = 0;
+  rli.on('line', function(line) {
+    assert.equal(line, expectedLines[callCount]);
+    callCount++;
+  });
+  fi.emit('data', expectedLines.join('\r\n'));
+  assert.equal(callCount, expectedLines.length - 1);
+  rli.close();
+
   // sending a multi-byte utf8 char over multiple writes
   var buf = Buffer('☮', 'utf8');
   fi = new FakeInput();


### PR DESCRIPTION
Make lines ending \r\n emit one 'line' event, not two (where the second
one is an empty string).

This adds a new keypress name: 'return' (as in: 'carriage return').

Fixes #3305.

Suggested reviewer: @TooTallNate
