### PR TITLE
Fixed unexpected non-RSA verification failures.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1533,6 +1533,7 @@ Handle<Value> Connection::GetPeerCertificate(const Arguments& args) {
     EVP_PKEY *pkey = NULL;
     RSA *rsa = NULL;
     if( NULL != (pkey = X509_get_pubkey(peer_cert))
+        && EVP_PKEY_RSA == EVP_PKEY_id(pkey)
         && NULL != (rsa = EVP_PKEY_get1_RSA(pkey)) ) {
         BN_print(bio, rsa->n);
         BIO_get_mem_ptr(bio, &mem);


### PR DESCRIPTION
I have signed the CLA.

This fix ensures that RSA verification is only used for RSA signatures and fixes intermittent connection failures to a variety of Google application servers.

joyent/node#4771
