### PR TITLE
zlib: ability to supply options with convenience methods

### DIFF
--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -187,37 +187,35 @@ the header.
 
 <!--type=misc-->
 
-All of these take a string or buffer as the first argument, and call the
-supplied callback with `callback(error, result)`.  The
-compression/decompression engine is created using the default settings
-in all convenience methods.  To supply different options, use the
-zlib classes directly.
+All of these take a string or buffer as the first argument, an optional second
+argument to supply options to the zlib classes and will call the supplied
+callback with `callback(error, result)`.
 
-## zlib.deflate(buf, callback)
+## zlib.deflate(buf, [options], callback)
 
 Compress a string with Deflate.
 
-## zlib.deflateRaw(buf, callback)
+## zlib.deflateRaw(buf, [options], callback)
 
 Compress a string with DeflateRaw.
 
-## zlib.gzip(buf, callback)
+## zlib.gzip(buf, [options], callback)
 
 Compress a string with Gzip.
 
-## zlib.gunzip(buf, callback)
+## zlib.gunzip(buf, [options], callback)
 
 Decompress a raw Buffer with Gunzip.
 
-## zlib.inflate(buf, callback)
+## zlib.inflate(buf, [options], callback)
 
 Decompress a raw Buffer with Inflate.
 
-## zlib.inflateRaw(buf, callback)
+## zlib.inflateRaw(buf, [options], callback)
 
 Decompress a raw Buffer with InflateRaw.
 
-## zlib.unzip(buf, callback)
+## zlib.unzip(buf, [options], callback)
 
 Decompress a raw Buffer with Unzip.
 
@@ -225,8 +223,7 @@ Decompress a raw Buffer with Unzip.
 
 <!--type=misc-->
 
-Each class takes an options object.  All options are optional.  (The
-convenience methods use the default settings for all options.)
+Each class takes an options object.  All options are optional.
 
 Note that some options are only relevant when compressing, and are
 ignored by the decompression classes.

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -107,32 +107,60 @@ exports.createUnzip = function(o) {
 
 // Convenience methods.
 // compress/decompress a string or buffer in one step.
-exports.deflate = function(buffer, callback) {
-  zlibBuffer(new Deflate(), buffer, callback);
+exports.deflate = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new Deflate(opts), buffer, callback);
 };
 
-exports.gzip = function(buffer, callback) {
-  zlibBuffer(new Gzip(), buffer, callback);
+exports.gzip = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new Gzip(opts), buffer, callback);
 };
 
-exports.deflateRaw = function(buffer, callback) {
-  zlibBuffer(new DeflateRaw(), buffer, callback);
+exports.deflateRaw = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new DeflateRaw(opts), buffer, callback);
 };
 
-exports.unzip = function(buffer, callback) {
-  zlibBuffer(new Unzip(), buffer, callback);
+exports.unzip = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new Unzip(opts), buffer, callback);
 };
 
-exports.inflate = function(buffer, callback) {
-  zlibBuffer(new Inflate(), buffer, callback);
+exports.inflate = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new Inflate(opts), buffer, callback);
 };
 
-exports.gunzip = function(buffer, callback) {
-  zlibBuffer(new Gunzip(), buffer, callback);
+exports.gunzip = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new Gunzip(opts), buffer, callback);
 };
 
-exports.inflateRaw = function(buffer, callback) {
-  zlibBuffer(new InflateRaw(), buffer, callback);
+exports.inflateRaw = function(buffer, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  zlibBuffer(new InflateRaw(opts), buffer, callback);
 };
 
 function zlibBuffer(engine, buffer, callback) {

--- a/test/simple/test-zlib-convenience-methods.js
+++ b/test/simple/test-zlib-convenience-methods.js
@@ -1,0 +1,65 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// test convenience methods with and without options supplied
+
+var common = require('../common.js');
+var assert = require('assert');
+var zlib = require('zlib');
+
+var hadRun = 0;
+
+var expect = 'blahblahblahblahblahblah';
+var opts = {
+  level: 9,
+  chunkSize: 1024,
+};
+
+[
+  ['gzip', 'gunzip'],
+  ['gzip', 'unzip'],
+  ['deflate', 'inflate'],
+  ['deflateRaw', 'inflateRaw'],
+].forEach(function(method) {
+
+  zlib[method[0]](expect, opts, function(err, result) {
+    zlib[method[1]](result, opts, function(err, result) {
+      assert.equal(result, expect,
+        'Should get original string after ' +
+        method[0] + '/' + method[1] + ' with options.');
+      hadRun++;
+    });
+  });
+
+  zlib[method[0]](expect, function(err, result) {
+    zlib[method[1]](result, function(err, result) {
+      assert.equal(result, expect,
+        'Should get original string after ' +
+        method[0] + '/' + method[1] + ' without options.');
+      hadRun++;
+    });
+  });
+
+});
+
+process.on('exit', function() {
+  assert.equal(hadRun, 8, 'expect 8 compressions');
+});


### PR DESCRIPTION
This change allows optionally supplying options to the zlib classes using the convenience methods.

Based on this previously attempted pull request: #4400

Thanks!
