### PR TITLE
url: fix hostname pattern to not accept empty string

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -66,8 +66,8 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
       .concat(unwise).concat(autoEscape),
     nonAuthChars = ['/', '@', '?', '#'].concat(delims),
     hostnameMaxLen = 255,
-    hostnamePartPattern = /^[a-z0-9A-Z_-]{0,63}$/,
-    hostnamePartStart = /^([a-z0-9A-Z_-]{0,63})(.*)$/,
+    hostnamePartPattern = /^[a-z0-9A-Z_-]{1,63}$/,
+    hostnamePartStart = /^([a-z0-9A-Z_-]{1,63})(.*)$/,
     // protocols that can allow "unsafe" and "unwise" chars.
     unsafeProtocol = {
       'javascript': true,

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -1408,3 +1408,36 @@ relativeTests2.forEach(function(relativeTest) {
                'format(' + relativeTest[1] + ') == ' + expected +
                '\nactual:' + actual);
 });
+
+// Do not parse ".*" as a hostname (breaks regex matching in http-proxy)
+var regexHostname = {
+  'http://.*/': {
+	  'protocol': 'http:',
+    'slashes': true,
+		'host': '',
+	  'hostname': '',
+		'path': '/',
+    'pathname': '/',
+    'href': 'http:///'
+  }
+};
+
+for (var u in regexHostname) {
+  var actual = url.parse(u);
+  var expected = regexHostname[u];
+
+  Object.keys(actual).forEach(function (i) {
+    if (expected[i] === undefined && actual[i] === null) {
+      expected[i] = null;
+    }
+  });
+
+  assert.deepEqual(actual, expected,
+			'Regex .* should not parse as a host and hostname ("." is not a valid hostname)');
+
+  var expected = regexHostname[u].href,
+      actual = url.format(regexHostname[u]);
+
+  assert.equal(actual, expected,
+               'format(' + u + ') == ' + u + '\nactual:' + actual);
+}


### PR DESCRIPTION
Disallow matching of empty string as a valid hostname.  Could lead to failure in URL remapping tables for http-proxy.
