### PR TITLE
http: incoming parser set to null twice causes crash

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -420,7 +420,7 @@ IncomingMessage.prototype._dump = function() {
     return;
 
   this._dumped = true;
-  this.socket.parser.incoming = null;
+  if (this.socket.parser) this.socket.parser.incoming = null;
   this.push(null);
   readStart(this.socket);
 };

--- a/test/simple/test-regress-GH-4948.js
+++ b/test/simple/test-regress-GH-4948.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// https://github.com/joyent/node/issues/4948
+
+var common = require('../common');
+var http = require('http');
+
+var reqCount = 0;
+var server = http.createServer(function(serverReq, serverRes){
+  if (reqCount) {
+    serverRes.end();
+    server.close();
+    return;
+  }
+  reqCount = 1;
+
+
+  // normally the use case would be to call an external site
+  // does not require connecting locally or to itself to fail
+  var r = http.request({hostname: 'localhost', port: common.PORT}, function(res) {
+    // required, just needs to be in the client response somewhere
+    serverRes.end(); 
+
+    // required for test to fail
+    res.on('data', function(data) { });
+
+  });
+  r.on('error', function(e) {});
+  r.end();
+
+  serverRes.write('some data');
+}).listen(common.PORT);
+
+// simulate a client request that closes early
+var net = require('net');
+
+var sock = new net.Socket();
+sock.connect(common.PORT, 'localhost');
+
+sock.on('connect', function() {
+  sock.write('GET / HTTP/1.1\r\n\r\n');
+  sock.end();
+});


### PR DESCRIPTION
The error:

```
http.js:423
  this.socket.parser.incoming = null;
                              ^
TypeError: Cannot set property 'incoming' of null
    at IncomingMessage._dump (http.js:423:31)
    at ServerResponse.<anonymous> (http.js:1979:13)
    at ServerResponse.EventEmitter.emit (events.js:91:17)
    at ServerResponse.OutgoingMessage._finish (http.js:963:8)
    at ServerResponse.OutgoingMessage.end (http.js:946:10)
    at IncomingMessage.<anonymous> (###### user code #####)
    at IncomingMessage.EventEmitter.emit (events.js:116:20)
    at _stream_readable.js:852:12
    at process._tickCallback (node.js:403:13)
```
