### PR TITLE
stream: Fix incorrect error throw when pipe'ing

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -469,7 +469,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.removeListener('close', onclose);
     dest.removeListener('finish', onfinish);
     dest.removeListener('drain', ondrain);
-    dest.removeListener('error', onerror);
+    dest.removeListener('__error__', onerror);
     dest.removeListener('unpipe', onunpipe);
     src.removeListener('end', onend);
     src.removeListener('end', cleanup);
@@ -484,13 +484,12 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   }
 
   // if the dest has an error, then stop piping into it.
-  // however, don't suppress the throwing behavior for this.
+  // however, use the internal shadow error listener '__error__'
+  // to not suppress the throwing behavior.
   function onerror(er) {
     unpipe();
-    if (EE.listenerCount(dest, 'error') === 0)
-      dest.emit('error', er);
   }
-  dest.once('error', onerror);
+  dest.once('__error__', onerror);
 
   // Both close and finish should trigger unpipe, but only once.
   function onclose() {

--- a/lib/events.js
+++ b/lib/events.js
@@ -58,10 +58,14 @@ EventEmitter.prototype.emit = function(type) {
 
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
+    er = arguments[1];
+
+    // Allow internal listeners to hook to error without affecting throwing
+    this.emit('__error__', er);
+
     if (!this._events.error ||
         (typeof this._events.error === 'object' &&
          !this._events.error.length)) {
-      er = arguments[1];
       if (this.domain) {
         if (!er) er = new TypeError('Uncaught, unspecified "error" event.');
         er.domainEmitter = this;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -90,13 +90,11 @@ Stream.prototype.pipe = function(dest, options) {
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (EE.listenerCount(this, 'error') === 0) {
-      throw er; // Unhandled stream error in pipe.
-    }
   }
 
-  source.on('error', onerror);
-  dest.on('error', onerror);
+  // attach to '__error__' to not suppress throwing behavior.
+  source.on('__error__', onerror);
+  dest.on('__error__', onerror);
 
   // remove all the event listeners that were added.
   function cleanup() {
@@ -106,8 +104,8 @@ Stream.prototype.pipe = function(dest, options) {
     source.removeListener('end', onend);
     source.removeListener('close', onclose);
 
-    source.removeListener('error', onerror);
-    dest.removeListener('error', onerror);
+    source.removeListener('__error__', onerror);
+    dest.removeListener('__error__', onerror);
 
     source.removeListener('end', cleanup);
     source.removeListener('close', cleanup);

--- a/test/simple/test-event-emitter-error-throw.js
+++ b/test/simple/test-event-emitter-error-throw.js
@@ -1,0 +1,57 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var EE = require('events').EventEmitter;
+
+var errorCatched = false;
+
+(function testZeroListenerErrorThrow() {
+  var e = new EE();
+
+  assert.equal(EE.listenerCount(e, 'error'), 0);
+  assert.throws(function() {
+    e.emit('error');
+  });
+})();
+
+(function testListenerErrorEmitNotThrow() {
+  var errorEmitted = 0;
+  var e = new EE();
+
+  e.once('error', function(er) {
+    errorEmitted++;
+  });
+
+  assert.equal(EE.listenerCount(e, 'error'), 1);
+  e.emit('error');
+
+  // now test that it still throws when listener is gone
+  assert.equal(EE.listenerCount(e, 'error'), 0);
+  assert.throws(function() {
+    e.emit('error');
+  });
+
+  process.on('exit', function() {
+    assert.equal(errorEmitted, 1);
+  });
+})();

--- a/test/simple/test-event-emitter-error-throw.js
+++ b/test/simple/test-event-emitter-error-throw.js
@@ -55,3 +55,44 @@ var errorCatched = false;
     assert.equal(errorEmitted, 1);
   });
 })();
+
+(function testZeroListenerShadowErrorEmit() {
+  var shadowErrorEmitted = 0;
+  var e = new EE();
+
+  e.once('__error__', function(er) {
+    shadowErrorEmitted++;
+  });
+
+  assert.equal(EE.listenerCount(e, 'error'), 0);
+  assert.throws(function() {
+    e.emit('error');
+  }, function(er) {
+    // test that '__error__' has been emitted before the throw
+    assert.equal(shadowErrorEmitted, 1);
+    return true;
+  });
+})();
+
+(function testListenerShadowErrorEmit() {
+  var shadowErrorEmitted = 0;
+  var errorEmitted = 0;
+  var e = new EE();
+
+  e.once('error', function(er) {
+    errorEmitted++;
+    // test that '__error__' has been emitted before 'error'
+    assert.equal(shadowErrorEmitted, 1);
+  });
+
+  e.once('__error__', function(er) {
+    shadowErrorEmitted++;
+  });
+
+  assert.equal(EE.listenerCount(e, 'error'), 1);
+  e.emit('error');
+
+  process.on('exit', function() {
+    assert.equal(errorEmitted, 1);
+  });
+})();

--- a/test/simple/test-stream-pipe-error-handling.js
+++ b/test/simple/test-stream-pipe-error-handling.js
@@ -39,6 +39,27 @@ var Stream = require('stream').Stream;
   assert.strictEqual(gotErr, err);
 })();
 
+// This test matches the first, except the listener is attached before
+// pipe() is called, and it is removed again in the error callback
+(function testErrorListenerCatchesCleanup() {
+  var source = new Stream();
+  var dest = new Stream();
+
+  var gotErr = null;
+  source.on('error', onerror);
+
+  function onerror(err) {
+    source.removeListener('error', onerror);
+    gotErr = err;
+  }
+
+  source.pipe(dest);
+
+  var err = new Error('This stream turned into bacon.');
+  source.emit('error', err);
+  assert.strictEqual(gotErr, err);
+})();
+
 (function testErrorWithoutListenerThrows() {
   var source = new Stream();
   var dest = new Stream();


### PR DESCRIPTION
Specifically, if an error listener is attached to a stream _before_ it is piped to, _and_ it cleans up efter itself by removing the error listener, the pipe logic will miss this and throw as if it was unhandled.

I'm not sure this is the best way to fix it, but I don't really see any other way with the current EventEmitter interface.

As far as I can tell this error handling error has been there since 0.4.
