### PR TITLE
fs: Remove duplicate `!options` conditions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -173,8 +173,6 @@ fs.readFile = function(path, options, callback_) {
     options = { encoding: null, flag: 'r' };
   } else if (typeof options === 'string') {
     options = { encoding: options, flag: 'r' };
-  } else if (!options) {
-    options = { encoding: null, flag: 'r' };
   } else if (typeof options !== 'object') {
     throw new TypeError('Bad arguments');
   }
@@ -917,8 +915,6 @@ fs.writeFile = function(path, data, options, callback) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
   } else if (typeof options === 'string') {
     options = { encoding: options, mode: 438, flag: 'w' };
-  } else if (!options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
   } else if (typeof options !== 'object') {
     throw new TypeError('Bad arguments');
   }
@@ -974,8 +970,6 @@ fs.appendFile = function(path, data, options, callback_) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
   } else if (typeof options === 'string') {
     options = { encoding: options, mode: 438, flag: 'a' };
-  } else if (!options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
   } else if (typeof options !== 'object') {
     throw new TypeError('Bad arguments');
   }


### PR DESCRIPTION
These `if` statements are already handled so this code will never be called. Removing due to duplication.
