### PR TITLE
Fix `emit()` with no listeners.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -73,6 +73,7 @@ EventEmitter.prototype.emit = function(type) {
     }
   }
 
+  if (!this._events) return false;
   handler = this._events[type];
 
   if (typeof handler === 'undefined')


### PR DESCRIPTION
In commit 4f7f8bbd the check for a null `_events` object was removed.  This
is required to avoid a null dereference in the case where the `EventEmitter`
is not called and `addListener()` has not been called yet.  It seems many
modules do not properly chain to the `EventEmitter` constructor.
