### PR TITLE
src: include scopeid for IPv6 addresses

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -235,6 +235,10 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
     o = Object::New();
     o->Set(String::New("address"), String::New(ip));
     o->Set(String::New("family"), family);
+    if (interfaces[i].address.address4.sin_family == AF_INET6) {
+      o->Set(String::New("scopeid"),
+          Number::New(interfaces[i].address.address6.sin6_scope_id));
+    }
 
     const bool internal = interfaces[i].is_internal;
     o->Set(String::New("internal"),

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -236,8 +236,8 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
     o->Set(String::New("address"), String::New(ip));
     o->Set(String::New("family"), family);
     if (interfaces[i].address.address4.sin_family == AF_INET6) {
-      o->Set(String::New("scopeid"),
-          Number::New(interfaces[i].address.address6.sin6_scope_id));
+      uint32_t scopeid = interfaces[i].address.address6.sin6_scope_id;
+      o->Set(String::New("scopeid"), Integer::NewFromUnsigned(scopeid));
     }
 
     const bool internal = interfaces[i].is_internal;


### PR DESCRIPTION
Include scopeid for IPv6 addresses in the output of `os.networkInterfaces`.
