### PR TITLE
stream: Fix stall in Transform under very specific conditions

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -101,6 +101,7 @@ function afterTransform(stream, er, data) {
     cb(er);
 
   var rs = stream._readableState;
+  rs.reading = false;
   if (rs.needReadable || rs.length < rs.highWaterMark) {
     stream._read(rs.highWaterMark);
   }


### PR DESCRIPTION
The stall is exposed in the test, though the test itself asserts before it stalls.

The test is constructed to replicate the stalling state of a complex Passthrough usecase since I was not able to reliable trigger the stall.

Some of the preconditions for triggering the stall are:
- rs.length >= rs.highWaterMark
- !rs.needReadable
- _transform() handler that can return empty transforms
- multiple sync write() calls

Combined this can trigger a case where rs.reading is not cleared when further progress requires this. The fix is to always clear rs.reading.
