### PR TITLE
docs: update path.join() example for v0.10

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -36,8 +36,8 @@ Example:
     '/foo/bar/baz/asdf'
 
     path.join('foo', {}, 'bar')
-    // returns
-    'foo/bar'
+    // throws exception
+    TypeError: Arguments to path.join must be strings
 
 ## path.resolve([from ...], to)
 


### PR DESCRIPTION
The current example shows the behavior of v0.8. In v0.10 arguments
to path.join() must be strings; otherwise, an exception is thrown.
