### PR TITLE
cares: Set process._errno, not global.errno

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -261,9 +261,9 @@ static const char* AresErrnoString(int errorno) {
 
 static void SetAresErrno(int errorno) {
   HandleScope scope;
-  Handle<Value> key = String::NewSymbol("errno");
-  Handle<Value> value = String::NewSymbol(AresErrnoString(errorno));
-  Context::GetCurrent()->Global()->Set(key, value);
+  Local<Value> key = String::NewSymbol("_errno");
+  Local<Value> value = String::NewSymbol(AresErrnoString(errorno));
+  node::process->Set(key, value);
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -99,7 +99,9 @@ ngx_queue_t req_wrap_queue = { &req_wrap_queue, &req_wrap_queue };
 Persistent<String> process_symbol;
 Persistent<String> domain_symbol;
 
-static Persistent<Object> process;
+// declared in node_internals.h
+Persistent<Object> process;
+
 static Persistent<Function> process_tickDomainCallback;
 static Persistent<Function> process_tickFromSpinner;
 static Persistent<Function> process_tickCallback;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -31,6 +31,9 @@ namespace node {
 // Defined in node.cc
 extern v8::Isolate* node_isolate;
 
+// Defined in node.cc at startup.
+extern v8::Persistent<v8::Object> process;
+
 #ifdef _WIN32
 // emulate snprintf() on windows, _snprintf() doesn't zero-terminate the buffer
 // on overflow...


### PR DESCRIPTION
This makes test-internet pass
