### PR TITLE
Added prompt to fix repl_test.js example

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -159,7 +159,7 @@ associated with each `REPLServer`.  For example:
     var repl = require("repl"),
         msg = "message";
 
-    repl.start().context.m = msg;
+    repl.start("> ").context.m = msg;
 
 Things in the `context` object appear as local within the REPL:
 


### PR DESCRIPTION
Running repl.start without the prompt produces this error:

repl.js:95
    throw new Error('An options Object, or a prompt String are required');
          ^
Error: An options Object, or a prompt String are required
    at new REPLServer (repl.js:95:11)
    at Object.exports.start (repl.js:321:14)
    at Object.<anonymous> (/Users/dan/Dropbox/Documents/dev/nextgen/repl_test.js:5:6)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
