### PR TITLE
Assertion failed if resume called on half-closed connection

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -405,18 +405,19 @@ function onread(buffer, offset, length) {
 
   } else if (errno == 'EOF') {
     // EOF
-    self.readable = false;
+    if (!(self._flags & FLAG_GOT_EOF)) {
+      self.readable = false;
 
-    assert.ok(!(self._flags & FLAG_GOT_EOF));
-    self._flags |= FLAG_GOT_EOF;
+      self._flags |= FLAG_GOT_EOF;
 
-    // We call destroy() before end(). 'close' not emitted until nextTick so
-    // the 'end' event will come first as required.
-    if (!self.writable) self._destroy();
+      // We call destroy() before end(). 'close' not emitted until nextTick so
+      // the 'end' event will come first as required.
+      if (!self.writable) self._destroy();
 
-    if (!self.allowHalfOpen) self.end();
-    if (self._events && self._events['end']) self.emit('end');
-    if (self.onend) self.onend();
+      if (!self.allowHalfOpen) self.end();
+      if (self._events && self._events['end']) self.emit('end');
+      if (self.onend) self.onend();
+    }
   } else {
     // Error
     if (errno == 'ECONNRESET') {

--- a/test/simple/test-http-half-closed-resume.js
+++ b/test/simple/test-http-half-closed-resume.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var net = require('net');
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  req.on('data', function (chunk) {
+    req.pause();
+    setTimeout(function () {
+      req.resume();
+    }, 10);
+  });
+  req.on('end', function () {
+    setTimeout(function () {
+      res.writeHead(200);
+      res.end();
+    }, 10);
+  });
+});
+server.httpAllowHalfOpen = true;
+server.listen(common.PORT);
+
+server.on('listening', function() {
+  var c = net.createConnection(common.PORT);
+  c.write('PUT / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\n');
+  c.on('data', function (chunk) {});
+  c.on('end', function () { server.close(); });
+  c.end('abcde');
+});


### PR DESCRIPTION
Bumped into following problem when working with half-closed client connection: resume called when socket already marked with EOF (check the test case in the PR).
With 0.8.22 the outcome is:

```
assert.js:102
  throw new assert.AssertionError({
        ^
AssertionError: false == true
    at TCP.onread (net.js:410:12)
```

I suppose that assertion could be removed. The same test works fine with current master.
