### PR TITLE
events: Handle emit before constructor call

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -53,6 +53,9 @@ EventEmitter.prototype.setMaxListeners = function(n) {
 EventEmitter.prototype.emit = function(type) {
   var er, handler, len, args, i, listeners;
 
+  if (!this._events)
+    this._events = {};
+
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events.error ||
@@ -72,9 +75,6 @@ EventEmitter.prototype.emit = function(type) {
       return false;
     }
   }
-
-  if (!this._events)
-    this._events = {};
 
   handler = this._events[type];
 

--- a/test/simple/test-event-emitter-subclass.js
+++ b/test/simple/test-event-emitter-subclass.js
@@ -38,6 +38,16 @@ var myee = new MyEE(function() {
   called = true;
 });
 
+
+util.inherits(ErrorEE, EventEmitter);
+function ErrorEE() {
+  this.emit('error', new Error('blerg'));
+}
+
+assert.throws(function() {
+  new ErrorEE();
+}, /blerg/);
+
 process.on('exit', function() {
   assert(called);
   console.log('ok');


### PR DESCRIPTION
This is breaking all tests that use tap right now.
