### PR TITLE
test: fix tap output on windows

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -235,9 +235,9 @@ class TapProgressIndicator(SimpleProgressIndicator):
     command = basename(output.command[1])
     if output.UnexpectedOutput():
       print 'not ok %i - %s' % (self._done, command)
-      for l in output.output.stderr.split(os.linesep):
+      for l in output.output.stderr.splitlines():
         print '#' + l
-      for l in output.output.stdout.split(os.linesep):
+      for l in output.output.stdout.splitlines():
         print '#' + l
     else:
       print 'ok %i - %s' % (self._done, command)


### PR DESCRIPTION
Test output is always \n and not platform dependent
