### PR TITLE
Preserve environment when forking child process

### DIFF
--- a/test/simple/test-child-process-fork-exec-path.js
+++ b/test/simple/test-child-process-fork-exec-path.js
@@ -44,9 +44,12 @@ else {
   fs.writeFileSync(copyPath, fs.readFileSync(nodePath));
   fs.chmodSync(copyPath, '0755');
 
+  // slow but simple
+  var envCopy = JSON.parse(JSON.stringify(process.env));
+  envCopy.FORK = 'true';
   var child = require('child_process').fork(__filename, {
     execPath: copyPath,
-    env: { FORK: 'true' }
+    env: envCopy
   });
   child.on('message', common.mustCall(function(recv) {
     assert.deepEqual(msg, recv);

--- a/test/simple/test-init.js
+++ b/test/simple/test-init.js
@@ -34,12 +34,16 @@
     // being in the test folder
     process.chdir(__dirname);
 
-    child.exec(process.execPath + ' test-init', {env: {'TEST_INIT': 1}},
+    // slow but simple
+    var envCopy = JSON.parse(JSON.stringify(process.env));
+    envCopy.TEST_INIT = 1;
+
+    child.exec(process.execPath + ' test-init', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init` failed!');
         });
-    child.exec(process.execPath + ' test-init.js', {env: {'TEST_INIT': 1}},
+    child.exec(process.execPath + ' test-init.js', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init.js` failed!');
@@ -48,7 +52,7 @@
     // test-init-index is in fixtures dir as requested by ry, so go there
     process.chdir(common.fixturesDir);
 
-    child.exec(process.execPath + ' test-init-index', {env: {'TEST_INIT': 1}},
+    child.exec(process.execPath + ' test-init-index', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init-index failed!');
@@ -59,7 +63,7 @@
     // expected in node
     process.chdir(common.fixturesDir + '/test-init-native/');
 
-    child.exec(process.execPath + ' fs', {env: {'TEST_INIT': 1}},
+    child.exec(process.execPath + ' fs', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'fs loaded successfully',
                        '`node fs` failed!');


### PR DESCRIPTION
In some cases preserving environment can be crucial for tests to succeed so we
copy original environment and add FORK variable to it.
