### PR TITLE
fix error causing socket to not return to the http agent until timeout occurs.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1627,8 +1627,39 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   COUNTER_HTTP_CLIENT_RESPONSE();
   req.res = res;
   res.req = req;
-  var handled = req.emit('response', res);
-  res.on('end', responseOnEnd);
+  var handled;
+  try {
+    handled = req.emit('response', res);
+  }
+  catch (ex){
+    req.shouldKeepAlive = false;
+    responseOnEnd.apply(res);
+    throw ex;
+  }
+
+  //res.on("end", responseOnEnd)
+  
+  // Override the emit event to explicetly look for the "end" event of the request.
+  // This will make sure the socket is returned back to the pull if the "end" throws
+  // an exception.
+  var emit = res.emit;
+  res.emit = function () {
+    var ended = false;
+    try{
+      emit.apply(this, Array.prototype.slice.call(arguments))
+    }
+    catch (ex) {
+      this.req.shouldKeepAlive = false;
+      responseOnEnd.apply(this);
+      ended = true;
+      throw ex
+    }
+    finally {
+      if (!ended && arguments.length > 0 && arguments[0] == "end"){
+        responseOnEnd.apply(this);
+      }
+    } 
+  }
 
   // If the user did not listen for the 'response' event, then they
   // can't possibly read the data, so we ._dump() it into the void

--- a/test/pummel/test-http-agent-exception.js
+++ b/test/pummel/test-http-agent-exception.js
@@ -1,0 +1,90 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var server = http.Server(function(req, res) {
+  res.writeHead(200);
+  res.end('hello world\n');
+});
+
+var N = 30;
+
+var responses = 0;
+
+
+process.on("uncaughtException", function () {
+  //this will be called but we do nothing.
+})
+
+
+
+function doRequest() {
+  var req = http.get({ port: common.PORT, path: '/' }, function(res) {
+    req.returned = true;
+    responses++;
+
+    //end condition
+    if (responses == N) {
+      console.error('Received all responses, closing server');
+      process.exit(responses == N ? 0 : 1)
+      return;
+    }
+    
+    var test = responses % 3;
+    
+    if (test == 1) {
+      res.on('data', function (){
+        throw new Error("HI")
+      })
+      res.resume();
+    }
+    else if (test == 2) {
+      res.on('end', function (){
+        throw new Error("HI")
+      })
+      res.resume();
+    }
+    else{
+      throw new Error("hi")
+    }
+
+  })
+  setTimeout(function () {
+    if (!req.returned){
+      console.log("Timeout waiting for agent.")
+      process.exit(1)
+    }
+   
+  }, 1000)
+}
+
+server.listen(common.PORT, function() {
+  for (var j = 0; j < N; j++) {
+    doRequest();
+  }
+});
+


### PR DESCRIPTION
# The Problem

I have found an issue where if there is an exception thrown in the handler of a http response, then this connection will not be returned to the pool until it times out a few minutes later. This causes the pool to backup and can lead to a denial of service attack or other issues in which node will not be able to talk to a host for a given amount of time.

Here is a simple proof of concept:

``` javascript
var http = require("http")

function test() {
    var options = {
        host: "google.com",
        port: 80,
        path: "/"
    }

    console.log("started")
    var req = http.request(options, function (res) {
        console.log("response")

        res.on("end", function () {
            throw new Error("HELLO")

        })
    })
    req.end()

}

process.on("uncaughtException", function () {
    console.log("uncaught");
})

for (var i = 0; i < 10; i++)
    test();
```

This code sample will display "started" 10 times and "response" 5 times (maxSockets is 5) then hang for a couple of minutes until those sockets timeout, then show "response" 5 more times.

This exception can be thrown on the response callback or in any of the emit events and will cause a similar issue.

This is especially noticeable when you are running a test framework like mocha and on the response you check the JSON object with an assert which throws an exception and causes the rest of the tests that talk to the same endpoint to fail or timeout.

For example if you have the following type of code

``` javascript
test.makeRequest(function (result) {
    assert(result.firstName != "")
})
```

After 5 of these tests fail, the rest will fail with a timeout even though the test might otherwise pass.
# The Fix

There is now a try-catch wrapper around the emit handling code in http.js which overrides the emit event and ensures that responseEnd is always called. If there is an exception on getting the response or in the "data" event, then it will kill the socket and return it to the pool.

There is now 1 added test to test this exact problem in pummel/test-http-agent-exception.js
