### PR TITLE
No next tick main

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -495,6 +495,8 @@ Module._extensions['.node'] = process.dlopen;
 Module.runMain = function() {
   // Load the main module--the command line argument.
   Module._load(process.argv[1], null, true);
+  // Handle any nextTicks added in the first tick of the program
+  process._tickCallback();
 };
 
 Module._initPaths = function() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1337,13 +1337,13 @@ Local<Value> ExecuteString(Handle<String> source, Handle<Value> filename) {
   Local<v8::Script> script = v8::Script::Compile(source, filename);
   if (script.IsEmpty()) {
     ReportException(try_catch, true);
-    exit(1);
+    exit(3);
   }
 
   Local<Value> result = script->Run();
   if (result.IsEmpty()) {
     ReportException(try_catch, true);
-    exit(1);
+    exit(4);
   }
 
   return scope.Close(result);
@@ -1966,7 +1966,7 @@ static void OnFatalError(const char* location, const char* message) {
   } else {
     fprintf(stderr, "FATAL ERROR: %s\n", message);
   }
-  exit(1);
+  exit(5);
 }
 
 void FatalException(TryCatch &try_catch) {
@@ -1981,7 +1981,7 @@ void FatalException(TryCatch &try_catch) {
     // failed before the process._fatalException function was added!
     // this is probably pretty bad.  Nothing to do but report and exit.
     ReportException(try_catch, true);
-    exit(1);
+    exit(6);
   }
 
   Local<Function> fatal_f = Local<Function>::Cast(fatal_v);
@@ -1997,12 +1997,12 @@ void FatalException(TryCatch &try_catch) {
   if (fatal_try_catch.HasCaught()) {
     // the fatal exception function threw, so we must exit
     ReportException(fatal_try_catch, true);
-    exit(1);
+    exit(7);
   }
 
   if (false == caught->BooleanValue()) {
     ReportException(try_catch, true);
-    exit(1);
+    exit(8);
   }
 }
 
@@ -2488,7 +2488,7 @@ static void AtExit() {
 
 static void SignalExit(int signal) {
   uv_tty_reset_mode();
-  _exit(1);
+  _exit(128 + signal);
 }
 
 
@@ -2537,8 +2537,7 @@ void Load(Handle<Object> process_l) {
   f->Call(global, 1, args);
 
   if (try_catch.HasCaught())  {
-    ReportException(try_catch, true);
-    exit(11);
+    FatalException(try_catch);
   }
 }
 
@@ -2568,7 +2567,7 @@ static void ParseDebugOpt(const char* arg) {
   if (p) fprintf(stderr, "Debug port must be in range 1025 to 65535.\n");
 
   PrintHelp();
-  exit(1);
+  exit(12);
 }
 
 static void PrintHelp() {
@@ -2632,7 +2631,7 @@ static void ParseArgs(int argc, char **argv) {
       // argument to -p and --print is optional
       if (is_eval == true && i + 1 >= argc) {
         fprintf(stderr, "Error: %s requires an argument\n", arg);
-        exit(1);
+        exit(13);
       }
 
       print_eval = print_eval || is_print;

--- a/src/node.js
+++ b/src/node.js
@@ -114,10 +114,8 @@
         setTimeout(Module.runMain, debugTimeout);
 
       } else {
-        // REMOVEME: nextTick should not be necessary. This hack to get
-        // test/simple/test-exception-handler2.js working.
         // Main entry point into most programs:
-        process.nextTick(Module.runMain);
+        Module.runMain();
       }
 
     } else {
@@ -156,8 +154,6 @@
         });
       }
     }
-
-    process._needTickCallback();
   }
 
   startup.globalVariables = function() {

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -9,6 +9,6 @@ AssertionError: 1 == 2
     at Object.Module._extensions..js (module.js:*:*)
     at Module.load (module.js:*:*)
     at Function.Module._load (module.js:*:*)
-    at Module.runMain (module.js:*:*)
-    at _tickCallback (node.js:*:*)
-    at process._tickFromSpinner (node.js:*:*)
+    at Function.Module.runMain (module.js:*:*)
+    at startup (node.js:*:*)
+    at node.js:*:*

--- a/test/message/max_tick_depth.out
+++ b/test/message/max_tick_depth.out
@@ -7,8 +7,8 @@ tick 15
 tick 14
 tick 13
 tick 12
-(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 tick 11
+(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 tick 10
 tick 9
 tick 8
@@ -18,6 +18,6 @@ tick 5
 tick 4
 tick 3
 tick 2
-(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 tick 1
+(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 tick 0

--- a/test/message/max_tick_depth_trace.out
+++ b/test/message/max_tick_depth_trace.out
@@ -7,13 +7,14 @@ tick 15
 tick 14
 tick 13
 tick 12
+tick 11
 Trace: (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
     at maxTickWarn (node.js:*:*)
-    at process.nextTick (node.js:*:*
+    at process.nextTick (node.js:*:*)
     at f (*test*message*max_tick_depth_trace.js:*:*)
-    at _tickCallback (node.js:*:*)
-    at process._tickFromSpinner (node.js:*:*)
-tick 11
+    at process._tickCallback (node.js:*:*)
+    at startup (node.js:*:*)
+    at node.js:*:*
 tick 10
 tick 9
 tick 8
@@ -23,11 +24,11 @@ tick 5
 tick 4
 tick 3
 tick 2
+tick 1
 Trace: (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
     at maxTickWarn (node.js:*:*)
-    at process.nextTick (node.js:*:*
+    at process.nextTick (node.js:*:*)
     at f (*test*message*max_tick_depth_trace.js:*:*)
     at _tickCallback (node.js:*:*)
     at process._tickFromSpinner (node.js:*:*)
-tick 1
 tick 0

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -1,7 +1,9 @@
+
 *test*message*nexttick_throw.js:*
         undefined_reference_error_maker;
         ^
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
-    at _tickCallback (node.js:*:*)
-    at process._tickFromSpinner (node.js:*:*)
+    at process._tickCallback (node.js:*:*)
+    at startup (node.js:*:*)
+    at node.js:*:*

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -9,7 +9,7 @@ ReferenceError: foo is not defined
     at Module._compile (module.js:*)
     at *..js (module.js:*)
     at Module.load (module.js:*)
-    at *._load (module.js:*)
-    at Module.runMain (module.js:*)
-    at _tickCallback (node.js:*)
-    at *._tickFromSpinner (node.js:*)
+    at Function.Module._load (module.js:*:*)
+    at Function.Module.runMain (module.js:*:*)
+    at startup (node.js:*:*)
+    at node.js:*:*

--- a/test/simple/test-cluster-master-error.js
+++ b/test/simple/test-cluster-master-error.js
@@ -62,7 +62,8 @@ if (cluster.isWorker) {
 
       // throw accidently error
       process.nextTick(function() {
-        throw 'accidently error';
+        console.error('about to throw');
+        throw new Error('accidently error');
       });
     }
 
@@ -110,7 +111,7 @@ if (cluster.isWorker) {
   master.on('exit', function(code) {
 
     // Check that the cluster died accidently
-    existMaster = (code === 1);
+    existMaster = !!code;
 
     // Give the workers time to shut down
     setTimeout(checkWorkers, 200);

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -110,6 +110,12 @@ d.on('error', function(er) {
       assert.ok(!er.domainBound);
       break;
 
+    case 'nextTick execution loop':
+      assert.equal(er.domain, d);
+      assert.ok(!er.domainEmitter);
+      assert.ok(!er.domainBound);
+      break;
+
     default:
       console.error('unexpected error, throwing %j', er.message, er);
       throw er;
@@ -125,6 +131,18 @@ process.on('exit', function() {
   assert.equal(caught, expectCaught, 'caught the expected number of errors');
   console.log('ok');
 });
+
+
+
+// revert to using the domain when a callback is passed to nextTick in
+// the middle of a tickCallback loop
+d.run(function() {
+  process.nextTick(function() {
+    throw new Error('nextTick execution loop');
+  });
+});
+expectCaught++;
+
 
 
 // catch thrown errors no matter how many times we enter the event loop


### PR DESCRIPTION
This fixes #4856, speeds up startup by a miniscule amount, and fixes a `FIXME` comment that's been around for about a year now.

Don't nextTick the main module, and set exit codes in a way so that we can get some info out of them.
