### PR TITLE
stream: Handle highWaterMark option with 'Infinity' value

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -38,7 +38,7 @@ function ReadableState(options, stream) {
   this.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
 
   // cast to ints.
-  this.highWaterMark = ~~this.highWaterMark;
+  this.highWaterMark = Math.floor(this.highWaterMark);
 
   this.buffer = [];
   this.length = 0;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -52,7 +52,7 @@ function WritableState(options, stream) {
   this.objectMode = !!options.objectMode;
 
   // cast to ints.
-  this.highWaterMark = ~~this.highWaterMark;
+  this.highWaterMark = Math.floor(this.highWaterMark);
 
   this.needDrain = false;
   // at the start of calling end()


### PR DESCRIPTION
Currently `Infinity` is treated as 0.
