### PR TITLE
[docs] Changes the stability level Domains

### DIFF
--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -1,6 +1,6 @@
 # Domain
 
-    Stability: 1 - Experimental
+    Stability: 2 - Unstable
 
 Domains provide a way to handle multiple different IO operations as a
 single group.  If any of the event emitters or callbacks registered to a


### PR DESCRIPTION
This is an insane, mad-science uber-hack that magically converts the status of Domains from `Experimental` to `Unstable`. Don't ask how this patch works, it's definitely beyond anyones capacity for understanding.
