### PR TITLE
process: fix bug where spinner wasn't called

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -483,6 +483,11 @@
 
       nextTickQueue.push(obj);
       infoBox[length]++;
+
+      if (needSpinner) {
+        _needTickCallback();
+        needSpinner = false;
+      }
     }
   };
 


### PR DESCRIPTION
Apperently there is a case where calling the spinner was required after
passing a callback to nextTick(). This fixes that issue.

This is to fix an issue as mentioned by @TooTallNate in https://github.com/joyent/node/commit/86c0745a5ebd75a4a5fa69420dfde657a5e717bc#commitcomment-2664427.

A test should be included here, but it's way too late for me to figure it out.
