### PR TITLE
stream: Writable should ignore encoding for buffers

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -150,8 +150,8 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     len = chunk.length;
     if (false === state.decodeStrings)
       chunk = [chunk, encoding || 'utf8'];
-    else if (typeof chunk === 'string' || encoding) {
-      chunk = new Buffer(chunk + '', encoding);
+    else if (typeof chunk === 'string') {
+      chunk = new Buffer(chunk, encoding);
       len = chunk.length;
     }
   }

--- a/test/simple/test-stream2-writable.js
+++ b/test/simple/test-stream2-writable.js
@@ -280,3 +280,14 @@ test('end callback after .write() call', function (t) {
     t.end();
   });
 });
+
+test('encoding should be ignored for buffers', function(t) {
+  var tw = new W();
+  var hex = '018b5e9a8f6236ffe30e31baf80d2cf6eb';
+  tw._write = function(chunk, cb) {
+    t.equal(chunk.toString('hex'), hex);
+    t.end();
+  };
+  var buf = new Buffer(hex, 'hex');
+  tw.write(buf, 'binary');
+});


### PR DESCRIPTION
Fix #4727
Fix einaros/ws#159
