### PR TITLE
build: depend on v8 postmortem-metadata if enabled

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -220,6 +220,9 @@
             'tools/msvs/genfiles/node_perfctr_provider.rc',
           ]
         } ],
+        [ 'v8_postmortem_support=="true"', {
+          'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],
+        }],
         [ 'node_shared_v8=="false"', {
           'sources': [
             'deps/v8/include/v8.h',


### PR DESCRIPTION
This makes sure postmortem metadata is generated before trying to build node, this only appeared to be a problem when building inside of xcode

see #4020
