### PR TITLE
doc: update that ascii write doesn't convert null

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -20,10 +20,6 @@ encoding method.  Here are the different string encodings.
 * `'ascii'` - for 7 bit ASCII data only.  This encoding method is very fast, and
   will strip the high bit if set.
 
-  Note that when converting from string to buffer, this encoding converts a null
-  character (`'\0'` or `'\u0000'`) into `0x20` (character code of a space). If
-  you want to convert a null character into `0x00`, you should use `'utf8'`.
-
 * `'utf8'` - Multibyte encoded Unicode characters. Many web pages and other
   document formats use UTF-8.
 


### PR DESCRIPTION
Since WriteBuffer has been replaced with WriteOneByte, writing ascii
will no longer automatically convert 0x0 to 0x20. So removed mention of
this special case from docs.
