### PR TITLE
Adding support for util.extend(origin, [...]);

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -227,3 +227,18 @@ through the `constructor.super_` property.
         console.log('Received data: "' + data + '"');
     })
     stream.write("It works!"); // Received data: "It works!"
+
+## util.extend(origin, [...])
+
+Copy properties from any number of other objects onto the `origin` object.
+This is a shallow copy only, nested objects are not traversed.
+The origin object is returned.
+
+    var util = require("util");
+    
+    var original = { key: 'value' };
+    var copy = {};
+    
+    util.extend(copy, original);
+    copy.key;
+      // "value"

--- a/lib/util.js
+++ b/lib/util.js
@@ -560,6 +560,7 @@ exports.inherits = function(ctor, superCtor) {
   });
 };
 
+
 exports._extend = function(origin, add) {
   // Don't do anything if add isn't an object
   if (!add || typeof add !== 'object') return origin;
@@ -568,6 +569,20 @@ exports._extend = function(origin, add) {
   var i = keys.length;
   while (i--) {
     origin[keys[i]] = add[keys[i]];
+  }
+  return origin;
+};
+
+
+/**
+ * Copy properties from any number of other objects onto a target origin object.
+ *
+ * @param {Object} origin The object to copy properties onto.
+ * @return {Object} The origin object.
+ */
+exports.extend = function(origin) {
+  for (var i = 1, l = arguments.length; i < l; i++) {
+    exports._extend(origin, arguments[i]);
   }
   return origin;
 };

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -78,3 +78,16 @@ assert.deepEqual(util._extend({a:1}, true),       {a:1});
 assert.deepEqual(util._extend({a:1}, false),      {a:1});
 assert.deepEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
 assert.deepEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});
+
+// extend
+assert.deepEqual(util.extend({a:1}),                      {a:1});
+assert.deepEqual(util.extend({}, {a:1}),                  {a:1});
+assert.deepEqual(util.extend({a:1}, []),                  {a:1});
+assert.deepEqual(util.extend({a:1}, null),                {a:1});
+assert.deepEqual(util.extend({a:1}, true),                {a:1});
+assert.deepEqual(util.extend({a:1}, false),               {a:1});
+assert.deepEqual(util.extend({a:1}, {b:2}),               {a:1, b:2});
+assert.deepEqual(util.extend({a:1, b:2}, {b:3}),          {a:1, b:3});
+assert.deepEqual(util.extend({a:1}, {b:2}, {c:3}),        {a:1, b:2, c:3});
+assert.deepEqual(util.extend({a:1, b:2}, {b:3}, {b:4}),   {a:1, b:4});
+assert.deepEqual(util.extend({}, null, [], false, {a:1}), {a:1});


### PR DESCRIPTION
The extend function is a staple of modern JavaScript
development. Yes, it's easy to implement, and everyone does it.
But functionality that everyone implements is exactly the kind
of thing that belongs in the core.

The extend function is so useful, in fact, that node already has
one, it just happens to be called _extend to make it secret.
Let's make it public and save everyone the burden of re-
inventing this particular wheel every time we make something.
