### PR TITLE
net: fix socket.bytesWritten Buffers support

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -667,11 +667,17 @@ Socket.prototype.__defineGetter__('bytesWritten', function() {
       encoding = this._pendingEncoding;
 
   state.buffer.forEach(function(el) {
-    bytes += Buffer.byteLength(el.chunk, el.encoding);
+    if (Buffer.isBuffer(el.chunk))
+      bytes += el.chunk.length;
+    else
+      bytes += Buffer.byteLength(el.chunk, el.encoding);
   });
 
   if (data)
-    bytes += Buffer.byteLength(data, encoding);
+    if (Buffer.isBuffer(data))
+      bytes += data.length;
+    else
+      bytes += Buffer.byteLength(data, encoding);
 
   return bytes;
 });


### PR DESCRIPTION
Buffer.byteLength() works only for string inputs. Thus, when connection
has pending Buffer to write, it should just use it's length instead of
throwing exception.

/cc @isaacs @bnoordhuis @piscisaureus
