### PR TITLE
crypto: Only throw if randomBytes arg is a non-number

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -464,6 +464,23 @@ Generates cryptographically strong pseudo-random data. Usage:
       // handle error
     }
 
+Note that this function will throw an error if the size argument is
+not a number.
+
+An exception will be raised (either thrown, or returned to the
+callback) if the size value is negative, or larger than 0x3fffffff.
+
+## crypto.pseudoRandomBytes(size, [callback])
+
+Generates non-cryptographically strong pseudo-random data.  Usage is
+identical to `crypto.randomBytes`, above.
+
+Note that this function will throw an error if the size argument is
+not a number.
+
+An exception will be raised (either thrown, or returned to the
+callback) if the size value is negative, or larger than 0x3fffffff.
+
 ## crypto.DEFAULT_ENCODING
 
 The default encoding to use for functions that can take either strings

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -27,8 +27,6 @@ exports.DEFAULT_ENCODING = 'buffer';
 try {
   var binding = process.binding('crypto');
   var SecureContext = binding.SecureContext;
-  var randomBytes = binding.randomBytes;
-  var pseudoRandomBytes = binding.pseudoRandomBytes;
   var getCiphers = binding.getCiphers;
   var getHashes = binding.getHashes;
   var crypto = true;
@@ -550,8 +548,60 @@ function pbkdf2(password, salt, iterations, keylen, callback) {
 
 
 
+var max = 0x3fffffff;
 exports.randomBytes = randomBytes;
+function randomBytes(size, cb) {
+  if (typeof size !== 'number')
+    throw new Error('size must be a number between 0 and ' + max);
+
+  if (size > max || size < 0) {
+    var er = new Error('size out of range');
+    if (!cb)
+      throw er;
+    return process.nextTick(function() {
+      cb(er);
+    });
+  }
+
+  if (size === 0) {
+    // short circuit
+    var b = new Buffer(0);
+    if (!cb)
+      return b;
+    return process.nextTick(function() {
+      cb(null, b);
+    });
+  }
+
+  binding.randomBytes(~~size, cb);
+}
+
 exports.pseudoRandomBytes = pseudoRandomBytes;
+function pseudoRandomBytes(size, cb) {
+  if (typeof size !== 'number')
+    throw new Error('size must be a number between 0 and ' + max);
+
+  if (size > max || size < 0) {
+    var er = new Error('size out of range');
+    if (!cb)
+      throw er;
+    return process.nextTick(function() {
+      cb(er);
+    });
+  }
+
+  if (size === 0) {
+    // short circuit
+    var b = new Buffer(0);
+    if (!cb)
+      return b;
+    return process.nextTick(function() {
+      cb(null, b);
+    });
+  }
+
+  binding.pseudoRandomBytes(~~size, cb);
+}
 
 exports.rng = randomBytes;
 exports.prng = pseudoRandomBytes;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3929,7 +3929,7 @@ Handle<Value> RandomBytes(const Arguments& args) {
   // maybe allow a buffer to write to? cuts down on object creation
   // when generating random data in a loop
   if (!args[0]->IsUint32()) {
-    Local<String> s = String::New("Argument #1 must be number > 0");
+    Local<String> s = String::New("Argument #1 must be uint32");
     return ThrowException(Exception::TypeError(s));
   }
 

--- a/test/simple/test-crypto-random.js
+++ b/test/simple/test-crypto-random.js
@@ -37,8 +37,7 @@ process.setMaxListeners(256);
 [crypto.randomBytes,
   crypto.pseudoRandomBytes
 ].forEach(function(f) {
-  [-1,
-    undefined,
+  [ undefined,
     null,
     false,
     true,
@@ -49,10 +48,17 @@ process.setMaxListeners(256);
     assert.throws(function() { f(value, function() {}); });
   });
 
-  [0, 1, 2, 4, 16, 256, 1024].forEach(function(len) {
+  [ -1, 0x3fffffff + 1 ].forEach(function(value) {
+    assert.throws(function() { f(value); });
+    f(value, function(er) {
+      assert(er);
+    });
+  });
+
+  [0, 1, 1.5, 2, 4, 16, 256, 1024].forEach(function(len) {
     f(len, checkCall(function(ex, buf) {
       assert.equal(null, ex);
-      assert.equal(len, buf.length);
+      assert.equal(Math.floor(len), buf.length);
       assert.ok(Buffer.isBuffer(buf));
     }));
   });
@@ -67,6 +73,7 @@ function checkCall(cb, desc) {
   });
 
   return function() {
-    return called_ = true, cb.apply(cb, Array.prototype.slice.call(arguments));
+    called_ = true;
+    return cb.apply(cb, arguments);
   };
 }


### PR DESCRIPTION
If it is out of the acceptable range, then return a more sensible error message.  (Throw for sync, call the callback for async.)

Implements the compromise suggested in #4583.
