### PR TITLE
etw: update prototypes to match dtrace provider

### DIFF
--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -112,7 +112,8 @@ extern int events_enabled;
 
 
 void NODE_HTTP_SERVER_REQUEST(node_dtrace_http_server_request_t* req,
-    node_dtrace_connection_t* conn) {
+    node_dtrace_connection_t* conn, const char *remote, int port,
+    const char *method, const char *url, int fd) {
   EVENT_DATA_DESCRIPTOR descriptors[7];
   ETW_WRITE_HTTP_SERVER_REQUEST(descriptors, req);
   ETW_WRITE_NET_CONNECTION(descriptors + 3, conn);
@@ -120,7 +121,8 @@ void NODE_HTTP_SERVER_REQUEST(node_dtrace_http_server_request_t* req,
 }
 
 
-void NODE_HTTP_SERVER_RESPONSE(node_dtrace_connection_t* conn) {
+void NODE_HTTP_SERVER_RESPONSE(node_dtrace_connection_t* conn,
+    const char *remote, int port, int fd) {
   EVENT_DATA_DESCRIPTOR descriptors[4];
   ETW_WRITE_NET_CONNECTION(descriptors, conn);
   ETW_WRITE_EVENT(NODE_HTTP_SERVER_RESPONSE_EVENT, descriptors);
@@ -128,7 +130,8 @@ void NODE_HTTP_SERVER_RESPONSE(node_dtrace_connection_t* conn) {
 
 
 void NODE_HTTP_CLIENT_REQUEST(node_dtrace_http_client_request_t* req,
-    node_dtrace_connection_t* conn) {
+    node_dtrace_connection_t* conn, const char *remote, int port,
+    const char *method, const char *url, int fd) {
   EVENT_DATA_DESCRIPTOR descriptors[6];
   ETW_WRITE_HTTP_CLIENT_REQUEST(descriptors, req);
   ETW_WRITE_NET_CONNECTION(descriptors + 2, conn);
@@ -136,21 +139,24 @@ void NODE_HTTP_CLIENT_REQUEST(node_dtrace_http_client_request_t* req,
 }
 
 
-void NODE_HTTP_CLIENT_RESPONSE(node_dtrace_connection_t* conn) {
+void NODE_HTTP_CLIENT_RESPONSE(node_dtrace_connection_t* conn,
+    const char *remote, int port, int fd) {
   EVENT_DATA_DESCRIPTOR descriptors[4];
   ETW_WRITE_NET_CONNECTION(descriptors, conn);
   ETW_WRITE_EVENT(NODE_HTTP_CLIENT_RESPONSE_EVENT, descriptors);
 }
 
 
-void NODE_NET_SERVER_CONNECTION(node_dtrace_connection_t* conn) {
+void NODE_NET_SERVER_CONNECTION(node_dtrace_connection_t* conn,
+    const char *remote, int port, int fd) {
   EVENT_DATA_DESCRIPTOR descriptors[4];
   ETW_WRITE_NET_CONNECTION(descriptors, conn);
   ETW_WRITE_EVENT(NODE_NET_SERVER_CONNECTION_EVENT, descriptors);
 }
 
 
-void NODE_NET_STREAM_END(node_dtrace_connection_t* conn) {
+void NODE_NET_STREAM_END(node_dtrace_connection_t* conn,
+    const char *remote, int port, int fd) {
   EVENT_DATA_DESCRIPTOR descriptors[4];
   ETW_WRITE_NET_CONNECTION(descriptors, conn);
   ETW_WRITE_EVENT(NODE_NET_STREAM_END_EVENT, descriptors);

--- a/src/node_win32_etw_provider.h
+++ b/src/node_win32_etw_provider.h
@@ -57,13 +57,19 @@ void init_etw();
 void shutdown_etw();
 
 INLINE void NODE_HTTP_SERVER_REQUEST(node_dtrace_http_server_request_t* req,
-  node_dtrace_connection_t* conn);
-INLINE void NODE_HTTP_SERVER_RESPONSE(node_dtrace_connection_t* conn);
+  node_dtrace_connection_t* conn, const char *remote, int port,
+  const char *method, const char *url, int fd);
+INLINE void NODE_HTTP_SERVER_RESPONSE(node_dtrace_connection_t* conn,
+  const char *remote, int port, int fd);
 INLINE void NODE_HTTP_CLIENT_REQUEST(node_dtrace_http_client_request_t* req,
-  node_dtrace_connection_t* conn);
-INLINE void NODE_HTTP_CLIENT_RESPONSE(node_dtrace_connection_t* conn);
-INLINE void NODE_NET_SERVER_CONNECTION(node_dtrace_connection_t* conn);
-INLINE void NODE_NET_STREAM_END(node_dtrace_connection_t* conn);
+  node_dtrace_connection_t* conn, const char *remote, int port,
+  const char *method, const char *url, int fd);
+INLINE void NODE_HTTP_CLIENT_RESPONSE(node_dtrace_connection_t* conn,
+  const char *remote, int port, int fd);
+INLINE void NODE_NET_SERVER_CONNECTION(node_dtrace_connection_t* conn,
+  const char *remote, int port, int fd);
+INLINE void NODE_NET_STREAM_END(node_dtrace_connection_t* conn,
+  const char *remote, int port, int fd);
 INLINE void NODE_GC_START(GCType type, GCCallbackFlags flags);
 INLINE void NODE_GC_DONE(GCType type, GCCallbackFlags flags);
 INLINE void NODE_V8SYMBOL_REMOVE(const void* addr1, const void* addr2);


### PR DESCRIPTION
The DTrace probes were updated to accomodate platforms that can't
handle structs, update the prototypes for ETW but it's not necessary
to do anything with the new arguments as it's redundant information.

@sblom or @piscisaureus can you please verify that ETW still works?

BTW I've incentivized you by making the build fail on windows without a change
