### PR TITLE
Fixed offset checks in `Buffer.readInt32LE()` and `Buffer.readInt32BE()`.

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -738,14 +738,14 @@ function readInt32(buffer, offset, isBigEndian) {
 
 Buffer.prototype.readInt32LE = function(offset, noAssert) {
   if (!noAssert)
-    checkOffset(offset, 2, this.length);
+    checkOffset(offset, 4, this.length);
   return readInt32(this, offset, false);
 };
 
 
 Buffer.prototype.readInt32BE = function(offset, noAssert) {
   if (!noAssert)
-    checkOffset(offset, 2, this.length);
+    checkOffset(offset, 4, this.length);
   return readInt32(this, offset, true);
 };
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -899,6 +899,40 @@ assert.throws(function() {
   buf.writeFloatLE(0.0, -1);
 }, /offset is not uint/);
 
+// offset checks
+var buf = new Buffer(0);
+
+assert.throws(function() { buf.readUInt8(0); }, /beyond buffer length/);
+assert.throws(function() { buf.readInt8(0); }, /beyond buffer length/);
+
+[16, 32].forEach(function(bits)
+{
+  var buf = new Buffer(bits / 8 - 1);
+
+  assert.throws(
+    function() { buf['readUInt' + bits + 'BE'](0); },
+    /beyond buffer length/,
+    'readUInt' + bits + 'BE'
+  );
+
+  assert.throws(
+    function() { buf['readUInt' + bits + 'LE'](0); },
+    /beyond buffer length/,
+    'readUInt' + bits + 'LE'
+  );
+
+  assert.throws(
+    function() { buf['readInt' + bits + 'BE'](0); },
+    /beyond buffer length/,
+    'readInt' + bits + 'BE()'
+  );
+
+  assert.throws(
+    function() { buf['readInt' + bits + 'LE'](0); },
+    /beyond buffer length/,
+    'readInt' + bits + 'LE()'
+  );
+});
 
 // SlowBuffer sanity checks.
 assert.throws(function() {


### PR DESCRIPTION
Fixed offset checks in `Buffer.readInt32LE()` and `Buffer.readInt32BE()`.
