### PR TITLE
Implement automatic out-of-tree-builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,22 +41,22 @@ node_g: config.gypi out/Makefile
 	ln -fs out/Debug/node $@
 endif
 
-out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp deps/v8/build/common.gypi deps/v8/tools/gyp/v8.gyp node.gyp config.gypi
+out/Makefile: $(srcdir)common.gypi $(srcdir)deps/uv/uv.gyp $(srcdir)deps/http_parser/http_parser.gyp $(srcdir)deps/zlib/zlib.gyp $(srcdir)deps/v8/build/common.gypi $(srcdir)deps/v8/tools/gyp/v8.gyp $(srcdir)node.gyp config.gypi
 ifeq ($(USE_NINJA),1)
 	touch out/Makefile
-	$(PYTHON) tools/gyp_node -f ninja
+	$(PYTHON) $(srcdir)tools/gyp_node -f ninja
 else
-	$(PYTHON) tools/gyp_node -f make
+	$(PYTHON) $(srcdir)tools/gyp_node -f make
 endif
 
-config.gypi: configure
-	$(PYTHON) ./configure
+config.gypi: $(srcdir)configure
+	$(PYTHON) $(srcdir)configure
 
 install: all
-	$(PYTHON) tools/install.py $@ $(DESTDIR)
+	$(PYTHON) $(srcdir)tools/install.py $@ $(DESTDIR)
 
 uninstall:
-	$(PYTHON) tools/install.py $@ $(DESTDIR)
+	$(PYTHON) $(srcdir)tools/install.py $@ $(DESTDIR)
 
 clean:
 	-rm -rf out/Makefile node node_g out/$(BUILDTYPE)/node blog.html email.md
@@ -69,16 +69,17 @@ distclean:
 	-rm -f config.mk
 	-rm -rf node node_g blog.html email.md
 	-rm -rf node_modules
+	-rm -f Makefile
 
 test: all
-	$(PYTHON) tools/test.py --mode=release simple message
+	$(PYTHON) $(srcdir)tools/test.py --mode=release simple message
 	$(MAKE) jslint
 
 test-http1: all
-	$(PYTHON) tools/test.py --mode=release --use-http1 simple message
+	$(PYTHON) $(srcdir)tools/test.py --mode=release --use-http1 simple message
 
 test-valgrind: all
-	$(PYTHON) tools/test.py --mode=release --valgrind simple message
+	$(PYTHON) $(srcdir)tools/test.py --mode=release --valgrind simple message
 
 test/gc/node_modules/weak/build:
 	@if [ ! -f node ]; then make all; fi
@@ -87,35 +88,35 @@ test/gc/node_modules/weak/build:
 		--nodedir="$(shell pwd)"
 
 test-gc: all test/gc/node_modules/weak/build
-	$(PYTHON) tools/test.py --mode=release gc
+	$(PYTHON) $(srcdir)tools/test.py --mode=release gc
 
 test-all: all test/gc/node_modules/weak/build
-	$(PYTHON) tools/test.py --mode=debug,release
+	$(PYTHON) $(srcdir)tools/test.py --mode=debug,release
 	make test-npm
 
 test-all-http1: all
-	$(PYTHON) tools/test.py --mode=debug,release --use-http1
+	$(PYTHON) $(srcdir)tools/test.py --mode=debug,release --use-http1
 
 test-all-valgrind: all
-	$(PYTHON) tools/test.py --mode=debug,release --valgrind
+	$(PYTHON) $(srcdir)tools/test.py --mode=debug,release --valgrind
 
 test-release: all
-	$(PYTHON) tools/test.py --mode=release
+	$(PYTHON) $(srcdir)tools/test.py --mode=release
 
 test-debug: all
-	$(PYTHON) tools/test.py --mode=debug
+	$(PYTHON) $(srcdir)tools/test.py --mode=debug
 
 test-message: all
-	$(PYTHON) tools/test.py message
+	$(PYTHON) $(srcdir)tools/test.py message
 
 test-simple: all
-	$(PYTHON) tools/test.py simple
+	$(PYTHON) $(srcdir)tools/test.py simple
 
 test-pummel: all
-	$(PYTHON) tools/test.py pummel
+	$(PYTHON) $(srcdir)tools/test.py pummel
 
 test-internet: all
-	$(PYTHON) tools/test.py internet
+	$(PYTHON) $(srcdir)tools/test.py internet
 
 test-npm: node
 	./node deps/npm/test/run.js
@@ -123,7 +124,7 @@ test-npm: node
 test-npm-publish: node
 	npm_package_config_publishtest=true ./node deps/npm/test/run.js
 
-apidoc_sources = $(wildcard doc/api/*.markdown)
+apidoc_sources = $(wildcard $(srcdir)doc/api/*.markdown)
 apidocs = $(addprefix out/,$(apidoc_sources:.markdown=.html)) \
           $(addprefix out/,$(apidoc_sources:.markdown=.json))
 
@@ -150,41 +151,41 @@ website_files = \
 	out/doc/changelog.html \
 	$(doc_images)
 
-doc: $(apidoc_dirs) $(website_files) $(apiassets) $(apidocs) tools/doc/ blog node
+doc: $(apidoc_dirs) $(website_files) $(apiassets) $(apidocs) $(srcdir)tools/doc/ blog node
 
 blogclean:
 	rm -rf out/blog
 
-blog: doc/blog out/Release/node tools/blog
-	out/Release/node tools/blog/generate.js doc/blog/ out/blog/ doc/blog.html doc/rss.xml
+blog: $(srcdir)doc/blog out/Release/node $(srcdir)tools/blog
+	out/Release/node $(srcdir)tools/blog/generate.js $(srcdir)doc/blog/ out/blog/ $(srcdir)doc/blog.html $(srcdir)doc/rss.xml
 
 $(apidoc_dirs):
 	mkdir -p $@
 
-out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets/
+out/doc/api/assets/%: $(srcdir)doc/api_assets/% out/doc/api/assets/
 	cp $< $@
 
-out/doc/changelog.html: ChangeLog doc/changelog-head.html doc/changelog-foot.html tools/build-changelog.sh node
-	bash tools/build-changelog.sh
+out/doc/changelog.html: $(srcdir)ChangeLog $(srcdir)doc/changelog-head.html $(srcdir)doc/changelog-foot.html $(srcdir)tools/build-changelog.sh node
+	bash $(srcdir)tools/build-changelog.sh
 
-out/doc/%.html: doc/%.html node
+out/doc/%.html: $(srcdir)doc/%.html node
 	cat $< | sed -e 's|__VERSION__|'$(VERSION)'|g' > $@
 
-out/doc/%: doc/%
+out/doc/%: $(srcdir)doc/%
 	cp -r $< $@
 
-out/doc/api/%.json: doc/api/%.markdown node
-	out/Release/node tools/doc/generate.js --format=json $< > $@
+out/doc/api/%.json: $(srcdir)doc/api/%.markdown node
+	out/Release/node $(srcdir)tools/doc/generate.js --format=json $< > $@
 
 out/doc/api/%.html: doc/api/%.markdown node
-	out/Release/node tools/doc/generate.js --format=html --template=doc/template.html $< > $@
+	out/Release/node $(srcdir)tools/doc/generate.js --format=html --template=$(srcdir)doc/template.html $< > $@
 
-email.md: ChangeLog tools/email-footer.md
-	bash tools/changelog-head.sh | sed 's|^\* #|* \\#|g' > $@
-	cat tools/email-footer.md | sed -e 's|__VERSION__|'$(VERSION)'|g' >> $@
+email.md: $(srcdir)ChangeLog $(srcdir)tools/email-footer.md
+	bash $(srcdir)tools/changelog-head.sh | sed 's|^\* #|* \\#|g' > $@
+	cat $(srcdir)tools/email-footer.md | sed -e 's|__VERSION__|'$(VERSION)'|g' >> $@
 
-blog.html: email.md
-	cat $< | ./node tools/doc/node_modules/.bin/marked > $@
+blog.html: $(srcdir)email.md
+	cat $< | ./node $(srcdir)tools/doc/node_modules/.bin/marked > $@
 
 blog-upload: blog
 	rsync -r out/blog/ node@nodejs.org:~/web/nodejs.org/blog/
@@ -205,8 +206,8 @@ docopen: out/doc/api/all.html
 docclean:
 	-rm -rf out/doc
 
-VERSION=v$(shell $(PYTHON) tools/getnodeversion.py)
-RELEASE=$(shell $(PYTHON) tools/getnodeisrelease.py)
+VERSION=v$(shell $(PYTHON) $(srcdir)tools/getnodeversion.py)
+RELEASE=$(shell $(PYTHON) $(srcdir)tools/getnodeisrelease.py)
 PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
 ifeq ($(findstring x86_64,$(shell uname -m)),x86_64)
 DESTCPU ?= x64
@@ -260,12 +261,12 @@ pkg: $(PKG)
 $(PKG): release-only
 	rm -rf $(PKGDIR)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --prefix=$(PKGDIR)/32/usr/local --without-snapshot --dest-cpu=ia32
+	$(PYTHON) $(srcdir)configure --prefix=$(PKGDIR)/32/usr/local --without-snapshot --dest-cpu=ia32
 	$(MAKE) install V=$(V)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --prefix=$(PKGDIR)/usr/local --without-snapshot --dest-cpu=x64
+	$(PYTHON) $(srcdir)configure --prefix=$(PKGDIR)/usr/local --without-snapshot --dest-cpu=x64
 	$(MAKE) install V=$(V)
-	SIGN="$(SIGN)" PKGDIR="$(PKGDIR)" bash tools/osx-codesign.sh
+	SIGN="$(SIGN)" PKGDIR="$(PKGDIR)" bash $(srcdir)tools/osx-codesign.sh
 	lipo $(PKGDIR)/32/usr/local/bin/node \
 		$(PKGDIR)/usr/local/bin/node \
 		-output $(PKGDIR)/usr/local/bin/node-universal \
@@ -274,14 +275,14 @@ $(PKG): release-only
 	rm -rf $(PKGDIR)/32
 	$(packagemaker) \
 		--id "org.nodejs.Node" \
-		--doc tools/osx-pkg.pmdoc \
+		--doc $(srcdir)tools/osx-pkg.pmdoc \
 		--out $(PKG)
-	SIGN="$(SIGN)" PKG="$(PKG)" bash tools/osx-productsign.sh
+	SIGN="$(SIGN)" PKG="$(PKG)" bash $(srcdir)tools/osx-productsign.sh
 
 $(TARBALL): release-only node doc
 	git archive --format=tar --prefix=$(TARNAME)/ HEAD | tar xf -
 	mkdir -p $(TARNAME)/doc/api
-	cp doc/node.1 $(TARNAME)/doc/node.1
+	cp $(srcdir)doc/node.1 $(TARNAME)/doc/node.1
 	cp -r out/doc/api/* $(TARNAME)/doc/api/
 	rm -rf $(TARNAME)/deps/v8/test # too big
 	rm -rf $(TARNAME)/doc/images # too big
@@ -295,11 +296,11 @@ tar: $(TARBALL)
 $(BINARYTAR): release-only
 	rm -rf $(BINARYNAME)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --prefix=/ --without-snapshot --dest-cpu=$(DESTCPU) $(CONFIG_FLAGS)
+	$(PYTHON) $(srcdir)configure --prefix=/ --without-snapshot --dest-cpu=$(DESTCPU) $(CONFIG_FLAGS)
 	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
-	cp README.md $(BINARYNAME)
-	cp LICENSE $(BINARYNAME)
-	cp ChangeLog $(BINARYNAME)
+	cp $(srcdir)README.md $(BINARYNAME)
+	cp $(srcdir)LICENSE $(BINARYNAME)
+	cp $(srcdir)ChangeLog $(BINARYNAME)
 	tar -cf $(BINARYNAME).tar $(BINARYNAME)
 	rm -rf $(BINARYNAME)
 	gzip -f -9 $(BINARYNAME).tar
@@ -312,21 +313,21 @@ dist-upload: $(TARBALL) $(PKG)
 	scp $(PKG) node@nodejs.org:~/web/nodejs.org/dist/$(VERSION)/$(TARNAME).pkg
 
 bench:
-	 benchmark/http_simple_bench.sh
+	 $(srcdir)benchmark/http_simple_bench.sh
 
 bench-idle:
-	./node benchmark/idle_server.js &
+	./node $(srcdir)benchmark/idle_server.js &
 	sleep 1
-	./node benchmark/idle_clients.js &
+	./node $(srcdir)benchmark/idle_clients.js &
 
 jslintfix:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=$(srcdir)tools/closure_linter/ $(PYTHON) $(srcdir)tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
 
 jslint:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=$(srcdir)tools/closure_linter/ $(PYTHON) $(srcdir)tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
 
 cpplint:
-	@$(PYTHON) tools/cpplint.py $(wildcard src/*.cc src/*.h src/*.c)
+	@$(PYTHON) $(srcdir)tools/cpplint.py $(wildcard $(srcdir)src/*.cc $(srcdir)src/*.h $(srcdir)src/*.c)
 
 lint: jslint cpplint
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 BUILDTYPE ?= Release
 PYTHON ?= python
+override PYTHON := NODE_BUILDDIR=$(builddir) $(PYTHON)
 NINJA ?= ninja
 DESTDIR ?=
 SIGN ?=

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,15 @@ distclean:
 	-rm -rf node_modules
 	-rm -f Makefile
 
-test: all
+test: all test-nested-index
 	$(PYTHON) $(srcdir)tools/test.py --mode=release simple message
 	$(MAKE) jslint
+
+test-nested-index:
+	@if [ ! -d $(builddir)test/fixtures/nested-index ]; then \
+		mkdir -p $(builddir)test/fixtures; \
+		cp -a $(srcdir)test/fixtures/nested-index $(builddir)test/fixtures; \
+	fi
 
 test-http1: all
 	$(PYTHON) $(srcdir)tools/test.py --mode=release --use-http1 simple message

--- a/configure
+++ b/configure
@@ -6,11 +6,13 @@ import re
 import shlex
 import subprocess
 import sys
+import shutil
 
 CC = os.environ.get('CC', 'cc')
 
 root_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root_dir, 'deps', 'v8', 'tools'))
+build_dir = '.' if os.getcwd() != root_dir else root_dir
 
 # parse our options
 parser = optparse.OptionParser()
@@ -648,7 +650,7 @@ output = {
 pprint.pprint(output, indent=2)
 
 def write(filename, data):
-  filename = os.path.join(root_dir, filename)
+  filename = os.path.join(build_dir, filename)
   print "creating ", filename
   f = open(filename, 'w+')
   f.write(data)
@@ -662,6 +664,11 @@ config = {
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
 }
+if build_dir != root_dir:
+  config['srcdir'] = os.path.abspath(root_dir) + os.sep
+  config['builddir'] = os.path.abspath(build_dir) + os.sep
+  shutil.copy(os.path.join(config['srcdir'], 'Makefile'), os.path.join(config['builddir'], 'Makefile'))
+
 config = '\n'.join(map('='.join, config.iteritems())) + '\n'
 
 write('config.mk',
@@ -678,4 +685,4 @@ elif options.dest_os:
 else:
   gyp_args = ['-f', 'make']
 
-subprocess.call([sys.executable, 'tools/gyp_node'] + gyp_args)
+subprocess.call([sys.executable, os.path.join(root_dir, 'tools/gyp_node')] + gyp_args)

--- a/node.gyp
+++ b/node.gyp
@@ -333,7 +333,7 @@
           'action_name': 'node_js2c',
           'inputs': [
             '<@(library_files)',
-            './config.gypi',
+            '$(abs_builddir)/../../config.gypi',
           ],
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/node_natives.h',

--- a/test/common.js
+++ b/test/common.js
@@ -21,10 +21,30 @@
 
 var path = require('path');
 var assert = require('assert');
+var fs = require('fs');
 
-exports.testDir = path.dirname(__filename);
-exports.fixturesDir = path.join(exports.testDir, 'fixtures');
-exports.libDir = path.join(exports.testDir, '../lib');
+/* Must make an assumption here, namely, that the host executable is in a
+   descedent path of the build directory. This allows us to walk up the
+   ancestory looking for the signature of the build root.
+   This could be upset by symlinks to an executable outside the build
+   directory.
+ */
+var walk = process.execPath;
+while (walk != path.sep && !fs.existsSync(path.join(walk, 'config.gypi'))) {
+ walk = path.dirname(walk);
+}
+exports.buildDir = walk;
+
+// Find the root of the source tree
+var walk = path.dirname(__filename);
+while (walk != path.sep && !fs.existsSync(path.join(walk, 'common.gypi'))) {
+ walk = path.dirname(walk);
+}
+exports.srcDir = walk;
+
+exports.testDir = path.join(exports.buildDir, 'test');
+exports.fixturesDir = path.join(exports.srcDir, 'test', 'fixtures');
+exports.libDir = path.join(exports.srcDir, 'lib');
 exports.tmpDir = path.join(exports.testDir, 'tmp');
 exports.PORT = 12346;
 

--- a/test/common.js
+++ b/test/common.js
@@ -48,6 +48,11 @@ exports.libDir = path.join(exports.srcDir, 'lib');
 exports.tmpDir = path.join(exports.testDir, 'tmp');
 exports.PORT = 12346;
 
+// ensure test directories exist
+[exports.testDir, exports.tmpDir].forEach( function(val, index, array) {
+ if (!fs.existsSync(val)) fs.mkdirSync(val);
+});
+
 if (process.platform === 'win32') {
   exports.PIPE = '\\\\.\\pipe\\libuv-test';
 } else {

--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -28,6 +28,7 @@ if (module.parent) {
 var common = require('../common.js'),
     assert = require('assert'),
     child = require('child_process'),
+    path = require('path'),
     nodejs = '"' + process.execPath + '"';
 
 
@@ -73,7 +74,7 @@ child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
     });
 
 // module path resolve bug, regression test
-child.exec(nodejs + ' --eval "require(\'./test/simple/test-cli-eval.js\')"',
+child.exec(nodejs + ' --eval "require(\'' + path.join(common.srcDir, './test/simple/test-cli-eval.js') + '\')"',
     function(status, stdout, stderr) {
       assert.equal(status.code, 42);
     });

--- a/test/simple/test-executable-path.js
+++ b/test/simple/test-executable-path.js
@@ -26,13 +26,13 @@ var match = false;
 
 var isDebug = process.features.debug;
 
-var debugPaths = [path.normalize(path.join(__dirname, '..', '..',
+var debugPaths = [path.normalize(path.join(common.buildDir,
                                            'out', 'Debug', 'node')),
-                  path.normalize(path.join(__dirname, '..', '..',
+                  path.normalize(path.join(common.buildDir,
                                            'Debug', 'node'))];
-var defaultPaths = [path.normalize(path.join(__dirname, '..', '..',
+var defaultPaths = [path.normalize(path.join(common.buildDir,
                                              'out', 'Release', 'node')),
-                    path.normalize(path.join(__dirname, '..', '..',
+                    path.normalize(path.join(common.buildDir,
                                              'Release', 'node'))];
 
 console.error('debugPaths: ' + debugPaths);

--- a/test/simple/test-fs-realpath.js
+++ b/test/simple/test-fs-realpath.js
@@ -132,8 +132,8 @@ function test_simple_absolute_symlink(callback) {
 
   console.log('using type=%s', type);
 
-  var entry = tmpAbsDir + '/symlink',
-      expected = fixturesAbsDir + '/nested-index/one';
+  var entry = path.join(tmpAbsDir, 'symlink'),
+      expected = path.join(fixturesAbsDir, 'nested-index', 'one');
   [
     [entry, expected]
   ].forEach(function(t) {
@@ -324,8 +324,13 @@ function test_deep_symlink_mix(callback) {
     -> /node/test/fixtures/nested-index/two/realpath-c
   /node/test/fixtures/nested-index/two/realpath-c -> ../../cycles/root.js
   /node/test/fixtures/cycles/root.js (hard)
+
+  must use build location when creating links. Makefile target 'test-nested-index'
+  will copy the static entries over to the build location if necessary.
   */
-  var entry = tmp('node-test-realpath-f1');
+  var buildFixturesAbsDir = path.join(common.buildDir, 'test', 'fixtures');
+
+  var entry = path.join('test', 'tmp', 'node-test-realpath-f1');
   try { fs.unlinkSync(tmp('node-test-realpath-d2/foo')); } catch (e) {}
   try { fs.rmdirSync(tmp('node-test-realpath-d2')); } catch (e) {}
   fs.mkdirSync(tmp('node-test-realpath-d2'), 0700);
@@ -334,14 +339,14 @@ function test_deep_symlink_mix(callback) {
       [entry, '../tmp/node-test-realpath-d1/foo'],
       [tmp('node-test-realpath-d1'), '../tmp/node-test-realpath-d2'],
       [tmp('node-test-realpath-d2/foo'), '../node-test-realpath-f2'],
-      [tmp('node-test-realpath-f2'), fixturesAbsDir +
+      [tmp('node-test-realpath-f2'), buildFixturesAbsDir +
            '/nested-index/one/realpath-c'],
-      [fixturesAbsDir + '/nested-index/one/realpath-c', fixturesAbsDir +
+      [buildFixturesAbsDir + '/nested-index/one/realpath-c', buildFixturesAbsDir +
             '/nested-index/two/realpath-c'],
-      [fixturesAbsDir + '/nested-index/two/realpath-c',
+      [buildFixturesAbsDir + '/nested-index/two/realpath-c',
         '../../../tmp/cycles/root.js']
     ].forEach(function(t) {
-      //common.debug('setting up '+t[0]+' -> '+t[1]);
+      common.debug('setting up '+t[0]+' -> '+t[1]);
       try { fs.unlinkSync(t[0]); } catch (e) {}
       fs.symlinkSync(t[1], t[0]);
       unlink.push(t[0]);

--- a/test/simple/test-process-config.js
+++ b/test/simple/test-process-config.js
@@ -30,7 +30,7 @@ assert(process.hasOwnProperty('config'));
 // ensure that `process.config` is an Object
 assert(Object(process.config) === process.config);
 
-var configPath = path.resolve(__dirname, '..', '..', 'config.gypi');
+var configPath = path.resolve(common.testDir, '..', 'config.gypi');
 var config = fs.readFileSync(configPath, 'utf8');
 
 // clean up comment at the first line

--- a/test/simple/testcfg.py
+++ b/test/simple/testcfg.py
@@ -46,7 +46,7 @@ class SimpleTestCase(test.TestCase):
     self.file = file
     self.config = config
     self.mode = mode
-    self.tmpdir = join(dirname(self.config.root), 'tmp')
+    self.tmpdir = join(os.getenv('NODE_BUILDDIR', dirname(self.config.root)), 'test', 'tmp')
   
   def AfterRun(self, result):
     # delete the whole tmp dir

--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -1942,11 +1942,18 @@ def GenerateOutput(target_list, target_dicts, data, params):
     base_path = gyp.common.RelativePath(os.path.dirname(build_file),
                                         options.depth)
     # We write the file in the base_path directory.
-    output_file = os.path.join(options.depth, base_path, base_name)
+    if not os.path.abspath(build_file).startswith(os.getcwd()):
+      output_path = gyp.common.RelativePath(os.path.dirname(build_file), options.toplevel_dir)
+      output_file = os.path.join(output_path, base_name)
+      gyp.DebugOutput(gyp.DEBUG_GENERAL, "toplevel='%s', output_path='%s'" % (options.toplevel_dir, output_path))
+    else:
+      output_file = os.path.join(options.depth, base_path, base_name)
+    
     if options.generator_output:
       output_file = os.path.join(options.generator_output, output_file)
     base_path = gyp.common.RelativePath(os.path.dirname(build_file),
                                         options.toplevel_dir)
+    gyp.DebugOutput(gyp.DEBUG_GENERAL, "('%s', '%s') = '%s', '%s'" % (build_file, base_name, base_path, output_file))
     return base_path, output_file
 
   # TODO:  search for the first non-'Default' target.  This can go
@@ -1964,12 +1971,17 @@ def GenerateOutput(target_list, target_dicts, data, params):
 
   srcdir = '.'
   makefile_name = 'Makefile' + options.suffix
-  makefile_path = os.path.join(options.toplevel_dir, makefile_name)
+  makefile_path = os.path.abspath(os.path.join(builddir_name, makefile_name))
   if options.generator_output:
     global srcdir_prefix
     makefile_path = os.path.join(options.generator_output, makefile_path)
-    srcdir = gyp.common.RelativePath(srcdir, options.generator_output)
+    if options.toplevel_dir:
+      srcdir = options.toplevel_dir
+    else:
+      srcdir = gyp.common.RelativePath(srcdir, options.generator_output)
     srcdir_prefix = '$(srcdir)/'
+
+  gyp.DebugOutput(gyp.DEBUG_GENERAL, "\n builddir=name'%s'\n makefile_path='%s'\n options.generator_output='%s'\n srcdir='%s'\n srcdir_prefix='%s'" % (builddir_name, makefile_path, options.generator_output if options.generator_output else '', srcdir, srcdir_prefix))
 
   flock_command= 'flock'
   header_params = {

--- a/tools/gyp_node
+++ b/tools/gyp_node
@@ -6,13 +6,16 @@ import sys
 
 script_dir = os.path.dirname(__file__)
 node_root  = os.path.normpath(os.path.join(script_dir, os.pardir))
+toplevel_dir = os.path.abspath(node_root)
+build_dir = os.path.relpath(os.getcwd(), os.path.abspath(script_dir)) if os.getcwd() != node_root else node_root
+out_dir = os.path.join(os.getcwd(), 'out')
 
 sys.path.insert(0, os.path.join(node_root, 'tools', 'gyp', 'pylib'))
 import gyp
 
 # Directory within which we want all generated files (including Makefiles)
 # to be written.
-output_dir = os.path.join(os.path.abspath(node_root), 'out')
+output_dir = os.path.join(os.getcwd(), 'out')
 
 def run_gyp(args):
   rc = gyp.main(args)
@@ -29,11 +32,11 @@ if __name__ == '__main__':
   if sys.platform == 'win32':
     args.append(os.path.join(node_root, 'node.gyp'))
     common_fn  = os.path.join(node_root, 'common.gypi')
-    options_fn = os.path.join(node_root, 'config.gypi')
+    options_fn = os.path.join(os.path.abspath(os.path.join(script_dir, build_dir)), 'config.gypi')
   else:
     args.append(os.path.join(os.path.abspath(node_root), 'node.gyp'))
     common_fn  = os.path.join(os.path.abspath(node_root), 'common.gypi')
-    options_fn = os.path.join(os.path.abspath(node_root), 'config.gypi')
+    options_fn = os.path.join(os.path.abspath(os.path.join(script_dir, build_dir)), 'config.gypi')
 
   if os.path.exists(common_fn):
     args.extend(['-I', common_fn])
@@ -41,7 +44,7 @@ if __name__ == '__main__':
   if os.path.exists(options_fn):
     args.extend(['-I', options_fn])
 
-  args.append('--depth=' + node_root)
+  args.append('--depth=' + (node_root if node_root == build_dir else '.'))
 
   # There's a bug with windows which doesn't allow this feature.
   if sys.platform != 'win32' and 'ninja' not in args:
@@ -53,5 +56,6 @@ if __name__ == '__main__':
 
   args.append('-Dcomponent=static_library')
   args.append('-Dlibrary=static_library')
+  args.append('--toplevel-dir=' + toplevel_dir)
   gyp_args = list(args)
   run_gyp(gyp_args)


### PR DESCRIPTION
This series of patches introduces automatic out-of-tree builds. Simply create and change to an alternate directory and call the configure script in the source tree directly. It will use the current working directory as the root of the build tree.

This series should include all the fixes to ensure the test suite works correctly in-tree or out-of-tree.
