### PR TITLE
domain: fix domain callback from MakeCallback

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -32,9 +32,8 @@ var endMethods = ['end', 'abort', 'destroy', 'destroySoon'];
 // a few side effects.
 events.usingDomains = true;
 
-// replace tickers with domain specific implementation
-process.nextTick = process._nextDomainTick;
-process._tickCallback = process._tickDomainCallback;
+// let the process know we're using domains
+process._usingDomains();
 
 exports.Domain = Domain;
 

--- a/src/node.js
+++ b/src/node.js
@@ -331,12 +331,12 @@
     var index = 1;
     var depth = 2;
 
-    process._tickCallback = _tickCallback;
-    process._tickFromSpinner = _tickFromSpinner;
-    // needs to be accessible from cc land
-    process._tickDomainCallback = _tickDomainCallback;
     process.nextTick = nextTick;
+    // needs to be accessible from cc land
     process._nextDomainTick = _nextDomainTick;
+    process._tickCallback = _tickCallback;
+    process._tickDomainCallback = _tickDomainCallback;
+    process._tickFromSpinner = _tickFromSpinner;
 
     // the maximum number of times it'll process something like
     // nextTick(function f(){nextTick(f)})

--- a/test/simple/test-domain-from-timer.js
+++ b/test/simple/test-domain-from-timer.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Simple tests of most basic domain functionality.
+
+var common = require('../common');
+var assert = require('assert');
+
+// timeouts call the callback directly from cc, so need to make sure the
+// domain will be used regardless
+setTimeout(function() {
+  var domain = require('domain');
+  var d = domain.create();
+  d.run(function() {
+    process.nextTick(function() {
+      console.trace('in nexttick', process.domain === d)
+      assert.equal(process.domain, d);
+    });
+  });
+});


### PR DESCRIPTION
Since _tickCallback and _tickDomainCallback were both called from
MakeCallback, it was possible for a callback to be called that required
a domain directly to _tickCallback.

The fix was to implement process.usingDomains(). This will set all
applicable functions to their domain counterparts, and set a flag in cc
to let MakeCallback know domain callbacks always need to be checked.

Added test in own file. It's important that the test remains isolated.

Fix for #5131
