### PR TITLE
test: Fix tls tests which fail sporadically

### DIFF
--- a/test/simple/test-tls-over-http-tunnel.js
+++ b/test/simple/test-tls-over-http-tunnel.js
@@ -34,7 +34,6 @@ var https = require('https');
 
 var proxyPort = common.PORT + 1;
 var gotRequest = false;
-var errorCount = 0;
 
 var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
@@ -164,12 +163,15 @@ proxy.listen(proxyPort, function() {
         server.close();
       });
     }).on('error', function() {
-      errorCount++;
+      // We're ok with getting ECONNRESET in this test, but it's
+      // timing-dependent, and thus unreliable. Any other errors
+      // are just failures, though.
+      if (er.code !== 'ECONNRESET')
+        throw er;
     }).end();
   }
 });
 
 process.on('exit', function() {
   assert.ok(gotRequest);
-  assert.equal(errorCount, 1);
 });

--- a/test/simple/test-tls-session-cache.js
+++ b/test/simple/test-tls-session-cache.js
@@ -50,12 +50,15 @@ function doTest() {
     requestCert: true
   };
   var requestCount = 0;
-  var errorCount = 0;
   var session;
 
   var server = tls.createServer(options, function(cleartext) {
-    cleartext.on('error', function() {
-      errorCount++;
+    cleartext.on('error', function(er) {
+      // We're ok with getting ECONNRESET in this test, but it's
+      // timing-dependent, and thus unreliable. Any other errors
+      // are just failures, though.
+      if (er.code !== 'ECONNRESET')
+        throw er;
     });
     ++requestCount;
     cleartext.end();
@@ -98,6 +101,5 @@ function doTest() {
 
     // initial request + reconnect requests (5 times)
     assert.equal(requestCount, 6);
-    assert.equal(errorCount, 4);
   });
 }


### PR DESCRIPTION
The count of ECONNRESETs is dependent on timing, and thus unreliable, especially on Linux machines.

/cc @trevnorris @indutny
