### PR TITLE
Made path.join throw a TypeError if its arguments were not strings.

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -198,6 +198,9 @@ if (isWindows) {
   // windows version
   exports.join = function() {
     function f(p) {
+      if (typeof p !== 'string') {
+        throw new TypeError('Arguments to join must be strings');
+      }
       return p && typeof p === 'string';
     }
 
@@ -349,6 +352,9 @@ if (isWindows) {
   exports.join = function() {
     var paths = Array.prototype.slice.call(arguments, 0);
     return exports.normalize(paths.filter(function(p, index) {
+      if (typeof p !== 'string') {
+        throw new TypeError('Arguments to join must be strings');
+      }
       return p && typeof p === 'string';
     }).join('/'));
   };

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -218,9 +218,7 @@ var joinTests =
      [['/', '//foo'], '/foo'],
      [['/', '', '/foo'], '/foo'],
      [['', '/', 'foo'], '/foo'],
-     [['', '/', '/foo'], '/foo'],
-     // filtration of non-strings.
-     [['x', true, 7, 'y', null, {}], 'x/y']
+     [['', '/', '/foo'], '/foo']
     ];
 
 // Windows-specific join tests
@@ -284,6 +282,13 @@ joinTests.forEach(function(test) {
   // assert.equal(actual, expected, message);
 });
 assert.equal(failures.length, 0, failures.join(''));
+var joinThrowTests = [true, false, 7, null, {}, undefined, [], NaN];
+joinThrowTests.forEach(function(test) {
+  assert.throws(function() {
+    path.join(test);
+  }, TypeError);
+});
+
 
 // path normalize tests
 if (isWindows) {


### PR DESCRIPTION
lib/path.js:
    - throws a TypeError on the filter if the argument is not a string.

  test/simple/test-path.js:
    - removed the test to check if non-string types are filtered.
    - added a test to check if path.join throws TypeError on arguments that
      are not strings.
