### PR TITLE
test: Unit test fixes for Windows

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -176,6 +176,11 @@ if (isWindows) {
         tail = result[3],
         trailingSlash = /[\\\/]$/.test(tail);
 
+    // If device is a drive letter, we'll normalize to lower case.
+    if (device && device.charAt(1) === ':') {
+      device = device[0].toLowerCase() + device.substr(1);
+    }
+
     // Normalize the tail path
     tail = normalizeArray(tail.split(/[\\\/]+/).filter(function(p) {
       return !!p;

--- a/test/simple/test-fs-realpath.js
+++ b/test/simple/test-fs-realpath.js
@@ -267,6 +267,10 @@ function test_cyclic_link_overprotection(callback) {
 
 function test_relative_input_cwd(callback) {
   console.log('test_relative_input_cwd');
+  if (skipSymlinks) {
+    console.log('skipping symlink test (no privs)');
+    return runNextTest();
+  }
 
   // we need to get the relative path to the tmp dir from cwd.
   // When the test runner is running it, that will be .../node/test

--- a/test/simple/test-http-curl-chunk-problem.js
+++ b/test/simple/test-http-curl-chunk-problem.js
@@ -73,7 +73,7 @@ var server = http.createServer(function(req, res) {
   cat.on('exit', function(code) {
     if (code !== 0) {
       console.error('subprocess exited with code ' + code);
-      exit(1);
+      process.exit(1);
     }
     res.end();
   });

--- a/test/simple/test-require-resolve.js
+++ b/test/simple/test-require-resolve.js
@@ -25,11 +25,11 @@ var assert = require('assert');
 var path = require('path');
 
 assert.equal(path.join(__dirname, '../fixtures/a.js'),
-             require.resolve('../fixtures/a'));
+             path.normalize(require.resolve('../fixtures/a')));
 assert.equal(path.join(fixturesDir, 'a.js'),
-             require.resolve(path.join(fixturesDir, 'a')));
+             path.normalize(require.resolve(path.join(fixturesDir, 'a'))));
 assert.equal(path.join(fixturesDir, 'nested-index', 'one', 'index.js'),
-             require.resolve('../fixtures/nested-index/one'));
+             path.normalize(require.resolve('../fixtures/nested-index/one')));
 assert.equal('path', require.resolve('path'));
 
 console.log('ok');


### PR DESCRIPTION
- test: Ignore symlink tests (Windows) if not admin
- test: Fix typo on failure-path code
- path: Normalize capitalization of drive letter  … 

Fixes #5071, #5073.

The `test_relative_input_cwd()` test was failing on Windows when
`skipSymlinks` was `true`. So we won't run it if `skipSymlinks` is
`true`.

When it failed, the unhandled error caused Node to die before
having a chance to clean up, which resulted in two files missing
in subsequent unit tests:
- `test/fixtures/nested-index/one/hello.js`
- `test/fixtures/nested-index/one/index.js`

We should probably find a way to isolate this test from the other
test (`simple/test-module-loading`) that was failing when this test
poluted the disk state.
