### PR TITLE
events: Loop backwards in removeListener

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -201,7 +201,7 @@ EventEmitter.prototype.removeListener = function(type, listener) {
       this.emit('removeListener', type, listener);
 
   } else if (typeof list === 'object') {
-    for (i = 0; i < length; i++) {
+    for (i = length; i-- > 0;) {
       if (list[i] === listener ||
           (list[i].listener && list[i].listener === listener)) {
         position = i;


### PR DESCRIPTION
This slowed removeAllListeners down (was `O(n^2)`, is now `O(n)`).

Of course, there are cases where the opposite is true; node should probably switch to ES6 sets as soon as they are an alternative (ie. enabled by default in V8 and fast enough).
