### PR TITLE
Streams2-ify `dgram.Socket`.

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -21,7 +21,7 @@
 
 var assert = require('assert');
 var util = require('util');
-var events = require('events');
+var stream = require('stream');
 
 var UDP = process.binding('udp_wrap').UDP;
 
@@ -106,8 +106,10 @@ exports._createSocketHandle = function(address, port, addressType, fd) {
 };
 
 
-function Socket(type, listener) {
-  events.EventEmitter.call(this);
+function Socket(type, listener, opts) {
+  opts = opts || {};
+  opts.objectMode = true;
+  stream.Duplex.call(this, opts);
 
   var handle = newHandle(type);
   handle.owner = this;
@@ -118,17 +120,22 @@ function Socket(type, listener) {
   this.type = type;
   this.fd = null; // compatibility hack
 
+  this.on('end', this._onEnd.bind(this));
+  this.on('finish', this._onEnd.bind(this));
+
   if (typeof listener === 'function')
     this.on('message', listener);
 }
-util.inherits(Socket, events.EventEmitter);
+util.inherits(Socket, stream.Duplex);
 exports.Socket = Socket;
 
+Socket.prototype._read = function(n) {
+  // do nothing as onMessage calls push() directly
+};
 
 exports.createSocket = function(type, listener) {
   return new Socket(type, listener);
 };
-
 
 function startListening(socket) {
   socket._handle.onmessage = onMessage;
@@ -141,6 +148,72 @@ function startListening(socket) {
   socket.emit('listening');
 }
 
+Socket.prototype._write = function(msg, encoding, cb) {
+  if (!Buffer.isBuffer(msg.data)) {
+    throw new Error('msg.data must be a Buffer');
+  }
+  if (!msg.udp || typeof msg.udp.dstPort !== 'number') {
+    throw new Error('msg.udp.dstPort must be provided');
+  }
+  if (!msg.ip || typeof msg.ip.dst !== 'string') {
+    throw new Error('msg.ip.dst must be provided');
+  }
+  this._send(msg.data, 0, msg.data.length, msg.udp.dstPort, msg.ip.dst, cb);
+};
+
+Socket.prototype.send = function(buffer,
+                                 offset,
+                                 length,
+                                 port,
+                                 address,
+                                 callback) {
+
+  if (!Buffer.isBuffer(buffer))
+    throw new TypeError('First argument must be a buffer object.');
+
+  if (offset >= buffer.length)
+    throw new Error('Offset into buffer too large');
+
+  if (offset + length > buffer.length)
+    throw new Error('Offset + length beyond buffer length');
+
+  var msg = {
+    data: buffer.slice(offset, offset + length),
+    ip: { dst: address },
+    udp: { dstPort: port }
+  };
+
+  // legacy: must include byte length in callback to send()
+  var cb = null;
+  if (typeof callback === 'function') {
+    cb = callback.bind(null, null, length);
+  }
+
+  this.write(msg, null, cb);
+};
+
+Socket.prototype.on = function(ev, fn) {
+  stream.Duplex.prototype.on.call(this, ev, fn);
+
+  if (ev === 'message') {
+    this._flowMessages();
+  }
+};
+
+Socket.prototype._flowMessages = function() {
+  var msg = this.read();
+  if (!msg) {
+    this.once('readable', this._flowMessages.bind(this));
+    return;
+  }
+  var rinfo = {
+    address: msg.ip.src,
+    port: msg.udp.srcPort,
+    size: msg.data.length
+  };
+  this.emit('message', msg.data, rinfo);
+  return this._flowMessages();
+};
 
 Socket.prototype.bind = function(port, address, callback) {
   var self = this;
@@ -219,22 +292,13 @@ Socket.prototype.sendto = function(buffer,
 };
 
 
-Socket.prototype.send = function(buffer,
-                                 offset,
-                                 length,
-                                 port,
-                                 address,
-                                 callback) {
+Socket.prototype._send = function(buffer,
+                                  offset,
+                                  length,
+                                  port,
+                                  address,
+                                  callback) {
   var self = this;
-
-  if (!Buffer.isBuffer(buffer))
-    throw new TypeError('First argument must be a buffer object.');
-
-  if (offset >= buffer.length)
-    throw new Error('Offset into buffer too large');
-
-  if (offset + length > buffer.length)
-    throw new Error('Offset + length beyond buffer length');
 
   callback = callback || noop;
 
@@ -253,7 +317,7 @@ Socket.prototype.send = function(buffer,
       self.once('listening', function() {
         // Flush the send queue.
         for (var i = 0; i < self._sendQueue.length; i++)
-          self.send.apply(self, self._sendQueue[i]);
+          self._send.apply(self, self._sendQueue[i]);
         self._sendQueue = undefined;
       });
     }
@@ -293,6 +357,10 @@ function afterSend(status, handle, req, buffer) {
 
 
 Socket.prototype.close = function() {
+  this.push(null);
+};
+
+Socket.prototype._onEnd = function() {
   this._healthCheck();
   this._stopReceiving();
   this._handle.close();
@@ -406,7 +474,12 @@ function onMessage(handle, slab, start, len, rinfo) {
     return self.emit('error', errnoException(process._errno, 'recvmsg'));
   }
   rinfo.size = len; // compatibility
-  self.emit('message', slab.slice(start, start + len), rinfo);
+  var msg = {
+    data: slab.slice(start, start + len),
+    ip: { src: rinfo.address, protocol: 'udp' },
+    udp: { srcPort: rinfo.port, dataLength: len }
+  };
+  self.push(msg);
 }
 
 

--- a/test/simple/test-dgram-pingpong-stream.js
+++ b/test/simple/test-dgram-pingpong-stream.js
@@ -1,0 +1,140 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+var Buffer = require('buffer').Buffer;
+var dgram = require('dgram');
+var stream = require('stream');
+var util = require('util');
+
+var debug = false;
+var tests_run = 0;
+
+function PingPongServer(opts) {
+  opts = opts || {};
+  opts.objectMode = true;
+  stream.Transform.call(this, opts);
+
+  this.messages = 0;
+}
+util.inherits(PingPongServer, stream.Transform);
+
+PingPongServer.prototype._transform = function(msg, encoding, callback) {
+  if (debug) console.log('server got: ' + msg.data +
+                         ' from ' + msg.ip.src + ':' + msg.udp.srcPort);
+  if (/PING/.exec(msg.data)) {
+    var buf = new Buffer(4);
+    buf.write('PONG');
+    this.messages += 1;
+    this.push({
+      data: buf,
+      ip: { dst: msg.ip.src },
+      udp: { dstPort: msg.udp.srcPort }
+    });
+  }
+  callback();
+};
+
+function PingPongClient(opts) {
+  opts = opts || {};
+  opts.objectMode = true;
+  stream.Transform.call(this, opts);
+
+  this.buf = new Buffer('PING');
+  this.port = ~~opts.port;
+  this.limit = ~~opts.limit;
+  this.count = 0;
+}
+util.inherits(PingPongClient, stream.Transform);
+
+PingPongClient.prototype.sendMsg = function() {
+  this.push({
+    data: this.buf,
+    ip: { dst: 'localhost' },
+    udp: { dstPort: this.port }
+  });
+  this.count += 1;
+};
+
+PingPongClient.prototype._transform = function(msg, encoding, callback) {
+  if (debug) console.log('client got: ' + msg.data +
+                         ' from ' + msg.ip.src + ':' + msg.udp.srcPort);
+  assert.equal('PONG', msg.data.toString('ascii'));
+  this.sendMsg();
+  if (this.count >= this.limit) {
+    this.push(null);
+  }
+  callback();
+};
+
+function pingPongTest(port, host) {
+  var N = 500;
+
+  var pingPongServer = new PingPongServer();
+
+  var server = dgram.createSocket('udp4');
+  server.on('error', function(e) {
+    throw e;
+  });
+
+  server.pipe(pingPongServer).pipe(server);
+
+  server.on('listening', function() {
+    console.log('server listening on ' + port + ' ' + host);
+
+    var client = dgram.createSocket('udp4');
+
+    var pingPongClient = new PingPongClient({ port: port, limit: N });
+    client.on('error', function(e) {
+      throw e;
+    });
+
+    client.pipe(pingPongClient).pipe(client);
+
+    pingPongClient.on('end', function() {
+      console.log('client has closed, closing server');
+      assert.equal(N, pingPongClient.count);
+      tests_run += 1;
+      client.end();
+      server.end();
+      assert.equal(N - 1, pingPongServer.messages);
+    });
+
+    console.log('Client sending to ' + port + ', localhost ' + pingPongClient.buf);
+    pingPongClient.sendMsg();
+  });
+  server.bind(port, host);
+}
+
+// All are run at once, so run on different ports
+pingPongTest(common.PORT + 0, 'localhost');
+pingPongTest(common.PORT + 1, 'localhost');
+pingPongTest(common.PORT + 2);
+//pingPongTest('/tmp/pingpong.sock');
+
+process.on('exit', function() {
+  assert.equal(3, tests_run);
+  console.log('done');
+});


### PR DESCRIPTION
This is a proof-of-concept implementation of a stream-based `dgram.Socket`.
The class is based on `stream.Duplex` with `{objectMode: true}`.

Received UDP packets can be retrieved by calling `read()` and look like
this:

```
{
  data: udpDataPayload,
  ip: { src: '1.2.3.4' },
  udp { srcPort: 52 }
}
```

UDP packets can be sent by passing objects that look like the following to
`write()`:

```
{
  data: udpDataPayload,
  ip: { dst: '4.3.2.1' },
  udp: { dstPort: 123 }
}
```

Backward compatibility is maintained.  The existing `send()` call can be
used freely.  If `on('message')` is called, then packets will automatically
be drained from the read queue and emitted using the existing `'message'`
event API.

See the new stream-based ping-pong test in `test-dgram-pingpong-stream.js`.

Again, this is only a proof-of-concept to get feedback at this point.  If
this is considered something worth pursuing then more tests and API
documentation would need to be written.  I just wanted to get some feedback
before spending more time on it.

The main goal of this change is to be able to take advantage of the `pipe()`
API to easily combine object streams together.  Obviously the streams
back-pressure mechanism won't benefit UDP, but it shouldn't harm it either
since packets can already be lost at any layer during transmission.

Clearly this could also be done as a module wrapper.

Thank you.
