### PR TITLE
stream: call write's callback before end's callback

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -341,10 +341,13 @@ function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
   if (cb) {
-    if (state.finished)
+    if (state.finished) {
       process.nextTick(cb);
-    else
-      stream.once('finish', cb);
+    } else {
+      stream.once('finish', function() {
+        process.nextTick(cb);
+      });
+    }
   }
   state.ended = true;
 }

--- a/test/simple/test-stream2-writable.js
+++ b/test/simple/test-stream2-writable.js
@@ -275,6 +275,18 @@ test('end callback after .write() call', function (t) {
   });
 });
 
+test('end callback called after write callback', function (t) {
+  var tw = new TestWriter();
+  var writeCalledback = false;
+  tw.write(new Buffer('hello world'),  function() {
+    writeCalledback = true;
+  });
+  tw.end(function () {
+    t.equal(writeCalledback, true);
+    t.end();
+  });
+});
+
 test('encoding should be ignored for buffers', function(t) {
   var tw = new W();
   var hex = '018b5e9a8f6236ffe30e31baf80d2cf6eb';


### PR DESCRIPTION
Since commit joyent/node@049903e an end callback could be called before a write callback, if end() is called before the write is done. This patch makes sure write's callback is called before end's callback.

This patch should fix the issue discussed in felixge/node-formidable#209.
