### PR TITLE
stream: Ignore new chunks once stream is ended

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -107,16 +107,20 @@ function Readable(options) {
 // write() some more.
 Readable.prototype.push = function(chunk) {
   var state = this._readableState;
-  if (typeof chunk === 'string' && !state.objectMode)
-    chunk = new Buffer(chunk, arguments[1]);
-  return readableAddChunk(this, state, chunk, false);
+  if (!state.ended) {
+    if (typeof chunk === 'string' && !state.objectMode)
+      chunk = new Buffer(chunk, arguments[1]);
+    return readableAddChunk(this, state, chunk, false);
+  }
 };
 
 Readable.prototype.unshift = function(chunk) {
   var state = this._readableState;
-  if (typeof chunk === 'string' && !state.objectMode)
-    chunk = new Buffer(chunk, arguments[1]);
-  return readableAddChunk(this, state, chunk, true);
+  if (!state.ended) {
+    if (typeof chunk === 'string' && !state.objectMode)
+      chunk = new Buffer(chunk, arguments[1]);
+    return readableAddChunk(this, state, chunk, true);
+  }
 };
 
 function readableAddChunk(stream, state, chunk, addToFront) {


### PR DESCRIPTION
Currently, new chunks are buffered, and possibly forwarded to read() before 'end' is emitted.

Alternatively, an 'error' could be emitted when this occurs, but I chose this solution since it seems weird to error on post end `push(x)`, while allowing multiple `push(null)`.
