### PR TITLE
stream: Handle late 'readable' event listeners

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -236,7 +236,7 @@ Readable.prototype.read = function(n) {
   // the 'readable' event and move on.
   if (n === 0 &&
       state.needReadable &&
-      state.length >= state.highWaterMark) {
+      (state.length >= state.highWaterMark || state.ended)) {
     emitReadable(this);
     return null;
   }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -65,6 +65,7 @@ function ReadableState(options, stream) {
   // that we're awaiting a 'readable' event emission.
   this.needReadable = false;
   this.emittedReadable = false;
+  this.readableListening = false;
 
 
   // object stream flag. Used to make read(n) ignore n and to
@@ -378,7 +379,6 @@ function emitReadable(stream) {
 }
 
 function emitReadable_(stream) {
-  var state = stream._readableState;
   stream.emit('readable');
 }
 
@@ -655,8 +655,19 @@ Readable.prototype.on = function(ev, fn) {
   if (ev === 'data' && !this._readableState.flowing)
     emitDataEvents(this);
 
-  if (ev === 'readable' && !this._readableState.reading)
-    this.read(0);
+  if (ev === 'readable' && this.readable) {
+    var state = this._readableState;
+    if (!state.readableListening) {
+      state.readableListening = true;
+      state.emittedReadable = false;
+      state.needReadable = true;
+      if (!state.reading) {
+        this.read(0);
+      } else if (state.length) {
+        emitReadable(this, state);
+      }
+    }
+  }
 
   return res;
 };

--- a/test/simple/test-stream-readable-event.js
+++ b/test/simple/test-stream-readable-event.js
@@ -80,3 +80,27 @@ var Readable = require('stream').Readable;
     console.log('ok 2');
   });
 })();
+
+(function third() {
+  // Third test, not reading when the stream has not passed
+  // the highWaterMark but *has* reached EOF.
+  var r = new Readable({
+    highWaterMark: 30
+  });
+
+  // This triggers a 'readable' event, which is lost.
+  r.push(new Buffer('blerg'));
+  r.push(null);
+
+  var caughtReadable = false;
+  setTimeout(function() {
+    r.on('readable', function() {
+      caughtReadable = true;
+    });
+  });
+
+  process.on('exit', function() {
+    assert(caughtReadable);
+    console.log('ok 3');
+  });
+})();

--- a/test/simple/test-stream-readable-event.js
+++ b/test/simple/test-stream-readable-event.js
@@ -1,0 +1,82 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var Readable = require('stream').Readable;
+
+(function first() {
+  // First test, not reading when the readable is added.
+  // make sure that read(0) triggers a readable event.
+  var r = new Readable({
+    highWaterMark: 3
+  });
+
+  r._read = function(n) {
+    r.push(new Buffer(new Array(n + 1).join('x')));
+  };
+
+  // This triggers a 'readable' event, which is lost.
+  r.push(new Buffer('blerg'));
+
+  var caughtReadable = false;
+  setTimeout(function() {
+    r.on('readable', function() {
+      caughtReadable = true;
+    });
+  });
+
+  process.on('exit', function() {
+    assert(caughtReadable);
+    console.log('ok 1');
+  });
+})();
+
+(function second() {
+  // second test, make sure that readable is re-emitted if there's
+  // already a length, while it IS reading.
+
+  var r = new Readable({
+    highWaterMark: 3
+  });
+
+  r._read = function(n) {
+    setTimeout(function() {
+      r.push(new Buffer(new Array(n + 1).join('x')));
+    });
+  };
+
+  // This triggers a 'readable' event, which is lost.
+  r.push(new Buffer('blerg'));
+
+  var caughtReadable = false;
+  process.nextTick(function() {
+    r.on('readable', function() {
+      caughtReadable = true;
+    });
+  });
+
+  process.on('exit', function() {
+    assert(caughtReadable);
+    console.log('ok 2');
+  });
+})();


### PR DESCRIPTION
In cases where a stream may have data added to the read queue before the
user adds a 'readable' event, there is never any indication that it's
time to start reading.

True, there's already data there, which the user would get if they
checked However, as we use 'readable' event listening as the signal to
start the flow of data with a read(0) call internally, we ought to
trigger the same effect (ie, emitting a 'readable' event) even if the
'readable' listener is added after the first emission.

To avoid confusing weirdness, only the _first_ 'readable' event listener
is granted this privileged status.  After we've started the flow (or,
alerted the consumer that the flow has started) we don't need to start
it again.  At that point, it's the consumer's responsibility to consume
the stream.

Closes #5141

cc: @mjijackson
