### PR TITLE
Non standard JavaScript API

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -204,9 +204,12 @@
   };
 
   startup.globalConsole = function() {
-    global.__defineGetter__('console', function() {
+    var descriptor = {};
+    descriptor.get = function() {
       return NativeModule.require('console');
-    });
+    };
+
+    Object.defineProperty(global, 'console', descriptor);
   };
 
 


### PR DESCRIPTION
`__defineGetter__` is not standardized in ECMAScript.
In stead of this API, `Object.defineProperty()` is recommended 
for the future ECMAScript standard.
