### PR TITLE
Isolate, domain, etc cleanup

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -33,7 +33,7 @@ var endMethods = ['end', 'abort', 'destroy', 'destroySoon'];
 events.usingDomains = true;
 
 // let the process know we're using domains
-process._usingDomains();
+process._setupDomainUse();
 
 exports.Domain = Domain;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -133,7 +133,7 @@ static bool use_debug_agent = false;
 static bool debug_wait_connect = false;
 static int debug_port=5858;
 static int max_stack_size = 0;
-static bool using_domains = false;
+bool using_domains = false;
 
 // used by C++ modules as well
 bool no_deprecation = false;

--- a/src/node.cc
+++ b/src/node.cc
@@ -2377,7 +2377,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
     }
   }
   versions->Set(String::NewSymbol("openssl"),
-                String::New(OPENSSL_VERSION_TEXT + i, j - i));
+                String::New(&OPENSSL_VERSION_TEXT[i], j - i));
 #endif
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -899,7 +899,7 @@ Handle<Value> FromConstructorTemplate(Persistent<FunctionTemplate> t,
 }
 
 
-Handle<Value> UsingDomains(const Arguments& args) {
+Handle<Value> SetupDomainUse(const Arguments& args) {
   HandleScope scope(node_isolate);
   if (using_domains)
     return Undefined();
@@ -2507,7 +2507,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
   NODE_SET_METHOD(process, "binding", Binding);
 
-  NODE_SET_METHOD(process, "_usingDomains", UsingDomains);
+  NODE_SET_METHOD(process, "_setupDomainUse", SetupDomainUse);
 
   // values use to cross communicate with processNextTick
   Local<Object> info_box = Object::New();

--- a/src/node.cc
+++ b/src/node.cc
@@ -3143,7 +3143,7 @@ int Start(int argc, char *argv[]) {
   V8::Initialize();
   {
     Locker locker(node_isolate);
-    HandleScope handle_scope;
+    HandleScope handle_scope(node_isolate);
 
     // Create the one and only Context.
     Persistent<Context> context = Context::New();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -638,7 +638,7 @@ Handle<Value> SecureContext::SetSessionIdContext(const Arguments& args) {
 }
 
 Handle<Value> SecureContext::SetSessionTimeout(const Arguments& args) {
-  HandleScope scope;
+  HandleScope scope(node_isolate);
 
   SecureContext *sc = ObjectWrap::Unwrap<SecureContext>(args.Holder());
 
@@ -3567,7 +3567,7 @@ static void array_push_back(const TypeName* md,
 
 
 Handle<Value> GetCiphers(const Arguments& args) {
-  HandleScope scope;
+  HandleScope scope(node_isolate);
   Local<Array> arr = Array::New();
   EVP_CIPHER_do_all_sorted(array_push_back<EVP_CIPHER>, &arr);
   return scope.Close(arr);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -110,6 +110,9 @@ v8::Handle<v8::Value> FromConstructorTemplate(
     v8::Persistent<v8::FunctionTemplate> t,
     const v8::Arguments& args);
 
+// allow for quick domain check
+extern bool using_domains;
+
 } // namespace node
 
 #endif // SRC_NODE_INTERNALS_H_

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -78,7 +78,7 @@ inline static int snprintf(char* buf, unsigned int len, const char* fmt, ...) {
 // sometimes fails to resolve it...
 #define THROW_ERROR(fun)                                                      \
   do {                                                                        \
-    v8::HandleScope scope;                                                    \
+    v8::HandleScope scope(node_isolate);                                      \
     return v8::ThrowException(fun(v8::String::New(errmsg)));                  \
   }                                                                           \
   while (0)

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -116,7 +116,7 @@ class NODE_EXTERN ObjectWrap {
   static void WeakCallback(v8::Isolate* env,
                            v8::Persistent<v8::Value> value,
                            void* data) {
-    v8::HandleScope scope;
+    v8::HandleScope scope(node_isolate);
 
     ObjectWrap *obj = static_cast<ObjectWrap*>(data);
     assert(value == obj->handle_);

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -35,7 +35,7 @@ template <typename T>
 class ReqWrap {
  public:
   ReqWrap() {
-    v8::HandleScope scope;
+    v8::HandleScope scope(node_isolate);
     object_ = v8::Persistent<v8::Object>::New(node_isolate, v8::Object::New());
 
     v8::Local<v8::Value> domain = v8::Context::GetCurrent()

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -23,6 +23,7 @@
 #define REQ_WRAP_H_
 
 #include "ngx-queue.h"
+#include "node_internals.h"
 
 namespace node {
 
@@ -38,15 +39,16 @@ class ReqWrap {
     v8::HandleScope scope(node_isolate);
     object_ = v8::Persistent<v8::Object>::New(node_isolate, v8::Object::New());
 
-    v8::Local<v8::Value> domain = v8::Context::GetCurrent()
-                                  ->Global()
-                                  ->Get(process_symbol)
-                                  ->ToObject()
-                                  ->Get(domain_symbol);
+    if (using_domains) {
+      v8::Local<v8::Value> domain = v8::Context::GetCurrent()
+                                    ->Global()
+                                    ->Get(process_symbol)
+                                    ->ToObject()
+                                    ->Get(domain_symbol);
 
-    if (!domain->IsUndefined()) {
-      // fprintf(stderr, "setting domain on ReqWrap\n");
-      object_->Set(domain_symbol, domain);
+      if (!domain->IsUndefined()) {
+        object_->Set(domain_symbol, domain);
+      }
     }
 
     ngx_queue_insert_tail(&req_wrap_queue, &req_wrap_queue_);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -258,7 +258,7 @@ Handle<Value> TCPWrap::SetSimultaneousAccepts(const Arguments& args) {
 
 
 Handle<Value> TCPWrap::Open(const Arguments& args) {
-  HandleScope scope;
+  HandleScope scope(node_isolate);
   UNWRAP(TCPWrap)
   int fd = args[0]->IntegerValue();
   uv_tcp_open(&wrap->handle_, fd);


### PR DESCRIPTION
Simple things. Fix compiler warning. Add `node_isolate` where missing. Be consistent about retrieving domain objects only when domains are in use. etc.
