### PR TITLE
change 'ps ax|grep ssh' code from exit to close

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -298,7 +298,7 @@ Example: A very elaborate way to run 'ps ax | grep ssh'
       console.log('ps stderr: ' + data);
     });
 
-    ps.on('exit', function (code) {
+    ps.on('close', function (code) {
       if (code !== 0) {
         console.log('ps process exited with code ' + code);
       }


### PR DESCRIPTION
stdio streams may be shared with parent process.

Using exit in this example causes:

``` bash
events.js:71
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: This socket is closed.
```
