### PR TITLE
tls: Destroy socket when encrypted side closes

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1322,6 +1322,12 @@ function pipe(pair, socket) {
   pair.encrypted.pipe(socket);
   socket.pipe(pair.encrypted);
 
+  pair.encrypted.on('close', function() {
+    process.nextTick(function() {
+      socket.destroy();
+    });
+  });
+
   pair.fd = socket.fd;
   var cleartext = pair.cleartext;
   cleartext.socket = socket;


### PR DESCRIPTION
The v0.8 Stream.pipe() method automatically destroyed the destination
stream whenever the src stream closed.  However, this caused a lot of
problems, and was removed by popular demand.  (Many userland modules
still have a no-op destroy() method just because of this.) It was also
very hazardous because this would be done even if { end: false } was
passed in the pipe options.

In v0.10, we decided that the 'close' event and destroy() method are
application-specific, and pipe() doesn't automatically call destroy().
However, TLS actually depended (silently) on this behavior.  So, in this
case, we should just go ahead and destroy the thing when close happens.

Closes #5145
