### PR TITLE
Removing some vestiges

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -70,8 +70,6 @@ util.inherits(Transform, Duplex);
 
 
 function TransformState(options, stream) {
-  var ts = this;
-
   this.afterTransform = function(er, data) {
     return afterTransform(stream, er, data);
   };

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -152,7 +152,7 @@ Transform.prototype.push = function(chunk) {
 // Call `cb(err)` when you are done with this chunk.  If you pass
 // an error, then that'll put the hurt on the whole operation.  If you
 // never call cb(), then you'll never get another chunk.
-Transform.prototype._transform = function(chunk, output, cb) {
+Transform.prototype._transform = function(chunk, encoding, cb) {
   throw new Error('not implemented');
 };
 
@@ -171,7 +171,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 };
 
 // Doesn't matter what the args are here.
-// the output and callback functions passed to _transform do all the work.
+// _transform does all the work.
 // That we got here means that the readable side wants more data.
 Transform.prototype._read = function(n) {
   var ts = this._transformState;


### PR DESCRIPTION
Removing evidence of _transform's old `output` callback.
