### PR TITLE
Add documentation for http.ServerResponse finish, fixes #4494

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -197,6 +197,17 @@ passed as the second parameter to the `'request'` event.
 The response implements the [Writable Stream][] interface. This is an
 [EventEmitter][] with the following events:
 
+### Event: 'finish'
+
+`function () { }`
+
+Emitted when the response has been sent. More specifically, this event is
+emitted when the last segment of the response headers and body have been
+handed off to the operating system for transmission over the network. It
+does not imply that the client has received anything yet.
+
+After this event, no more events will be emitted on the response object.
+
 ### Event: 'close'
 
 `function () { }`


### PR DESCRIPTION
Please merge this as soon as possible, this event is in the released version of node but the documentation doesn't match that.

See the referenced bug for more details.
