### PR TITLE
events: remove type check for event type

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -84,7 +84,7 @@ EventEmitter.prototype.emit = function(type) {
   if (this.domain && this !== process)
     this.domain.enter();
 
-  if (typeof handler == 'function') {
+  if (typeof handler === 'function') {
     switch (arguments.length) {
       // fast cases
       case 1:
@@ -267,11 +267,14 @@ EventEmitter.prototype.removeAllListeners = function(type) {
 };
 
 EventEmitter.prototype.listeners = function(type) {
+  var ret;
   if (!this._events || !this._events[type])
-    return [];
-  if (typeof this._events[type] === 'function')
-    return [this._events[type]];
-  return this._events[type].slice();
+    ret = [];
+  else if (typeof this._events[type] === 'function')
+    ret = [this._events[type]];
+  else
+    ret = this._events[type].slice();
+  return ret;
 };
 
 EventEmitter.listenerCount = function(emitter, type) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -125,8 +125,6 @@ EventEmitter.prototype.emit = function(type) {
 EventEmitter.prototype.addListener = function(type, listener) {
   var m;
 
-  if (typeof type !== 'string')
-    throw TypeError('type must be a string');
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');
 
@@ -168,8 +166,6 @@ EventEmitter.prototype.addListener = function(type, listener) {
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 EventEmitter.prototype.once = function(type, listener) {
-  if (typeof type !== 'string')
-    throw TypeError('type must be a string');
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');
 
@@ -188,8 +184,6 @@ EventEmitter.prototype.once = function(type, listener) {
 EventEmitter.prototype.removeListener = function(type, listener) {
   var list, position, length, i;
 
-  if (typeof type !== 'string')
-    throw TypeError('type must be a string');
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');
 
@@ -235,9 +229,6 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 EventEmitter.prototype.removeAllListeners = function(type) {
   var key, listeners;
 
-  if (arguments.length > 0 && typeof type !== 'string')
-    throw TypeError('type must not be set or must be a string');
-
   if (!this._events)
     return this;
 
@@ -276,9 +267,6 @@ EventEmitter.prototype.removeAllListeners = function(type) {
 };
 
 EventEmitter.prototype.listeners = function(type) {
-  if (typeof type !== 'string')
-    throw TypeError('event type must be a string');
-
   if (!this._events || !this._events[type])
     return [];
   if (typeof this._events[type] === 'function')

--- a/test/simple/test-event-emitter-subclass.js
+++ b/test/simple/test-event-emitter-subclass.js
@@ -27,9 +27,9 @@ var util = require('util');
 util.inherits(MyEE, EventEmitter);
 
 function MyEE(cb) {
-  this.emit('bar');
-  this.on('foo', cb);
-  process.nextTick(this.emit.bind(this, 'foo'));
+  this.once(1, cb);
+  this.emit(1);
+  this.removeAllListeners();
   EventEmitter.call(this);
 }
 
@@ -50,5 +50,6 @@ assert.throws(function() {
 
 process.on('exit', function() {
   assert(called);
+  assert.deepEqual(myee._events, {});
   console.log('ok');
 });


### PR DESCRIPTION
Strict checking for typeof types broke backwards compatibility for other
libraries. This reverts those checks.
