### PR TITLE
assert: manutally create stack trace message

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -45,9 +45,9 @@ assert.AssertionError = function AssertionError(options) {
   this.operator = options.operator;
   var stackStartFunction = options.stackStartFunction || fail;
 
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this, stackStartFunction);
-  }
+  Error.captureStackTrace(this, stackStartFunction);
+  this.stack = this.stack.substr(this.name.length);
+  this.stack = this.toString() + this.stack;
 };
 
 // assert.AssertionError instanceof Error

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -3,7 +3,7 @@ Exiting with code=1
 assert.js:*
   throw new assert.AssertionError({
         ^
-AssertionError
+AssertionError: 1 == 2
     at Object.<anonymous> (*test*message*error_exit.js:*:*)
     at Module._compile (module.js:*:*)
     at Object.Module._extensions..js (module.js:*:*)


### PR DESCRIPTION
v8 has changed how it generates it's messages, so as a fix the stack is
manually manipulated after to properly display the assert message text.

This change is absolute crap, and I don't like manipulating the stack trace string this way. But so far it's the only way I've figured out how to do it. Will look for a better way for a little longer, but go ahead and use this if you want.
