### PR TITLE
process: separate nextTick domain logic

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -32,6 +32,10 @@ var endMethods = ['end', 'abort', 'destroy', 'destroySoon'];
 // a few side effects.
 events.usingDomains = true;
 
+// replace tickers with domain specific implementation
+process.nextTick = process._nextDomainTick;
+process._tickCallback = process._tickDomainCallback;
+
 exports.Domain = Domain;
 
 exports.create = exports.createDomain = function(cb) {

--- a/src/node.js
+++ b/src/node.js
@@ -305,7 +305,6 @@
   startup.processNextTick = function() {
     var _needTickCallback = process._needTickCallback;
     var nextTickQueue = [];
-    var usingDomains = false;
     var needSpinner = true;
     var inTick = false;
 
@@ -324,6 +323,7 @@
     // needs to be accessible from cc land
     process._tickDomainCallback = _tickDomainCallback;
     process.nextTick = nextTick;
+    process._nextDomainTick = _nextDomainTick;
 
     // the maximum number of times it'll process something like
     // nextTick(function f(){nextTick(f)})
@@ -372,10 +372,7 @@
       // no callbacks to run
       if (infoBox[length] === 0)
         return infoBox[index] = infoBox[depth] = 0;
-      if (nextTickQueue[infoBox[length] - 1].domain)
-        _tickDomainCallback();
-      else
-        _tickCallback();
+      process._tickCallback();
     }
 
     // run callbacks that have no domain
@@ -468,16 +465,27 @@
         maxTickWarn();
 
       var obj = { callback: callback };
-      if (process.domain !== null) {
-        obj.domain = process.domain;
-        // user has opt'd to use domains, so override default functionality
-        if (!usingDomains) {
-          process._tickCallback = _tickDomainCallback;
-          usingDomains = true;
-        }
-      }
 
       nextTickQueue.push(obj);
+      infoBox[length]++;
+
+      if (needSpinner) {
+        _needTickCallback();
+        needSpinner = false;
+      }
+    }
+
+    function _nextDomainTick(callback) {
+      // on the way out, don't bother. it won't get fired anyway.
+      if (process._exiting)
+        return;
+      if (infoBox[depth] >= process.maxTickDepth)
+        maxTickWarn();
+
+      nextTickQueue.push({
+        callback: callback,
+        domain: process.domain
+      });
       infoBox[length]++;
 
       if (needSpinner) {

--- a/test/message/max_tick_depth_trace.out
+++ b/test/message/max_tick_depth_trace.out
@@ -30,6 +30,6 @@ Trace: (node) warning: Recursive process.nextTick detected. This will break in t
     at maxTickWarn (node.js:*:*)
     at process.nextTick (node.js:*:*)
     at f (*test*message*max_tick_depth_trace.js:*:*)
-    at _tickCallback (node.js:*:*)
+    at process._tickCallback (node.js:*:*)
     at process._tickFromSpinner (node.js:*:*)
 tick 0


### PR DESCRIPTION
It's cleaner to only load domain ticker logic when the domains are being
used. This makes execution slightly quicker in both cases, and simpler
from the spinner since there is no need to check if the latest callback
requires use of domains.

@isaacs this has been on my mind since the initial ticker changes, and wanted to throw it out there and see if it stuck. Part of the purpose was to explicitly enforce the use of `_tickCallback` regardless of using domains and w/o depending on `nextTick` to catch if a domain was in place.

And the anal side wanted to simplify the old logic flow (left) to the new logic flow (right):
![old-new-nexttick](https://f.cloud.github.com/assets/289174/203572/2813437a-813d-11e2-9eb8-47bab5cdcac4.png)
