### PR TITLE
Stream writable refactor

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var path = require('path');
+var silent = +process.env.NODE_BENCH_SILENT;
 
 exports.PORT = process.env.PORT || 12346;
 
@@ -184,7 +185,8 @@ Benchmark.prototype.end = function(operations) {
 
 Benchmark.prototype.report = function(value) {
   var heading = this.getHeading();
-  console.log('%s: %s', heading, value.toPrecision(5));
+  if (!silent)
+    console.log('%s: %s', heading, value.toPrecision(5));
   process.exit(0);
 };
 

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -36,6 +36,6 @@ function PassThrough(options) {
   Transform.call(this, options);
 }
 
-PassThrough.prototype._transform = function(chunk, output, cb) {
+PassThrough.prototype._transform = function(chunk, cb) {
   cb(null, chunk);
 };

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -36,6 +36,6 @@ function PassThrough(options) {
   Transform.call(this, options);
 }
 
-PassThrough.prototype._transform = function(chunk, cb) {
+PassThrough.prototype._transform = function(chunk, encoding, cb) {
   cb(null, chunk);
 };

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -71,10 +71,6 @@ util.inherits(Transform, Duplex);
 
 function TransformState(options, stream) {
   var ts = this;
-  this.output = function(chunk) {
-    ts.needTransform = false;
-    stream.push(chunk);
-  };
 
   this.afterTransform = function(er, data) {
     return afterTransform(stream, er, data);
@@ -99,7 +95,7 @@ function afterTransform(stream, er, data) {
   ts.writecb = null;
 
   if (data !== null && data !== undefined)
-    ts.output(data);
+    stream.push(data);
 
   if (cb)
     cb(er);
@@ -132,7 +128,7 @@ function Transform(options) {
 
   this.once('finish', function() {
     if ('function' === typeof this._flush)
-      this._flush(ts.output, function(er) {
+      this._flush(function(er) {
         done(stream, er);
       });
     else
@@ -140,12 +136,17 @@ function Transform(options) {
   });
 }
 
+Transform.prototype.push = function(chunk) {
+  this._transformState.needTransform = false;
+  return Duplex.prototype.push.call(this, chunk);
+};
+
 // This is the part where you do stuff!
 // override this function in implementation classes.
 // 'chunk' is an input chunk.
 //
-// Call `output(newChunk)` to pass along transformed output
-// to the readable side.  You may call 'output' zero or more times.
+// Call `push(newChunk)` to pass along transformed output
+// to the readable side.  You may call 'push' zero or more times.
 //
 // Call `cb(err)` when you are done with this chunk.  If you pass
 // an error, then that'll put the hurt on the whole operation.  If you
@@ -158,11 +159,13 @@ Transform.prototype._write = function(chunk, cb) {
   var ts = this._transformState;
   ts.writecb = cb;
   ts.writechunk = chunk;
-  if (ts.transforming)
-    return;
-  var rs = this._readableState;
-  if (ts.needTransform || rs.needReadable || rs.length < rs.highWaterMark)
-    this._read(rs.bufferSize);
+  if (!ts.transforming) {
+    var rs = this._readableState;
+    if (ts.needTransform ||
+        rs.needReadable ||
+        rs.length < rs.highWaterMark)
+      this._read(rs.bufferSize);
+  }
 };
 
 // Doesn't matter what the args are here.
@@ -173,13 +176,12 @@ Transform.prototype._read = function(n) {
 
   if (ts.writechunk && ts.writecb && !ts.transforming) {
     ts.transforming = true;
-    this._transform(ts.writechunk, ts.output, ts.afterTransform);
-    return;
+    this._transform(ts.writechunk, ts.afterTransform);
+  } else {
+    // mark that we need a transform, so that any data that comes in
+    // will get processed, now that we've asked for it.
+    ts.needTransform = true;
   }
-
-  // mark that we need a transform, so that any data that comes in
-  // will get processed, now that we've asked for it.
-  ts.needTransform = true;
 };
 
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -155,10 +155,11 @@ Transform.prototype._transform = function(chunk, output, cb) {
   throw new Error('not implemented');
 };
 
-Transform.prototype._write = function(chunk, cb) {
+Transform.prototype._write = function(chunk, encoding, cb) {
   var ts = this._transformState;
   ts.writecb = cb;
   ts.writechunk = chunk;
+  ts.writeencoding = encoding;
   if (!ts.transforming) {
     var rs = this._readableState;
     if (ts.needTransform ||
@@ -176,7 +177,7 @@ Transform.prototype._read = function(n) {
 
   if (ts.writechunk && ts.writecb && !ts.transforming) {
     ts.transforming = true;
-    this._transform(ts.writechunk, ts.afterTransform);
+    this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {
     // mark that we need a transform, so that any data that comes in
     // will get processed, now that we've asked for it.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -32,6 +32,12 @@ var Stream = require('stream');
 
 util.inherits(Writable, Stream);
 
+function WriteReq(chunk, encoding, cb) {
+  this.chunk = chunk;
+  this.encoding = encoding;
+  this.callback = cb;
+}
+
 function WritableState(options, stream) {
   options = options || {};
 
@@ -190,7 +196,7 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
   state.needDrain = !ret;
 
   if (state.writing)
-    state.buffer.push([chunk, encoding, cb]);
+    state.buffer.push(new WriteReq(chunk, encoding, cb));
   else
     doWrite(stream, state, len, chunk, encoding, cb);
 
@@ -268,9 +274,9 @@ function clearBuffer(stream, state) {
 
   for (var c = 0; c < state.buffer.length; c++) {
     var entry = state.buffer[c];
-    var chunk = entry[0];
-    var encoding = entry[1];
-    var cb = entry[2];
+    var chunk = entry.chunk;
+    var encoding = entry.encoding;
+    var cb = entry.callback;
     var len = state.objectMode ? 1 : chunk.length;
 
     doWrite(stream, state, len, chunk, encoding, cb);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -146,15 +146,6 @@ function validChunk(stream, state, chunk, cb) {
   return valid;
 }
 
-function decodeChunk(state, chunk, encoding) {
-  if (!state.objectMode &&
-      state.decodeStrings !== false &&
-      typeof chunk === 'string') {
-    chunk = new Buffer(chunk, encoding);
-  }
-  return chunk;
-}
-
 Writable.prototype.write = function(chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
@@ -177,6 +168,15 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   return ret;
 };
 
+function decodeChunk(state, chunk, encoding) {
+  if (!state.objectMode &&
+      state.decodeStrings !== false &&
+      typeof chunk === 'string') {
+    chunk = new Buffer(chunk, encoding);
+  }
+  return chunk;
+}
+
 // if we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
@@ -184,17 +184,13 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
   chunk = decodeChunk(state, chunk, encoding);
   var len = state.objectMode ? 1 : chunk.length;
 
-  // XXX Remove.  _write() should take an encoding.
-  if (state.decodeStrings === false)
-    chunk = [chunk, encoding];
-
   state.length += len;
 
   var ret = state.length < state.highWaterMark;
   state.needDrain = !ret;
 
   if (state.writing)
-    state.buffer.push([chunk, cb]); // XXX [chunk,encoding,cb]
+    state.buffer.push([chunk, encoding, cb]);
   else
     doWrite(stream, state, len, chunk, encoding, cb);
 
@@ -206,8 +202,7 @@ function doWrite(stream, state, len, chunk, encoding, cb) {
   state.writecb = cb;
   state.writing = true;
   state.sync = true;
-  // XXX stream._write(chunk, encoding, state.onwrite)
-  stream._write(chunk, state.onwrite);
+  stream._write(chunk, encoding, state.onwrite);
   state.sync = false;
 }
 
@@ -271,21 +266,12 @@ function onwriteDrain(stream, state) {
 function clearBuffer(stream, state) {
   state.bufferProcessing = true;
 
-  // XXX buffer entry should be [chunk, encoding, cb]
   for (var c = 0; c < state.buffer.length; c++) {
-    var chunkCb = state.buffer[c];
-    var chunk = chunkCb[0];
-    var cb = chunkCb[1];
-    var encoding = '';
-    var len;
-
-    if (state.objectMode)
-      len = 1;
-    else if (false === state.decodeStrings) {
-      len = chunk[0].length;
-      encoding = chunk[1];
-    } else
-      len = chunk.length;
+    var entry = state.buffer[c];
+    var chunk = entry[0];
+    var encoding = entry[1];
+    var cb = entry[2];
+    var len = state.objectMode ? 1 : chunk.length;
 
     doWrite(stream, state, len, chunk, encoding, cb);
 
@@ -306,10 +292,8 @@ function clearBuffer(stream, state) {
     state.buffer.length = 0;
 }
 
-Writable.prototype._write = function(chunk, cb) {
-  process.nextTick(function() {
-    cb(new Error('not implemented'));
-  });
+Writable.prototype._write = function(chunk, encoding, cb) {
+  cb(new Error('not implemented'));
 };
 
 Writable.prototype.end = function(chunk, encoding, cb) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -53,10 +53,8 @@ function WritableState(options, stream) {
   this.ending = false;
   // when end() has been called, and returned
   this.ended = false;
-  // when 'finish' has emitted
+  // when 'finish' is emitted
   this.finished = false;
-  // when 'finish' is being emitted
-  this.finishing = false;
 
   // should we decode strings into buffers before passing to _write?
   // this is here so that some node-core streams can optimize string
@@ -116,183 +114,196 @@ Writable.prototype.pipe = function() {
   this.emit('error', new Error('Cannot pipe. Not readable.'));
 };
 
-// Override this method or _write(chunk, cb)
-Writable.prototype.write = function(chunk, encoding, cb) {
-  var state = this._writableState;
 
-  if (typeof encoding === 'function') {
-    cb = encoding;
-    encoding = null;
-  }
+function writeAfterEnd(stream, state, cb) {
+  var er = new Error('write after end');
+  // TODO: defer error events consistently everywhere, not just the cb
+  stream.emit('error', er);
+  process.nextTick(function() {
+    cb(er);
+  });
+}
 
-  if (state.ended) {
-    var self = this;
-    var er = new Error('write after end');
-    // TODO: defer error events consistently everywhere, not just the cb
-    self.emit('error', er);
-    if (typeof cb === 'function') {
-      process.nextTick(function() {
-        cb(er);
-      });
-    }
-    return;
-  }
-
-  // If we get something that is not a buffer, string, null, or undefined,
-  // and we're not in objectMode, then that's an error.
-  // Otherwise stream chunks are all considered to be of length=1, and the
-  // watermarks determine how many objects to keep in the buffer, rather than
-  // how many bytes or characters.
+// If we get something that is not a buffer, string, null, or undefined,
+// and we're not in objectMode, then that's an error.
+// Otherwise stream chunks are all considered to be of length=1, and the
+// watermarks determine how many objects to keep in the buffer, rather than
+// how many bytes or characters.
+function validChunk(stream, state, chunk, cb) {
+  var valid = true;
   if (!Buffer.isBuffer(chunk) &&
       'string' !== typeof chunk &&
       chunk !== null &&
       chunk !== undefined &&
       !state.objectMode) {
     var er = new TypeError('Invalid non-string/buffer chunk');
-    if (typeof cb === 'function')
+    stream.emit('error', er);
+    process.nextTick(function() {
       cb(er);
-    this.emit('error', er);
-    return;
+    });
+    valid = false;
   }
+  return valid;
+}
 
-  var len;
-  if (state.objectMode)
-    len = 1;
-  else {
-    len = chunk.length;
-    if (false === state.decodeStrings)
-      chunk = [chunk, encoding || 'utf8'];
-    else if (typeof chunk === 'string') {
-      chunk = new Buffer(chunk, encoding);
-      len = chunk.length;
-    }
+function decodeChunk(state, chunk, encoding) {
+  if (!state.objectMode &&
+      state.decodeStrings !== false &&
+      typeof chunk === 'string') {
+    chunk = new Buffer(chunk, encoding);
   }
+  return chunk;
+}
+
+Writable.prototype.write = function(chunk, encoding, cb) {
+  var state = this._writableState;
+  var ret = false;
+
+  if (typeof encoding === 'function') {
+    cb = encoding;
+    encoding = null;
+  }
+  if (!encoding)
+    encoding = 'utf8';
+
+  if (typeof cb !== 'function')
+    cb = function() {};
+
+  if (state.ended)
+    writeAfterEnd(this, state, cb);
+  else if (validChunk(this, state, chunk, cb))
+    ret = writeOrBuffer(this, state, chunk, encoding, cb);
+
+  return ret;
+};
+
+// if we're already writing something, then just put this
+// in the queue, and wait our turn.  Otherwise, call _write
+// If we return false, then we need a drain event, so set that flag.
+function writeOrBuffer(stream, state, chunk, encoding, cb) {
+  chunk = decodeChunk(state, chunk, encoding);
+  var len = state.objectMode ? 1 : chunk.length;
+
+  // XXX Remove.  _write() should take an encoding.
+  if (state.decodeStrings === false)
+    chunk = [chunk, encoding];
 
   state.length += len;
 
   var ret = state.length < state.highWaterMark;
-  if (ret === false)
-    state.needDrain = true;
+  state.needDrain = !ret;
 
-  // if we're already writing something, then just put this
-  // in the queue, and wait our turn.
-  if (state.writing) {
-    state.buffer.push([chunk, cb]);
-    return ret;
-  }
-
-  state.writing = true;
-  state.sync = true;
-  state.writelen = len;
-  state.writecb = cb;
-  this._write(chunk, state.onwrite);
-  state.sync = false;
+  if (state.writing)
+    state.buffer.push([chunk, cb]); // XXX [chunk,encoding,cb]
+  else
+    doWrite(stream, state, len, chunk, encoding, cb);
 
   return ret;
-};
+}
+
+function doWrite(stream, state, len, chunk, encoding, cb) {
+  state.writelen = len;
+  state.writecb = cb;
+  state.writing = true;
+  state.sync = true;
+  // XXX stream._write(chunk, encoding, state.onwrite)
+  stream._write(chunk, state.onwrite);
+  state.sync = false;
+}
+
+function onwriteError(stream, state, sync, er, cb) {
+  if (sync)
+    process.nextTick(function() {
+      cb(er);
+    });
+  else
+    cb(er);
+
+  stream.emit('error', er);
+}
+
+function onwriteStateUpdate(state) {
+  state.writing = false;
+  state.writecb = null;
+  state.length -= state.writelen;
+  state.writelen = 0;
+}
 
 function onwrite(stream, er) {
   var state = stream._writableState;
   var sync = state.sync;
   var cb = state.writecb;
-  var len = state.writelen;
 
-  state.writing = false;
-  state.writelen = null;
-  state.writecb = null;
+  onwriteStateUpdate(state);
 
-  if (er) {
-    if (cb) {
-      // If _write(chunk,cb) calls cb() in this tick, we still defer
-      // the *user's* write callback to the next tick.
-      // Never present an external API that is *sometimes* async!
-      if (sync)
-        process.nextTick(function() {
-          cb(er);
-        });
-      else
-        cb(er);
+  if (er)
+    onwriteError(stream, state, sync, er, cb);
+  else {
+    if (!finishMaybe(stream, state)) {
+      if (state.length === 0 && state.needDrain)
+        onwriteDrain(stream, state);
+
+      if (!state.bufferProcessing && state.buffer.length)
+        clearBuffer(stream, state);
     }
 
-    // backwards compatibility.  still emit if there was a cb.
-    stream.emit('error', er);
-    return;
-  }
-  state.length -= len;
-
-  if (cb) {
-    // Don't call the cb until the next tick if we're in sync mode.
     if (sync)
       process.nextTick(cb);
     else
       cb();
   }
+}
 
-  if (state.length === 0 && (state.ended || state.ending) &&
-      !state.finished && !state.finishing) {
-    // emit 'finish' at the very end.
-    state.finishing = true;
-    stream.emit('finish');
-    state.finished = true;
-    return;
-  }
-
-  if (state.length === 0 && state.needDrain) {
-    // Must force callback to be called on nextTick, so that we don't
-    // emit 'drain' before the write() consumer gets the 'false' return
-    // value, and has a chance to attach a 'drain' listener.
-    process.nextTick(function() {
-      if (!state.needDrain)
-        return;
+// Must force callback to be called on nextTick, so that we don't
+// emit 'drain' before the write() consumer gets the 'false' return
+// value, and has a chance to attach a 'drain' listener.
+function onwriteDrain(stream, state) {
+  process.nextTick(function() {
+    if (state.needDrain) {
       state.needDrain = false;
       stream.emit('drain');
-    });
-  }
-
-  // if there's something in the buffer waiting, then process it
-  // It would be nice if there were TCO in JS, and we could just
-  // shift the top off the buffer and _write that, but that approach
-  // causes RangeErrors when you have a very large number of very
-  // small writes, and is not very efficient otherwise.
-  if (!state.bufferProcessing && state.buffer.length) {
-    state.bufferProcessing = true;
-
-    for (var c = 0; c < state.buffer.length; c++) {
-      var chunkCb = state.buffer[c];
-      var chunk = chunkCb[0];
-      cb = chunkCb[1];
-
-      if (state.objectMode)
-        len = 1;
-      else if (false === state.decodeStrings)
-        len = chunk[0].length;
-      else
-        len = chunk.length;
-
-      state.writelen = len;
-      state.writecb = cb;
-      state.writechunk = chunk;
-      state.writing = true;
-      state.sync = true;
-      stream._write(chunk, state.onwrite);
-      state.sync = false;
-
-      // if we didn't call the onwrite immediately, then
-      // it means that we need to wait until it does.
-      // also, that means that the chunk and cb are currently
-      // being processed, so move the buffer counter past them.
-      if (state.writing) {
-        c++;
-        break;
-      }
     }
+  });
+}
 
-    state.bufferProcessing = false;
-    if (c < state.buffer.length)
-      state.buffer = state.buffer.slice(c);
-    else
-      state.buffer.length = 0;
+
+// if there's something in the buffer waiting, then process it
+function clearBuffer(stream, state) {
+  state.bufferProcessing = true;
+
+  // XXX buffer entry should be [chunk, encoding, cb]
+  for (var c = 0; c < state.buffer.length; c++) {
+    var chunkCb = state.buffer[c];
+    var chunk = chunkCb[0];
+    var cb = chunkCb[1];
+    var encoding = '';
+    var len;
+
+    if (state.objectMode)
+      len = 1;
+    else if (false === state.decodeStrings) {
+      len = chunk[0].length;
+      encoding = chunk[1];
+    } else
+      len = chunk.length;
+
+    doWrite(stream, state, len, chunk, encoding, cb);
+
+    // if we didn't call the onwrite immediately, then
+    // it means that we need to wait until it does.
+    // also, that means that the chunk and cb are currently
+    // being processed, so move the buffer counter past them.
+    if (state.writing) {
+      c++;
+      break;
+    }
   }
+
+  state.bufferProcessing = false;
+  if (c < state.buffer.length)
+    state.buffer = state.buffer.slice(c);
+  else
+    state.buffer.length = 0;
 }
 
 Writable.prototype._write = function(chunk, cb) {
@@ -317,19 +328,23 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     this.write(chunk, encoding);
 
   // ignore unnecessary end() calls.
-  if (!state.ending && !state.ended && !state.finished)
+  if (!state.ending && !state.finished)
     endWritable(this, state, cb);
 };
 
+function finishMaybe(stream, state) {
+  if (state.ending && state.length === 0 && !state.finished) {
+    state.finished = true;
+    stream.emit('finish');
+  }
+  return state.finished;
+}
+
 function endWritable(stream, state, cb) {
   state.ending = true;
-  if (state.length === 0 && !state.finishing) {
-    state.finishing = true;
-    stream.emit('finish');
-    state.finished = true;
-  }
+  finishMaybe(stream, state);
   if (cb) {
-    if (state.finished || state.finishing)
+    if (state.finished)
       process.nextTick(cb);
     else
       stream.once('finish', cb);

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -160,8 +160,8 @@ function Hash(algorithm, options) {
 
 util.inherits(Hash, stream.Transform);
 
-Hash.prototype._transform = function(chunk, callback) {
-  this._binding.update(chunk);
+Hash.prototype._transform = function(chunk, encoding, callback) {
+  this._binding.update(chunk, encoding);
   callback();
 };
 
@@ -226,8 +226,8 @@ function Cipher(cipher, password, options) {
 
 util.inherits(Cipher, stream.Transform);
 
-Cipher.prototype._transform = function(chunk, callback) {
-  this.push(this._binding.update(chunk));
+Cipher.prototype._transform = function(chunk, encoding, callback) {
+  this.push(this._binding.update(chunk, encoding));
   callback();
 };
 
@@ -351,8 +351,8 @@ function Sign(algorithm, options) {
 
 util.inherits(Sign, stream.Writable);
 
-Sign.prototype._write = function(chunk, callback) {
-  this._binding.update(chunk);
+Sign.prototype._write = function(chunk, encoding, callback) {
+  this._binding.update(chunk, encoding);
   callback();
 };
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -160,13 +160,13 @@ function Hash(algorithm, options) {
 
 util.inherits(Hash, stream.Transform);
 
-Hash.prototype._transform = function(chunk, output, callback) {
+Hash.prototype._transform = function(chunk, callback) {
   this._binding.update(chunk);
   callback();
 };
 
-Hash.prototype._flush = function(output, callback) {
-  output(this._binding.digest());
+Hash.prototype._flush = function(callback) {
+  this.push(this._binding.digest());
   callback();
 };
 
@@ -226,13 +226,13 @@ function Cipher(cipher, password, options) {
 
 util.inherits(Cipher, stream.Transform);
 
-Cipher.prototype._transform = function(chunk, output, callback) {
-  output(this._binding.update(chunk));
+Cipher.prototype._transform = function(chunk, callback) {
+  this.push(this._binding.update(chunk));
   callback();
 };
 
-Cipher.prototype._flush = function(output, callback) {
-  output(this._binding.final());
+Cipher.prototype._flush = function(callback) {
+  this.push(this._binding.final());
   callback();
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1650,12 +1650,14 @@ WriteStream.prototype.open = function() {
 };
 
 
-WriteStream.prototype._write = function(data, cb) {
+WriteStream.prototype._write = function(data, encoding, cb) {
   if (!Buffer.isBuffer(data))
     return this.emit('error', new Error('Invalid data'));
 
   if (typeof this.fd !== 'number')
-    return this.once('open', this._write.bind(this, data, cb));
+    return this.once('open', function() {
+      this._write(data, encoding, cb);
+    });
 
   var self = this;
   fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -161,7 +161,8 @@ function Socket(options) {
 
   initSocketHandle(this);
 
-  this._pendingWrite = null;
+  this._pendingData = null;
+  this._pendingEncoding = '';
 
   // handle strings directly
   this._writableState.decodeStrings = false;
@@ -583,22 +584,20 @@ Socket.prototype.write = function(chunk, encoding, cb) {
 };
 
 
-Socket.prototype._write = function(dataEncoding, cb) {
-  // assert(Array.isArray(dataEncoding));
-  var data = dataEncoding[0];
-  var encoding = dataEncoding[1] || 'utf8';
-
+Socket.prototype._write = function(data, encoding, cb) {
   // If we are still connecting, then buffer this for later.
   // The Writable logic will buffer up any more writes while
   // waiting for this one to be done.
   if (this._connecting) {
-    this._pendingWrite = dataEncoding;
+    this._pendingData = data;
+    this._pendingEncoding = encoding;
     this.once('connect', function() {
-      this._write(dataEncoding, cb);
+      this._write(data, encoding, cb);
     });
     return;
   }
-  this._pendingWrite = null;
+  this._pendingData = null;
+  this._pendingEncoding = '';
 
   timers.active(this);
 
@@ -651,15 +650,16 @@ function createWriteReq(handle, data, encoding) {
 Socket.prototype.__defineGetter__('bytesWritten', function() {
   var bytes = this._bytesDispatched,
       state = this._writableState,
-      pending = this._pendingWrite;
+      data = this._pendingData,
+      encoding = this._pendingEncoding;
 
   state.buffer.forEach(function(el) {
     el = el[0];
     bytes += Buffer.byteLength(el[0], el[1]);
   });
 
-  if (pending)
-    bytes += Buffer.byteLength(pending[0], pending[1]);
+  if (data)
+    bytes += Buffer.byteLength(data, encoding);
 
   return bytes;
 });

--- a/lib/net.js
+++ b/lib/net.js
@@ -391,7 +391,7 @@ Socket.prototype.destroySoon = function() {
   if (this.writable)
     this.end();
 
-  if (this._writableState.finishing || this._writableState.finished)
+  if (this._writableState.finished)
     this.destroy();
   else
     this.once('finish', this.destroy);
@@ -748,7 +748,6 @@ Socket.prototype.connect = function(options, cb) {
     this._writableState.ended = false;
     this._writableState.ending = false;
     this._writableState.finished = false;
-    this._writableState.finishing = false;
     this.destroyed = false;
     this._handle = null;
   }

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -239,6 +239,7 @@ function CryptoStream(pair, options) {
 
   this.pair = pair;
   this._pending = null;
+  this._pendingEncoding = '';
   this._pendingCallback = null;
   this._doneFlag = false;
   this._resumingSession = false;
@@ -300,7 +301,7 @@ function onCryptoStreamEnd() {
 }
 
 
-CryptoStream.prototype._write = function write(data, cb) {
+CryptoStream.prototype._write = function write(data, encoding, cb) {
   assert(this._pending === null);
 
   // Black-hole data
@@ -361,6 +362,7 @@ CryptoStream.prototype._write = function write(data, cb) {
 
   // No write has happened
   this._pending = data;
+  this._pendingEncoding = encoding;
   this._pendingCallback = cb;
 
   if (this === this.pair.cleartext) {
@@ -373,11 +375,13 @@ CryptoStream.prototype._write = function write(data, cb) {
 
 CryptoStream.prototype._writePending = function writePending() {
   var data = this._pending,
+      encoding = this._pendingEncoding,
       cb = this._pendingCallback;
 
   this._pending = null;
+  this._pendingEncoding = '';
   this._pendingCallback = null;
-  this._write(data, cb);
+  this._write(data, encoding, cb);
 };
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -573,7 +573,7 @@ CryptoStream.prototype.destroySoon = function(err) {
   if (this.writable)
     this.end();
 
-  if (this._writableState.finishing || this._writableState.finished)
+  if (this._writableState.finished)
     this.destroy();
   else
     this.once('finish', this.destroy);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -309,7 +309,7 @@ Zlib.prototype.reset = function reset() {
 };
 
 Zlib.prototype._flush = function(callback) {
-  this._transform(null, callback);
+  this._transform(null, '', callback);
 };
 
 Zlib.prototype.flush = function(callback) {
@@ -343,7 +343,7 @@ Zlib.prototype.close = function(callback) {
   });
 };
 
-Zlib.prototype._transform = function(chunk, cb) {
+Zlib.prototype._transform = function(chunk, encoding, cb) {
   var flushFlag;
   var ws = this._writableState;
   var ending = ws.ending || ws.ended;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -308,8 +308,8 @@ Zlib.prototype.reset = function reset() {
   return this._binding.reset();
 };
 
-Zlib.prototype._flush = function(output, callback) {
-  this._transform(null, output, callback);
+Zlib.prototype._flush = function(callback) {
+  this._transform(null, callback);
 };
 
 Zlib.prototype.flush = function(callback) {
@@ -320,12 +320,10 @@ Zlib.prototype.flush = function(callback) {
     ws.needDrain = true;
     var self = this;
     this.once('drain', function() {
-      self._flush(ts.output, callback);
+      self._flush(callback);
     });
-    return;
-  }
-
-  this._flush(ts.output, callback || function() {});
+  } else
+    this._flush(callback || function() {});
 };
 
 Zlib.prototype.close = function(callback) {
@@ -345,7 +343,7 @@ Zlib.prototype.close = function(callback) {
   });
 };
 
-Zlib.prototype._transform = function(chunk, output, cb) {
+Zlib.prototype._transform = function(chunk, cb) {
   var flushFlag;
   var ws = this._writableState;
   var ending = ws.ending || ws.ended;
@@ -392,7 +390,7 @@ Zlib.prototype._transform = function(chunk, output, cb) {
       var out = self._buffer.slice(self._offset, self._offset + have);
       self._offset += have;
       // serve some output to the consumer.
-      output(out);
+      self.push(out);
     }
 
     // exhausted the output buffer, or used all the input create a new one.

--- a/test/simple/test-stream2-finish-pipe.js
+++ b/test/simple/test-stream2-finish-pipe.js
@@ -29,7 +29,7 @@ r._read = function(size) {
 };
 
 var w = new stream.Writable();
-w._write = function(data, cb) {
+w._write = function(data, encoding, cb) {
   cb(null);
 };
 

--- a/test/simple/test-stream2-objects.js
+++ b/test/simple/test-stream2-objects.js
@@ -261,7 +261,7 @@ test('high watermark push', function(t) {
 test('can write objects to stream', function(t) {
   var w = new Writable({ objectMode: true });
 
-  w._write = function(chunk, cb) {
+  w._write = function(chunk, encoding, cb) {
     assert.deepEqual(chunk, { foo: 'bar' });
     cb();
   };
@@ -278,7 +278,7 @@ test('can write multiple objects to stream', function(t) {
   var w = new Writable({ objectMode: true });
   var list = [];
 
-  w._write = function(chunk, cb) {
+  w._write = function(chunk, encoding, cb) {
     list.push(chunk);
     cb();
   };
@@ -303,7 +303,7 @@ test('can write strings as objects', function(t) {
   });
   var list = [];
 
-  w._write = function(chunk, cb) {
+  w._write = function(chunk, encoding, cb) {
     list.push(chunk);
     process.nextTick(cb);
   };
@@ -328,7 +328,7 @@ test('buffers finish until cb is called', function(t) {
   });
   var called = false;
 
-  w._write = function(chunk, cb) {
+  w._write = function(chunk, encoding, cb) {
     assert.equal(chunk, 'foo');
 
     process.nextTick(function() {

--- a/test/simple/test-stream2-pipe-error-handling.js
+++ b/test/simple/test-stream2-pipe-error-handling.js
@@ -40,7 +40,7 @@ var stream = require('stream');
   };
 
   var dest = new stream.Writable();
-  dest._write = function(chunk, cb) {
+  dest._write = function(chunk, encoding, cb) {
     cb();
   };
 
@@ -80,7 +80,7 @@ var stream = require('stream');
   };
 
   var dest = new stream.Writable();
-  dest._write = function(chunk, cb) {
+  dest._write = function(chunk, encoding, cb) {
     cb();
   };
 

--- a/test/simple/test-stream2-push.js
+++ b/test/simple/test-stream2-push.js
@@ -90,9 +90,9 @@ var expectWritten =
     'asdfgasdfgasdfgasdfg',
     'asdfgasdfgasdfgasdfg' ];
 
-writer._write = function(chunk, cb) {
-  console.error('WRITE %s', chunk[0]);
-  written.push(chunk[0]);
+writer._write = function(chunk, encoding, cb) {
+  console.error('WRITE %s', chunk);
+  written.push(chunk);
   process.nextTick(cb);
 };
 

--- a/test/simple/test-stream2-stderr-sync.js
+++ b/test/simple/test-stream2-stderr-sync.js
@@ -61,7 +61,7 @@ function child0() {
     Writable.call(this, opts);
   }
 
-  W.prototype._write = function(chunk, cb) {
+  W.prototype._write = function(chunk, encoding, cb) {
     var req = handle.writeUtf8String(chunk.toString() + '\n');
     // here's the problem.
     // it needs to tell the Writable machinery that it's ok to write

--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -67,7 +67,7 @@ test('writable side consumption', function(t) {
   });
 
   var transformed = 0;
-  tx._transform = function(chunk, cb) {
+  tx._transform = function(chunk, encoding, cb) {
     transformed += chunk.length;
     tx.push(chunk);
     cb();
@@ -106,7 +106,7 @@ test('passthrough', function(t) {
 
 test('simple transform', function(t) {
   var pt = new Transform;
-  pt._transform = function(c, cb) {
+  pt._transform = function(c, e, cb) {
     var ret = new Buffer(c.length);
     ret.fill('x');
     pt.push(ret);
@@ -128,7 +128,7 @@ test('simple transform', function(t) {
 
 test('async passthrough', function(t) {
   var pt = new Transform;
-  pt._transform = function(chunk, cb) {
+  pt._transform = function(chunk, encoding, cb) {
     setTimeout(function() {
       pt.push(chunk);
       cb();
@@ -154,7 +154,7 @@ test('assymetric transform (expand)', function(t) {
   var pt = new Transform;
 
   // emit each chunk 2 times.
-  pt._transform = function(chunk, cb) {
+  pt._transform = function(chunk, encoding, cb) {
     setTimeout(function() {
       pt.push(chunk);
       setTimeout(function() {
@@ -189,7 +189,7 @@ test('assymetric transform (compress)', function(t) {
   // or whatever's left.
   pt.state = '';
 
-  pt._transform = function(chunk, cb) {
+  pt._transform = function(chunk, encoding, cb) {
     if (!chunk)
       chunk = '';
     var s = chunk.toString();
@@ -359,7 +359,7 @@ test('passthrough facaded', function(t) {
 test('object transform (json parse)', function(t) {
   console.error('json parse stream');
   var jp = new Transform({ objectMode: true });
-  jp._transform = function(data, cb) {
+  jp._transform = function(data, encoding, cb) {
     try {
       jp.push(JSON.parse(data));
       cb();
@@ -399,7 +399,7 @@ test('object transform (json parse)', function(t) {
 test('object transform (json stringify)', function(t) {
   console.error('json parse stream');
   var js = new Transform({ objectMode: true });
-  js._transform = function(data, cb) {
+  js._transform = function(data, encoding, cb) {
     try {
       js.push(JSON.stringify(data));
       cb();

--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -82,7 +82,7 @@ test('writable side consumption', function(t) {
   t.equal(transformed, 10);
   t.equal(tx._transformState.writechunk.length, 5);
   t.same(tx._writableState.buffer.map(function(c) {
-    return c[0].length;
+    return c.chunk.length;
   }), [6, 7, 8, 9, 10]);
 
   t.end();

--- a/test/simple/test-stream2-unpipe-drain.js
+++ b/test/simple/test-stream2-unpipe-drain.js
@@ -32,7 +32,7 @@ function TestWriter() {
 }
 util.inherits(TestWriter, stream.Writable);
 
-TestWriter.prototype._write = function (buffer, callback) {
+TestWriter.prototype._write = function (buffer, encoding, callback) {
   console.log('write called');
   // super slow write stream (callback never called)
 };

--- a/test/simple/test-stream2-unpipe-leak.js
+++ b/test/simple/test-stream2-unpipe-leak.js
@@ -31,7 +31,7 @@ function TestWriter() {
 }
 util.inherits(TestWriter, stream.Writable);
 
-TestWriter.prototype._write = function(buffer, callback) {
+TestWriter.prototype._write = function(buffer, encoding, callback) {
   callback(null);
 };
 

--- a/test/simple/test-stream2-writable.js
+++ b/test/simple/test-stream2-writable.js
@@ -33,7 +33,7 @@ function TestWriter() {
   this.written = 0;
 }
 
-TestWriter.prototype._write = function(chunk, cb) {
+TestWriter.prototype._write = function(chunk, encoding, cb) {
   // simulate a small unpredictable latency
   setTimeout(function() {
     this.buffer.push(chunk.toString());
@@ -186,11 +186,10 @@ test('write no bufferize', function(t) {
     decodeStrings: false
   });
 
-  tw._write = function(chunk, cb) {
-    assert(Array.isArray(chunk));
-    assert(typeof chunk[0] === 'string');
-    chunk = new Buffer(chunk[0], chunk[1]);
-    return TestWriter.prototype._write.call(this, chunk, cb);
+  tw._write = function(chunk, encoding, cb) {
+    assert(typeof chunk === 'string');
+    chunk = new Buffer(chunk, encoding);
+    return TestWriter.prototype._write.call(this, chunk, encoding, cb);
   };
 
   var encodings =
@@ -279,7 +278,7 @@ test('end callback after .write() call', function (t) {
 test('encoding should be ignored for buffers', function(t) {
   var tw = new W();
   var hex = '018b5e9a8f6236ffe30e31baf80d2cf6eb';
-  tw._write = function(chunk, cb) {
+  tw._write = function(chunk, encoding, cb) {
     t.equal(chunk.toString('hex'), hex);
     t.end();
   };


### PR DESCRIPTION
This is still a bit of a wip branch, and ought to be squashed somewhat before being merged.  But the results are promising.

Semantic changes to the stream2 API:
1. `Writable.prototype._write` now takes 3 arguments, always: `chunk, encoding, cb`.  If you have not set `decodeStrings: false` in the options, then the first argument will always be a Buffer.  If you have, then it'll be whatever the user provided.
2. `Transform.prototype._transform` does not get an `output` function.  Instead, it also receives `chunk, encoding, cb`, and the user needs to call `stream.push(chunk)` to provide output, just like with Readable streams.

These are both breaking changes to Streams2 up until this point.  @TooTallNate: Please provide feedback.

Cosmetic changes:
1. The `write` and `onwrite` functions in `_stream_writable.js` are completely split up into small methods that do not return early, and get called with consistent argument types (except for the String/Buffer disparity in `_write`, but that can't be helped.)
2. If the user calls `stream.write(chunk)` while a write is already in progress, then the entry in the buffer is a `WriteReq` object, instead of an array.

The performance effect is promising.  I'm seeing about a 6% increase on benchmark/http.sh, and a [lot of green](http://static.izs.me/benchmark-write-refactor-vs-0.8.html) on bench-http, testing against the latest v0.8 branch.

I suspect that more gains could be had by similarly organizing and optimizing the code paths in Socket.write and Readable.read.
