### PR TITLE
http: Avoid EE warning on ECONNREFUSED handling

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -509,9 +509,9 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
     // ignored in the first place.  We'll probably emit 'close' on the
     // next tick, but just in case it's not coming, set a timeout that
     // will emit it for us.
-    if (!this._hangupClose) {
-      this._hangupClose = true;
+    if (!this._hangupClose && !this.socket._hangupClose) {
       var socket = this.socket;
+      socket._hangupClose = this._hangupClose = true;
       var timer = setTimeout(function() {
         socket.emit('close');
       });

--- a/test/simple/test-http-many-ended-pipelines.js
+++ b/test/simple/test-http-many-ended-pipelines.js
@@ -1,0 +1,57 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+// no warnings should happen!
+var trace = console.trace;
+console.trace = function() {
+  trace.apply(console, arguments);
+  throw new Error('no tracing allowed.');
+};
+
+var http = require('http');
+var net = require('net');
+
+var server = http.createServer(function(req, res) {
+  res.end('ok');
+
+  // Oh no!  The connection died!
+  req.socket.destroy();
+});
+
+server.listen(common.PORT);
+
+var client = net.connect({ port: common.PORT, allowHalfOpen: true });
+client.on('connect', function() {
+  for (var i = 0; i < 200; i++) {
+    client.write('GET / HTTP/1.1\r\n' +
+                 'Host: some.host.name\r\n'+
+                 '\r\n\r\n');
+  }
+  client.end();
+
+  setTimeout(function() {
+    server.close();
+  });
+});
+client.pipe(process.stdout);


### PR DESCRIPTION
This is a back-port of the same fix in
deb1dc279d49463e13af44feed45c79ae0f379f9, for v0.8.
