### PR TITLE
domain: fix domain callback from MakeCallback

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -26,6 +26,19 @@ which can be piped to and from.
 The ChildProcess class is not intended to be used directly.  Use the
 `spawn()` or `fork()` methods to create a Child Process instance.
 
+### Event:  'error'
+
+* `err` {Error Object} the error.
+
+Emitted when:
+
+1. The process could not be spawned, or
+2. The process could not be killed, or
+3. Sending a message to the child process failed for whatever reason.
+
+See also [`ChildProcess#kill()`](#child_process_child_kill_signal) and
+[`ChildProcess#send()`](#child_process_child_send_message_sendhandle).
+
 ### Event:  'exit'
 
 * `code` {Number} the exit code, if it exited normally.
@@ -125,8 +138,15 @@ be sent `'SIGTERM'`. See `signal(7)` for a list of available signals.
     // send SIGHUP to process
     grep.kill('SIGHUP');
 
-Note that while the function is called `kill`, the signal delivered to the child
-process may not actually kill it.  `kill` really just sends a signal to a process.
+May emit an `'error'` event when the signal cannot be delivered. Sending a
+signal to a child process that has already exited is not an error but may
+have unforeseen consequences: if the PID (the process ID) has been reassigned
+to another process, the signal will be delivered to that process instead.
+What happens next is anyone's guess.
+
+Note that while the function is called `kill`, the signal delivered to the
+child process may not actually kill it.  `kill` really just sends a signal
+to a process.
 
 See `kill(2)`
 
@@ -171,6 +191,9 @@ should by all means avoid using this feature, it is subject to change without no
 The `sendHandle` option to `child.send()` is for sending a TCP server or
 socket object to another process. The child will receive the object as its
 second argument to the `message` event.
+
+Emits an `'error'` event if the message cannot be sent, for example because
+the child process has already exited.
 
 #### Example: sending server object
 

--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -46,7 +46,7 @@ of the `tty.ReadStream` instance.
 to the resulting mode.
 
 
-## Class WriteStream
+## Class: WriteStream
 
 A `net.Socket` subclass that represents the writable portion of a tty. In normal
 circumstances, `process.stdout` will be the only `tty.WriteStream` instance

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -32,9 +32,8 @@ var endMethods = ['end', 'abort', 'destroy', 'destroySoon'];
 // a few side effects.
 events.usingDomains = true;
 
-// replace tickers with domain specific implementation
-process.nextTick = process._nextDomainTick;
-process._tickCallback = process._tickDomainCallback;
+// let the process know we're using domains
+process.usingDomains();
 
 exports.Domain = Domain;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -102,7 +102,6 @@ Persistent<String> domain_symbol;
 // declared in node_internals.h
 Persistent<Object> process;
 
-static Persistent<Function> process_tickDomainCallback;
 static Persistent<Function> process_tickFromSpinner;
 static Persistent<Function> process_tickCallback;
 
@@ -134,6 +133,7 @@ static bool use_debug_agent = false;
 static bool debug_wait_connect = false;
 static int debug_port=5858;
 static int max_stack_size = 0;
+static bool using_domains = false;
 
 // used by C++ modules as well
 bool no_deprecation = false;
@@ -899,23 +899,36 @@ Handle<Value> FromConstructorTemplate(Persistent<FunctionTemplate> t,
 }
 
 
+Handle<Value> UsingDomains(const Arguments& args) {
+  HandleScope scope;
+  if (using_domains)
+    return scope.Close(Undefined());
+  using_domains = true;
+  Local<Value> tdc_v = process->Get(String::New("_tickDomainCallback"));
+  Local<Value> ndt_v = process->Get(String::New("_nextDomainTick"));
+  if (!tdc_v->IsFunction()) {
+    fprintf(stderr, "process._tickDomainCallback assigned to non-function\n");
+    abort();
+  }
+  if (!ndt_v->IsFunction()) {
+    fprintf(stderr, "process._nextDomainTick assigned to non-function\n");
+    abort();
+  }
+  Local<Function> tdc = tdc_v.As<Function>();
+  Local<Function> ndt = ndt_v.As<Function>();
+  process->Set(String::New("_tickCallback"), tdc);
+  process->Set(String::New("nextTick"), ndt);
+  process_tickCallback = Persistent<Function>::New(tdc);
+  return scope.Close(Undefined());
+}
+
+
 Handle<Value>
 MakeDomainCallback(const Handle<Object> object,
                    const Handle<Function> callback,
                    int argc,
                    Handle<Value> argv[]) {
   // TODO Hook for long stack traces to be made here.
-
-  // lazy load _tickDomainCallback
-  if (process_tickDomainCallback.IsEmpty()) {
-    Local<Value> cb_v = process->Get(String::New("_tickDomainCallback"));
-    if (!cb_v->IsFunction()) {
-      fprintf(stderr, "process._tickDomainCallback assigned to non-function\n");
-      abort();
-    }
-    Local<Function> cb = cb_v.As<Function>();
-    process_tickDomainCallback = Persistent<Function>::New(cb);
-  }
 
   // lazy load domain specific symbols
   if (enter_symbol.IsEmpty()) {
@@ -931,19 +944,22 @@ MakeDomainCallback(const Handle<Object> object,
 
   TryCatch try_catch;
 
-  domain = domain_v->ToObject();
-  assert(!domain.IsEmpty());
-  if (domain->Get(disposed_symbol)->IsTrue()) {
-    // domain has been disposed of.
-    return Undefined();
-  }
-  enter = Local<Function>::Cast(domain->Get(enter_symbol));
-  assert(!enter.IsEmpty());
-  enter->Call(domain, 0, NULL);
+  bool has_domain = !(domain_v->IsNull() || domain_v->IsUndefined());
+  if (has_domain) {
+    domain = domain_v->ToObject();
+    assert(!domain.IsEmpty());
+    if (domain->Get(disposed_symbol)->IsTrue()) {
+      // domain has been disposed of.
+      return Undefined();
+    }
+    enter = Local<Function>::Cast(domain->Get(enter_symbol));
+    assert(!enter.IsEmpty());
+    enter->Call(domain, 0, NULL);
 
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-    return Undefined();
+    if (try_catch.HasCaught()) {
+      FatalException(try_catch);
+      return Undefined();
+    }
   }
 
   Local<Value> ret = callback->Call(object, argc, argv);
@@ -953,13 +969,15 @@ MakeDomainCallback(const Handle<Object> object,
     return Undefined();
   }
 
-  exit = Local<Function>::Cast(domain->Get(exit_symbol));
-  assert(!exit.IsEmpty());
-  exit->Call(domain, 0, NULL);
+  if (has_domain) {
+    exit = Local<Function>::Cast(domain->Get(exit_symbol));
+    assert(!exit.IsEmpty());
+    exit->Call(domain, 0, NULL);
 
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-    return Undefined();
+    if (try_catch.HasCaught()) {
+      FatalException(try_catch);
+      return Undefined();
+    }
   }
 
   if (tick_infobox.length == 0) {
@@ -969,7 +987,7 @@ MakeDomainCallback(const Handle<Object> object,
   }
 
   // process nextTicks after call
-  process_tickDomainCallback->Call(process, 0, NULL);
+  process_tickCallback->Call(process, 0, NULL);
 
   if (try_catch.HasCaught()) {
     FatalException(try_catch);
@@ -1033,10 +1051,8 @@ MakeCallback(const Handle<Object> object,
   HandleScope scope;
 
   Local<Function> callback = object->Get(symbol).As<Function>();
-  Local<Value> domain = object->Get(domain_symbol);
 
-  // has domain, off with you
-  if (!domain->IsNull() && !domain->IsUndefined())
+  if (using_domains)
     return scope.Close(MakeDomainCallback(object, callback, argc, argv));
   return scope.Close(MakeCallback(object, callback, argc, argv));
 }
@@ -2487,6 +2503,8 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   NODE_SET_METHOD(process, "memoryUsage", MemoryUsage);
 
   NODE_SET_METHOD(process, "binding", Binding);
+
+  NODE_SET_METHOD(process, "usingDomains", UsingDomains);
 
   // values use to cross communicate with processNextTick
   Local<Object> info_box = Object::New();

--- a/src/node.js
+++ b/src/node.js
@@ -331,12 +331,12 @@
     var index = 1;
     var depth = 2;
 
-    process._tickCallback = _tickCallback;
-    process._tickFromSpinner = _tickFromSpinner;
-    // needs to be accessible from cc land
-    process._tickDomainCallback = _tickDomainCallback;
     process.nextTick = nextTick;
+    // needs to be accessible from cc land
     process._nextDomainTick = _nextDomainTick;
+    process._tickCallback = _tickCallback;
+    process._tickDomainCallback = _tickDomainCallback;
+    process._tickFromSpinner = _tickFromSpinner;
 
     // the maximum number of times it'll process something like
     // nextTick(function f(){nextTick(f)})

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -145,6 +145,22 @@ expectCaught++;
 
 
 
+// timeouts call the callback directly from cc, so need to make sure the
+// domain will be used regardless
+setTimeout(function() {
+  var domain = require('domain');
+  var d = domain.create();
+  d.run(function() {
+    process.nextTick(function domainsSuck() {
+      console.trace('in nexttick', process.domain === d)
+      assert.equal(process.domain, d);
+    });
+  });
+});
+
+
+
+
 // catch thrown errors no matter how many times we enter the event loop
 // this only uses implicit binding, except for the first function
 // passed to d.run().  The rest are implicitly bound by virtue of being


### PR DESCRIPTION
Since _tickCallback and _tickDomainCallback were both called from
MakeCallback, it was possible for a callback to be called that required
a domain directly to _tickCallback.

The fix was to implement process.usingDomains(). This will set all
applicable functions to their domain counterparts, and set a flag in cc
to let MakeCallback know domain callbacks always need to be checked.

Added test for this case.

Fix for #5131

/cc @isaacs
