### PR TITLE
crypto: fix constructor call in crypto streams

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -155,7 +155,10 @@ function LazyTransform(options) {
 }
 util.inherits(LazyTransform, stream.Transform);
 
-['read', 'write', 'end'].forEach(function(action, i, actions) {
+var transformMethods = ['read', 'write', 'end', 'pipe', 'unpipe',
+  'setEncoding', 'pause', 'resume'];
+
+transformMethods.forEach(function(action, i, actions) {
   LazyTransform.prototype[action] = function() {
     stream.Transform.call(this, this._options);
 

--- a/test/simple/test-crypto-stream.js
+++ b/test/simple/test-crypto-stream.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var stream = require('stream');
+var util = require('util');
+
+try {
+  var crypto = require('crypto');
+} catch (e) {
+  console.log('Not compiled with OPENSSL support.');
+  process.exit();
+}
+
+// Small stream to buffer converter
+function Stream2buffer(callback) {
+  stream.Writable.call(this);
+  
+  this._buffers = [];
+  this.once('finish', function () {
+    callback(null, Buffer.concat(this._buffers));
+  });
+}
+util.inherits(Stream2buffer, stream.Writable);
+
+Stream2buffer.prototype._write = function (data, encodeing, done) {
+  this._buffers.push(data);
+  return done(null);
+};
+
+// Create an md5 hash of "Hallo world"
+var hasher1 = crypto.createHash('md5');
+    hasher1.pipe(new Stream2buffer(common.mustCall(function end(err, hash) {
+      assert.equal(err, null);
+      assert.equal(hash.toString('hex'), '06460dadb35d3d503047ce750ceb2d07');
+    })));
+    hasher1.end('Hallo world');
+
+// Simpler check for unpipe, setEncoding, pause and resume
+crypto.createHash('md5').unpipe({});
+crypto.createHash('md5').setEncoding('utf8');
+crypto.createHash('md5').pause();
+crypto.createHash('md5').resume();


### PR DESCRIPTION
When using some stream method on a lazy crypto stream, the transform constructor
wasn't called. This caused the internal state object to be undefined.
