### PR TITLE
test: add create raw EventEmitter object

### DIFF
--- a/test/simple/test-event-emitter-baseclass.js
+++ b/test/simple/test-event-emitter-baseclass.js
@@ -22,23 +22,10 @@
 var common = require('../common');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
-var util = require('util');
 
-util.inherits(MyEE, EventEmitter);
-
-function MyEE(cb) {
-  this.on('foo', cb);
-  process.nextTick(this.emit.bind(this, 'foo'));
-  EventEmitter.call(this);
-}
-
-var called = false;
-var myee = new MyEE(function() {
-  called = true;
-});
+var ee = new require('events').EventEmitter();
 
 process.on('exit', function() {
-  assert(called);
-  assert(myee instanceof EventEmitter);
+  assert(ee instanceof EventEmitter);
   console.log('ok');
 });


### PR DESCRIPTION
This test currently fails, but I think it should succeed.  (Pull request as example of bug, basically.)  

These two forms are not parallel:

``` js
e = new require('events').EventEmitter(); // undefined
s = new require('http').Server(); // http.Server object
```

However, for some reason, adding parens to the first form makes it returns the expected result:

``` js
e = new (require('events').EventEmitter)();
```

(The `http.Server` version also works with parens in the same place.)
