### PR TITLE
Add require.package() for access to the package.json used by require()

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -54,6 +54,7 @@ Module._contextLoad = (+process.env['NODE_MODULE_CONTEXTS'] > 0);
 Module._cache = {};
 Module._pathCache = {};
 Module._extensions = {};
+Module._resolvedPackages = {};
 var modulePaths = [];
 Module.globalPaths = [];
 
@@ -125,8 +126,12 @@ function tryPackage(requestPath, exts) {
   if (!pkg || !pkg.main) return false;
 
   var filename = path.resolve(requestPath, pkg.main);
-  return tryFile(filename) || tryExtensions(filename, exts) ||
+  var resolved = tryFile(filename) || tryExtensions(filename, exts) ||
          tryExtensions(path.resolve(filename, 'index'), exts);
+  if (resolved) {
+    Module._resolvedPackages[resolved] = pkg;
+  }
+  return resolved;
 }
 
 // In order to minimize unnecessary lstat() calls,
@@ -382,6 +387,10 @@ Module.prototype._compile = function(content, filename) {
 
   require.resolve = function(request) {
     return Module._resolveFilename(request, self);
+  };
+
+  require.package = function (request) {
+    return Module._resolvedPackages[Module._resolveFilename(request, self)];
   };
 
   Object.defineProperty(require, 'paths', { get: function() {


### PR DESCRIPTION
Adds the require.package() method, setup similar to require.resolve(). The method returns the package.json file that is used when loading a module using require(). If the module did not have a package.json, returns undefined. If the module fails to resolve, throws (same as require).

This is useful for building framework plugins utilizing extension keys in package.json, instead of requiring yet another manifest document. My use case is that I need access to the name, version, and dependencies already specified in package.json. I can manually load package.json if the require() call uses absolute path, but that's usually impractical.

Usage:

``` javascript
var package = require.package('request');
```
