### PR TITLE
timers: handle signed int32 overflow in enroll()

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -150,6 +150,11 @@ exports.enroll = function(item, msecs) {
   // then we should unenroll it from that
   if (item._idleNext) unenroll(item);
 
+  // Ensure that msecs fits into signed int32
+  if (msecs > 0x7fffffff) {
+    msecs = 0x7fffffff;
+  }
+
   item._idleTimeout = msecs;
   L.init(item);
 };

--- a/test/simple/test-http-timeout-overflow.js
+++ b/test/simple/test-http-timeout-overflow.js
@@ -1,0 +1,64 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+var port = common.PORT;
+var serverRequests = 0;
+var clientRequests = 0;
+
+var server = http.createServer(function(req, res) {
+  serverRequests++;
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.end('OK');
+});
+
+server.listen(port, function() {
+  function callback(){}
+
+  var req = http.request({
+    port: port,
+    path: '/',
+    agent: false
+  }, function(res) {
+    req.clearTimeout(callback);
+
+    res.on('end', function() {
+      clientRequests++;
+      server.close();
+    })
+
+    res.resume();
+  });
+
+  // Overflow signed int32
+  req.setTimeout(0xffffffff, callback);
+  req.end();
+});
+
+process.once('exit', function() {
+  assert.equal(clientRequests, 1);
+  assert.equal(serverRequests, 1);
+});


### PR DESCRIPTION
Before this patch calling `socket.setTimeout(0xffffffff)` will result in
signed int32 overflow in C++ which resulted in assertion error:

```
Assertion failed: (timeout >= -1), function uv__io_poll, file
../deps/uv/src/unix/kqueue.c, line 121.
```

see #5101

/cc @bnoordhuis
