### PR TITLE
process: rethink how the ticker works

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -100,6 +100,8 @@ Persistent<String> process_symbol;
 Persistent<String> domain_symbol;
 
 static Persistent<Object> process;
+static Persistent<Function> process_tickWDCallback;
+static Persistent<Function> process_tickFromSpinner;
 static Persistent<Function> process_tickCallback;
 
 static Persistent<String> exports_symbol;
@@ -169,20 +171,19 @@ static void Tick(void) {
 
   HandleScope scope;
 
-  if (tick_callback_sym.IsEmpty()) {
-    // Lazily set the symbol
-    tick_callback_sym = NODE_PSYMBOL("_tickCallback");
+  if (process_tickFromSpinner.IsEmpty()) {
+    Local<Value> cb_v = process->Get(String::New("_tickFromSpinner"));
+    if (!cb_v->IsFunction()) {
+      fprintf(stderr, "process._tickFromSpinner assigned to non-function\n");
+      abort();
+    }
+    Local<Function> cb = cb_v.As<Function>();
+    process_tickFromSpinner = Persistent<Function>::New(cb);
   }
-
-  Local<Value> cb_v = process->Get(tick_callback_sym);
-  if (!cb_v->IsFunction()) return;
-  Local<Function> cb = Local<Function>::Cast(cb_v);
 
   TryCatch try_catch;
 
-  // Let the tick callback know that this is coming from the spinner
-  Handle<Value> argv[] = { True(node_isolate) };
-  cb->Call(process, ARRAY_SIZE(argv), argv);
+  process_tickFromSpinner->Call(process, 0, NULL);
 
   if (try_catch.HasCaught()) {
     FatalException(try_catch);
@@ -877,24 +878,78 @@ Handle<Value> FromConstructorTemplate(Persistent<FunctionTemplate> t,
 }
 
 
-// MakeCallback may only be made directly off the event loop.
-// That is there can be no JavaScript stack frames underneath it.
-// (Is there any way to assert that?)
-//
-// Maybe make this a method of a node::Handle super class
-//
 Handle<Value>
-MakeCallback(const Handle<Object> object,
-             const char* method,
+MCWithDomain(const Handle<Object> object,
+             const Handle<Function> callback,
              int argc,
              Handle<Value> argv[]) {
-  HandleScope scope;
+  // lazy load _tickWDCallback
+  if (process_tickWDCallback.IsEmpty()) {
+    Local<Value> cb_v = process->Get(String::New("_tickWDCallback"));
+    if (!cb_v->IsFunction()) {
+      fprintf(stderr, "process._tickWDCallback assigned to non-function\n");
+      abort();
+    }
+    Local<Function> cb = cb_v.As<Function>();
+    process_tickWDCallback = Persistent<Function>::New(cb);
+  }
 
-  Handle<Value> ret =
-    MakeCallback(object, String::NewSymbol(method), argc, argv);
+  // lazy load domain specific symbols
+  if (enter_symbol.IsEmpty()) {
+    enter_symbol = NODE_PSYMBOL("enter");
+    exit_symbol = NODE_PSYMBOL("exit");
+    disposed_symbol = NODE_PSYMBOL("_disposed");
+  }
 
-  return scope.Close(ret);
+  Local<Value> domain_v = object->Get(domain_symbol);
+  Local<Object> domain;
+  Local<Function> enter;
+  Local<Function> exit;
+
+  TryCatch try_catch;
+
+  domain = domain_v->ToObject();
+  assert(!domain.IsEmpty());
+  if (domain->Get(disposed_symbol)->IsTrue()) {
+    // domain has been disposed of.
+    return Undefined(node_isolate);
+  }
+  enter = Local<Function>::Cast(domain->Get(enter_symbol));
+  assert(!enter.IsEmpty());
+  enter->Call(domain, 0, NULL);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  Local<Value> ret = callback->Call(object, argc, argv);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  exit = Local<Function>::Cast(domain->Get(exit_symbol));
+  assert(!exit.IsEmpty());
+  exit->Call(domain, 0, NULL);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  // process nextTicks after call
+  process_tickWDCallback->Call(process, 0, NULL);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  return ret;
 }
+
 
 Handle<Value>
 MakeCallback(const Handle<Object> object,
@@ -906,61 +961,15 @@ MakeCallback(const Handle<Object> object,
   Local<Value> callback_v = object->Get(symbol);
   if (!callback_v->IsFunction()) {
     String::Utf8Value method(symbol);
-    // XXX: If the object has a domain attached, handle it there?
-    // At least, would be good to get *some* sort of indication
-    // of how we got here, even if it's not catchable.
     fprintf(stderr, "Non-function in MakeCallback. method = %s\n", *method);
     abort();
   }
 
+  Local<Function> callback = Local<Function>::Cast(callback_v);
+
   // TODO Hook for long stack traces to be made here.
 
-  TryCatch try_catch;
-
-  if (enter_symbol.IsEmpty()) {
-    enter_symbol = NODE_PSYMBOL("enter");
-    exit_symbol = NODE_PSYMBOL("exit");
-    disposed_symbol = NODE_PSYMBOL("_disposed");
-  }
-
-  Local<Value> domain_v = object->Get(domain_symbol);
-  Local<Object> domain;
-  Local<Function> enter;
-  Local<Function> exit;
-  if (!domain_v->IsUndefined()) {
-    domain = domain_v->ToObject();
-    if (domain->Get(disposed_symbol)->BooleanValue()) {
-      // domain has been disposed of.
-      return Undefined(node_isolate);
-    }
-    enter = Local<Function>::Cast(domain->Get(enter_symbol));
-    enter->Call(domain, 0, NULL);
-  }
-
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-    return Undefined(node_isolate);
-  }
-
-  Local<Function> callback = Local<Function>::Cast(callback_v);
-  Local<Value> ret = callback->Call(object, argc, argv);
-
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-    return Undefined(node_isolate);
-  }
-
-  if (!domain_v->IsUndefined()) {
-    exit = Local<Function>::Cast(domain->Get(exit_symbol));
-    exit->Call(domain, 0, NULL);
-  }
-
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-    return Undefined(node_isolate);
-  }
-
-  // process nextTicks after every time we get called.
+  // lazy load no domain next tick callbacks
   if (process_tickCallback.IsEmpty()) {
     Local<Value> cb_v = process->Get(String::New("_tickCallback"));
     if (!cb_v->IsFunction()) {
@@ -970,12 +979,43 @@ MakeCallback(const Handle<Object> object,
     Local<Function> cb = cb_v.As<Function>();
     process_tickCallback = Persistent<Function>::New(cb);
   }
-  process_tickCallback->Call(process, NULL, 0);
+
+  // has domain, off with you
+  if (object->Has(domain_symbol) &&
+      !object->Get(domain_symbol)->IsNull() &&
+      !object->Get(domain_symbol)->IsUndefined())
+    return scope.Close(MCWithDomain(object, callback, argc, argv));
+
+  TryCatch try_catch;
+
+  Local<Value> ret = callback->Call(object, argc, argv);
 
   if (try_catch.HasCaught()) {
     FatalException(try_catch);
     return Undefined(node_isolate);
   }
+
+  // process nextTicks after call
+  process_tickCallback->Call(process, 0, NULL);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  return scope.Close(ret);
+}
+
+
+Handle<Value>
+MakeCallback(const Handle<Object> object,
+             const char* method,
+             int argc,
+             Handle<Value> argv[]) {
+  HandleScope scope;
+
+  Handle<Value> ret =
+    MakeCallback(object, String::NewSymbol(method), argc, argv);
 
   return scope.Close(ret);
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -100,6 +100,7 @@ Persistent<String> process_symbol;
 Persistent<String> domain_symbol;
 
 static Persistent<Object> process;
+static Persistent<Function> process_tickCallback;
 
 static Persistent<String> exports_symbol;
 
@@ -114,7 +115,9 @@ static Persistent<String> heap_used_symbol;
 
 static Persistent<String> fatal_exception_symbol;
 
-static Persistent<Function> process_makeCallback;
+static Persistent<String> enter_symbol;
+static Persistent<String> exit_symbol;
+static Persistent<String> disposed_symbol;
 
 
 static bool print_eval = false;
@@ -900,11 +903,6 @@ MakeCallback(const Handle<Object> object,
              Handle<Value> argv[]) {
   HandleScope scope;
 
-  if (argc > 6) {
-    fprintf(stderr, "node::MakeCallback - Too many args (%d)\n", argc);
-    abort();
-  }
-
   Local<Value> callback_v = object->Get(symbol);
   if (!callback_v->IsFunction()) {
     String::Utf8Value method(symbol);
@@ -919,27 +917,60 @@ MakeCallback(const Handle<Object> object,
 
   TryCatch try_catch;
 
-  if (process_makeCallback.IsEmpty()) {
-    Local<Value> cb_v = process->Get(String::New("_makeCallback"));
+  if (enter_symbol.IsEmpty()) {
+    enter_symbol = NODE_PSYMBOL("enter");
+    exit_symbol = NODE_PSYMBOL("exit");
+    disposed_symbol = NODE_PSYMBOL("_disposed");
+  }
+
+  Local<Value> domain_v = object->Get(domain_symbol);
+  Local<Object> domain;
+  Local<Function> enter;
+  Local<Function> exit;
+  if (!domain_v->IsUndefined()) {
+    domain = domain_v->ToObject();
+    if (domain->Get(disposed_symbol)->BooleanValue()) {
+      // domain has been disposed of.
+      return Undefined(node_isolate);
+    }
+    enter = Local<Function>::Cast(domain->Get(enter_symbol));
+    enter->Call(domain, 0, NULL);
+  }
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  Local<Function> callback = Local<Function>::Cast(callback_v);
+  Local<Value> ret = callback->Call(object, argc, argv);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  if (!domain_v->IsUndefined()) {
+    exit = Local<Function>::Cast(domain->Get(exit_symbol));
+    exit->Call(domain, 0, NULL);
+  }
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+    return Undefined(node_isolate);
+  }
+
+  // process nextTicks after every time we get called.
+  if (process_tickCallback.IsEmpty()) {
+    Local<Value> cb_v = process->Get(String::New("_tickCallback"));
     if (!cb_v->IsFunction()) {
-      fprintf(stderr, "process._makeCallback assigned to non-function\n");
+      fprintf(stderr, "process._tickCallback assigned to non-function\n");
       abort();
     }
     Local<Function> cb = cb_v.As<Function>();
-    process_makeCallback = Persistent<Function>::New(cb);
+    process_tickCallback = Persistent<Function>::New(cb);
   }
-
-  Local<Array> argArray = Array::New(argc);
-  for (int i = 0; i < argc; i++) {
-    argArray->Set(Integer::New(i, node_isolate), argv[i]);
-  }
-
-  Local<Value> object_l = Local<Value>::New(node_isolate, object);
-  Local<Value> symbol_l = Local<Value>::New(node_isolate, symbol);
-
-  Local<Value> args[3] = { object_l, symbol_l, argArray };
-
-  Local<Value> ret = process_makeCallback->Call(process, ARRAY_SIZE(args), args);
+  process_tickCallback->Call(process, NULL, 0);
 
   if (try_catch.HasCaught()) {
     FatalException(try_catch);

--- a/src/node.cc
+++ b/src/node.cc
@@ -100,7 +100,7 @@ Persistent<String> process_symbol;
 Persistent<String> domain_symbol;
 
 static Persistent<Object> process;
-static Persistent<Function> process_tickWDCallback;
+static Persistent<Function> process_tickDomainCallback;
 static Persistent<Function> process_tickFromSpinner;
 static Persistent<Function> process_tickCallback;
 
@@ -139,6 +139,12 @@ static uv_idle_t tick_spinner;
 static bool need_tick_cb;
 static Persistent<String> tick_callback_sym;
 
+// for quick ref to tickCallback values
+struct {
+  uint32_t length;
+  uint32_t index;
+  uint32_t depth;
+} tick_infobox;
 
 #ifdef OPENSSL_NPN_NEGOTIATED
 static bool use_npn = true;
@@ -162,7 +168,10 @@ static uv_async_t dispatch_debug_messages_async;
 Isolate* node_isolate = NULL;
 
 
-static void Tick(void) {
+static void Spin(uv_idle_t* handle, int status) {
+  assert((uv_idle_t*) handle == &tick_spinner);
+  assert(status == 0);
+
   // Avoid entering a V8 scope.
   if (!need_tick_cb) return;
   need_tick_cb = false;
@@ -191,26 +200,9 @@ static void Tick(void) {
 }
 
 
-static void Spin(uv_idle_t* handle, int status) {
-  assert((uv_idle_t*) handle == &tick_spinner);
-  assert(status == 0);
-  Tick();
-}
-
-
-static void StartTickSpinner() {
-  need_tick_cb = true;
-  // TODO: this tick_spinner shouldn't be necessary. An ev_prepare should be
-  // sufficent, the problem is only in the case of the very last "tick" -
-  // there is nothing left to do in the event loop and libev will exit. The
-  // ev_prepare callback isn't called before exiting. Thus we start this
-  // tick_spinner to keep the event loop alive long enough to handle it.
-  uv_idle_start(&tick_spinner, Spin);
-}
-
-
 static Handle<Value> NeedTickCallback(const Arguments& args) {
-  StartTickSpinner();
+  need_tick_cb = true;
+  uv_idle_start(&tick_spinner, Spin);
   return Undefined(node_isolate);
 }
 
@@ -879,19 +871,19 @@ Handle<Value> FromConstructorTemplate(Persistent<FunctionTemplate> t,
 
 
 Handle<Value>
-MCWithDomain(const Handle<Object> object,
+MakeDomainCallback(const Handle<Object> object,
              const Handle<Function> callback,
              int argc,
              Handle<Value> argv[]) {
-  // lazy load _tickWDCallback
-  if (process_tickWDCallback.IsEmpty()) {
-    Local<Value> cb_v = process->Get(String::New("_tickWDCallback"));
+  // lazy load _tickDomainCallback
+  if (process_tickDomainCallback.IsEmpty()) {
+    Local<Value> cb_v = process->Get(String::New("_tickDomainCallback"));
     if (!cb_v->IsFunction()) {
-      fprintf(stderr, "process._tickWDCallback assigned to non-function\n");
+      fprintf(stderr, "process._tickDomainCallback assigned to non-function\n");
       abort();
     }
     Local<Function> cb = cb_v.As<Function>();
-    process_tickWDCallback = Persistent<Function>::New(cb);
+    process_tickDomainCallback = Persistent<Function>::New(cb);
   }
 
   // lazy load domain specific symbols
@@ -939,8 +931,14 @@ MCWithDomain(const Handle<Object> object,
     return Undefined(node_isolate);
   }
 
+  if (tick_infobox.length == 0) {
+    tick_infobox.index = 0;
+    tick_infobox.depth = 0;
+    return ret;
+  }
+
   // process nextTicks after call
-  process_tickWDCallback->Call(process, 0, NULL);
+  process_tickDomainCallback->Call(process, 0, NULL);
 
   if (try_catch.HasCaught()) {
     FatalException(try_catch);
@@ -958,16 +956,14 @@ MakeCallback(const Handle<Object> object,
              Handle<Value> argv[]) {
   HandleScope scope;
 
-  Local<Value> callback_v = object->Get(symbol);
-  if (!callback_v->IsFunction()) {
-    String::Utf8Value method(symbol);
-    fprintf(stderr, "Non-function in MakeCallback. method = %s\n", *method);
-    abort();
-  }
-
-  Local<Function> callback = Local<Function>::Cast(callback_v);
+  Local<Function> callback = object->Get(symbol).As<Function>();
+  Local<Value> domain = object->Get(domain_symbol);
 
   // TODO Hook for long stack traces to be made here.
+
+  // has domain, off with you
+  if (!domain->IsNull() && !domain->IsUndefined())
+    return scope.Close(MakeDomainCallback(object, callback, argc, argv));
 
   // lazy load no domain next tick callbacks
   if (process_tickCallback.IsEmpty()) {
@@ -980,12 +976,6 @@ MakeCallback(const Handle<Object> object,
     process_tickCallback = Persistent<Function>::New(cb);
   }
 
-  // has domain, off with you
-  if (object->Has(domain_symbol) &&
-      !object->Get(domain_symbol)->IsNull() &&
-      !object->Get(domain_symbol)->IsUndefined())
-    return scope.Close(MCWithDomain(object, callback, argc, argv));
-
   TryCatch try_catch;
 
   Local<Value> ret = callback->Call(object, argc, argv);
@@ -993,6 +983,12 @@ MakeCallback(const Handle<Object> object,
   if (try_catch.HasCaught()) {
     FatalException(try_catch);
     return Undefined(node_isolate);
+  }
+
+  if (tick_infobox.length == 0) {
+    tick_infobox.index = 0;
+    tick_infobox.depth = 0;
+    return scope.Close(ret);
   }
 
   // process nextTicks after call
@@ -2418,6 +2414,13 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   NODE_SET_METHOD(process, "memoryUsage", MemoryUsage);
 
   NODE_SET_METHOD(process, "binding", Binding);
+
+  // values use to cross communicate with processNextTick
+  Local<Object> info_box = Object::New();
+  info_box->SetIndexedPropertiesToExternalArrayData(&tick_infobox,
+                                                    kExternalUnsignedIntArray,
+                                                    3);
+  process->Set(String::NewSymbol("_tickInfoBox"), info_box);
 
   return process;
 }

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -10,4 +10,5 @@ AssertionError: 1 == 2
     at Module.load (module.js:*:*)
     at Function.Module._load (module.js:*:*)
     at Module.runMain (module.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at _tickCallback (node.js:*:*)
+    at process._tickFromSpinner (node.js:*:*)

--- a/test/message/max_tick_depth_trace.out
+++ b/test/message/max_tick_depth_trace.out
@@ -11,7 +11,8 @@ Trace: (node) warning: Recursive process.nextTick detected. This will break in t
     at maxTickWarn (node.js:*:*)
     at process.nextTick (node.js:*:*
     at f (*test*message*max_tick_depth_trace.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at _tickCallback (node.js:*:*)
+    at process._tickFromSpinner (node.js:*:*)
 tick 11
 tick 10
 tick 9
@@ -26,6 +27,7 @@ Trace: (node) warning: Recursive process.nextTick detected. This will break in t
     at maxTickWarn (node.js:*:*)
     at process.nextTick (node.js:*:*
     at f (*test*message*max_tick_depth_trace.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at _tickCallback (node.js:*:*)
+    at process._tickFromSpinner (node.js:*:*)
 tick 1
 tick 0

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -3,4 +3,5 @@
         ^
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
-    at process._tickCallback (node.js:*:*)
+    at _tickCallback (node.js:*:*)
+    at process._tickFromSpinner (node.js:*:*)

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -11,7 +11,6 @@ SyntaxError: Strict mode code may not include a with statement
     at Socket.EventEmitter.emit (events.js:*:*)
     at _stream_readable.js:*:*
     at process._tickCallback (node.js:*:*)
-    at process._makeCallback (node.js:*:*)
 42
 42
 
@@ -27,7 +26,6 @@ Error: hello
     at Socket.EventEmitter.emit (events.js:*:*)
     at _stream_readable.js:*:*
     at process._tickCallback (node.js:*:*)
-    at process._makeCallback (node.js:*:*)
 
 [stdin]:1
 throw new Error("hello")
@@ -41,7 +39,6 @@ Error: hello
     at Socket.EventEmitter.emit (events.js:*:*)
     at _stream_readable.js:*:*
     at process._tickCallback (node.js:*:*)
-    at process._makeCallback (node.js:*:*)
 100
 
 [stdin]:1
@@ -56,7 +53,6 @@ ReferenceError: y is not defined
     at Socket.EventEmitter.emit (events.js:*:*)
     at _stream_readable.js:*:*
     at process._tickCallback (node.js:*:*)
-    at process._makeCallback (node.js:*:*)
 
 [stdin]:1
 var ______________________________________________; throw 10

--- a/test/message/timeout_throw.out
+++ b/test/message/timeout_throw.out
@@ -4,4 +4,3 @@
 ReferenceError: undefined_reference_error_maker is not defined
     at null._onTimeout (*test*message*timeout_throw.js:*:*)
     at Timer.listOnTimeout [as ontimeout] (timers.js:*:*)
-    at process._makeCallback (node.js:*:*)

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -11,4 +11,5 @@ ReferenceError: foo is not defined
     at Module.load (module.js:*)
     at *._load (module.js:*)
     at Module.runMain (module.js:*)
-    at *._tickCallback (node.js:*)
+    at _tickCallback (node.js:*)
+    at *._tickFromSpinner (node.js:*)

--- a/test/simple/test-timers-uncaught-exception.js
+++ b/test/simple/test-timers-uncaught-exception.js
@@ -27,24 +27,32 @@ var timer1 = 0;
 var timer2 = 0;
 
 // the first timer throws...
+console.error('set first timer');
 setTimeout(function() {
+  console.error('first timer');
   timer1++;
   throw new Error('BAM!');
 }, 100);
 
 // ...but the second one should still run
+console.error('set second timer');
 setTimeout(function() {
+  console.error('second timer');
   assert.equal(timer1, 1);
   timer2++;
 }, 100);
 
 function uncaughtException(err) {
+  console.error('uncaught handler');
   assert.equal(err.message, 'BAM!');
   exceptions++;
 }
 process.on('uncaughtException', uncaughtException);
 
+var exited = false;
 process.on('exit', function() {
+  assert(!exited);
+  exited = true;
   process.removeListener('uncaughtException', uncaughtException);
   assert.equal(exceptions, 1);
   assert.equal(timer1, 1);


### PR DESCRIPTION
Everything in processNextTick is going to be called a lot. It should be
written in a way that allows it to be inlined. First change here is
working out how to remove the .splice() calls.

I'm looking for feedback on how to get this sucker working. Basically instead of keeping track of queues within a single large array, I have an array of array queues and keep a pointer to the current one. This is better only because `splice` is super costly and doesn't allow v8 to optimize the function near as well.

Also you'll notice that I've removed the `domain` stuff. Those calls are causing massive `DEOPT` bailouts. Off of the gimp version here, along with @isaacs GH-4686, there's about a 20% increase in performance.

Anyways, the basic goal is to get this whole section inline-able.
