### PR TITLE
http: Support write(data, 'hex')

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -772,15 +772,18 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
 
   var len, ret;
   if (this.chunkedEncoding) {
-    if (typeof(chunk) === 'string') {
+    if (typeof(chunk) === 'string' &&
+        encoding !== 'hex' &&
+        encoding !== 'base64' &&
+        encoding !== 'binary') {
       len = Buffer.byteLength(chunk, encoding);
       chunk = len.toString(16) + CRLF + chunk + CRLF;
       ret = this._send(chunk, encoding);
     } else {
-      // buffer
+      // buffer, or a non-toString-friendly encoding
       len = chunk.length;
       this._send(len.toString(16) + CRLF);
-      this._send(chunk);
+      this._send(chunk, encoding);
       ret = this._send(CRLF);
     }
   } else {

--- a/test/simple/test-http-byteswritten.js
+++ b/test/simple/test-http-byteswritten.js
@@ -35,10 +35,12 @@ var httpServer = http.createServer(function(req, res) {
   });
   res.writeHead(200, { 'Content-Type': 'text/plain' });
 
-  // Write 1mb to cause some requests to buffer
-  var chunk = new Array(1024).join('A');
+  // Write 1.5mb to cause some requests to buffer
+  // Also, mix up the encodings a bit.
+  var chunk = new Array(1024 + 1).join('7');
   for (var i = 0; i < 1024; i++) {
     res.write(chunk);
+    res.write(chunk, 'hex');
   }
   // Get .bytesWritten while buffer is not empty
   assert(res.connection.bytesWritten > 0);


### PR DESCRIPTION
We were assuming that any string can be concatenated safely to
CRLF.  However, for hex, base64, or binary encoded writes, this
is not the case, and results in sending the incorrect response.

An unusual edge case, but certainly a bug.
