### PR TITLE
cluster: Rename destroy() to kill(signal=SIGTERM)

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -178,8 +178,9 @@ on more than one address.
 
 * `worker` {Worker object}
 
-When a workers IPC channel has disconnected this event is emitted. This will happen
-when the worker dies, usually after calling `.destroy()`.
+When a workers IPC channel has disconnected this event is emitted.
+This will happen when the worker dies, usually after calling
+`.kill()`.
 
 When calling `.disconnect()`, there may be a delay between the
 `disconnect` and `exit` events.  This event can be used to detect if
@@ -323,8 +324,9 @@ See: [Child Process module](child_process.html)
 
 * {Boolean}
 
-This property is a boolean. It is set when a worker dies after calling `.destroy()`
-or immediately after calling the `.disconnect()` method. Until then it is `undefined`.
+This property is a boolean. It is set when a worker dies after calling
+`.kill()` or immediately after calling the `.disconnect()` method.
+Until then it is `undefined`.
 
 ### worker.send(message, [sendHandle])
 
@@ -348,7 +350,10 @@ This example will echo back all messages from the master:
       });
     }
 
-### worker.destroy()
+### worker.kill([signal='SIGTERM'])
+
+* `signal` {String} Name of the kill signal to send to the worker
+  process.
 
 This function will kill the worker, and inform the master to not spawn a
 new worker.  The boolean `suicide` lets you distinguish between voluntary
@@ -360,9 +365,11 @@ and accidental exit.
       }
     });
 
-    // destroy worker
-    worker.destroy();
+    // kill worker
+    worker.kill();
 
+This method is aliased as `worker.destroy()` for backwards
+compatibility.
 
 ### worker.disconnect()
 
@@ -375,7 +382,7 @@ the worker finally die.
 
 Because there might be long living connections, it is useful to implement a timeout.
 This example ask the worker to disconnect and after 2 seconds it will destroy the
-server. An alternative would be to execute `worker.destroy()` after 2 seconds, but
+server. An alternative would be to execute `worker.kill()` after 2 seconds, but
 that would normally not allow the worker to do any cleanup if needed.
 
     if (cluster.isMaster) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -401,7 +401,10 @@ Worker.prototype.send = function() {
 };
 
 // Kill the worker without restarting
-Worker.prototype.destroy = function() {
+Worker.prototype.kill = Worker.prototype.destroy = function(signal) {
+  if (!signal)
+    signal = 'SIGTERM';
+
   var self = this;
 
   this.suicide = true;
@@ -411,11 +414,11 @@ Worker.prototype.destroy = function() {
     // this way the worker won't need to propagate suicide state to master
     if (self.process.connected) {
       self.process.once('disconnect', function() {
-        self.process.kill();
+        self.process.kill(signal);
       });
       self.process.disconnect();
     } else {
-      self.process.kill();
+      self.process.kill(signal);
     }
 
   } else {

--- a/test/simple/test-cluster-basic.js
+++ b/test/simple/test-cluster-basic.js
@@ -102,7 +102,7 @@ else if (cluster.isMaster) {
 
   //Kill worker when listening
   cluster.on('listening', function() {
-    worker.destroy();
+    worker.kill();
   });
 
   //Kill process when worker is killed

--- a/test/simple/test-cluster-listening-port.js
+++ b/test/simple/test-cluster-listening-port.js
@@ -32,7 +32,7 @@ if (cluster.isMaster) {
     assert(port);
     // ensure that the port is numerical
     assert.strictEqual(typeof(port), 'number');
-    worker.destroy();
+    worker.kill();
   });
   process.on('exit', function() {
     // ensure that the 'listening' handler has been called

--- a/test/simple/test-cluster-message.js
+++ b/test/simple/test-cluster-message.js
@@ -123,7 +123,7 @@ else if (cluster.isMaster) {
 
     // When the connection ends kill worker and shutdown process
     client.on('end', function() {
-      worker.destroy();
+      worker.kill();
     });
 
     worker.on('exit', function() {

--- a/test/simple/test-cluster-setup-master.js
+++ b/test/simple/test-cluster-setup-master.js
@@ -66,7 +66,7 @@ if (cluster.isWorker) {
       if (correctIn === totalWorkers) {
         checks.args = true;
       }
-      worker.destroy();
+      worker.kill();
     });
 
     // All workers are online


### PR DESCRIPTION
Fix #4133, bringing the cluster worker API more in line with the child process API.
