### PR TITLE
crypto: fix base64 padding regression

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -258,7 +258,7 @@ Cipher.prototype.final = function(outputEncoding) {
 
   if (outputEncoding && outputEncoding !== 'buffer') {
     this._decoder = getDecoder(this._decoder, outputEncoding);
-    ret = this._decoder.write(ret);
+    ret = this._decoder.end(ret);
   }
 
   return ret;

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -858,3 +858,10 @@ assertSorted(crypto.getHashes());
   var c = crypto.createDecipher('aes-128-ecb', '');
   assert.throws(function() { c.final('utf8') }, /invalid public key/);
 })();
+
+// Base64 padding regression test, see #4837.
+(function() {
+  var c = crypto.createCipher('aes-256-cbc', 'secret');
+  var s = c.update('test', 'utf8', 'base64') + c.final('base64');
+  assert.equal(s, '375oxUQCIocvxmC5At+rvA==');
+})();


### PR DESCRIPTION
Commit 9901b69c introduces a small regression where the trailing base64
padding is no longer written out when Cipher#final is called. Rectify
that.

Fixes #4837.

Reviewer: @isaacs or @indutny
