### PR TITLE
process: fix domain nextTick regression

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -376,10 +376,7 @@
       // no callbacks to run
       if (infoBox[length] === 0)
         return infoBox[index] = infoBox[depth] = 0;
-      if (nextTickQueue[infoBox[length] - 1].domain)
-        _tickDomainCallback();
-      else
-        _tickCallback();
+      process._tickCallback();
     }
 
     // run callbacks that have no domain
@@ -396,6 +393,8 @@
       inTick = true;
 
       while (infoBox[depth]++ < process.maxTickDepth) {
+        if (usingDomains)
+          return tickDone(0);
         nextTickLength = infoBox[length];
         if (infoBox[index] === nextTickLength)
           return tickDone(0);

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -10,5 +10,5 @@ AssertionError: 1 == 2
     at Module.load (module.js:*:*)
     at Function.Module._load (module.js:*:*)
     at Module.runMain (module.js:*:*)
-    at _tickCallback (node.js:*:*)
+    at process._tickCallback (node.js:*:*)
     at process._tickFromSpinner (node.js:*:*)

--- a/test/message/max_tick_depth_trace.out
+++ b/test/message/max_tick_depth_trace.out
@@ -11,7 +11,7 @@ Trace: (node) warning: Recursive process.nextTick detected. This will break in t
     at maxTickWarn (node.js:*:*)
     at process.nextTick (node.js:*:*
     at f (*test*message*max_tick_depth_trace.js:*:*)
-    at _tickCallback (node.js:*:*)
+    at process._tickCallback (node.js:*:*)
     at process._tickFromSpinner (node.js:*:*)
 tick 11
 tick 10
@@ -27,7 +27,7 @@ Trace: (node) warning: Recursive process.nextTick detected. This will break in t
     at maxTickWarn (node.js:*:*)
     at process.nextTick (node.js:*:*
     at f (*test*message*max_tick_depth_trace.js:*:*)
-    at _tickCallback (node.js:*:*)
+    at process._tickCallback (node.js:*:*)
     at process._tickFromSpinner (node.js:*:*)
 tick 1
 tick 0

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -3,5 +3,5 @@
         ^
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
-    at _tickCallback (node.js:*:*)
+    at process._tickCallback (node.js:*:*)
     at process._tickFromSpinner (node.js:*:*)

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -11,5 +11,5 @@ ReferenceError: foo is not defined
     at Module.load (module.js:*)
     at *._load (module.js:*)
     at Module.runMain (module.js:*)
-    at _tickCallback (node.js:*)
+    at process._tickCallback (node.js:*)
     at *._tickFromSpinner (node.js:*)

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -110,6 +110,12 @@ d.on('error', function(er) {
       assert.ok(!er.domainBound);
       break;
 
+    case 'nextTick execution loop':
+      assert.equal(er.domain, d);
+      assert.ok(!er.domainEmitter);
+      assert.ok(!er.domainBound);
+      break;
+
     default:
       console.error('unexpected error, throwing %j', er.message, er);
       throw er;
@@ -125,6 +131,18 @@ process.on('exit', function() {
   assert.equal(caught, expectCaught, 'caught the expected number of errors');
   console.log('ok');
 });
+
+
+
+// revert to using the domain when a callback is passed to nextTick in
+// the middle of a tickCallback loop
+d.run(function() {
+  process.nextTick(function() {
+    throw new Error('nextTick execution loop');
+  });
+});
+expectCaught++;
+
 
 
 // catch thrown errors no matter how many times we enter the event loop


### PR DESCRIPTION
Fix for GH-4856

I'm not happy with the additional check in the `_tickCallback` outer loop, but i'll save optimizing that for another day. The issue is fixed, and added the additional test.
