### PR TITLE
Make EventEmitter properties non-enumerable.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -24,16 +24,21 @@ var domain;
 exports.usingDomains = false;
 
 function EventEmitter() {
-  this.domain = null;
+  var thisDomain = null;
   if (exports.usingDomains) {
     // if there is an active domain, then attach to it.
     domain = domain || require('domain');
     if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
+      thisDomain = domain.active;
     }
   }
-  this._events = this._events || {};
-  this._maxListeners = this._maxListeners || defaultMaxListeners;
+
+  var properties = {
+    domain: { writable: true, value: thisDomain },
+    _events: { writable: true, value: this._events || {} },
+    _maxListeners: { writable: true, value: this._maxListeners || defaultMaxListeners }
+  };
+  Object.defineProperties(this, properties);
 }
 exports.EventEmitter = EventEmitter;
 


### PR DESCRIPTION
I'm working on an evented data API and the default properties for EventEmitter are really getting in the way. It would be really nice to make these non-enumerable, especially since they are already prefixed with _ and aren't really supposed to used.

This pull request makes domain, _event, and _maxListeners non-enumerable.
