### PR TITLE
debugger: Make the debugger timeout configurable

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -111,7 +111,8 @@
         // global.v8debug object about a connection, and runMain when
         // that occurs.  --isaacs
 
-        setTimeout(Module.runMain, 50);
+        var debugTimeout = +process.env.NODE_DEBUG_TIMEOUT || 50;
+        setTimeout(Module.runMain, debugTimeout);
 
       } else {
         // REMOVEME: nextTick should not be necessary. This hack to get

--- a/test/simple/test-debugger-client.js
+++ b/test/simple/test-debugger-client.js
@@ -22,6 +22,7 @@
 
 
 
+process.env.NODE_DEBUGGER_TIMEOUT = 200;
 var common = require('../common');
 var assert = require('assert');
 var debug = require('_debugger');

--- a/test/simple/test-debugger-repl-utf8.js
+++ b/test/simple/test-debugger-repl-utf8.js
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+process.env.NODE_DEBUGGER_TIMEOUT = 200;
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;

--- a/test/simple/test-debugger-repl.js
+++ b/test/simple/test-debugger-repl.js
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+process.env.NODE_DEBUGGER_TIMEOUT = 200;
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;


### PR DESCRIPTION
If the NODE_DEBUGGER_TIMEOUT environment variable is set, then use
that as the number of ms to wait for the debugger to start.

This is primarily to work around a race condition that almost never
happens in real usage with the debugger, but happens EVERY FRACKING
TIME when the debugger tests run as part of 'make test'.
