### PR TITLE
Remove harmful + unnecessary bounds checking in tls

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1313,11 +1313,6 @@ Handle<Value> Connection::EncIn(const Arguments& args) {
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
-  if (off >= buffer_length) {
-    return ThrowException(Exception::Error(
-          String::New("Offset is out of bounds")));
-  }
-
   size_t len = args[2]->Int32Value();
   if (off + len > buffer_length) {
     return ThrowException(Exception::Error(
@@ -1359,11 +1354,6 @@ Handle<Value> Connection::ClearOut(const Arguments& args) {
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
-  if (off >= buffer_length) {
-    return ThrowException(Exception::Error(
-          String::New("Offset is out of bounds")));
-  }
-
   size_t len = args[2]->Int32Value();
   if (off + len > buffer_length) {
     return ThrowException(Exception::Error(
@@ -1431,11 +1421,6 @@ Handle<Value> Connection::EncOut(const Arguments& args) {
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
-  if (off >= buffer_length) {
-    return ThrowException(Exception::Error(
-          String::New("Offset is out of bounds")));
-  }
-
   size_t len = args[2]->Int32Value();
   if (off + len > buffer_length) {
     return ThrowException(Exception::Error(
@@ -1470,11 +1455,6 @@ Handle<Value> Connection::ClearIn(const Arguments& args) {
   size_t buffer_length = Buffer::Length(args[0]);
 
   size_t off = args[1]->Int32Value();
-  if (off > buffer_length) {
-    return ThrowException(Exception::Error(
-          String::New("Offset is out of bounds")));
-  }
-
   size_t len = args[2]->Int32Value();
   if (off + len > buffer_length) {
     return ThrowException(Exception::Error(


### PR DESCRIPTION
The EncIn, EncOut, ClearIn & ClearOut functions are victims of some code
copy + pasting. A common line copied to all of them is:

`if (off >= buffer_length) { ...`

448e0f43 corrected ClearIn's check from `>=` to `>`, but left the others
unchanged (with an incorrect bounds check). However, if you look down at
the next very next bounds check you'll see:

`if (off + len > buffer_length) { ...`

So the check is actually obviated by the next line, and should be
removed.

This fixes an issue where writing a zero-length buffer to an encrypted
pair's _encrypted_ stream you would get a crash.
