### PR TITLE
crypto: fix LazyTransform is too lazy

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -155,19 +155,24 @@ function LazyTransform(options) {
 }
 util.inherits(LazyTransform, stream.Transform);
 
-var transformMethods = ['read', 'write', 'end', 'pipe', 'unpipe',
-  'setEncoding', 'pause', 'resume'];
-
-transformMethods.forEach(function(action, i, actions) {
-  LazyTransform.prototype[action] = function() {
-    stream.Transform.call(this, this._options);
-
-    actions.forEach(function(action) {
-      this[action] = stream.Transform.prototype[action];
-    }, this);
-
-    return this[action].apply(this, arguments);
-  };
+['_readableState', '_writableState', '_transformState'].forEach(
+function(prop, i, props) {
+  Object.defineProperty(LazyTransform.prototype, prop, {
+    get: function() {
+      stream.Transform.call(this, this._options);
+      return this[prop];
+    },
+    set: function(val) {
+      Object.defineProperty(this, prop, {
+        value: val,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    },
+    configurable: true,
+    enumerable: true
+  });
 });
 
 

--- a/test/simple/test-crypto-hash-stream-pipe.js
+++ b/test/simple/test-crypto-hash-stream-pipe.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var crypto = require('crypto');
+var stream = require('stream')
+var s = new stream.PassThrough();
+var h = crypto.createHash('sha1');
+var expect = '15987e60950cf22655b9323bc1e281f9c4aff47e';
+var gotData = false;
+
+process.on('exit', function() {
+  assert(gotData);
+  console.log('ok');
+});
+
+s.pipe(h).on('data', function(c) {
+  assert.equal(c, expect);
+  gotData = true;
+}).setEncoding('hex');
+
+s.end('aoeu');


### PR DESCRIPTION
It needs to apply the Transform class when the _readableState,
_writableState, or _transformState properties are accessed,
otherwise things like setEncoding and on('data') don't work
properly.
