### PR TITLE
doc: Fix readable.unshift() example

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -264,6 +264,7 @@ SimpleProtocol.prototype._read = function(n) {
       }
       // now, because we got some extra data, unshift the rest
       // back into the read queue so that our consumer will see it.
+      var b = chunk.slice(split);
       this.unshift(b);
 
       // and let them know that we are done parsing the header.


### PR DESCRIPTION
Updated the Stream readable.unshift() example (added in #4878) to fix the reference to an undeclared variable. Thanks for adding unshift() - I was excited to see it land in v0.9.11.

FWIW I recently submitted the Contributor License Agreement.
