### PR TITLE
make error argument optional

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -61,7 +61,7 @@ EventEmitter.prototype.emit = function(type) {
     if (!this._events.error ||
         (typeof this._events.error === 'object' &&
          !this._events.error.length)) {
-      er = arguments[1];
+      er = arguments[1] || new Error();
       if (this.domain) {
         er.domainEmitter = this;
         er.domain = this.domain;

--- a/lib/events.js
+++ b/lib/events.js
@@ -61,8 +61,9 @@ EventEmitter.prototype.emit = function(type) {
     if (!this._events.error ||
         (typeof this._events.error === 'object' &&
          !this._events.error.length)) {
-      er = arguments[1] || new Error();
+      er = arguments[1];
       if (this.domain) {
+        if (!er) er = new Error();
         er.domainEmitter = this;
         er.domain = this.domain;
         er.domainThrown = false;

--- a/lib/events.js
+++ b/lib/events.js
@@ -63,7 +63,7 @@ EventEmitter.prototype.emit = function(type) {
          !this._events.error.length)) {
       er = arguments[1];
       if (this.domain) {
-        if (!er) er = new Error();
+        if (!er) er = new TypeError('Uncaught, unspecified "error" event.');
         er.domainEmitter = this;
         er.domain = this.domain;
         er.domainThrown = false;

--- a/test/simple/test-event-emitter-no-error-provided-to-error-event.js
+++ b/test/simple/test-event-emitter-no-error-provided-to-error-event.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+var domain = require('domain');
+
+var errorCatched = false;
+
+var e = new events.EventEmitter();
+
+var d = domain.create();
+d.add(e);
+d.on('error', function (er) {
+  assert(er instanceof Error, 'error created');
+  errorCatched = true;
+});
+
+e.emit('error');
+
+process.on('exit', function () {
+  assert(errorCatched, 'error got catched');
+});

--- a/test/simple/test-event-emitter-no-error-provided-to-error-event.js
+++ b/test/simple/test-event-emitter-no-error-provided-to-error-event.js
@@ -31,7 +31,7 @@ var e = new events.EventEmitter();
 var d = domain.create();
 d.add(e);
 d.on('error', function (er) {
-  assert(er instanceof Error, 'error created');
+  assert(er instanceof TypeError, 'type error created');
   errorCatched = true;
 });
 


### PR DESCRIPTION
`ee.emit('error')` (without an emitted message) doesn't throw when domains aren't active. With them, it does, because `er` is null and starting from line 66 properties are added to it. 

domains shouldn't change the current behavior of EventEmitters.
