### PR TITLE
_makeLong now normalizes paths on windows

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -453,7 +453,7 @@ if (isWindows) {
       return '';
     }
 
-    var resolvedPath = exports.resolve(path);
+    var resolvedPath = exports.resolve(exports.normalize(path));
 
     if (/^[a-zA-Z]\:\\/.test(resolvedPath)) {
       // path is local filesystem path, which needs to be converted


### PR DESCRIPTION
This allows developers to use a common style of paths across systems without concern for resolving paths on windows.  Today, a developer must normalize paths if they want to have their code work on windows.  With this change a developer can call file system module functions without having to call path.normalize first.
