### PR TITLE
child_process: handle ENOENT correctly on Windows

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -882,9 +882,9 @@ ChildProcess.prototype.spawn = function(options) {
     if (stdio.handle) {
       // when i === 0 - we're dealing with stdin
       // (which is the only one writable pipe)
-      stdio.socket = createSocket(stdio.handle, i > 0);
+      stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, i > 0);
 
-      if (i > 0) {
+      if (i > 0 && self.pid !== 0) {
         self._closesNeeded++;
         stdio.socket.on('close', function() {
           maybeClose(self);


### PR DESCRIPTION
Fixes #4674 

Depends on libuv pull request https://github.com/joyent/libuv/pull/713

We were doing all kinds of crazy stuff on Windows when a developer tried to `child_process.spawn()` a non-existent process.

Now Windows works more like Posix. And passes the child-process unit tests that were previously failing. And we still pass the unit tests on Posix as well.
