### PR TITLE
doc: Fix File System document

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -687,7 +687,7 @@ some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
 default mode `w`.
 
-## fs.WriteStream
+## Class: fs.WriteStream
 
 `WriteStream` is a [Writable Stream](stream.html#stream_class_stream_writable).
 

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -663,7 +663,7 @@ An example to read the last 10 bytes of a file which is 100 bytes long:
 
 ## Class: fs.ReadStream
 
-`ReadStream` is a [Readable Stream](stream.html#stream_readable_stream).
+`ReadStream` is a [Readable Stream](stream.html#stream_class_stream_readable).
 
 ### Event: 'open'
 
@@ -689,7 +689,7 @@ default mode `w`.
 
 ## fs.WriteStream
 
-`WriteStream` is a [Writable Stream](stream.html#stream_writable_stream).
+`WriteStream` is a [Writable Stream](stream.html#stream_class_stream_writable).
 
 ### Event: 'open'
 


### PR DESCRIPTION
Including two fixes on File System document:
- Fix missing Class in header
- Fix the link to Stream document
