### PR TITLE
os: modify os.tmpdir() to judge more recommended order in windows

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -43,9 +43,9 @@ exports.platform = function() {
 
 exports.tmpdir = function() {
   return process.env.TMPDIR ||
-         process.env.TMP ||
          process.env.TEMP ||
-         (process.platform === 'win32' ? 'c:\\windows\\temp' : '/tmp');
+         process.env.TMP ||
+         (process.platform === 'win32' ? (process.env.systemroot || process.env.windir) + "\\temp" : '/tmp');
 };
 
 exports.tmpDir = exports.tmpdir;

--- a/lib/os.js
+++ b/lib/os.js
@@ -21,6 +21,7 @@
 
 var binding = process.binding('os');
 var util = require('util');
+var isWindows = process.platform === 'win32';
 
 exports.endianness = binding.getEndianness;
 exports.hostname = binding.getHostname;
@@ -42,11 +43,17 @@ exports.platform = function() {
 };
 
 exports.tmpdir = function() {
-  return process.env.TMPDIR ||
-         process.env.TEMP ||
-         process.env.TMP ||
-         (process.platform === 'win32' ? (process.env.systemroot || process.env.windir) + "\\temp" : '/tmp');
-};
+  if (isWindows) {
+    return process.env.TEMP ||
+           process.env.TMP ||
+           (process.env.SystemRoot || process.env.windir) + "\\temp";
+  } else {
+    return process.env.TMPDIR ||
+           process.env.TMP ||
+           process.env.TEMP ||
+           '/tmp';
+  }
+}
 
 exports.tmpDir = exports.tmpdir;
 
@@ -54,4 +61,4 @@ exports.getNetworkInterfaces = util.deprecate(function() {
   return exports.networkInterfaces();
 }, 'getNetworkInterfaces is now called `os.networkInterfaces`.');
 
-exports.EOL = process.platform === 'win32' ? '\r\n' : '\n';
+exports.EOL = isWindows ? '\r\n' : '\n';


### PR DESCRIPTION
If someone(e.g. amdin) want to use an old NT command script
or has installed old windows in another dirve,
then %SystemRoot% would be more suitable.
And %windir is also used for old windows compatibility.

See: #3407
