### PR TITLE
http: Do not buffer writes to a destroyed socket

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -484,7 +484,8 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
 
   if (this.connection &&
       this.connection._httpMessage === this &&
-      this.connection.writable) {
+      this.connection.writable &&
+      !this.connection.destroyed) {
     // There might be pending data in the this.output buffer.
     while (this.output.length) {
       if (!this.connection.writable) {
@@ -498,7 +499,16 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
 
     // Directly write to socket.
     return this.connection.write(data, encoding);
+  } else if (this.connection && this.connection.destroyed) {
+    // The socket was destroyed.  If we're still trying to write to it,
+    // then something bad happened.
+    // If we've already raised an error on this message, then just ignore.
+    if (!this._hadError) {
+      this.emit('error', createHangUpError());
+      this._hadError = true;
+    }
   } else {
+    // buffer, as long as we're not destroyed.
     this._buffer(data, encoding);
     return false;
   }
@@ -1398,7 +1408,16 @@ function socketCloseListener() {
     // receive a response. The error needs to
     // fire on the request.
     req.emit('error', createHangUpError());
+    req._hadError = true;
   }
+
+  // Too bad.  That output wasn't getting written.
+  // This is pretty terrible that it doesn't raise an error.
+  // Fixed better in v0.10
+  if (req.output)
+    req.output.length = 0;
+  if (req.outputEncodings)
+    req.outputEncodings.length = 0;
 
   if (parser) {
     parser.finish();

--- a/lib/http.js
+++ b/lib/http.js
@@ -1131,7 +1131,8 @@ function Agent(options) {
       name += ':' + localAddress;
     }
 
-    if (self.requests[name] && self.requests[name].length) {
+    if (!socket.destroyed &&
+        self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket);
       if (self.requests[name].length === 0) {
         // don't leak

--- a/test/simple/test-http-agent-destroyed-socket.js
+++ b/test/simple/test-http-agent-destroyed-socket.js
@@ -1,0 +1,106 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.end('Hello World\n');
+}).listen(common.PORT);
+
+var agent = new http.Agent({maxSockets: 1});
+
+agent.on('free', function(socket, host, port) {
+  console.log('freeing socket. destroyed? ', socket.destroyed);
+});
+
+var requestOptions = {
+  agent: agent,
+  host: 'localhost',
+  port: common.PORT,
+  path: '/'
+};
+
+var request1 = http.get(requestOptions, function(response) {
+  // assert request2 is queued in the agent
+  var key = 'localhost:' + common.PORT;
+  assert(agent.requests[key].length === 1);
+  console.log('got response1');
+  request1.socket.on('close', function() {
+    console.log('request1 socket closed');
+  });
+  response.pipe(process.stdout);
+  response.on('end', function() {
+    console.log('response1 done');
+    /////////////////////////////////
+    //
+    // THE IMPORTANT PART
+    //
+    // It is possible for the socket to get destroyed and other work
+    // to run before the 'close' event fires because it happens on
+    // nextTick. This example is contrived because it destroys the
+    // socket manually at just the right time, but at Voxer we have
+    // seen cases where the socket is destroyed by non-user code
+    // then handed out again by an agent *before* the 'close' event
+    // is triggered.
+    request1.socket.destroy();
+
+    process.nextTick(function() {
+      // assert request2 was removed from the queue
+      assert(!agent.requests[key]);
+      console.log("waiting for request2.onSocket's nextTick");
+      process.nextTick(function() {
+        // assert that the same socket was not assigned to request2,
+        // since it was destroyed.
+        assert(request1.socket !== request2.socket);
+        assert(!request2.socket.destroyed, 'the socket is destroyed');
+      });
+    });
+  });
+});
+
+var request2 = http.get(requestOptions, function(response) {
+  assert(!request2.socket.destroyed);
+  assert(request1.socket.destroyed);
+  // assert not reusing the same socket, since it was destroyed.
+  assert(request1.socket !== request2.socket);
+  console.log('got response2');
+  var gotClose = false;
+  var gotResponseEnd = false;
+  request2.socket.on('close', function() {
+    console.log('request2 socket closed');
+    gotClose = true;
+    done();
+  });
+  response.pipe(process.stdout);
+  response.on('end', function() {
+    console.log('response2 done');
+    gotResponseEnd = true;
+    done();
+  });
+
+  function done() {
+    if (gotResponseEnd && gotClose)
+      server.close();
+  }
+});

--- a/test/simple/test-http-destroyed-socket-write.js
+++ b/test/simple/test-http-destroyed-socket-write.js
@@ -1,0 +1,131 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+// Fix the memory explosion that happens when writing to a http request
+// where the server has destroyed the socket on us between a successful
+// first request, and a subsequent request that reuses the socket.
+//
+// This test should not be ported to v0.10 and higher, because the
+// problem is fixed by not ignoring ECONNRESET in the first place.
+
+var http = require('http');
+var net = require('net');
+var server = http.createServer(function(req, res) {
+  // simulate a server that is in the process of crashing or something
+  // it only crashes after the first request, but before the second,
+  // which reuses the connection.
+  res.end('hallo wereld\n', function() {
+    setTimeout(function() {
+      req.connection.destroy();
+    }, 100);
+  });
+});
+
+var gotFirstResponse = false;
+var gotFirstData = false;
+var gotFirstEnd = false;
+server.listen(common.PORT, function() {
+
+  var gotFirstResponse = false;
+  var first = http.request({
+    port: common.PORT,
+    path: '/'
+  });
+  first.on('response', function(res) {
+    gotFirstResponse = true;
+    res.on('data', function(chunk) {
+      gotFirstData = true;
+    });
+    res.on('end', function() {
+      gotFirstEnd = true;
+    })
+  });
+  first.end();
+  second();
+
+  function second() {
+    var sec = http.request({
+      port: common.PORT,
+      path: '/',
+      method: 'POST'
+    });
+
+    var timer = setTimeout(write, 200);
+    var writes = 0;
+    var sawFalseWrite;
+
+    var gotError = false;
+    sec.on('error', function(er) {
+      assert.equal(gotError, false);
+      gotError = true;
+      assert(er.code === 'ECONNRESET');
+      clearTimeout(timer);
+      test();
+    });
+
+    function write() {
+      if (++writes === 64) {
+        clearTimeout(timer);
+        sec.end();
+        test();
+      } else {
+        timer = setTimeout(write);
+        var writeRet = sec.write(new Buffer('hello'));
+
+        // Once we find out that the connection is destroyed, every
+        // write() returns false
+        if (sawFalseWrite)
+          assert.equal(writeRet, false);
+        else
+          sawFalseWrite = writeRet === false;
+      }
+    }
+
+    assert.equal(first.connection, sec.connection,
+                 'should reuse connection');
+
+    sec.on('response', function(res) {
+      res.on('data', function(chunk) {
+        console.error('second saw data: ' + chunk);
+      });
+      res.on('end', function() {
+        console.error('second saw end');
+      });
+    });
+
+    function test() {
+      server.close();
+      assert(sec.connection.destroyed);
+      if (sec.output.length || sec.outputEncodings.length)
+        console.error('bad happened', sec.output, sec.outputEncodings);
+      assert.equal(sec.output.length, 0);
+      assert.equal(sec.outputEncodings, 0);
+      assert(gotError);
+      assert(gotFirstResponse);
+      assert(gotFirstData);
+      assert(gotFirstEnd);
+      console.log('ok');
+    }
+  }
+});


### PR DESCRIPTION
This fix fills me with sadness.  Here is why:

Prior to v0.10, Node ignored ECONNRESET errors in many situations.
There _are_ valid cases in which ECONNRESET should be ignored as a
normal part of the TCP dance, but in many others, it's a very relevant
signal that must be heeded with care.

Exacerbating this problem, if the OutgoingMessage does not have a
req.connection._handle, it assumes that it is in the process of
connecting, and thus buffers writes up in an array.

The problem happens when you reuse a socket between two requests, and it
is destroyed abruptly in between them.  The writes will be buffered,
because the socket has no handle, but it's not ever going to GET a
handle, because it's not connecting, it's destroyed.

The proper fix is to treat ECONNRESET correctly.  However, this is a
behavior/semantics change, and cannot land in a stable branch.  So, the
full-of-sad bandaid fix is to not put data into the output buffer if the
socket is destroyed, and also remove anything that is in the output
buffer when the HTTP request sees that it closes.

/cc @dpacheco @bcantrill @mranney @piscisaureus
