### PR TITLE
console: `console.dir()` bypasses inspect() methods

### DIFF
--- a/doc/api/stdio.markdown
+++ b/doc/api/stdio.markdown
@@ -33,7 +33,8 @@ Same as `console.error`.
 
 ## console.dir(obj)
 
-Uses `util.inspect` on `obj` and prints resulting string to stdout.
+Uses `util.inspect` on `obj` and prints resulting string to stdout. This function
+bypasses any custom `inspect()` function on `obj`.
 
 ## console.time(label)
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -66,7 +66,7 @@ Console.prototype.error = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object) {
-  this._stdout.write(util.inspect(object) + '\n');
+  this._stdout.write(util.inspect(object, { customInspect: false }) + '\n');
 };
 
 

--- a/test/simple/test-console.js
+++ b/test/simple/test-console.js
@@ -31,20 +31,29 @@ assert.ok(process.stderr.writable);
 assert.equal('number', typeof process.stdout.fd);
 assert.equal('number', typeof process.stderr.fd);
 
+// an Object with a custom .inspect() function
+var custom_inspect = { foo: 'bar', inspect: function () { return 'inspect'; } };
 
 var stdout_write = global.process.stdout.write;
 var strings = [];
 global.process.stdout.write = function(string) {
   strings.push(string);
 };
+console._stderr = process.stdout;
 
+// test console.log()
 console.log('foo');
 console.log('foo', 'bar');
 console.log('%s %s', 'foo', 'bar', 'hop');
 console.log({slashes: '\\\\'});
+console.log(custom_inspect);
 
-console._stderr = process.stdout;
+// test console.dir()
+console.dir(custom_inspect);
+
+// test console.trace()
 console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
+
 
 global.process.stdout.write = stdout_write;
 
@@ -52,6 +61,8 @@ assert.equal('foo\n', strings.shift());
 assert.equal('foo bar\n', strings.shift());
 assert.equal('foo bar hop\n', strings.shift());
 assert.equal("{ slashes: '\\\\\\\\' }\n", strings.shift());
+assert.equal('inspect\n', strings.shift());
+assert.equal("{ foo: 'bar', inspect: [Function] }\n", strings.shift());
 assert.equal('Trace: This is a {"formatted":"trace"} 10 foo',
              strings.shift().split('\n').shift());
 


### PR DESCRIPTION
Use the `customInspect: false` option of `util.inspect()` to bypass any custom
inspect() function on the object being logged. This is more in-line with how the browsers do it.

Closes #2717.
