### PR TITLE
Added ability to run interactively with arguments

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2677,6 +2677,8 @@ static void ParseArgs(int argc, char **argv) {
       throw_deprecation = true;
     } else if (argv[i][0] != '-') {
       break;
+    } else if (strcmp(arg, "--") == 0) {
+      break;
     }
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -78,7 +78,7 @@
     } else if (process._eval != null) {
       // User passed '-e' or '--eval' arguments to Node.
       evalScript('[eval]');
-    } else if (process.argv[1]) {
+    } else if (process.argv[1] && process.argv[1] !== '--') {
       // make process.argv[1] into a full path
       var path = NativeModule.require('path');
       process.argv[1] = path.resolve(process.argv[1]);
@@ -121,7 +121,7 @@
 
     } else {
       var Module = NativeModule.require('module');
-
+      if (process.argv[0] === '--') process._forceRepl = true;
       // If -i or --interactive were passed, or stdin is a TTY.
       if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
         // REPL
@@ -818,6 +818,10 @@
     // execute cwd\node.exe, or some %PATH%\node.exe on Windows,
     // and that every directory has its own cwd, so d:node.exe is valid.
     var argv0 = process.argv[0];
+
+    // Don't do anything if argv[0] is '--'
+    if (argv0 === '--') return;
+
     if (!isWindows && argv0.indexOf('/') !== -1 && argv0.charAt(0) !== '/') {
       var path = NativeModule.require('path');
       process.argv[0] = path.join(cwd, process.argv[0]);

--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -84,6 +84,19 @@ child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
   assert.equal(stderr, '');
 });
 
+// '--' should be the filename if it is the first argument
+child.exec(nodejs + ' -p -e "process.argv[1]" -- foo bar baz', 
+    function(status, stdout, stderr) {
+      assert.equal(stderr, '');
+      assert.equal(stdout, "--\n");
+    });
+
+// '--' should force the interpreter to run without looking for a file
+child.exec(nodejs + ' -i -- foo bar', {timeout:1000, killSignal:'SIGINT'}, 
+    function(status, stdout, stderr) {
+      assert.equal(stdout, "> ");
+    });
+
 // "\\-42" should be interpreted as an escaped expression, not a switch
 child.exec(nodejs + ' -p "\\-42"',
     function(err, stdout, stderr) {


### PR DESCRIPTION
There currently is no way to run node interactively and pass arguments without
a file: `node -i foo bar baz` will instruct node to load `foo`.

This commit adds a `--` argument that instructs node to run interactive and not
to load any file in the argv:

```
$ node -i -- foo bar baz
> process.argv
[ '/the/path/to/node',
  '--',
  'foo',
  'bar',
  'baz' ]
```

The same thing works without the '-i':

```
$ node -- foo bar baz
> process.argv
[ '/the/path/to/node',
  '--',
  'foo',
  'bar',
  'baz' ]
```
