### PR TITLE
Querystring brackets

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -130,23 +130,34 @@ var stringifyPrimitive = function(v) {
   }
 };
 
+var _isObject = function(object) {
+  return object === Object(object);
+};
 
-QueryString.stringify = QueryString.encode = function(obj, sep, eq, name,
-    brackets) {
-  sep = sep || '&';
-  eq = eq || '=';
+QueryString.stringify = QueryString.encode = function(obj, options) {
+  if (!_isObject(options)) {
+    options = {
+      sep: arguments[1],
+      eq: arguments[2],
+      name: arguments[3]
+    };
+  }
 
-  if (brackets) {
+  var sep = options.sep || '&';
+  var eq = options.eq || '=';
+  var name = options.name;
+
+  if (options.brackets) {
     return (function _encode(obj, name) {
-      if (obj === null)
+      if (obj === null) {
         return (name && (name + eq)) + 'null';
-      else if (obj === undefined)
+      } else if (obj === undefined) {
         return (name && (name + eq)) + 'undefined';
-      else if (Array.isArray(obj)) {
+      } else if (Array.isArray(obj)) {
         return obj.map(function(value) {
           return _encode(value, name + '%5B%5D');
         }).join(sep);
-      } else if (obj === Object(obj)) {
+      } else if (_isObject(obj)) {
         return Object.keys(obj).map(function(k) {
           var ks = QueryString.escape(k);
           return _encode(obj[k], (name) ? name + '%5B' + ks + '%5D' : ks);
@@ -182,9 +193,17 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name,
 };
 
 // Parse a key=val string.
-QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
-  sep = sep || '&';
-  eq = eq || '=';
+QueryString.parse = QueryString.decode = function(qs, options) {
+  if (!_isObject(options)) {
+    options = {
+      sep: arguments[1],
+      eq: arguments[2],
+      maxKeys: arguments[3] && arguments[3].maxKeys
+    };
+  }
+
+  var sep = options.sep || '&';
+  var eq = options.eq || '=';
   var obj = {};
 
   if (typeof qs !== 'string' || qs.length === 0) {
@@ -195,7 +214,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   qs = qs.split(sep);
 
   var maxKeys = 1000;
-  if (options && typeof options.maxKeys === 'number') {
+  if (typeof options.maxKeys === 'number') {
     maxKeys = options.maxKeys;
   }
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -131,30 +131,54 @@ var stringifyPrimitive = function(v) {
 };
 
 
-QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
+QueryString.stringify = QueryString.encode = function(obj, sep, eq, name,
+    brackets) {
   sep = sep || '&';
   eq = eq || '=';
-  if (obj === null) {
-    obj = undefined;
-  }
 
-  if (typeof obj === 'object') {
-    return Object.keys(obj).map(function(k) {
-      var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
-      if (Array.isArray(obj[k])) {
-        return obj[k].map(function(v) {
-          return ks + QueryString.escape(stringifyPrimitive(v));
+  if (brackets) {
+    return (function _encode(obj, name) {
+      if (obj === null)
+        return (name && (name + eq)) + 'null';
+      else if (obj === undefined)
+        return (name && (name + eq)) + 'undefined';
+      else if (Array.isArray(obj)) {
+        return obj.map(function(value) {
+          return _encode(value, name + '%5B%5D');
+        }).join(sep);
+      } else if (obj === Object(obj)) {
+        return Object.keys(obj).map(function(k) {
+          var ks = QueryString.escape(k);
+          return _encode(obj[k], (name) ? name + '%5B' + ks + '%5D' : ks);
         }).join(sep);
       } else {
-        return ks + QueryString.escape(stringifyPrimitive(obj[k]));
+        return (name && (name + eq)) +
+            QueryString.escape(stringifyPrimitive(obj));
       }
-    }).join(sep);
+    })(obj, QueryString.escape(name || ''));
+  } else {
+    if (obj === null) {
+      obj = undefined;
+    }
 
+    if (typeof obj === 'object') {
+      return Object.keys(obj).map(function(k) {
+        var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
+        if (Array.isArray(obj[k])) {
+          return obj[k].map(function(v) {
+            return ks + QueryString.escape(stringifyPrimitive(v));
+          }).join(sep);
+        } else {
+          return ks + QueryString.escape(stringifyPrimitive(obj[k]));
+        }
+      }).join(sep);
+
+    }
+
+    if (!name) return '';
+    return QueryString.escape(stringifyPrimitive(name)) + eq +
+           QueryString.escape(stringifyPrimitive(obj));
   }
-
-  if (!name) return '';
-  return QueryString.escape(stringifyPrimitive(name)) + eq +
-         QueryString.escape(stringifyPrimitive(obj));
 };
 
 // Parse a key=val string.
@@ -202,12 +226,44 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
       v = QueryString.unescape(vstr, true);
     }
 
-    if (!hasOwnProperty(obj, k)) {
-      obj[k] = v;
-    } else if (Array.isArray(obj[k])) {
-      obj[k].push(v);
+    if (options && options.brackets) {
+      if (!~k.indexOf('[')) {
+        obj[k] = v;
+      } else {
+        var tokens = k.split('[');
+        var cursor = obj;
+
+        for (var j = 0; j < tokens.length; ++j) {
+          var token = tokens[j];
+          var nextToken = (j < (tokens.length - 1)) ? tokens[j + 1] : null;
+          var key = token.replace(/\]$/, '');
+
+          if (nextToken !== null) {
+            if (token === ']') {
+              if (nextToken === ']')
+                cursor.push(cursor = []);
+              else
+                cursor = cursor[key] || (cursor[key] = {});
+            } else {
+              cursor = cursor[key] ||
+                  (cursor[key] = (nextToken === ']') ? [] : {});
+            }
+          } else {
+            if (Array.isArray(cursor))
+              cursor.push(v);
+            else
+              cursor[key] = v;
+          }
+        }
+      }
     } else {
-      obj[k] = [obj[k], v];
+      if (!hasOwnProperty(obj, k)) {
+        obj[k] = v;
+      } else if (Array.isArray(obj[k])) {
+        obj[k].push(v);
+      } else {
+        obj[k] = [obj[k], v];
+      }
     }
   }
 

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -128,7 +128,7 @@ qsColonTestCases.forEach(function(testCase) {
 
 // test that the brackets test cases can do the same
 qsBracketsTestCases.forEach(function(testCase) {
-  assert.deepEqual(testCase[2], qs.parse(testCase[0], undefined, undefined, {brackets: true}));
+  assert.deepEqual(testCase[2], qs.parse(testCase[0], {brackets: true}));
 });
 
 // test the weird objects, that they get parsed properly
@@ -166,7 +166,7 @@ qsColonTestCases.forEach(function(testCase) {
 });
 
 qsBracketsTestCases.forEach(function(testCase) {
-  assert.equal(testCase[1], qs.stringify(testCase[2], undefined, undefined, undefined, true));
+  assert.equal(testCase[1], qs.stringify(testCase[2], {brackets: true}));
 });
 
 qsWeirdObjects.forEach(function(testCase) {

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -71,6 +71,13 @@ var qsColonTestCases = [
   ['foo:baz:bar', 'foo:baz%3Abar', {'foo': 'baz:bar'}]
 ];
 
+// [ wonkyQS, canonicalQS, obj ]
+var qsBracketsTestCases = [
+  ['A[]=1&A[]=2&A[]=3', 'A%5B%5D=1&A%5B%5D=2&A%5B%5D=3', {A: ['1','2','3']}],
+  ['B[C][D]=2&B[C][E]=3', 'B%5BC%5D%5BD%5D=2&B%5BC%5D%5BE%5D=3', {B: {C: {D: '2', E: '3'}}}],
+  ['A[][]=1&A[][]=2&A[][]=3', 'A%5B%5D%5B%5D=1&A%5B%5D%5B%5D=2&A%5B%5D%5B%5D=3', {A: [['1'],['2'],['3']]}]
+];
+
 // [wonkyObj, qs, canonicalObj]
 var extendedFunction = function() {};
 extendedFunction.prototype = {a: 'b'};
@@ -119,6 +126,11 @@ qsColonTestCases.forEach(function(testCase) {
   assert.deepEqual(testCase[2], qs.parse(testCase[0], ';', ':'));
 });
 
+// test that the brackets test cases can do the same
+qsBracketsTestCases.forEach(function(testCase) {
+  assert.deepEqual(testCase[2], qs.parse(testCase[0], undefined, undefined, {brackets: true}));
+});
+
 // test the weird objects, that they get parsed properly
 qsWeirdObjects.forEach(function(testCase) {
   assert.deepEqual(testCase[2], qs.parse(testCase[1]));
@@ -151,6 +163,10 @@ qsTestCases.forEach(function(testCase) {
 
 qsColonTestCases.forEach(function(testCase) {
   assert.equal(testCase[1], qs.stringify(testCase[2], ';', ':'));
+});
+
+qsBracketsTestCases.forEach(function(testCase) {
+  assert.equal(testCase[1], qs.stringify(testCase[2], undefined, undefined, undefined, true));
 });
 
 qsWeirdObjects.forEach(function(testCase) {


### PR DESCRIPTION
querystring.parse() function updated to parse string with brackets to create nested objects. querystring.stringify() also updated to generate a string with brackets.

parse() and stringify() now both takes a hash containing options in the second argument. The previous function signature is still valid.

Need to set "brackets" option to true to activate brackets parse or stringify.
