### PR TITLE
stream: Pipe data in chunks matching read data

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -137,8 +137,13 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return n === 0 ? 0 : 1;
 
-  if (isNaN(n) || n === null)
-    return state.length;
+  if (isNaN(n) || n === null) {
+    // only flow one buffer at a time
+    if (state.flowing && state.buffer.length)
+      return state.buffer[0].length;
+    else
+      return state.length;
+  }
 
   if (n <= 0)
     return 0;


### PR DESCRIPTION
This creates better flow when lowWaterMark is much bigger than bufferSize, and backpressure is applied.

Also changes the read() function to accept the number '-1', which will return a chunk of optimal size, as determined by read().

I'm not certain about the read() change, since it further overloads the meaning of the read() argument. In one sense it might make more sense to use _any_ negative number because, though the implementation has previously rejected negative read() arguments, the documentation doesn't prohibit them. Thus, logically, this would simply be a bug fix, and not further overloading the meaning of the read() argument.

I will happily make another patch without the overloaded read() argument, but initially I opted for the simpler implementation (with bigger implications).

Also, I have verified that it passes any relevant unit tests, and that it increases performance under the provided conditions.
