### PR TITLE
tls: Re-enable checking of CN-ID in server identity verification

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -140,7 +140,6 @@ function checkServerIdentity(host, cert) {
   //
   // Walk through altnames and generate lists of those names
   if (cert.subjectaltname) {
-    matchCN = false;
     cert.subjectaltname.split(/, /g).forEach(function(altname) {
       if (/^DNS:/.test(altname)) {
         dnsNames.push(altname.slice(4));
@@ -178,7 +177,7 @@ function checkServerIdentity(host, cert) {
 
     if (dnsNames.length > 0) matchCN = false;
 
-    // Match against Common Name (CN) only if altnames are not present.
+    // Match against Common Name (CN) only if no supported identifiers are present.
     //
     // "As noted, a client MUST NOT seek a match for a reference identifier
     //  of CN-ID if the presented identifiers include a DNS-ID, SRV-ID,


### PR DESCRIPTION
[RFC 6125](http://tools.ietf.org/html/rfc6125#section-6.4.4) explicitly states that a client "MUST NOT seek a match
for a reference identifier of CN-ID if the presented identifiers
include a DNS-ID, SRV-ID, URI-ID, or any application-specific
identifier types supported by the client", but it MAY do so if
none of the mentioned identifier types (but others) are present.

As certificates with unsupported identifiers in altnames (e. g. `email:`) are not uncommon, we should be more liberal by resorting to the (deprecated) CN-ID based verification in these cases.
