### PR TITLE
events: Allow non-string event names

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -126,7 +126,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
   var m;
 
   if (typeof type !== 'string')
-    throw TypeError('type must be a string');
+    type = '' + type;
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');
 

--- a/test/simple/test-event-emitter-add-listeners.js
+++ b/test/simple/test-event-emitter-add-listeners.js
@@ -59,6 +59,17 @@ var f = new events.EventEmitter();
 f.setMaxListeners(0);
 
 
+// people actually do this.
+// if it was not a locked part of node's API,
+// then this would throw.  Perhaps in 2.0.
+var e = new events.EventEmitter();
+var nonStringEventFired = false;
+e.on(1, function() {
+  nonStringEventFired = true;
+});
+e.emit({toString: function() { return '1'; }});
+assert(nonStringEventFired);
+
 process.on('exit', function() {
   assert.deepEqual(['hello', 'foo'], events_new_listener_emited);
   assert.deepEqual([hello, foo], listeners_new_listener_emited);


### PR DESCRIPTION
As crazy as it may sound, there are examples of this in the wild.

Since this is a locked portion of the API, we cannot introduce a
breaking change.
