### PR TITLE
Refactoring: semicolons and functions

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -484,7 +484,7 @@
       nextTickQueue.push(obj);
       infoBox[length]++;
     }
-  };
+  }
 
   function evalScript(name) {
     var Module = NativeModule.require('module');
@@ -784,7 +784,7 @@
       cp._forkChild(fd);
       assert(process.send);
     }
-  }
+  };
 
   startup.resolveArgv0 = function() {
     var cwd = process.cwd();
@@ -845,15 +845,15 @@
 
   NativeModule.getCached = function(id) {
     return NativeModule._cache[id];
-  }
+  };
 
   NativeModule.exists = function(id) {
     return NativeModule._source.hasOwnProperty(id);
-  }
+  };
 
   NativeModule.getSource = function(id) {
     return NativeModule._source[id];
-  }
+  };
 
   NativeModule.wrap = function(script) {
     return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];

--- a/src/node.js
+++ b/src/node.js
@@ -484,7 +484,7 @@
       nextTickQueue.push(obj);
       infoBox[length]++;
     }
-  }
+  };
 
   function evalScript(name) {
     var Module = NativeModule.require('module');


### PR DESCRIPTION
Accoring to Google javascript style guide, semicolons are necessary at the
end of function expressions, and not at function declarations.
http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml#semicolons
Modified src/node.js along to this guild line.
