### PR TITLE
process: expose NODE_MODULE_VERSION in process.versions

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -324,13 +324,16 @@ A property exposing version strings of node and its dependencies.
 
     console.log(process.versions);
 
-Will output:
+Will print something like:
 
-    { node: '0.4.12',
-      v8: '3.1.8.26',
-      ares: '1.7.4',
-      ev: '4.4',
-      openssl: '1.0.0e-fips' }
+    { http_parser: '1.0',
+      node: '0.10.4',
+      v8: '3.14.5.8',
+      ares: '1.9.0-DEV',
+      uv: '0.10.3',
+      zlib: '1.2.3',
+      modules: '0x000B',
+      openssl: '1.0.1e' }
 
 ## process.config
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2356,6 +2356,8 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   versions->Set(String::NewSymbol("ares"), String::New(ARES_VERSION_STR));
   versions->Set(String::NewSymbol("uv"), String::New(uv_version_string()));
   versions->Set(String::NewSymbol("zlib"), String::New(ZLIB_VERSION));
+  versions->Set(String::NewSymbol("modules"),
+                String::New(NODE_STRINGIFY(NODE_MODULE_VERSION)));
 #if HAVE_OPENSSL
   // Stupid code to slice out the version string.
   int c, l = strlen(OPENSSL_VERSION_TEXT);


### PR DESCRIPTION
Would be very helpful for determining appropriate versions of pre-compiled modules to use/download, in a post-install script for example.

Exposed as `process.versions.modules`

Leave as hex, e.g. `0x000B`, can be parsed easily with something like `parseInt(process.versions.modules || '0', 16)` if required.
