### PR TITLE
Fix child process sending UTF8.

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -325,7 +325,7 @@ function setupChannel(target, channel) {
   channel.buffering = false;
   channel.onread = function(pool, offset, length, recvHandle) {
     if (pool) {
-      jsonBuffer += pool.toString('ascii', offset, offset + length);
+      jsonBuffer += pool.toString('utf8', offset, offset + length);
 
       var i, start = 0;
 


### PR DESCRIPTION
Currently the child process messages are decoded as ASCII, which breaks when UTF8 characters are stringified. As mentioned in this StackOverflow question:
http://stackoverflow.com/questions/15378871/node-js-child-process-send-utf-8-char-issue

I'm happy to add more to this like tests if someone points me in the right direction. Or if there was a reason this was ascii, maybe there is some other solution.

Basic repro steps:

```
var n = require('child_process').fork(...);
n.send('中文');
```
