### PR TITLE
stream: Add reconfigure() call

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -56,6 +56,13 @@ function Duplex(options) {
   this.once('end', onend);
 }
 
+Duplex.prototype.reconfigure = function(options) {
+  Readable.prototype.reconfigure.apply(this, arguments);
+  Writable.prototype.reconfigure.apply(this, arguments);
+
+  // TODO: don't ignore Duplex specific options
+};
+
 // the no-half-open enforcer
 function onend() {
   // if we allow half-open state, or if the writable side ended,

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -29,28 +29,6 @@ var StringDecoder;
 util.inherits(Readable, Stream);
 
 function ReadableState(options, stream) {
-  options = options || {};
-
-  // the argument passed to this._read(n,cb)
-  this.bufferSize = options.bufferSize || 16 * 1024;
-
-  // the point at which it stops calling _read() to fill the buffer
-  // Note: 0 is a valid value, means "don't call _read preemptively ever"
-  var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
-
-  // the minimum number of bytes to buffer before emitting 'readable'
-  // default to pushing everything out as fast as possible.
-  this.lowWaterMark = options.lowWaterMark || 0;
-
-  // cast to ints.
-  this.bufferSize = ~~this.bufferSize;
-  this.lowWaterMark = ~~this.lowWaterMark;
-  this.highWaterMark = ~~this.highWaterMark;
-
-  if (this.lowWaterMark > this.highWaterMark)
-    throw new Error('lowWaterMark cannot be higher than highWaterMark');
-
   this.buffer = [];
   this.length = 0;
   this.pipes = null;
@@ -69,11 +47,6 @@ function ReadableState(options, stream) {
   this.needReadable = false;
   this.emittedReadable = false;
 
-
-  // object stream flag. Used to make read(n) ignore n and to
-  // make all the buffer merging and length checks go away
-  this.objectMode = !!options.objectMode;
-
   // when piping, we only care about 'readable' events that happen
   // after read()ing all the bytes and not getting any pushback.
   this.ranOut = false;
@@ -83,10 +56,53 @@ function ReadableState(options, stream) {
   this.pipeChunkSize = null;
 
   this.decoder = null;
+
+  setStreamOptions(options, this);
+}
+
+function setStreamOptions(options, state, reconfigure) {
+  options = options || {};
+
+  if (reconfigure) {
+    // retain any options that are not explictly specified.
+    ['bufferSize', 'highWaterMark', 'lowWaterMark', 'objectMode', 'encoding'].forEach(function(e) {
+      if (!(e in options))
+        options[e] = state[e];
+    });
+  }
+
+  // the argument passed to this._read(n,cb)
+  state.bufferSize = options.bufferSize || 16 * 1024;
+
+  // the point at which it stops calling _read() to fill the buffer
+  // Note: 0 is a valid value, means "don't call _read preemptively ever"
+  var hwm = options.highWaterMark;
+  state.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
+
+  // the minimum number of bytes to buffer before emitting 'readable'
+  // default to pushing everything out as fast as possible.
+  state.lowWaterMark = options.lowWaterMark || 0;
+
+  // cast to ints.
+  state.bufferSize = ~~state.bufferSize;
+  state.lowWaterMark = ~~state.lowWaterMark;
+  state.highWaterMark = ~~state.highWaterMark;
+
+  if (state.lowWaterMark > state.highWaterMark)
+    throw new Error('lowWaterMark cannot be higher than highWaterMark');
+
+  // object stream flag. Used to make read(n) ignore n and to
+  // make all the buffer merging and length checks go away
+  if (reconfigure && state.objectMode != !!options.objectMode)
+    throw new Error('objectMode cannot be reconfigured');
+  state.objectMode = !!options.objectMode;
+
   if (options.encoding) {
+    if (reconfigure && state.encoding != options.encoding)
+      throw new Error('encoding cannot be reconfigured');
     if (!StringDecoder)
       StringDecoder = require('string_decoder').StringDecoder;
-    this.decoder = new StringDecoder(options.encoding);
+    state.decoder = new StringDecoder(options.encoding);
   }
 }
 
@@ -821,3 +837,12 @@ function endReadable(stream) {
     stream.emit('end');
   });
 }
+
+// Allow extension classes to reconfigure buffering parameters.
+// Note: This must never be called from Readable itself.
+Readable.prototype.reconfigure = function(options) {
+  var state = stream._readableState;
+  setStreamOptions(options, state, true);
+
+  // TODO: emit 'readable' when required
+};

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -33,29 +33,6 @@ var Stream = require('stream');
 util.inherits(Writable, Stream);
 
 function WritableState(options, stream) {
-  options = options || {};
-
-  // the point at which write() starts returning false
-  // Note: 0 is a valid value, means that we always return false if
-  // the entire buffer is not flushed immediately on write()
-  var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
-
-  // the point that it has to get to before we call _write(chunk,cb)
-  // default to pushing everything out as fast as possible.
-  this.lowWaterMark = options.lowWaterMark || 0;
-
-  // object stream flag to indicate whether or not this stream
-  // contains buffers or objects.
-  this.objectMode = !!options.objectMode;
-
-  // cast to ints.
-  this.lowWaterMark = ~~this.lowWaterMark;
-  this.highWaterMark = ~~this.highWaterMark;
-
-  if (this.lowWaterMark > this.highWaterMark)
-    throw new Error('lowWaterMark cannot be higher than highWaterMark');
-
   this.needDrain = false;
   // at the start of calling end()
   this.ending = false;
@@ -65,12 +42,6 @@ function WritableState(options, stream) {
   this.finished = false;
   // when 'finish' is being emitted
   this.finishing = false;
-
-  // should we decode strings into buffers before passing to _write?
-  // this is here so that some node-core streams can optimize string
-  // handling at a lower level.
-  var noDecode = options.decodeStrings === false;
-  this.decodeStrings = !noDecode;
 
   // not an actual buffer we keep track of, but a measurement
   // of how much we're waiting to get pushed to some underlying
@@ -101,6 +72,48 @@ function WritableState(options, stream) {
   this.writelen = 0;
 
   this.buffer = [];
+
+  setStreamOptions(options, this);
+}
+
+function setStreamOptions(options, state, reconfigure) {
+  options = options || {};
+
+  if (reconfigure) {
+    // retain any options that are not explictly specified.
+    ['highWaterMark', 'lowWaterMark', 'objectMode', 'decodeStrings'].forEach(function(e) {
+      options[e] = options[e] || state[e];
+    });
+  }
+
+  // the point at which write() starts returning false
+  // Note: 0 is a valid value, means that we always return false if
+  // the entire buffer is not flushed immediately on write()
+  var hwm = options.highWaterMark;
+  state.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
+
+  // the point that it has to get to before we call _write(chunk,cb)
+  // default to pushing everything out as fast as possible.
+  state.lowWaterMark = options.lowWaterMark || 0;
+
+  // object stream flag to indicate whether or not this stream
+  // contains buffers or objects.
+  state.objectMode = !!options.objectMode;
+
+  // cast to ints.
+  state.lowWaterMark = ~~state.lowWaterMark;
+  state.highWaterMark = ~~state.highWaterMark;
+
+  if (state.lowWaterMark > state.highWaterMark)
+    throw new Error('lowWaterMark cannot be higher than highWaterMark');
+
+  // should we decode strings into buffers before passing to _write?
+  // this is here so that some node-core streams can optimize string
+  // handling at a lower level.
+  var noDecode = options.decodeStrings === false;
+  if (reconfigure && options.decodeStrings != !noDecode)
+    throw new Error('decodeStrings cannot be reconfigured');
+  state.decodeStrings = !noDecode;
 }
 
 function Writable(options) {
@@ -318,4 +331,13 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   }
 
   state.ended = true;
+};
+
+// Allow extension classes to reconfigure buffering parameters.
+// Note: This must never be called from Writeable itself.
+Writable.prototype.reconfigure = function(options) {
+  var state = this._writableState;
+  setStreamOptions(options, state, true);
+
+  // TODO: emit 'drain' when required
 };


### PR DESCRIPTION
This method is intended to allow extensible reconfiguration of the initially supplied stream options, as discussed in https://github.com/joyent/node/issues/4776.

The current implementation is intended for discussion of the implications of such a method.

Note: Calling `reconfigure()` with new options might break the stream buffering.
