### PR TITLE
doc: typo fixes

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -666,7 +666,7 @@ the file instead of the entire file.  Both `start` and `end` are inclusive and
 start at 0. The `encoding` can be `'utf8'`, `'ascii'`, or `'base64'`.
 
 If `autoClose` is false, then the file descriptor won't be closed, even if
-there's an error.  It is your responsiblity to close it and make sure
+there's an error.  It is your responsibility to close it and make sure
 there's no file descriptor leak.  If `autoClose` is set to true (default
 behavior), on `error` or `end` the file descriptor will be closed
 automatically.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -164,7 +164,7 @@ automatically set as a listener for the [secureConnection][] event.  The
     SecureContext). If `SNICallback` wasn't provided - default callback with
     high-level API will be used (see below).
 
-  - `sessionTimeout`: An integer specifiying the seconds after which TLS
+  - `sessionTimeout`: An integer specifying the seconds after which TLS
     session identifiers and TLS session tickets created by the server are
     timed out. See [SSL_CTX_set_timeout] for more details.
 

--- a/doc/blog/feature/streams2.md
+++ b/doc/blog/feature/streams2.md
@@ -13,7 +13,7 @@ category: feature
 * Readable streams have a `read()` method that returns a buffer or
   null.  (More documentation included below.)
 * `'data'` events, `pause()`, and `resume()` will still work as before
-  (except that they'll actully work how you'd expect).
+  (except that they'll actually work how you'd expect).
 * Old programs will **almost always** work without modification, but
   streams start out in a paused state, and need to be read from to be
   consumed.


### PR DESCRIPTION
A few typo fixes in the docs and blog. Thanks!
