### PR TITLE
tls: write pending data of opposite side

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -435,6 +435,7 @@ CryptoStream.prototype._read = function read(size) {
 
   // Try writing pending data
   if (this._pending !== null) this._writePending();
+  if (this._opposite._pending !== null) this._opposite._writePending();
 
   if (bytesRead === 0) {
     // EOF when cleartext has finished and we have nothing to read


### PR DESCRIPTION
Fix stucked CryptoStream behaviour, happening when one of the sides
locks-up in queued state.

fix #5023
