### PR TITLE
Windows/msi: Fix msi build issue with WiX 3.7/3.8

### DIFF
--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -9,6 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>node-v$(NodeVersion)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
+    <EnableProjectHarvesting>True</EnableProjectHarvesting>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <NodeVersion Condition=" '$(NodeVersion)' == '' ">0.0.0.0</NodeVersion>


### PR DESCRIPTION
No one is assigned
Fix the msi build with Wix 3.7/3.8 where I ran into the following error:

C:\Users\Raymond Feng\Projects\thirdparty\node\tools\msvs\msi\product.wxs(139):
error LGHT0094: Unresolved reference to symbol 'WixComponentGroup:Product.Gene
rated' in section 'Product:*'. [C:\Users\Raymond Feng\Projects\thirdparty\node\
tools\msvs\msi\nodemsi.wixproj]

The fix was based on:

http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/How-to-get-heat-exe-to-harvest-td7473250.html

I have signed CLA under name "Zhaohui Feng (aka Raymond Feng)".
