### PR TITLE
test: test intended code-paths

### DIFF
--- a/test/simple/test-stream-readable-event.js
+++ b/test/simple/test-stream-readable-event.js
@@ -26,13 +26,14 @@ var Readable = require('stream').Readable;
 
 (function first() {
   // First test, not reading when the readable is added.
-  // make sure that read(0) triggers a readable event.
+  // make sure that on('readable', ...) triggers a readable event.
   var r = new Readable({
     highWaterMark: 3
   });
 
+  var _readCalled = false;
   r._read = function(n) {
-    r.push(new Buffer(new Array(n + 1).join('x')));
+    _readCalled = true;
   };
 
   // This triggers a 'readable' event, which is lost.
@@ -40,12 +41,17 @@ var Readable = require('stream').Readable;
 
   var caughtReadable = false;
   setTimeout(function() {
+    // we're testing what we think we are
+    assert(!r._readableState.reading);
     r.on('readable', function() {
       caughtReadable = true;
     });
   });
 
   process.on('exit', function() {
+    // we're testing what we think we are
+    assert(!_readCalled);
+
     assert(caughtReadable);
     console.log('ok 1');
   });
@@ -59,23 +65,27 @@ var Readable = require('stream').Readable;
     highWaterMark: 3
   });
 
+  var _readCalled = false;
   r._read = function(n) {
-    setTimeout(function() {
-      r.push(new Buffer(new Array(n + 1).join('x')));
-    });
+    _readCalled = true;
   };
 
   // This triggers a 'readable' event, which is lost.
-  r.push(new Buffer('blerg'));
+  r.push(new Buffer('bl'));
 
   var caughtReadable = false;
-  process.nextTick(function() {
+  setTimeout(function() {
+    // assert we're testing what we think we are
+    assert(r._readableState.reading);
     r.on('readable', function() {
       caughtReadable = true;
     });
   });
 
   process.on('exit', function() {
+    // we're testing what we think we are
+    assert(_readCalled);
+
     assert(caughtReadable);
     console.log('ok 2');
   });
@@ -88,18 +98,28 @@ var Readable = require('stream').Readable;
     highWaterMark: 30
   });
 
+  var _readCalled = false;
+  r._read = function(n) {
+    _readCalled = true;
+  };
+
   // This triggers a 'readable' event, which is lost.
   r.push(new Buffer('blerg'));
   r.push(null);
 
   var caughtReadable = false;
   setTimeout(function() {
+    // assert we're testing what we think we are
+    assert(!r._readableState.reading);
     r.on('readable', function() {
       caughtReadable = true;
     });
   });
 
   process.on('exit', function() {
+    // we're testing what we think we are
+    assert(!_readCalled);
+
     assert(caughtReadable);
     console.log('ok 3');
   });


### PR DESCRIPTION
The tests did not agree with the test comments. Tests first and second
were both testing the !state.reading case. Now second tests the
state.reading && state.length case.

Fixes joyent/node#5183
