### PR TITLE
Readline should not require an output stream

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -30,7 +30,7 @@ the following values:
 
  - `input` - the readable stream to listen to (Required).
 
- - `output` - the writable stream to write readline data to (Required).
+ - `output` - the writable stream to write readline data to (Optional).
 
  - `completer` - an optional function that is used for Tab autocompletion. See
    below for an example of using this.
@@ -100,6 +100,8 @@ to `true` to prevent the cursor placement being reset to `0`.
 This will also resume the `input` stream used with `createInterface` if it has
 been paused.
 
+If `output` is set to null or undefined, nothing is diplayed
+
 ### rl.question(query, callback)
 
 Prepends the prompt with `query` and invokes `callback` with the user's
@@ -108,6 +110,8 @@ with the user's response after it has been typed.
 
 This will also resume the `input` stream used with `createInterface` if
 it has been paused.
+
+If `output` is set to null or undefined, nothing is diplayed
 
 Example usage:
 
@@ -134,6 +138,8 @@ Writes `data` to `output` stream. `key` is an object literal to represent a key
 sequence; available if the terminal is a TTY.
 
 This will also resume the `input` stream if it has been paused.
+
+If `output` is set to null or undefined, nothing is diplayed
 
 Example:
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -69,7 +69,7 @@ function Interface(input, output, completer, terminal) {
 
   // backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
-  if (typeof terminal == 'undefined') {
+  if ((typeof terminal == 'undefined')&&(output !== null)) {
     terminal = !!output.isTTY;
   }
 
@@ -131,11 +131,14 @@ function Interface(input, output, completer, terminal) {
 
     this.history = [];
     this.historyIndex = -1;
-
-    output.on('resize', onresize);
+    if (output !== null){
+      output.on('resize', onresize);
+    }
     self.once('close', function() {
       input.removeListener('keypress', onkeypress);
-      output.removeListener('resize', onresize);
+      if (output !== null){
+        output.removeListener('resize', onresize);
+      }
     });
   }
 
@@ -172,7 +175,7 @@ Interface.prototype.prompt = function(preserveCursor) {
   if (this.terminal) {
     if (!preserveCursor) this.cursor = 0;
     this._refreshLine();
-  } else {
+  } else if (this.output !== null){
     this.output.write(this._prompt);
   }
 };
@@ -243,10 +246,12 @@ Interface.prototype._refreshLine = function() {
   exports.clearScreenDown(this.output);
 
   // Write the prompt and the current buffer content.
-  this.output.write(line);
+  if (this.output !== null){
+    this.output.write(line);
+  }
 
   // Force terminal to allocate a new line
-  if (lineCols === 0) {
+  if (lineCols === 0 && this.output !== null) {
     this.output.write(' ');
   }
 
@@ -290,8 +295,10 @@ Interface.prototype.resume = function() {
 
 
 Interface.prototype.write = function(d, key) {
-  if (this.paused) this.resume();
-  this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d);
+  if (this.output !== null){
+    if (this.paused) this.resume();
+    this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d);
+  }
 };
 
 // \r\n, \n, or \r followed by something other than \n
@@ -343,7 +350,7 @@ Interface.prototype._insertString = function(c) {
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
-    } else {
+    } else if (this.output !== null){
       this.output.write(c);
     }
 
@@ -370,7 +377,7 @@ Interface.prototype._tabComplete = function() {
       // Apply/show completions.
       if (completions.length === 1) {
         self._insertString(completions[0].slice(completeOn.length));
-      } else {
+      } else if (self.output !== null){
         self.output.write('\r\n');
         var width = completions.reduce(function(a, b) {
           return a.length > b.length ? a : b;
@@ -415,17 +422,25 @@ function handleGroup(self, group, width, maxColumns) {
         break;
       }
       var item = group[idx];
-      self.output.write(item);
+      if (self.output !== null){
+        self.output.write(item);
+      }
       if (col < maxColumns - 1) {
         for (var s = 0, itemLen = item.length; s < width - itemLen;
              s++) {
-          self.output.write(' ');
+          if (self.output !== null){
+            self.output.write(' ');
+          }
         }
       }
     }
+    if (self.output !== null){
+      self.output.write('\r\n');
+    }
+  }
+  if (self.output !== null){
     self.output.write('\r\n');
   }
-  self.output.write('\r\n');
 }
 
 function commonPrefix(strings) {
@@ -518,7 +533,9 @@ Interface.prototype._deleteLineRight = function() {
 
 Interface.prototype.clearLine = function() {
   this._moveCursor(+Infinity);
-  this.output.write('\r\n');
+  if (this.output !== null) {
+    this.output.write('\r\n');
+  }
   this.line = '';
   this.cursor = 0;
   this.prevRows = 0;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -69,7 +69,7 @@ function Interface(input, output, completer, terminal) {
 
   // backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
-  if ((typeof terminal == 'undefined')&&(output != null)) {
+  if ((typeof terminal == 'undefined') && (output !== null && output !== undefined)) {
     terminal = !!output.isTTY;
   }
 
@@ -131,12 +131,12 @@ function Interface(input, output, completer, terminal) {
 
     this.history = [];
     this.historyIndex = -1;
-    if (output != null) {
+    if (output !== null && output !== undefined) {
       output.on('resize', onresize);
     }
     self.once('close', function() {
       input.removeListener('keypress', onkeypress);
-      if (output != null) {
+      if (output !== null && output !== undefined) {
         output.removeListener('resize', onresize);
       }
     });
@@ -175,7 +175,7 @@ Interface.prototype.prompt = function(preserveCursor) {
   if (this.terminal) {
     if (!preserveCursor) this.cursor = 0;
     this._refreshLine();
-  } else if (this.output != null) {
+  } else if (this.output !== null && this.output !== undefined) {
     this.output.write(this._prompt);
   }
 };
@@ -246,12 +246,12 @@ Interface.prototype._refreshLine = function() {
   exports.clearScreenDown(this.output);
 
   // Write the prompt and the current buffer content.
-  if (this.output != null) {
+  if (this.output !== null && this.output !== undefined) {
     this.output.write(line);
   }
 
   // Force terminal to allocate a new line
-  if (lineCols === 0 && this.output != null) {
+  if (lineCols === 0 && this.output !== null && this.output !== undefined) {
     this.output.write(' ');
   }
 
@@ -295,7 +295,7 @@ Interface.prototype.resume = function() {
 
 
 Interface.prototype.write = function(d, key) {
-  if (this.output != null) {
+  if (this.output !== null && this.output !== undefined) {
     if (this.paused) this.resume();
     this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d);
   }
@@ -350,7 +350,7 @@ Interface.prototype._insertString = function(c) {
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
-    } else if (this.output != null) {
+    } else if (this.output !== null && this.output !== undefined) {
       this.output.write(c);
     }
 
@@ -377,7 +377,7 @@ Interface.prototype._tabComplete = function() {
       // Apply/show completions.
       if (completions.length === 1) {
         self._insertString(completions[0].slice(completeOn.length));
-      } else if (self.output != null) {
+      } else if (self.output !== null && self.output !== undefined) {
         self.output.write('\r\n');
         var width = completions.reduce(function(a, b) {
           return a.length > b.length ? a : b;
@@ -422,23 +422,23 @@ function handleGroup(self, group, width, maxColumns) {
         break;
       }
       var item = group[idx];
-      if (self.output != null) {
+      if (self.output !== null && self.output !== undefined) {
         self.output.write(item);
       }
       if (col < maxColumns - 1) {
         for (var s = 0, itemLen = item.length; s < width - itemLen;
              s++) {
-          if (self.output != null) {
+          if (self.output !== null && self.output !== undefined) {
             self.output.write(' ');
           }
         }
       }
     }
-    if (self.output != null) {
+    if (self.output !== null && self.output !== undefined) {
       self.output.write('\r\n');
     }
   }
-  if (self.output != null) {
+  if (self.output !== null && self.output !== undefined) {
     self.output.write('\r\n');
   }
 }
@@ -533,7 +533,7 @@ Interface.prototype._deleteLineRight = function() {
 
 Interface.prototype.clearLine = function() {
   this._moveCursor(+Infinity);
-  if (this.output != null) {
+  if (this.output !== null && this.output !== undefined) {
     this.output.write('\r\n');
   }
   this.line = '';

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -69,7 +69,7 @@ function Interface(input, output, completer, terminal) {
 
   // backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
-  if ((typeof terminal == 'undefined')&&(output !== null)) {
+  if ((typeof terminal == 'undefined')&&(output != null)) {
     terminal = !!output.isTTY;
   }
 
@@ -131,12 +131,12 @@ function Interface(input, output, completer, terminal) {
 
     this.history = [];
     this.historyIndex = -1;
-    if (output !== null){
+    if (output != null) {
       output.on('resize', onresize);
     }
     self.once('close', function() {
       input.removeListener('keypress', onkeypress);
-      if (output !== null){
+      if (output != null) {
         output.removeListener('resize', onresize);
       }
     });
@@ -175,7 +175,7 @@ Interface.prototype.prompt = function(preserveCursor) {
   if (this.terminal) {
     if (!preserveCursor) this.cursor = 0;
     this._refreshLine();
-  } else if (this.output !== null){
+  } else if (this.output != null) {
     this.output.write(this._prompt);
   }
 };
@@ -246,12 +246,12 @@ Interface.prototype._refreshLine = function() {
   exports.clearScreenDown(this.output);
 
   // Write the prompt and the current buffer content.
-  if (this.output !== null){
+  if (this.output != null) {
     this.output.write(line);
   }
 
   // Force terminal to allocate a new line
-  if (lineCols === 0 && this.output !== null) {
+  if (lineCols === 0 && this.output != null) {
     this.output.write(' ');
   }
 
@@ -295,7 +295,7 @@ Interface.prototype.resume = function() {
 
 
 Interface.prototype.write = function(d, key) {
-  if (this.output !== null){
+  if (this.output != null) {
     if (this.paused) this.resume();
     this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d);
   }
@@ -350,7 +350,7 @@ Interface.prototype._insertString = function(c) {
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
-    } else if (this.output !== null){
+    } else if (this.output != null) {
       this.output.write(c);
     }
 
@@ -377,7 +377,7 @@ Interface.prototype._tabComplete = function() {
       // Apply/show completions.
       if (completions.length === 1) {
         self._insertString(completions[0].slice(completeOn.length));
-      } else if (self.output !== null){
+      } else if (self.output != null) {
         self.output.write('\r\n');
         var width = completions.reduce(function(a, b) {
           return a.length > b.length ? a : b;
@@ -422,23 +422,23 @@ function handleGroup(self, group, width, maxColumns) {
         break;
       }
       var item = group[idx];
-      if (self.output !== null){
+      if (self.output != null) {
         self.output.write(item);
       }
       if (col < maxColumns - 1) {
         for (var s = 0, itemLen = item.length; s < width - itemLen;
              s++) {
-          if (self.output !== null){
+          if (self.output != null) {
             self.output.write(' ');
           }
         }
       }
     }
-    if (self.output !== null){
+    if (self.output != null) {
       self.output.write('\r\n');
     }
   }
-  if (self.output !== null){
+  if (self.output != null) {
     self.output.write('\r\n');
   }
 }
@@ -533,7 +533,7 @@ Interface.prototype._deleteLineRight = function() {
 
 Interface.prototype.clearLine = function() {
   this._moveCursor(+Infinity);
-  if (this.output !== null) {
+  if (this.output != null) {
     this.output.write('\r\n');
   }
   this.line = '';

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -175,4 +175,27 @@ FakeInput.prototype.end = function() {};
 
   assert.deepEqual(fi.listeners('end'), []);
   assert.deepEqual(fi.listeners(terminal ? 'keypress' : 'data'), []);
-});
+
+  //can create a new readline Interface with a null output arugument
+  fi = new FakeInput();
+  rl1 = new readline.Interface({input: fi, output: null, terminal: terminal });
+
+  assert.doesNotThrow(function() {
+    r1.setPrompt("ddd> ");
+  });
+
+  assert.doesNotThrow(function() {
+    r1.prompt();
+  });
+
+  assert.doesNotThrow(function() {
+  r1.write('really shouldnt be seeing this');
+  });
+
+  assert.doesNotThrow(function() {
+    r1.question("What do you think of node.js? ", function(answer) {
+      console.log("Thank you for your valuable feedback:", answer);
+      r1.close();
+    })
+  });
+


### PR DESCRIPTION
If you pass in null as the output stream, then it should just not write output. This would make it easier to use readline to just parse out the line

Fixes joyent/node#4408

This is my first code contribution to node.js, I've signed the CLA.
