### PR TITLE
child_process: fix sending utf-8 to child process

### DIFF
--- a/benchmark/misc/child-process-read.js
+++ b/benchmark/misc/child-process-read.js
@@ -1,0 +1,28 @@
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  len: [64, 256, 1024, 4096, 32768],
+  dur: [5]
+});
+
+var spawn = require('child_process').spawn;
+function main(conf) {
+  bench.start();
+
+  var dur = +conf.dur;
+  var len = +conf.len;
+
+  var msg = '"' + Array(len).join('.') + '"';
+  var options = { 'stdio': ['ignore', 'ipc', 'ignore'] };
+  var child = spawn('yes', [msg], options);
+
+  var bytes = 0;
+  child.on('message', function(msg) {
+    bytes += msg.length;
+  });
+
+  setTimeout(function() {
+    child.kill();
+    var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+    bench.end(gbits);
+  }, dur * 1000);
+}

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var StringDecoder = require('string_decoder').StringDecoder;
 var EventEmitter = require('events').EventEmitter;
 var net = require('net');
 var dgram = require('dgram');
@@ -321,11 +322,12 @@ function handleMessage(target, message, handle) {
 function setupChannel(target, channel) {
   target._channel = channel;
 
+  var decoder = new StringDecoder('utf8');
   var jsonBuffer = '';
   channel.buffering = false;
   channel.onread = function(pool, offset, length, recvHandle) {
     if (pool) {
-      jsonBuffer += pool.toString('utf8', offset, offset + length);
+      jsonBuffer += decoder.write(pool.slice(offset, offset + length));
 
       var i, start = 0;
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -325,7 +325,7 @@ function setupChannel(target, channel) {
   channel.buffering = false;
   channel.onread = function(pool, offset, length, recvHandle) {
     if (pool) {
-      jsonBuffer += pool.toString('ascii', offset, offset + length);
+      jsonBuffer += pool.toString('utf8', offset, offset + length);
 
       var i, start = 0;
 

--- a/test/simple/test-child-process-send-utf8.js
+++ b/test/simple/test-child-process-send-utf8.js
@@ -23,7 +23,7 @@ var common = require('../common');
 var assert = require('assert');
 var fork = require('child_process').fork;
 
-var expected = 'ßßßß';
+var expected = Array(1e5).join('ßßßß');
 if (process.argv[2] === 'child') {
   process.send(expected);
 } else {

--- a/test/simple/test-child-process-send-utf8.js
+++ b/test/simple/test-child-process-send-utf8.js
@@ -1,0 +1,34 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fork = require('child_process').fork;
+
+var expected = 'ßßßß';
+if (process.argv[2] === 'child') {
+  process.send(expected);
+} else {
+  var child = fork(process.argv[1], ['child']);
+  child.on('message', common.mustCall(function(actual) {
+    assert.equal(actual, expected);
+  }));
+}


### PR DESCRIPTION
In process#send() and child_process.ChildProcess#send(), use 'utf8' as
the encoding instead of 'ascii' because 'ascii' mutilates non-ASCII
input.

It worked by accident in v0.8 but not in v0.10 because the high bits
are now stripped when converting Buffers to ASCII strings. See commit
96a314b for details.

Fixes #4999 and #5011.

Reviewer: @isaacs or @TooTallNate
