### PR TITLE
TLS Fast Writing

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -163,6 +163,16 @@ Readable.prototype.read = function(n) {
   if (typeof n !== 'number' || n > 0)
     state.emittedReadable = false;
 
+  // if we're doing read(0) to trigger a readable event, but we
+  // already have a bunch of data in the buffer, then just trigger
+  // the 'readable' event and move on.
+  if (n === 0 &&
+      state.needReadable &&
+      state.length >= state.highWaterMark) {
+    emitReadable(this);
+    return null;
+  }
+
   n = howMuchToRead(n, state);
 
   // if we've ended, and we're now clear, then finish it up.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -239,7 +239,7 @@ Readable.prototype.read = function(n) {
   else
     ret = null;
 
-  if (ret === null || (!state.objectMode && ret.length === 0)) {
+  if (ret === null) {
     state.needReadable = true;
     n = 0;
   }

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1298,6 +1298,18 @@ function pipe(pair, socket) {
   cleartext.encrypted = pair.encrypted;
   cleartext.authorized = false;
 
+  // cycle the data whenever the socket drains, so that
+  // we can pull some more into it.  normally this would
+  // be handled by the fact that pipe() triggers read() calls
+  // on writable.drain, but CryptoStreams are a bit more
+  // complicated.  Since the encrypted side actually gets
+  // its data from the cleartext side, we have to give it a
+  // light kick to get in motion again.
+  socket.on('drain', function() {
+    pair.encrypted.read(0);
+    pair.cleartext.read(0);
+  });
+
   function onerror(e) {
     if (cleartext._controlReleased) {
       cleartext.emit('error', e);

--- a/test/simple/test-tls-fast-writing.js
+++ b/test/simple/test-tls-fast-writing.js
@@ -1,0 +1,80 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var tls = require('tls');
+var fs = require('fs');
+
+var PORT = common.PORT;
+var dir = common.fixturesDir;
+var options = { key: fs.readFileSync(dir + '/test_key.pem'),
+                cert: fs.readFileSync(dir + '/test_cert.pem'),
+                ca: [ fs.readFileSync(dir + '/test_ca.pem') ] };
+
+var server = tls.createServer(options, onconnection);
+var gotChunk = false;
+var gotDrain = false;
+
+var timer = setTimeout(function() {
+  console.log('not ok - timed out');
+  process.exit(1);
+}, 500);
+
+function onconnection(conn) {
+  conn.on('data', function(c) {
+    if (!gotChunk) {
+      gotChunk = true;
+      console.log('ok - got chunk');
+    }
+
+    // just some basic sanity checks.
+    assert(c.length);
+    assert(Buffer.isBuffer(c));
+
+    if (gotDrain)
+      process.exit(0);
+  });
+}
+
+server.listen(PORT, function() {
+  var chunk = new Buffer(1024);
+  chunk.fill('x');
+  var opt = { port: PORT, rejectUnauthorized: false };
+  var conn = tls.connect(opt, function() {
+    conn.on('drain', ondrain);
+    write();
+  });
+  function ondrain() {
+    if (!gotDrain) {
+      gotDrain = true;
+      console.log('ok - got drain');
+    }
+    if (gotChunk)
+      process.exit(0);
+    write();
+  }
+  function write() {
+    // this needs to return false eventually
+    while (false !== conn.write(chunk));
+  }
+});


### PR DESCRIPTION
I found some odd behavior when writing a TLS throughput benchmark.  Given a script like this:

``` javascript
var server = tls.createServer(options, function(conn) {
  conn.on('data', function(chunk) {
    console.error('got chunk', chunk.length);
  });
}).listen(PORT, function() {
  var opt = {port:PORT, rejectUnauthorized: false };
  var conn = tls.connect(opt, function() {
    conn.on('drain', write);
    write();
  });

  function write() {
    while (false !== conn.write(chunk));
  }
});
```

it would never actually allow the server to receive the chunk.  The client cryptostream would just keep returning `true` from every write, and buffering more and more data up behind the TCP socket.  The TCP socket fills up, starts returning false, but we keep slamming it, and never give the event loop a chance to do its thing.

The reasons for this are twofold:
1. We're treating `read(0)` as a "trigger a _read()/readable-event" type of API.  While this is valuable, especially for oddball streams like TLS, it was doing it too aggressively.  With this change, if there is already enough data in the buffer, then `read(0)` will just immediately emit 'readable' rather than doing another call to _read.
2. The TLS pipes the encrypted CryptoStream onto the socket. However, this means that `socket.on('drain')` will attempt to read some more from the encrypted side, but it needs to also cycle the cleartext side, so that we handle cases where this "wrote too much, read(0) stopped doing anything" scenario is encountered.

Review, please: @indutny
