### PR TITLE
Fix missing signals on Windows

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -731,10 +731,6 @@
   };
 
   startup.processSignalHandlers = function() {
-    // Not supported on Windows.
-    if (process.platform === 'win32')
-      return;
-
     // Load events module in order to access prototype elements on process like
     // process.addListener.
     var signalWraps = {};

--- a/test/simple/test-signal-handler.js
+++ b/test/simple/test-signal-handler.js
@@ -20,11 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-// SIGUSR1 and SIGHUP are not supported on Windows
-if (process.platform === 'win32') {
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
 
@@ -65,7 +60,10 @@ process.on('SIGHUP', function() { sighup = true });
 process.kill(process.pid, 'SIGHUP');
 
 process.on('exit', function() {
-  assert.equal(1, first);
-  assert.equal(1, second);
+  // SIGUSR1 is not supported on Windows
+  if (process.platform !== 'win32') {
+    assert.equal(1, first);
+    assert.equal(1, second);
+  }
   assert.equal(true, sighup);
 });


### PR DESCRIPTION
The version of libuv in node v0.10+ now supports (a few) signals on Windows.
