### PR TITLE
objectMode transform should allow falsey values

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -174,7 +174,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 Transform.prototype._read = function(n) {
   var ts = this._transformState;
 
-  if (ts.writechunk && ts.writecb && !ts.transforming) {
+  if (ts.writechunk !== null && ts.writecb && !ts.transforming) {
     ts.transforming = true;
     this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {

--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -104,6 +104,28 @@ test('passthrough', function(t) {
   t.end();
 });
 
+test('object passthrough', function (t) {
+  var pt = new PassThrough({ objectMode: true });
+
+  pt.write(1);
+  pt.write(true);
+  pt.write(false);
+  pt.write(0);
+  pt.write('foo');
+  pt.write('');
+  pt.write({ a: 'b'});
+  pt.end();
+
+  t.equal(pt.read(), 1);
+  t.equal(pt.read(), true);
+  t.equal(pt.read(), false);
+  t.equal(pt.read(), 0);
+  t.equal(pt.read(), 'foo');
+  t.equal(pt.read(), '');
+  t.same(pt.read(), { a: 'b'});
+  t.end();
+});
+
 test('simple transform', function(t) {
   var pt = new Transform;
   pt._transform = function(c, e, cb) {
@@ -123,6 +145,32 @@ test('simple transform', function(t) {
   t.equal(pt.read(5).toString(), 'xxxxx');
   t.equal(pt.read(5).toString(), 'xxxxx');
   t.equal(pt.read(5).toString(), 'x');
+  t.end();
+});
+
+test('simple object transform', function(t) {
+  var pt = new Transform({ objectMode: true });
+  pt._transform = function(c, e, cb) {
+    pt.push(JSON.stringify(c));
+    cb();
+  };
+
+  pt.write(1);
+  pt.write(true);
+  pt.write(false);
+  pt.write(0);
+  pt.write('foo');
+  pt.write('');
+  pt.write({ a: 'b'});
+  pt.end();
+
+  t.equal(pt.read(), '1');
+  t.equal(pt.read(), 'true');
+  t.equal(pt.read(), 'false');
+  t.equal(pt.read(), '0');
+  t.equal(pt.read(), '"foo"');
+  t.equal(pt.read(), '""');
+  t.equal(pt.read(), '{"a":"b"}');
   t.end();
 });
 


### PR DESCRIPTION
objectMode transform should allow falsey values
if a transform (or passthrough) stream has objectMode = true, 
it should allow falsey values other than (null or undefined) like
0, false, ''.

null and undefined are reserved to indicate stream eof
but other falsey values should flow through properly.

tests and fix are attached.
