### PR TITLE
Fix #5110.

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -118,9 +118,8 @@ See `buffer.write()` example, above.
 
 ### buf.toJSON()
 
-Returns a JSON-representation of the Buffer instance, which is identical to the
-output for JSON Arrays. `JSON.stringify` implicitly calls this function when
-stringifying a Buffer instance.
+Returns a JSON-representation of the Buffer instance.  `JSON.stringify`
+implicitly calls this function when stringifying a Buffer instance.
 
 Example:
 
@@ -128,9 +127,13 @@ Example:
     var json = JSON.stringify(buf);
 
     console.log(json);
-    // '[116,101,115,116]'
+    // '{"type":"Buffer","data":[116,101,115,116]}'
 
-    var copy = new Buffer(JSON.parse(json));
+    var copy = JSON.parse(json, function(key, value) {
+        return value && value.type === 'Buffer'
+          ? new Buffer(value.data)
+          : value;
+      });
 
     console.log(copy);
     // <Buffer 74 65 73 74>

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -381,7 +381,10 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
 
 
 Buffer.prototype.toJSON = function() {
-  return Array.prototype.slice.call(this, 0);
+  return {
+    type: 'Buffer',
+    data: Array.prototype.slice.call(this, 0)
+  };
 };
 
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -853,8 +853,19 @@ Buffer(Buffer(0), 0, 0);
   });
 
 
-// GH-3905
-assert.equal(JSON.stringify(Buffer('test')), '[116,101,115,116]');
+// GH-5110
+(function () {
+  var buffer = new Buffer('test'),
+      string = JSON.stringify(buffer);
+
+  assert.equal(string, '{"type":"Buffer","data":[116,101,115,116]}');
+
+  assert.deepEqual(buffer, JSON.parse(string, function(key, value) {
+    return value && value.type === 'Buffer'
+      ? new Buffer(value.data)
+      : value;
+  }));
+})();
 
 // issue GH-4331
 assert.throws(function() {


### PR DESCRIPTION
Expand the JSON representation of `Buffer` to include type information
so that it can be deserialized in `JSON.parse` without context.
