### PR TITLE
http: Handle hangup writes more gently

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -447,6 +447,7 @@ function OutgoingMessage() {
   this._trailer = '';
 
   this.finished = false;
+  this._hangupClose = false;
 }
 util.inherits(OutgoingMessage, Stream);
 
@@ -501,12 +502,24 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
     return this.connection.write(data, encoding);
   } else if (this.connection && this.connection.destroyed) {
     // The socket was destroyed.  If we're still trying to write to it,
-    // then something bad happened.
-    // If we've already raised an error on this message, then just ignore.
-    if (!this._hadError) {
-      this.emit('error', createHangUpError());
-      this._hadError = true;
+    // then something bad happened, but it could be just that we haven't
+    // gotten the 'close' event yet.
+    //
+    // In v0.10 and later, this isn't a problem, since ECONNRESET isn't
+    // ignored in the first place.  We'll probably emit 'close' on the
+    // next tick, but just in case it's not coming, set a timeout that
+    // will emit it for us.
+    if (!this._hangupClose) {
+      this._hangupClose = true;
+      var socket = this.socket;
+      var timer = setTimeout(function() {
+        socket.emit('close');
+      });
+      socket.on('close', function() {
+        clearTimeout(timer);
+      });
     }
+    return false;
   } else {
     // buffer, as long as we're not destroyed.
     this._buffer(data, encoding);

--- a/test/simple/test-http-destroyed-socket-write.js
+++ b/test/simple/test-http-destroyed-socket-write.js
@@ -75,15 +75,6 @@ server.listen(common.PORT, function() {
     var writes = 0;
     var sawFalseWrite;
 
-    var gotError = false;
-    sec.on('error', function(er) {
-      assert.equal(gotError, false);
-      gotError = true;
-      assert(er.code === 'ECONNRESET');
-      clearTimeout(timer);
-      test();
-    });
-
     function write() {
       if (++writes === 64) {
         clearTimeout(timer);
@@ -121,7 +112,7 @@ server.listen(common.PORT, function() {
         console.error('bad happened', sec.output, sec.outputEncodings);
       assert.equal(sec.output.length, 0);
       assert.equal(sec.outputEncodings, 0);
-      assert(gotError);
+      assert(sawFalseWrite);
       assert(gotFirstResponse);
       assert(gotFirstData);
       assert(gotFirstEnd);


### PR DESCRIPTION
I'm not 100% sure that this is a good idea.

It's somewhat nice to be alerted that your write was not ever received.  And certainly, throwing an error (v0.8.20) is better than leaking memory (v0.8.19).

However, the introduction of a new error in this case is very shocking to people, and is causing some hardships.  Perhaps it would be nicer to treat an ECONNRESET as a close, and prevent data from being buffered forever, while ensuring that the `'close'` will actually get emitted.

What do you think?

cc: @bnoordhuis @davepacheco @dannycoates @mcavage
