### PR TITLE
src: write ascii strings using WriteOneByte

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1212,7 +1212,10 @@ ssize_t DecodeWrite(char *buf,
   }
 
   if (encoding == ASCII) {
-    str->WriteAscii(buf, 0, buflen, String::HINT_MANY_WRITES_EXPECTED);
+    str->WriteOneByte(reinterpret_cast<uint8_t*>(buf),
+                      0,
+                      buflen,
+                      String::HINT_MANY_WRITES_EXPECTED);
     return buflen;
   }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -749,11 +749,11 @@ Handle<Value> Buffer::AsciiWrite(const Arguments &args) {
 
   char *p = buffer->data_ + offset;
 
-  int written = s->WriteAscii(p,
-                              0,
-                              max_length,
-                              (String::HINT_MANY_WRITES_EXPECTED |
-                               String::NO_NULL_TERMINATION));
+  int written = s->WriteOneByte(reinterpret_cast<uint8_t*>(p),
+                                0,
+                                max_length,
+                                (String::HINT_MANY_WRITES_EXPECTED |
+                                 String::NO_NULL_TERMINATION));
 
   constructor_template->GetFunction()->Set(chars_written_sym,
                                            Integer::New(written, node_isolate));

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -392,7 +392,7 @@ Handle<Value> StreamWrap::WriteStringImpl(const Arguments& args) {
   size_t data_size;
   switch (encoding) {
   case kAscii:
-      data_size = string->WriteAscii(data, 0, -1,
+      data_size = string->WriteOneByte(reinterpret_cast<uint8_t*>(data), 0, -1,
           String::NO_NULL_TERMINATION | String::HINT_MANY_WRITES_EXPECTED);
       break;
 


### PR DESCRIPTION
WriteAscii will be deprecated soon from v8, and performance has
regressed. The v8 team recommended using WriteOneByte instead.

Running benchmarks now and will update w/ results when done.

/cc @indutny @bnoordhuis
