### PR TITLE
Default querystring separators to /[&;]/g

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -159,7 +159,7 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
 
 // Parse a key=val string.
 QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
-  sep = sep || '&';
+  sep = sep || /[&;]/g;
   eq = eq || '=';
   var obj = {};
 

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -57,7 +57,17 @@ var qsTestCases = [
       valueOf: 'bar',
       __defineGetter__: 'baz' }],
   // See: https://github.com/joyent/node/issues/3058
-  ['foo&bar=baz', 'foo=&bar=baz', { foo: '', bar: 'baz' }]
+  ['foo&bar=baz', 'foo=&bar=baz', { foo: '', bar: 'baz' }],
+  // See: https://github.com/joyent/node/issues/5055
+  ['foo=bar;foo=quux', 'foo=bar;foo=quux', {'foo': ['bar', 'quux']}],
+  ['foo=1%26bar:2;baz=quux%3bqix',
+   'foo=1%26bar%3A2;baz=quux%3Bqix',
+   {'foo': '1&bar:2', 'baz': 'quux;qix'}],
+  ['this&that;bob=carol&ted=alice;eve=victor',
+   'this&that;bob=carol&ted=alice;eve=victor,
+   {'this': '', 'that': '',
+   'bob': 'carol', 'ted': 'alice',
+   'eve': 'victor'}],
 ];
 
 // [ wonkyQS, canonicalQS, obj ]

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -64,7 +64,7 @@ var qsTestCases = [
    'foo=1%26bar%3A2;baz=quux%3Bqix',
    {'foo': '1&bar:2', 'baz': 'quux;qix'}],
   ['this&that;bob=carol&ted=alice;eve=victor',
-   'this&that;bob=carol&ted=alice;eve=victor,
+   'this&that;bob=carol&ted=alice;eve=victor',
    {'this': '', 'that': '',
    'bob': 'carol', 'ted': 'alice',
    'eve': 'victor'}],


### PR DESCRIPTION
This makes the querystring module compliant to http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2
