### PR TITLE
util.inspect properly formatting arrays with colors

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -418,7 +418,7 @@ function reduceToSingleString(output, base, braces) {
   var length = output.reduce(function(prev, cur) {
     numLinesEst++;
     if (cur.indexOf('\n') >= 0) numLinesEst++;
-    return prev + cur.length + 1;
+    return prev + cur.replace(/\u001b\[\d{1,2}m/g, '').length + 1;
   }, 0);
 
   if (length > 60) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -418,7 +418,7 @@ function reduceToSingleString(output, base, braces) {
   var length = output.reduce(function(prev, cur) {
     numLinesEst++;
     if (cur.indexOf('\n') >= 0) numLinesEst++;
-    return prev + cur.replace(/\u001b\[\d{1,2}m/g, '').length + 1;
+    return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
   }, 0);
 
   if (length > 60) {

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -172,7 +172,7 @@ function test_lines(input) {
     assert.equal(count_lines(without_color), count_lines(with_color));
 }
 
-test_lines([1, 2, 3, 4, 5]);
+test_lines([1, 2, 3, 4, 5, 6, 7]);
 test_lines(function () {
     var big_array = [];
     for (var i = 0; i < 100; i += 1) {

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -163,30 +163,28 @@ assert.equal(util.inspect(subject), '{ foo: \'bar\' }');
 
 // util.inspect with "colors" option should produce as many lines as without it
 function test_lines(input) {
-    var count_lines = function (str) {
-        return (str.match(/\n/g) || []).length;
-    }
+  var count_lines = function(str) {
+    return (str.match(/\n/g) || []).length;
+  }
 
-    var without_color = util.inspect(input);
-    var with_color = util.inspect(input, {colors: true});
-    assert.equal(count_lines(without_color), count_lines(with_color));
+  var without_color = util.inspect(input);
+  var with_color = util.inspect(input, {colors: true});
+  assert.equal(count_lines(without_color), count_lines(with_color));
 }
 
 test_lines([1, 2, 3, 4, 5, 6, 7]);
-test_lines(function () {
-    var big_array = [];
-    for (var i = 0; i < 100; i += 1) {
-        big_array.push(i);
-    }
-    return big_array;
+test_lines(function() {
+  var big_array = [];
+  for (var i = 0; i < 100; i++) {
+    big_array.push(i);
+  }
+  return big_array;
 }());
 test_lines({foo: 'bar', baz: 35, b: {a: 35}});
 test_lines({
-    foo: 'bar',
-    baz: 35,
-    b: {a: 35},
-    very_long_key: 'very_long_value',
-    even_longer_key: ['with even longer value in array']
+  foo: 'bar',
+  baz: 35,
+  b: {a: 35},
+  very_long_key: 'very_long_value',
+  even_longer_key: ['with even longer value in array']
 });
-
-

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -160,3 +160,33 @@ assert(util.inspect(subject, { customInspect: false }).indexOf('inspect') !== -1
 subject.inspect = function() { return { foo: 'bar' }; };
 
 assert.equal(util.inspect(subject), '{ foo: \'bar\' }');
+
+// util.inspect with "colors" option should produce as many lines as without it
+function test_lines(input) {
+    var count_lines = function (str) {
+        return (str.match(/\n/g) || []).length;
+    }
+
+    var without_color = util.inspect(input);
+    var with_color = util.inspect(input, {colors: true});
+    assert.equal(count_lines(without_color), count_lines(with_color));
+}
+
+test_lines([1, 2, 3, 4, 5]);
+test_lines(function () {
+    var big_array = [];
+    for (var i = 0; i < 100; i += 1) {
+        big_array.push(i);
+    }
+    return big_array;
+}());
+test_lines({foo: 'bar', baz: 35, b: {a: 35}});
+test_lines({
+    foo: 'bar',
+    baz: 35,
+    b: {a: 35},
+    very_long_key: 'very_long_value',
+    even_longer_key: ['with even longer value in array']
+});
+
+


### PR DESCRIPTION
This is a fix for Issue #5039 - line length is now computed without color codes.
