### PR TITLE
--throw-deprecation, fewer nextTick calls in Writable

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -56,6 +56,8 @@ and servers.
 
   --trace-deprecation    show stack traces on deprecations
 
+  --throw-deprecation    throw errors on deprecations
+
   --v8-options           print v8 command line options
 
   --max-stack-size=val   set max v8 stack size (bytes)

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -240,31 +240,35 @@ function onwrite(stream, er) {
   if (er)
     onwriteError(stream, state, sync, er, cb);
   else {
-    if (!finishMaybe(stream, state)) {
-      if (state.length === 0 && state.needDrain)
-        onwriteDrain(stream, state);
+    var finished = finishMaybe(stream, state);
 
-      if (!state.bufferProcessing && state.buffer.length)
-        clearBuffer(stream, state);
+    if (!finished && !state.bufferProcessing && state.buffer.length)
+      clearBuffer(stream, state);
+
+    if (sync) {
+      process.nextTick(function() {
+        afterWrite(stream, state, finished, cb);
+      });
+    } else {
+      afterWrite(stream, state, finished, cb);
     }
-
-    if (sync)
-      process.nextTick(cb);
-    else
-      cb();
   }
+}
+
+function afterWrite(stream, state, finished, cb) {
+  if (!finished)
+    onwriteDrain(stream, state);
+  cb();
 }
 
 // Must force callback to be called on nextTick, so that we don't
 // emit 'drain' before the write() consumer gets the 'false' return
 // value, and has a chance to attach a 'drain' listener.
 function onwriteDrain(stream, state) {
-  process.nextTick(function() {
-    if (state.needDrain) {
-      state.needDrain = false;
-      stream.emit('drain');
-    }
-  });
+  if (state.length === 0 && state.needDrain) {
+    state.needDrain = false;
+    stream.emit('drain');
+  }
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -65,7 +65,9 @@ exports.deprecate = function(fn, msg) {
   var warned = false;
   function deprecated() {
     if (!warned) {
-      if (process.traceDeprecation) {
+      if (process.throwDeprecation) {
+        throw new Error(msg);
+      } else if (process.traceDeprecation) {
         console.trace(msg);
       } else {
         console.error(msg);

--- a/src/node.cc
+++ b/src/node.cc
@@ -127,6 +127,7 @@ static Persistent<String> disposed_symbol;
 static bool print_eval = false;
 static bool force_repl = false;
 static bool trace_deprecation = false;
+static bool throw_deprecation = false;
 static char *eval_string = NULL;
 static int option_end_index = 0;
 static bool use_debug_agent = false;
@@ -2414,6 +2415,11 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
     process->Set(String::NewSymbol("noDeprecation"), True());
   }
 
+  // --throw-deprecation
+  if (throw_deprecation) {
+    process->Set(String::NewSymbol("throwDeprecation"), True());
+  }
+
   // --trace-deprecation
   if (trace_deprecation) {
     process->Set(String::NewSymbol("traceDeprecation"), True());
@@ -2666,6 +2672,9 @@ static void ParseArgs(int argc, char **argv) {
     } else if (strcmp(arg, "--trace-deprecation") == 0) {
       argv[i] = const_cast<char*>("");
       trace_deprecation = true;
+    } else if (strcmp(arg, "--throw-deprecation") == 0) {
+      argv[i] = const_cast<char*>("");
+      throw_deprecation = true;
     } else if (argv[i][0] != '-') {
       break;
     }

--- a/src/node.js
+++ b/src/node.js
@@ -359,7 +359,9 @@
       var msg = '(node) warning: Recursive process.nextTick detected. ' +
                 'This will break in the next version of node. ' +
                 'Please use setImmediate for recursive deferral.';
-      if (process.traceDeprecation)
+      if (process.throwDeprecation)
+        throw new Error(msg);
+      else if (process.traceDeprecation)
         console.trace(msg);
       else
         console.error(msg);

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -50,8 +50,15 @@ function makeRequest() {
 
   var stderrBuffer = '';
 
-  var child = spawn(process.execPath,
-      [childScript, common.PORT, bytesExpected]);
+  // Pass along --trace-deprecation/--throw-deprecation in
+  // process.execArgv to track down nextTick recursion errors
+  // more easily.  Also, this is handy when using this test to
+  // view V8 opt/deopt behavior.
+  var args = process.execArgv.concat([ childScript,
+                                       common.PORT,
+                                       bytesExpected ])
+
+  var child = spawn(process.execPath, args);
 
   child.on('exit', function(code) {
     assert.ok(/DONE/.test(stderrBuffer));


### PR DESCRIPTION
@tjfontaine noticed that a huge amount of nextTick recursion errors were showing up in pummel/test-regress-GH-892.  Since the last refactor to the Writable logic, this was also causing a range error.  (The warnings had previously been in Readable, but the refactor moved the warning to Writable.write, which triggered a console.error, which calls process.stderr.write, aka Socket.write, etc.)

The first commit adds `--throw-deprecation`.  This flag was very helpful in tracking down the recursion warning.  `--trace-deprecation` was not so helpful, since the recursive nature of the warning caused a range error and blew up the output.  It's often good to stop on the first deprecation, print a stack, and quit.

The second commit adds `execArgv` to the arguments passed to the child proc in pummel/test-regress-GH-892.

The third fixes the actual bug.
