### PR TITLE
tls: handle ZERO_RETURN

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -269,8 +269,12 @@ function onCryptoStreamFinish() {
       // Generate close notify
       // NOTE: first call checks if client has sent us shutdown,
       // second call enqueues shutdown into the BIO.
-      if (this.pair.ssl.shutdown() !== 1) {
-        this.pair.ssl.shutdown();
+      if (this.pair.ssl.shutdown() === 0) {
+        if (this.pair.ssl.zeroReturn) {
+          this.pair.error();
+        } else {
+          this.pair.ssl.shutdown();
+        }
       }
     }
   } else {
@@ -324,7 +328,10 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
       written = this.pair.ssl.encIn(data, 0, data.length);
     }
 
-    var self = this;
+    // Other side closed connection with CLOSE_NOTIFY
+    if (this.pair.ssl && this.pair.ssl.zeroReturn) {
+      return cb(this.pair.error());
+    }
 
     // Force SSL_read call to cycle some states/data inside OpenSSL
     this.pair.cleartext.read(0);
@@ -412,9 +419,17 @@ CryptoStream.prototype._read = function read(size) {
     }
 
     // Handle and report errors
-    if (this.pair.ssl && this.pair.ssl.error) {
-      this.pair.error();
-      break;
+    if (this.pair.ssl) {
+      if (this.pair.ssl.error) {
+        this.pair.error();
+        break;
+      }
+
+      // Other side closed connection with CLOSE_NOTIFY
+      if (this.pair.ssl.zeroReturn) {
+        this.pair.error();
+        break;
+      }
     }
 
     // Get NPN and Server name when ready
@@ -908,6 +923,7 @@ SecurePair.prototype.destroy = function() {
 SecurePair.prototype.error = function() {
   var err = this.ssl.error;
   this.ssl.error = null;
+  this.ssl.zeroReturn = false;
 
   if (!this._secureEstablished) {
     if (!err) {


### PR DESCRIPTION
ZERO_RETURN is generally returned when other side has closed (with
CLOSE_NOTIFY) connection. In such cases, error should be emitted.

/cc @bnoordhuis
