### PR TITLE
Correction to the docs for path.join()

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -25,7 +25,7 @@ Example:
 ## path.join([path1], [path2], [...])
 
 Join all arguments together and normalize the resulting path.
-Non-string arguments are ignored.
+Arguments must be strings.
 
 Example:
 


### PR DESCRIPTION
In previous versions of node, non-string arguments passed to path.join() were simply ignored.  Now these arguments must be strings, and passing non-string parameters will throw an error.
