### PR TITLE
crypto: fix RSA signature validation

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2831,7 +2831,7 @@ exit:
     return ThrowCryptoError(err);
   }
 
-  return scope.Close(r ? True() : False(node_isolate));
+  return scope.Close(r == 1 ? True() : False(node_isolate));
 }
 
 


### PR DESCRIPTION
There existed a potential security hole whereby openssl reporting an
error would result in node reporting the signature to be valid.

The return value from EVP_VerifyFinal() can be 1 for valid, 0 for
invalid or -1 for error.  It should therefore be tested for == 1, not
just != 0.
