### PR TITLE
Include netmask in os.networkInterfaces()

### DIFF
--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -127,17 +127,24 @@ Example inspection of os.cpus:
 
 Get a list of network interfaces:
 
-    { lo0: 
-       [ { address: '::1', family: 'IPv6', internal: true },
-         { address: 'fe80::1', family: 'IPv6', internal: true },
-         { address: '127.0.0.1', family: 'IPv4', internal: true } ],
-      en1: 
-       [ { address: 'fe80::cabc:c8ff:feef:f996', family: 'IPv6',
-           internal: false },
-         { address: '10.0.1.123', family: 'IPv4', internal: false } ],
-      vmnet1: [ { address: '10.99.99.254', family: 'IPv4', internal: false } ],
-      vmnet8: [ { address: '10.88.88.1', family: 'IPv4', internal: false } ],
-      ppp0: [ { address: '10.2.0.231', family: 'IPv4', internal: false } ] }
+    { lo0:
+       [ { address: 'fe80::1', netmask: 'ffff:ffff:ffff:ffff::',
+           family: 'IPv6', internal: true },
+         { address: '127.0.0.1', netmask: '255.0.0.0',
+           family: 'IPv4', internal: true },
+         { address: '::1', netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+           family: 'IPv6', internal: true } ],
+      en1:
+       [ { address: 'fe80::226:8ff:fedc:1dd', netmask: 'ffff:ffff:ffff:ffff::',
+           family: 'IPv6', internal: false },
+         { address: '10.0.1.6', netmask: '255.255.255.0',
+           family: 'IPv4', internal: false } ],
+      vmnet1:
+       [ { address: '192.168.252.1', netmask: '255.255.255.0',
+           family: 'IPv4', internal: false } ],
+      vmnet8:
+       [ { address: '192.168.207.1', netmask: '255.255.255.0',
+           family: 'IPv4', internal: false } ] }
 
 ## os.EOL
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -201,6 +201,7 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
   uv_interface_address_t* interfaces;
   int count, i;
   char ip[INET6_ADDRSTRLEN];
+  char netmask[INET6_ADDRSTRLEN];
   Local<Object> ret, o;
   Local<String> name, family;
   Local<Array> ifarr;
@@ -223,9 +224,11 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
 
     if (interfaces[i].address.address4.sin_family == AF_INET) {
       uv_ip4_name(&interfaces[i].address.address4,ip, sizeof(ip));
+      uv_ip4_name(&interfaces[i].netmask.netmask4, netmask, sizeof(netmask));
       family = String::New("IPv4");
     } else if (interfaces[i].address.address4.sin_family == AF_INET6) {
       uv_ip6_name(&interfaces[i].address.address6, ip, sizeof(ip));
+      uv_ip6_name(&interfaces[i].netmask.netmask6, netmask, sizeof(netmask));
       family = String::New("IPv6");
     } else {
       strncpy(ip, "<unknown sa family>", INET6_ADDRSTRLEN);
@@ -234,6 +237,7 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
 
     o = Object::New();
     o->Set(String::New("address"), String::New(ip));
+    o->Set(String::New("netmask"), String::New(netmask));
     o->Set(String::New("family"), family);
 
     const bool internal = interfaces[i].is_internal;

--- a/test/simple/test-os.js
+++ b/test/simple/test-os.js
@@ -85,13 +85,18 @@ switch (platform) {
   case 'linux':
     var filter = function(e) { return e.address == '127.0.0.1'; };
     var actual = interfaces.lo.filter(filter);
-    var expected = [{ address: '127.0.0.1', family: 'IPv4', internal: true }];
+    var expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
+                      family: 'IPv4', internal: true }];
     assert.deepEqual(actual, expected);
     break;
   case 'win32':
     var filter = function(e) { return e.address == '127.0.0.1'; };
     var actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
-    var expected = [{ address: '127.0.0.1', family: 'IPv4', internal: true }];
+    // NOTE: Windows does not set a prefix or netmask on 127.0.0.1, so we
+    //       default to /32 here.  We could put in a special case to force
+    //       to /8 if desired.
+    var expected = [{ address: '127.0.0.1', netmask: '255.255.255.255',
+                      family: 'IPv4', internal: true }];
     assert.deepEqual(actual, expected);
     break;
 }


### PR DESCRIPTION
This commit depends on joyent/libuv#705 in order to compile.  The libuv
changes are not included here as I assume dependencies are incorporated
under a separate process.

This is a partial fix for #3765.
