### PR TITLE
EventEmitter Cleanups

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -87,6 +87,12 @@ Returns an array of listeners for the specified event.
 
 Execute each of the listeners in order with the supplied arguments.
 
+
+### Class Method: EventEmitter.listenerCount(emitter, event)
+
+Return the number of listeners for a given event.
+
+
 ### Event: 'newListener'
 
 * `event` {String} The event name

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -22,6 +22,7 @@
 module.exports = Readable;
 Readable.ReadableState = ReadableState;
 
+var EE = require('events').EventEmitter;
 var Stream = require('stream');
 var util = require('util');
 var StringDecoder;
@@ -451,7 +452,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // however, don't suppress the throwing behavior for this.
   function onerror(er) {
     unpipe();
-    if (dest.listeners('error').length === 0)
+    if (EE.listenerCount(dest, 'error') === 0)
       dest.emit('error', er);
   }
   dest.once('error', onerror);
@@ -537,7 +538,7 @@ function flow(src) {
     state.flowing = false;
 
     // if there were data event listeners added, then switch to old mode.
-    if (src.listeners('data').length)
+    if (EE.listenerCount(src, 'data') > 0)
       emitDataEvents(src);
     return;
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -165,18 +165,18 @@ EventEmitter.prototype.addListener = function(type, listener) {
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 EventEmitter.prototype.once = function(type, listener) {
-  if ('function' !== typeof listener) {
-    throw TypeError('.once only takes instances of Function');
+  if (typeof type !== 'string')
+    throw TypeError('type must be a string');
+  if (typeof listener !== 'function')
+    throw TypeError('listener must be a function');
+
+  function g() {
+    this.removeListener(type, g);
+    listener.apply(this, arguments);
   }
 
-  var self = this;
-  function g() {
-    self.removeListener(type, g);
-    listener.apply(this, arguments);
-  };
-
   g.listener = listener;
-  self.on(type, g);
+  this.on(type, g);
 
   return this;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,8 @@
 var isArray = Array.isArray;
 var domain;
 
+exports.usingDomains = false;
+
 function EventEmitter() {
   this.domain = null;
   if (exports.usingDomains) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -245,37 +245,42 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 };
 
 EventEmitter.prototype.removeAllListeners = function(type) {
-  if (!this._events) return this;
+  var key, listeners;
 
-  // fast path
+  if (arguments.length > 0 && typeof type !== 'string')
+    throw TypeError('type must not be set or must be a string');
+
+  if (!this._events)
+    return this;
+
+  // not listening for removeListener, no need to emit
   if (!this._events.removeListener) {
-    if (arguments.length === 0) {
-      this._events = {};
-    } else if (type && this._events && this._events[type]) {
+    if (arguments.length === 0)
+      this._events = null;
+    else if (this._events[type])
       this._events[type] = null;
-    }
     return this;
   }
 
-  // slow(ish) path, emit 'removeListener' events for all removals
+  // emit removeListener for all listeners on all events
   if (arguments.length === 0) {
-    for (var key in this._events) {
+    for (key in this._events) {
       if (key === 'removeListener') continue;
       this.removeAllListeners(key);
     }
     this.removeAllListeners('removeListener');
-    this._events = {};
+    this._events = null;
     return this;
   }
 
-  var listeners = this._events[type];
-  if (isArray(listeners)) {
-    while (listeners.length) {
-      // LIFO order
-      this.removeListener(type, listeners[listeners.length - 1]);
-    }
-  } else if (listeners) {
+  listeners = this._events[type];
+
+  if (typeof listeners === 'function') {
     this.removeListener(type, listeners);
+  } else {
+    // LIFO order
+    while (listeners.length)
+      this.removeListener(type, listeners[listeners.length - 1]);
   }
   this._events[type] = null;
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -50,43 +50,38 @@ EventEmitter.prototype.setMaxListeners = function(n) {
   this._maxListeners = n;
 };
 
-// non-global reference, for speed.
-var PROCESS;
-
 EventEmitter.prototype.emit = function(type) {
+  var er, handler, len, args, i, listeners;
+
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events.error ||
         (typeof this._events.error === 'object' &&
          !this._events.error.length)) {
+      er = arguments[1];
       if (this.domain) {
-        var er = arguments[1];
         er.domainEmitter = this;
         er.domain = this.domain;
         er.domainThrown = false;
         this.domain.emit('error', er);
-        return false;
-      }
-
-      if (arguments[1] instanceof Error) {
-        throw arguments[1]; // Unhandled 'error' event
+      } else if (er instanceof Error) {
+        throw er; // Unhandled 'error' event
       } else {
-        throw TypeError("Uncaught, unspecified 'error' event.");
+        throw TypeError('Uncaught, unspecified "error" event.');
       }
       return false;
     }
   }
 
-  var handler = this._events[type];
-  if (!handler) return false;
+  handler = this._events[type];
+
+  if (typeof handler === 'undefined')
+    return false;
+
+  if (this.domain && this !== process)
+    this.domain.enter();
 
   if (typeof handler == 'function') {
-    if (this.domain) {
-      PROCESS = PROCESS || process;
-      if (this !== PROCESS) {
-        this.domain.enter();
-      }
-    }
     switch (arguments.length) {
       // fast cases
       case 1:
@@ -100,39 +95,28 @@ EventEmitter.prototype.emit = function(type) {
         break;
       // slower
       default:
-        var l = arguments.length;
-        var args = new Array(l - 1);
-        for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+        len = arguments.length;
+        args = new Array(len - 1);
+        for (i = 1; i < len; i++)
+          args[i - 1] = arguments[i];
         handler.apply(this, args);
     }
-    if (this.domain && this !== PROCESS) {
-      this.domain.exit();
-    }
-    return true;
-
   } else if (typeof handler === 'object') {
-    if (this.domain) {
-      PROCESS = PROCESS || process;
-      if (this !== PROCESS) {
-        this.domain.enter();
-      }
-    }
-    var l = arguments.length;
-    var args = new Array(l - 1);
-    for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+    len = arguments.length;
+    args = new Array(len - 1);
+    for (i = 1; i < len; i++)
+      args[i - 1] = arguments[i];
 
-    var listeners = handler.slice();
-    for (var i = 0, l = listeners.length; i < l; i++) {
+    listeners = handler.slice();
+    len = listeners.length;
+    for (i = 0; i < len; i++)
       listeners[i].apply(this, args);
-    }
-    if (this.domain && this !== PROCESS) {
-      this.domain.exit();
-    }
-    return true;
-
-  } else {
-    return false;
   }
+
+  if (this.domain && this !== process)
+    this.domain.exit();
+
+  return true;
 };
 
 EventEmitter.prototype.addListener = function(type, listener) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -203,42 +203,47 @@ EventEmitter.prototype.once = function(type, listener) {
 
 // emits a 'removeListener' event iff the listener was removed
 EventEmitter.prototype.removeListener = function(type, listener) {
-  if ('function' !== typeof listener) {
-    throw TypeError('removeListener only takes instances of Function');
-  }
+  var list, position, length, i;
 
-  // does not use listeners(), so no side effect of creating _events[type]
-  if (!this._events || !this._events[type]) return this;
+  if (typeof type !== 'string')
+    throw TypeError('type must be a string');
+  if (typeof listener !== 'function')
+    throw TypeError('listener must be a function');
 
-  var list = this._events[type];
+  if (!this._events || !this._events[type])
+    return this;
 
-  if (isArray(list)) {
-    var position = -1;
-    for (var i = 0, length = list.length; i < length; i++) {
+  list = this._events[type];
+  length = list.length;
+  position = -1;
+
+  if (list === listener ||
+      (typeof list.listener === 'function' && list.listener === listener)) {
+    this._events[type] = null;
+    if (this._events.removeListener)
+      this.emit('removeListener', type, listener);
+
+  } else if (isArray(list)) {
+    for (i = 0; i < length; i++) {
       if (list[i] === listener ||
-          (list[i].listener && list[i].listener === listener))
-      {
+          (list[i].listener && list[i].listener === listener)) {
         position = i;
         break;
       }
     }
 
-    if (position < 0) return this;
-    list.splice(position, 1);
-    if (list.length == 0)
+    if (position < 0)
+      return this;
+
+    if (list.length === 1) {
+      list.length = 0;
       this._events[type] = null;
-
-    if (this._events.removeListener) {
-      this.emit('removeListener', type, listener);
+    } else {
+      list.splice(position, 1);
     }
-  } else if (list === listener ||
-             (list.listener && list.listener === listener))
-  {
-    this._events[type] = null;
 
-    if (this._events.removeListener) {
+    if (this._events.removeListener)
       this.emit('removeListener', type, listener);
-    }
   }
 
   return this;

--- a/lib/events.js
+++ b/lib/events.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var isArray = Array.isArray;
 var domain;
 
 exports.usingDomains = false;
@@ -33,7 +32,7 @@ function EventEmitter() {
       this.domain = domain.active;
     }
   }
-  this._events = this._events || null;
+  this._events = this._events || {};
   this._maxListeners = this._maxListeners || defaultMaxListeners;
 }
 exports.EventEmitter = EventEmitter;
@@ -57,8 +56,9 @@ var PROCESS;
 EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
-    if (!this._events || !this._events.error ||
-        (isArray(this._events.error) && !this._events.error.length)) {
+    if (!this._events.error ||
+        (typeof this._events.error === 'object' &&
+         !this._events.error.length)) {
       if (this.domain) {
         var er = arguments[1];
         er.domainEmitter = this;
@@ -77,7 +77,6 @@ EventEmitter.prototype.emit = function(type) {
     }
   }
 
-  if (!this._events) return false;
   var handler = this._events[type];
   if (!handler) return false;
 
@@ -111,7 +110,7 @@ EventEmitter.prototype.emit = function(type) {
     }
     return true;
 
-  } else if (isArray(handler)) {
+  } else if (typeof handler === 'object') {
     if (this.domain) {
       PROCESS = PROCESS || process;
       if (this !== PROCESS) {
@@ -153,7 +152,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
   if (!this._events[type]) {
     // Optimize the case of one listener. Don't need the extra array object.
     this._events[type] = listener;
-  } else if (isArray(this._events[type])) {
+  } else if (typeof this._events[type] === 'object') {
 
     // If we've already got an array, just append.
     this._events[type].push(listener);
@@ -165,7 +164,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
   }
 
   // Check for listener leak
-  if (isArray(this._events[type]) && !this._events[type].warned) {
+  if (typeof this._events[type] === 'object' && !this._events[type].warned) {
     var m;
     m = this._maxListeners;
 
@@ -219,11 +218,11 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 
   if (list === listener ||
       (typeof list.listener === 'function' && list.listener === listener)) {
-    this._events[type] = null;
+    this._events[type] = undefined;
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
 
-  } else if (isArray(list)) {
+  } else if (typeof list === 'object') {
     for (i = 0; i < length; i++) {
       if (list[i] === listener ||
           (list[i].listener && list[i].listener === listener)) {
@@ -237,7 +236,7 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 
     if (list.length === 1) {
       list.length = 0;
-      this._events[type] = null;
+      this._events[type] = undefined;
     } else {
       list.splice(position, 1);
     }
@@ -261,9 +260,9 @@ EventEmitter.prototype.removeAllListeners = function(type) {
   // not listening for removeListener, no need to emit
   if (!this._events.removeListener) {
     if (arguments.length === 0)
-      this._events = null;
+      this._events = {};
     else if (this._events[type])
-      this._events[type] = null;
+      this._events[type] = undefined;
     return this;
   }
 
@@ -274,7 +273,7 @@ EventEmitter.prototype.removeAllListeners = function(type) {
       this.removeAllListeners(key);
     }
     this.removeAllListeners('removeListener');
-    this._events = null;
+    this._events = {};
     return this;
   }
 
@@ -287,7 +286,7 @@ EventEmitter.prototype.removeAllListeners = function(type) {
     while (listeners.length)
       this.removeListener(type, listeners[listeners.length - 1]);
   }
-  this._events[type] = null;
+  this._events[type] = undefined;
 
   return this;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -136,38 +136,35 @@ EventEmitter.prototype.emit = function(type) {
 };
 
 EventEmitter.prototype.addListener = function(type, listener) {
-  if ('function' !== typeof listener) {
-    throw TypeError('addListener only takes instances of Function');
-  }
+  var m;
 
-  if (!this._events) this._events = {};
+  if (typeof type !== 'string')
+    throw TypeError('type must be a string');
+  if (typeof listener !== 'function')
+    throw TypeError('listener must be a function');
 
-  // To avoid recursion in the case that type == "newListener"! Before
+  if (!this._events)
+    this._events = {};
+
+  // To avoid recursion in the case that type === "newListener"! Before
   // adding it to the listeners, first emit "newListener".
-  if (this._events.newListener) {
+  if (this._events.newListener)
     this.emit('newListener', type, typeof listener.listener === 'function' ?
               listener.listener : listener);
-  }
 
-  if (!this._events[type]) {
+  if (!this._events[type])
     // Optimize the case of one listener. Don't need the extra array object.
     this._events[type] = listener;
-  } else if (typeof this._events[type] === 'object') {
-
+  else if (typeof this._events[type] === 'object')
     // If we've already got an array, just append.
     this._events[type].push(listener);
-
-  } else {
+  else
     // Adding the second element, need to change to array.
     this._events[type] = [this._events[type], listener];
 
-  }
-
   // Check for listener leak
   if (typeof this._events[type] === 'object' && !this._events[type].warned) {
-    var m;
     m = this._maxListeners;
-
     if (m && m > 0 && this._events[type].length > m) {
       this._events[type].warned = true;
       console.error('(node) warning: possible EventEmitter memory ' +

--- a/lib/events.js
+++ b/lib/events.js
@@ -288,11 +288,14 @@ EventEmitter.prototype.removeAllListeners = function(type) {
 };
 
 EventEmitter.prototype.listeners = function(type) {
-  if (!this._events || !this._events[type]) return [];
-  if (!isArray(this._events[type])) {
+  if (typeof type !== 'string')
+    throw TypeError('event type must be a string');
+
+  if (!this._events || !this._events[type])
+    return [];
+  if (typeof this._events[type] === 'function')
     return [this._events[type]];
-  }
-  return this._events[type].slice(0);
+  return this._events[type].slice();
 };
 
 EventEmitter.listenerCount = function(emitter, type) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -46,6 +46,8 @@ exports.EventEmitter = EventEmitter;
 // that to be increased. Set to zero for unlimited.
 var defaultMaxListeners = 10;
 EventEmitter.prototype.setMaxListeners = function(n) {
+  if (typeof n !== 'number' || n < 0)
+    throw TypeError('n must be a positive number');
   this._maxListeners = n;
 };
 
@@ -56,8 +58,7 @@ EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events || !this._events.error ||
-        (isArray(this._events.error) && !this._events.error.length))
-    {
+        (isArray(this._events.error) && !this._events.error.length)) {
       if (this.domain) {
         var er = arguments[1];
         er.domainEmitter = this;
@@ -70,7 +71,7 @@ EventEmitter.prototype.emit = function(type) {
       if (arguments[1] instanceof Error) {
         throw arguments[1]; // Unhandled 'error' event
       } else {
-        throw new Error("Uncaught, unspecified 'error' event.");
+        throw TypeError("Uncaught, unspecified 'error' event.");
       }
       return false;
     }
@@ -137,7 +138,7 @@ EventEmitter.prototype.emit = function(type) {
 
 EventEmitter.prototype.addListener = function(type, listener) {
   if ('function' !== typeof listener) {
-    throw new Error('addListener only takes instances of Function');
+    throw TypeError('addListener only takes instances of Function');
   }
 
   if (!this._events) this._events = {};
@@ -185,7 +186,7 @@ EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 EventEmitter.prototype.once = function(type, listener) {
   if ('function' !== typeof listener) {
-    throw new Error('.once only takes instances of Function');
+    throw TypeError('.once only takes instances of Function');
   }
 
   var self = this;
@@ -203,7 +204,7 @@ EventEmitter.prototype.once = function(type, listener) {
 // emits a 'removeListener' event iff the listener was removed
 EventEmitter.prototype.removeListener = function(type, listener) {
   if ('function' !== typeof listener) {
-    throw new Error('removeListener only takes instances of Function');
+    throw TypeError('removeListener only takes instances of Function');
   }
 
   // does not use listeners(), so no side effect of creating _events[type]

--- a/lib/events.js
+++ b/lib/events.js
@@ -286,3 +286,14 @@ EventEmitter.prototype.listeners = function(type) {
   }
   return this._events[type].slice(0);
 };
+
+EventEmitter.listenerCount = function(emitter, type) {
+  var ret;
+  if (!emitter._events || !emitter._events[type])
+    ret = 0;
+  else if (typeof emitter._events[type] === 'function')
+    ret = 1;
+  else
+    ret = emitter._events[type].length;
+  return ret;
+};

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1161,7 +1161,7 @@ fs.unwatchFile = function(filename, listener) {
     stat.removeAllListeners('change');
   }
 
-  if (stat.listeners('change').length === 0) {
+  if (EventEmitter.listenerCount(stat, 'change') === 0) {
     stat.stop();
     statWatchers[filename] = undefined;
   }

--- a/lib/http.js
+++ b/lib/http.js
@@ -1523,7 +1523,7 @@ function socketOnData(d, start, end) {
     var bodyHead = d.slice(start + bytesParsed, end);
 
     var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-    if (req.listeners(eventName).length) {
+    if (EventEmitter.listenerCount(req, eventName) > 0) {
       req.upgradeOrConnect = true;
 
       // detach the socket
@@ -1874,7 +1874,7 @@ function connectionListener(socket) {
       var bodyHead = d.slice(start + bytesParsed, end);
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-      if (self.listeners(eventName).length) {
+      if (EventEmitter.listenerCount(self, eventName) > 0) {
         self.emit(eventName, req, req.socket, bodyHead);
       } else {
         // Got upgrade header or CONNECT method, but have no handler.
@@ -1958,7 +1958,7 @@ function connectionListener(socket) {
         (req.httpVersionMajor == 1 && req.httpVersionMinor == 1) &&
         continueExpression.test(req.headers['expect'])) {
       res._expect_continue = true;
-      if (self.listeners('checkContinue').length) {
+      if (EventEmitter.listenerCount(self, 'checkContinue') > 0) {
         self.emit('checkContinue', req, res);
       } else {
         res.writeContinue();

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -616,7 +616,7 @@ Interface.prototype._ttyWrite = function(s, key) {
 
     switch (key.name) {
       case 'c':
-        if (this.listeners('SIGINT').length) {
+        if (EventEmitter.listenerCount(this, 'SIGINT') > 0) {
           this.emit('SIGINT');
         } else {
           // This readline instance is finished
@@ -673,7 +673,7 @@ Interface.prototype._ttyWrite = function(s, key) {
 
       case 'z':
         if (process.platform == 'win32') break;
-        if (this.listeners('SIGTSTP').length) {
+        if (EventEmitter.listenerCount(this, 'SIGTSTP') > 0) {
           this.emit('SIGTSTP');
         } else {
           process.once('SIGCONT', (function(self) {
@@ -829,7 +829,7 @@ function emitKeypressEvents(stream) {
   stream._keypressDecoder = new StringDecoder('utf8');
 
   function onData(b) {
-    if (stream.listeners('keypress').length > 0) {
+    if (EventEmitter.listenerCount(stream, 'keypress') > 0) {
       var r = stream._keypressDecoder.write(b);
       if (r) emitKey(stream, r);
     } else {
@@ -846,7 +846,7 @@ function emitKeypressEvents(stream) {
     }
   }
 
-  if (stream.listeners('keypress').length > 0) {
+  if (EventEmitter.listenerCount(stream, 'keypress') > 0) {
     stream.on('data', onData);
   } else {
     stream.on('newListener', onNewListener);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -21,10 +21,10 @@
 
 module.exports = Stream;
 
-var events = require('events');
+var EE = require('events').EventEmitter;
 var util = require('util');
 
-util.inherits(Stream, events.EventEmitter);
+util.inherits(Stream, EE);
 Stream.Readable = require('_stream_readable');
 Stream.Writable = require('_stream_writable');
 Stream.Duplex = require('_stream_duplex');
@@ -40,7 +40,7 @@ Stream.Stream = Stream;
 // part of this class) is overridden in the Readable class.
 
 function Stream() {
-  events.EventEmitter.call(this);
+  EE.call(this);
 }
 
 Stream.prototype.pipe = function(dest, options) {
@@ -90,7 +90,7 @@ Stream.prototype.pipe = function(dest, options) {
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (this.listeners('error').length === 0) {
+    if (EE.listenerCount(this, 'error') === 0) {
       throw er; // Unhandled stream error in pipe.
     }
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -2477,6 +2477,9 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
                                                     3);
   process->Set(String::NewSymbol("_tickInfoBox"), info_box);
 
+  // pre-set _events object for faster emit checks
+  process->Set(String::NewSymbol("_events"), Object::New());
+
   return process;
 }
 

--- a/test/simple/test-event-emitter-listeners-side-effects.js
+++ b/test/simple/test-event-emitter-listeners-side-effects.js
@@ -33,7 +33,7 @@ var fl;  // foo listeners
 fl = e.listeners('foo');
 assert(Array.isArray(fl));
 assert(fl.length === 0);
-assert.equal(e._events, null);
+assert.deepEqual(e._events, {});
 
 e.on('foo', assert.fail);
 fl = e.listeners('foo');

--- a/test/simple/test-event-emitter-set-max-listeners-side-effects.js
+++ b/test/simple/test-event-emitter-set-max-listeners-side-effects.js
@@ -25,6 +25,6 @@ var events = require('events');
 
 var e = new events.EventEmitter;
 
-assert.strictEqual(e._events, null);
+assert.deepEqual(e._events, {});
 e.setMaxListeners(5);
-assert.strictEqual(e._events, null);
+assert.deepEqual(e._events, {});


### PR DESCRIPTION
Simple argument check additions and code cleanups for the event emitter.

Each commit was created to pass all tests.

`emit` also has a minimal performance gain (~5-10%) from the changes:

```
               emulsify       master
emit - 0 args: 38485 ops/ms   35049 ops/ms
emit - 1 args: 30151 ops/ms   27070 ops/ms
emit - 4 args: 12431 ops/ms   11685 ops/ms
emit - 2 calls: 6025 ops/ms    5900 ops/ms
```
