### PR TITLE
streams: both `finish` and `close` should unpipe

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -400,7 +400,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
 
   function cleanup() {
     // cleanup event handlers once the pipe is broken
-    dest.removeListener('close', unpipe);
+    dest.removeListener('close', onclose);
     dest.removeListener('finish', onfinish);
     dest.removeListener('drain', ondrain);
     dest.removeListener('error', onerror);
@@ -426,11 +426,15 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   }
   dest.once('error', onerror);
 
-  // if the dest emits close, then presumably there's no point writing
-  // to it any more.
-  dest.once('close', unpipe);
+  // Both close and finish should trigger unpipe, but only once.
+  function onclose() {
+    dest.removeListener('finish', onfinish);
+    unpipe();
+  }
+  dest.once('close', onclose);
   function onfinish() {
-    dest.removeListener('close', unpipe);
+    dest.removeListener('close', onclose);
+    unpipe();
   }
   dest.once('finish', onfinish);
 

--- a/test/simple/test-stream2-finish-pipe.js
+++ b/test/simple/test-stream2-finish-pipe.js
@@ -1,0 +1,37 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var stream = require('stream');
+var Buffer = require('buffer').Buffer;
+
+var R = new stream.Readable();
+R._read = function(size, cb) {
+  cb(null, new Buffer(size));
+};
+
+var W = new stream.Writable();
+W._write = function(data, cb) {
+  cb(null);
+};
+
+R.pipe(W);
+W.end();


### PR DESCRIPTION
Otherwise sockets that are 'finish'ed won't be unpiped and `writing to
ended stream` error will arise.

/cc @bnoordhuis @isaacs
