### PR TITLE
net: Avoid tickDepth warnings on small writes

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -601,14 +601,8 @@ Socket.prototype._write = function(dataEncoding, cb) {
     return this._destroy(errnoException(errno, 'write'), cb);
 
   writeReq.oncomplete = afterWrite;
+  writeReq.cb = cb;
   this._bytesDispatched += writeReq.bytes;
-
-  // If it was entirely flushed, we can write some more right now.
-  // However, if more is left in the queue, then wait until that clears.
-  if (this._handle.writeQueueSize === 0)
-    cb();
-  else
-    writeReq.cb = cb;
 };
 
 function createWriteReq(handle, data, encoding) {

--- a/test/simple/test-net-many-small-writes.js
+++ b/test/simple/test-net-many-small-writes.js
@@ -1,0 +1,84 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+// make sure we get no tickDepth warnings.
+
+if (process.argv[2] === 'child')
+  child();
+else
+  parent();
+
+function parent() {
+  var spawn = require('child_process').spawn;
+  var node = process.execPath;
+  var child = spawn(node, [__filename, 'child']);
+
+  child.stdout.pipe(process.stdout);
+
+  child.stderr.setEncoding('utf8');
+  var err = '';
+  child.stderr.on('data', function(c) {
+    err += c;
+  });
+  var gotClose = false;
+  child.on('close', function(code) {
+    assert(!code);
+    assert.equal(err, '');
+    gotClose = true;
+  });
+  process.on('exit', function() {
+    assert(gotClose);
+    console.log('PARENT: ok');
+  });
+}
+
+function child() {
+  var net = require('net');
+  process.maxTickDepth = 10;
+  var server = net.createServer(function(sock) {
+    var i = 0;
+    w();
+    function w() {
+      if (++i < 100)
+        sock.write(new Buffer(1), w);
+      else
+        sock.end();
+    }
+  });
+  server.listen(common.PORT);
+
+  var finished = false;
+  var client = net.connect(common.PORT);
+  client.resume();
+  client.on('end', function() {
+    server.close(function() {
+      finished = true;
+    });
+  });
+
+  process.on('exit', function() {
+    assert(finished);
+    console.log('CHILD: ok');
+  });
+}


### PR DESCRIPTION
Stumbled upon this running a benchmark that was (incorrectly) doing a very small write in the callback of a very small write.

Since the write was small, it was entirely flushed, and the callback was called on nextTick by the Stream.Writable class (so as to prevent a "sometimes-sync" API).

However, the net.Socket class calls its `_write` callback synchronously when the chunk was entirely flushed, leading to a tickDepth warning.

Synchronous write streams can still trigger the tickDepth warning, but at least we should not cause this in net.Socket, and the alternative is a stack overflow.  (Another alternative way to solve this would be for net.Socket to _always_ defer its write cb, but that is giving up a significant optimization.)

Also, this exposes process.tickDepth as a read-only property, which is pretty useful.
