### PR TITLE
stream: Clear read buffer on unshift(null)

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -126,6 +126,10 @@ function readableAddChunk(stream, state, chunk, addToFront) {
   if (er) {
     stream.emit('error', er);
   } else if (chunk === null || chunk === undefined) {
+    if (addToFront) {
+      state.length = 0;
+      state.buffer = [];
+    }
     onEofChunk(stream, state);
   } else if (state.objectMode || chunk && chunk.length > 0) {
     if (state.decoder)


### PR DESCRIPTION
If you add an 'end' to the front of the read queue with unshift(null), logically the buffered data should be discarded, which this patch enables.
