### PR TITLE
windows/msi: enhancements to installer

### DIFF
--- a/tools/msvs/msi/WixUI_en-us.wxl
+++ b/tools/msvs/msi/WixUI_en-us.wxl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+    <String Id="InstallDirDlgDescription">Choose a custom location or click Next to install</String>
+</WixLocalization>

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -33,6 +33,9 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NPMSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+	<EnableProjectHarvesting>True</EnableProjectHarvesting>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="product.wxs" />
     <Compile Include="..\..\..\npm.wxs" />

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -27,6 +26,7 @@
     <OutputPath>..\..\..\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NPMSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <Cultures>en-US</Cultures>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>..\..\..\$(Configuration)\</OutputPath>
@@ -34,11 +34,13 @@
     <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NPMSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-	<EnableProjectHarvesting>True</EnableProjectHarvesting>
+    <EnableProjectHarvesting>True</EnableProjectHarvesting>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="product.wxs" />
-    <Compile Include="..\..\..\npm.wxs" />
+    <Compile Include="..\..\..\npm.wxs">
+      <Link>npm.wxs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <WixExtension Include="WixUIExtension">
@@ -50,9 +52,16 @@
       <Name>WiXUtilExtension</Name>
     </WixExtension>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="WixUI_en-us.wxl" />
+  </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
-    <Target Name="BeforeBuild">
-      <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\deps\npm" PreprocessorVariable="var.NPMSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="NPMFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\npm.wxs">
-      </HeatDirectory>
-    </Target>
+  <Target Name="BeforeBuild">
+    <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\deps\npm" PreprocessorVariable="var.NPMSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="NPMFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\npm.wxs">
+    </HeatDirectory>
+  </Target>
+  <PropertyGroup>
+    <PostBuildEvent>move !(TargetPath) $(TargetDir)\$(TargetFileName)
+move !(TargetPdbPath) $(TargetDir)\$(TargetPdbName)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -106,6 +106,15 @@
                   Arguments='/k "[APPLICATIONROOTDIRECTORY]nodejsvars.bat"'
                   Show="normal"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
+        <Shortcut Id="UninstallProduct"
+                  Name="Uninstall Node.js"
+                  Target="[SystemFolder]msiexec.exe"
+                  Arguments="/x [ProductCode]"
+                  Description="Uninstalls $(var.ProductName)" />
+        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+        <RegistryValue Root="HKCU" Key="Software\Joyent\$(var.ProductName)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+      </Component>
+      <Component Id="InternetShortcuts" Guid="3351B877-49BA-4BC0-BF5E-21BA623FD07C">        
         <util:InternetShortcut Id="OnlineWebsiteShortcut"
                   Name="Node.js website"
                   Target="http://nodejs.org"
@@ -114,12 +123,6 @@
                   Name="Node.js documentation"
                   Target="http://nodejs.org/dist/v$(var.ProductVersion)/docs/api/"
                   Type="url"/>
-        <Shortcut Id="UninstallProduct"
-                  Name="Uninstall Node.js"
-                  Target="[SystemFolder]msiexec.exe"
-                  Arguments="/x [ProductCode]"
-                  Description="Uninstalls $(var.ProductName)" />
-        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
         <RegistryValue Root="HKCU" Key="Software\Joyent\$(var.ProductName)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
       </Component>
     </DirectoryRef>
@@ -135,13 +138,29 @@
       <?if $(var.Configuration) = Debug ?>
       <ComponentRef Id="nodepdb"/>
       <?endif?>
-      <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="nodejsvars" />
     </ComponentGroup>
 
-    <Feature Id="nodejs" Title="node.js engine" Level="1" Description="$(var.ProductDescription)">
+    <ComponentGroup Id="application.shortcuts">
+      <ComponentRef Id="ApplicationShortcut" />
+    </ComponentGroup>
+
+    <ComponentGroup Id="internet.shortcuts">
+      <ComponentRef Id="InternetShortcuts"/>
+    </ComponentGroup>
+
+    <Feature Id="nodejs" Title="node.js engine" Level="1" Description="$(var.ProductDescription)" Absent="disallow">
       <ComponentGroupRef Id="allfiles" />
       <ComponentGroupRef Id="Product.Generated" />
+    </Feature>
+
+    <Feature Id="nodejs.shortcuts" Title="node.js shortcuts" Description="$(var.ProductDescription) Shortcuts">
+      <Feature Id="feature.application.shortcuts" Title="Application Shortcuts" Level="1"  Description="$(var.ProductDescription) standard application shortcuts">
+        <ComponentGroupRef Id="application.shortcuts"/>
+      </Feature>
+      <Feature Id="feature.internet.shortcuts" Title="Internet Shortcuts" Level="1"  Description="$(var.ProductDescription) internet shortcuts to the project's website and online documentation for this version">
+        <ComponentGroupRef Id="internet.shortcuts"/>
+      </Feature>
     </Feature>
 
     <UI Id="NodeInstallUI">
@@ -150,7 +169,7 @@
       <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
-      <Property Id="WixUI_Mode" Value="Minimal" />
+      <Property Id="WixUI_Mode" Value="FeatureTree" />
 
       <DialogRef Id="ErrorDlg" />
       <DialogRef Id="FatalError" />
@@ -163,15 +182,22 @@
       <DialogRef Id="WelcomeDlg" />
       <DialogRef Id="LicenseAgreementDlg"/>
 
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="PrepareDlg">1</Publish>
+      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">LicenseAccepted = "1"</Publish>
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="1">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="3">Installed AND PATCH</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" Order="2">NOT Installed</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Property Id="ARPNOMODIFY" Value="1" />
       <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Node.js has been succesfully installed. To run Node.js open command prompt (cmd.exe), and run 'node'." />

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -144,7 +144,6 @@
       </Component>
     </DirectoryRef>
 
-
     <ComponentGroup Id="allfiles">
       <ComponentRef Id="nodeexe"/>
       <ComponentRef Id="npmcmd"/>
@@ -172,11 +171,11 @@
       <ComponentGroupRef Id="Product.Generated" />
     </Feature>
 
-    <Feature Id="nodejs.shortcuts" Title="node.js shortcuts" Description="$(var.ProductDescription) Shortcuts">
-      <Feature Id="feature.application.shortcuts" Title="Application Shortcuts" Level="1"  Description="$(var.ProductDescription) standard application shortcuts">
+    <Feature Id="nodejs.shortcuts" Title="node.js shortcuts" Level="1" Description="$(var.ProductDescription) Shortcuts">
+      <Feature Id="nodejs.shortcuts.application" Title="Application Shortcuts" Level="1"  Description="$(var.ProductDescription) standard application shortcuts">
         <ComponentGroupRef Id="application.shortcuts"/>
       </Feature>
-      <Feature Id="feature.internet.shortcuts" Title="Internet Shortcuts" Level="1"  Description="$(var.ProductDescription) internet shortcuts to the project's website and online documentation for this version">
+      <Feature Id="nodejs.shortcuts.internet" Title="Internet Shortcuts" Level="1"  Description="$(var.ProductDescription) internet shortcuts to the project's website and online documentation for this version">
         <ComponentGroupRef Id="internet.shortcuts"/>
       </Feature>
     </Feature>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -28,6 +28,11 @@
     <Property Id="ApplicationFolderName" Value="nodejs" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
 
+    <Property Id="INSTALLDIR">
+      <RegistrySearch Id='InstallPathRegistry' Type='raw'
+        Root='HKCU' Key='SOFTWARE\Joyent\node.js' Name='Path' />
+    </Property>
+
     <Directory Id="TARGETDIR" Name="SourceDir">
 
       <Directory Id="ProgramMenuFolder">
@@ -83,10 +88,10 @@
             <File Id="filenodejsvars" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\nodejsvars.bat" />
           </Component>
           <Component Id="noderegistry" Guid="35379DFF-1437-4DE2-98D0-16483480DD44" >
-            <RegistryKey Root="HKMU" Key="Software" Action="none" >
-              <RegistryKey Key="Joyent" Action="create" >
-                <RegistryKey Key="node.js" Action="create">
-                  <RegistryValue Name="Path" Type="string" Value="[NodeRoot]" KeyPath="yes" />
+            <RegistryKey Root="HKCU" Key="Software">
+              <RegistryKey Key="Joyent">
+                <RegistryKey Key="node.js">
+                  <RegistryValue Name="Path" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
                   <RegistryValue Name="Version" Type="string" Value="$(var.ProductVersion)" />
                 </RegistryKey>
               </RegistryKey>
@@ -98,7 +103,7 @@
       <Directory Id="AppDataFolder">
         <Directory Id="NPMAppData" Name="npm">
           <Component Id="npmappdata_folder" Guid="994B1F7F-60CD-4792-A96D-63BC7FFF29BF" Permanent="yes">
-            <RegistryKey Action="none" Key="dummy" Root="HKCU" >
+            <RegistryKey Key="dummy" Root="HKCU" >
               <RegistryValue Type="integer"  Value="1" KeyPath="yes" />
             </RegistryKey >
             <CreateFolder/>
@@ -151,6 +156,7 @@
       <ComponentRef Id="nodepdb"/>
       <?endif?>
       <ComponentRef Id="nodejsvars" />
+      <ComponentRef Id="noderegistry" />
     </ComponentGroup>
 
     <ComponentGroup Id="application.shortcuts">

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -80,6 +80,16 @@
           <Component Id="nodejsvars" Guid="*">
             <File Id="filenodejsvars" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\nodejsvars.bat" />
           </Component>
+          <Component Id="noderegistry" Guid="35379DFF-1437-4DE2-98D0-16483480DD44" >
+            <RegistryKey Root="HKMU" Key="Software" Action="none" >
+              <RegistryKey Key="Joyent" Action="create" >
+                <RegistryKey Key="node.js" Action="create">
+                  <RegistryValue Name="Path" Type="string" Value="[NodeRoot]" KeyPath="yes" />
+                  <RegistryValue Name="Version" Type="string" Value="$(var.ProductVersion)" />
+                </RegistryKey>
+              </RegistryKey>
+            </RegistryKey>
+          </Component>
         </Directory>
       </Directory>
 

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -131,7 +131,7 @@
         <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
         <RegistryValue Root="HKCU" Key="Software\Joyent\$(var.ProductName)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
       </Component>
-      <Component Id="InternetShortcuts" Guid="3351B877-49BA-4BC0-BF5E-21BA623FD07C">        
+      <Component Id="InternetShortcuts" Guid="3351B877-49BA-4BC0-BF5E-21BA623FD07C">
         <util:InternetShortcut Id="OnlineWebsiteShortcut"
                   Name="Node.js website"
                   Target="http://nodejs.org"
@@ -227,7 +227,6 @@
 
       <Property Id="ARPNOMODIFY" Value="1" />
       <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Node.js has been succesfully installed. To run Node.js open command prompt (cmd.exe), and run 'node'." />
-
     </UI>
 
     <UIRef Id="WixUI_Common" />

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -26,7 +26,7 @@
     <Icon Id="node.exe" SourceFile="$(var.RepoDir)\src\res\node.ico"/>
     <Property Id="ARPPRODUCTICON" Value="node.exe" />
     <Property Id="ApplicationFolderName" Value="nodejs" />
-    <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
 
@@ -35,7 +35,7 @@
       </Directory>
 
       <Directory Id="$(var.ProgramFilesFolderId)">
-        <Directory Id="APPLICATIONFOLDER" Name="nodejs">
+        <Directory Id="INSTALLDIR" Name="nodejs">
           <Directory Id="NodeModulesFolder" Name="node_modules">
             <Directory Id="NPMFolder" Name="npm">
               <Component Id="npmrc" Guid="55B2B03F-8F32-4D62-A54A-FA428615591D">
@@ -47,12 +47,12 @@
             <File Id="filenodeexe" KeyPath="yes" Source="$(var.SourceDir)\node.exe" />
             <?if $(var.NoETW) != 1 ?>
             <File Id="node_etw_provider_man" Name="node_etw_provider.man" Source="$(var.RepoDir)\src\res\node_etw_provider.man" >
-              <util:EventManifest MessageFile="[APPLICATIONFOLDER]node.exe" ResourceFile="[APPLICATIONFOLDER]node.exe"/>
+              <util:EventManifest MessageFile="[INSTALLDIR]node.exe" ResourceFile="[INSTALLDIR]node.exe"/>
             </File>
             <?endif?>
             <?if $(var.NoPerfCtr) != 1 ?>
             <File Id="node_perfctr_provider_man" Name="node_perfctr_provider.man" Source="$(var.RepoDir)\src\res\node_perfctr_provider.man" >
-              <util:PerfCounterManifest ResourceFileDirectory="[APPLICATIONFOLDER]"/>
+              <util:PerfCounterManifest ResourceFileDirectory="[INSTALLDIR]"/>
             </File>
             <?endif?>
             <Environment Id="npm_env"
@@ -66,7 +66,7 @@
                          Name="PATH"
                          Part="last"
                          System="yes"
-                         Value="[APPLICATIONFOLDER]" />
+                         Value="[INSTALLDIR]" />
           </Component>
           <Component Id="npmcmd" Guid="31e9986d-74cd-44e1-878c-194d3e997d32">
             <File Id="filenpmcmd" KeyPath="yes" Source="$(var.NPMSourceDir)\bin\npm.cmd" />
@@ -111,13 +111,13 @@
     <DirectoryRef Id="ApplicationProgramsFolder">
       <Component Id="ApplicationShortcut" Guid="9b1ab94a-8f54-4f19-a5c4-b890de474162">
         <Shortcut Id="ApplicationStartMenuShortcut" Name="Node.js"
-                  Description="$(var.ProductDescription)" Target="[APPLICATIONFOLDER]node.exe"
-                  WorkingDirectory="APPLICATIONFOLDER"/>
+                  Description="$(var.ProductDescription)" Target="[INSTALLDIR]node.exe"
+                  WorkingDirectory="INSTALLDIR"/>
         <Shortcut Id="NodePromptStartMenuShortcut" Name="Node.js command prompt"
                   Description="Node.js Command Prompt" Target="[%ComSpec]"
-                  Arguments='/k "[APPLICATIONFOLDER]nodejsvars.bat"'
+                  Arguments='/k "[INSTALLDIR]nodejsvars.bat"'
                   Show="normal"
-                  WorkingDirectory="APPLICATIONFOLDER"/>
+                  WorkingDirectory="INSTALLDIR"/>
         <Shortcut Id="UninstallProduct"
                   Name="Uninstall Node.js"
                   Target="[SystemFolder]msiexec.exe"

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -25,6 +25,8 @@
 
     <Icon Id="node.exe" SourceFile="$(var.RepoDir)\src\res\node.ico"/>
     <Property Id="ARPPRODUCTICON" Value="node.exe" />
+    <Property Id="ApplicationFolderName" Value="nodejs" />
+    <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
 
@@ -33,7 +35,7 @@
       </Directory>
 
       <Directory Id="$(var.ProgramFilesFolderId)">
-        <Directory Id="APPLICATIONROOTDIRECTORY" Name="nodejs">
+        <Directory Id="APPLICATIONFOLDER" Name="nodejs">
           <Directory Id="NodeModulesFolder" Name="node_modules">
             <Directory Id="NPMFolder" Name="npm">
               <Component Id="npmrc" Guid="55B2B03F-8F32-4D62-A54A-FA428615591D">
@@ -45,12 +47,12 @@
             <File Id="filenodeexe" KeyPath="yes" Source="$(var.SourceDir)\node.exe" />
             <?if $(var.NoETW) != 1 ?>
             <File Id="node_etw_provider_man" Name="node_etw_provider.man" Source="$(var.RepoDir)\src\res\node_etw_provider.man" >
-              <util:EventManifest MessageFile="[APPLICATIONROOTDIRECTORY]node.exe" ResourceFile="[APPLICATIONROOTDIRECTORY]node.exe"/>
+              <util:EventManifest MessageFile="[APPLICATIONFOLDER]node.exe" ResourceFile="[APPLICATIONFOLDER]node.exe"/>
             </File>
             <?endif?>
             <?if $(var.NoPerfCtr) != 1 ?>
             <File Id="node_perfctr_provider_man" Name="node_perfctr_provider.man" Source="$(var.RepoDir)\src\res\node_perfctr_provider.man" >
-              <util:PerfCounterManifest ResourceFileDirectory="[APPLICATIONROOTDIRECTORY]"/>
+              <util:PerfCounterManifest ResourceFileDirectory="[APPLICATIONFOLDER]"/>
             </File>
             <?endif?>
             <Environment Id="npm_env"
@@ -64,7 +66,7 @@
                          Name="PATH"
                          Part="last"
                          System="yes"
-                         Value="[APPLICATIONROOTDIRECTORY]" />
+                         Value="[APPLICATIONFOLDER]" />
           </Component>
           <Component Id="npmcmd" Guid="31e9986d-74cd-44e1-878c-194d3e997d32">
             <File Id="filenpmcmd" KeyPath="yes" Source="$(var.NPMSourceDir)\bin\npm.cmd" />
@@ -109,13 +111,13 @@
     <DirectoryRef Id="ApplicationProgramsFolder">
       <Component Id="ApplicationShortcut" Guid="9b1ab94a-8f54-4f19-a5c4-b890de474162">
         <Shortcut Id="ApplicationStartMenuShortcut" Name="Node.js"
-                  Description="$(var.ProductDescription)" Target="[APPLICATIONROOTDIRECTORY]node.exe"
-                  WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
+                  Description="$(var.ProductDescription)" Target="[APPLICATIONFOLDER]node.exe"
+                  WorkingDirectory="APPLICATIONFOLDER"/>
         <Shortcut Id="NodePromptStartMenuShortcut" Name="Node.js command prompt"
                   Description="Node.js Command Prompt" Target="[%ComSpec]"
-                  Arguments='/k "[APPLICATIONROOTDIRECTORY]nodejsvars.bat"'
+                  Arguments='/k "[APPLICATIONFOLDER]nodejsvars.bat"'
                   Show="normal"
-                  WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
+                  WorkingDirectory="APPLICATIONFOLDER"/>
         <Shortcut Id="UninstallProduct"
                   Name="Uninstall Node.js"
                   Target="[SystemFolder]msiexec.exe"
@@ -191,11 +193,19 @@
       <DialogRef Id="UserExit" />
       <DialogRef Id="WelcomeDlg" />
       <DialogRef Id="LicenseAgreementDlg"/>
+      <DialogRef Id="InstallDirDlg"/>
+      <DialogRef Id="BrowseDlg"/>
+      <DialogRef Id="InvalidDirDlg"/>
 
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">LicenseAccepted = "1"</Publish>
+      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1"</Publish>
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+      <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg" Order="20">1</Publish>
+      <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="10">1</Publish>
+      <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="10">1</Publish>
+      <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="20">1</Publish>
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="1">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
@@ -206,7 +216,7 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
       <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
-      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" Order="2">NOT Installed</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="2">NOT Installed</Publish>
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Property Id="ARPNOMODIFY" Value="1" />


### PR DESCRIPTION
This starts from contributed https://github.com/joyent/node/pull/4420 and https://github.com/joyent/node/pull/2948 and adds some additional enhancements and fixes.

Noteworthy improvements provided by the series:
- Support in the Installer UI for not installing shortcuts.
- Support in the Installer UI for choosing a custom install directory.
- Command line support for not installing shortcuts (ADDDEFAULT=nodejs)
- Command line support for custom install directory (INSTALLDIR=c:\tools\node)
- Placing Node's install location in the registry both to help other apps find node.exe and for future installations to be installed over the same place.
