### PR TITLE
node `-i` and `-` argument parsing

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -82,7 +82,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
   EventEmitter.call(this);
 
-  var options, input, output, dom;
+  var options, input, output, dom, paused = false;
   if (typeof prompt == 'object') {
     // an options object was given
     options = prompt;
@@ -94,6 +94,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     ignoreUndefined = options.ignoreUndefined;
     prompt = options.prompt;
     dom = options.domain;
+    paused = options.paused;
   } else if (typeof prompt != 'string') {
     throw new Error('An options Object, or a prompt String are required');
   } else {
@@ -166,6 +167,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     self.complete(text, callback);
   }
 
+  self._rliData = !paused;
   var rli = rl.createInterface({
     input: self.inputStream,
     output: self.outputStream,
@@ -219,7 +221,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     self.displayPrompt();
   });
 
-  rli.on('line', function(cmd) {
+  self._online = function(cmd) {
     sawSIGINT = false;
     var skipCatchall = false;
     cmd = trimWhitespace(cmd);
@@ -308,13 +310,18 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       // Display prompt again
       self.displayPrompt();
     };
-  });
-
+  };
   rli.on('SIGCONT', function() {
     self.displayPrompt(true);
   });
 
-  self.displayPrompt();
+  if(!paused) {
+    rli.on('line', self._online);
+    self.displayPrompt();
+  } 
+  else {
+    rli.pause();
+  }
 }
 inherits(REPLServer, EventEmitter);
 exports.REPLServer = REPLServer;
@@ -376,6 +383,12 @@ REPLServer.prototype.resetContext = function() {
 };
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
+  if(!this._rliData) {
+    this._rliData = true;
+    var rli = this.rli;
+    rli.resume();
+    rli.on('line', this._online);
+  }
   var prompt = this.prompt;
   if (this.bufferedCommand.length) {
     prompt = '...';

--- a/src/node.cc
+++ b/src/node.cc
@@ -2708,6 +2708,8 @@ static void ParseArgs(int argc, char **argv) {
       throw_deprecation = true;
     } else if (argv[i][0] != '-') {
       break;
+    } else if (strcmp(arg, "-") == 0) {
+      break; // allow "-" to pass through 
     }
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -78,7 +78,7 @@
     } else if (process._eval != null) {
       // User passed '-e' or '--eval' arguments to Node.
       evalScript('[eval]');
-    } else if (process.argv[1]) {
+    } else if (process.argv[1] && process.argv[1] !== '-' && !process._forceRepl) {
       // make process.argv[1] into a full path
       var path = NativeModule.require('path');
       process.argv[1] = path.resolve(process.argv[1]);
@@ -121,7 +121,6 @@
 
     } else {
       var Module = NativeModule.require('module');
-
       // If -i or --interactive were passed, or stdin is a TTY.
       if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
         // REPL
@@ -135,7 +134,31 @@
         if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {
           opts.useColors = false;
         }
-        var repl = Module.requireRepl().start(opts);
+        var Repl = Module.requireRepl()
+        var repl;
+        if(process.argv[1] && process.argv[1] !== '-') {
+          // start REPL in a paused state so that file can be processed first
+          opts.paused = true;
+          repl = Repl.start(opts);
+          
+          // Process and execute code
+          var path = NativeModule.require('path');
+          process.argv[1] = path.resolve(process.argv[1]);
+          var code = '';
+          var Fs = NativeModule.require('fs');
+          var rs = Fs.createReadStream(process.argv[1]);
+          rs.setEncoding('utf8');
+          rs.on('data', function(d) {
+            //repl.rli.input._events.data(d+"\n");
+            code += d;
+          });
+          
+          rs.on('end', function() { 
+            repl.eval(code+"\n");
+            repl.displayPrompt();
+          });
+        }
+        else repl = Repl.start(opts);
         repl.on('exit', function() {
           process.exit();
         });
@@ -816,6 +839,10 @@
     // execute cwd\node.exe, or some %PATH%\node.exe on Windows,
     // and that every directory has its own cwd, so d:node.exe is valid.
     var argv0 = process.argv[0];
+
+    // Don't do anything if argv[0] is '-'
+    if (argv0 === '-') return;
+
     if (!isWindows && argv0.indexOf('/') !== -1 && argv0.charAt(0) !== '/') {
       var path = NativeModule.require('path');
       process.argv[0] = path.join(cwd, process.argv[0]);

--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -84,6 +84,19 @@ child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
   assert.equal(stderr, '');
 });
 
+// '-' should be the filename if it is the first argument
+child.exec(nodejs + ' -p -e "process.argv[1]" - foo bar baz', 
+    function(status, stdout, stderr) {
+      assert.equal(stderr, '');
+      assert.equal(stdout, "-\n");
+    });
+
+// '-' should force the interpreter to run without looking for a file
+child.exec(nodejs + ' -i - foo bar', {timeout:1000, killSignal:'SIGINT'}, 
+    function(status, stdout, stderr) {
+      assert.equal(stdout, "> ");
+    });
+
 // "\\-42" should be interpreted as an escaped expression, not a switch
 child.exec(nodejs + ' -p "\\-42"',
     function(err, stdout, stderr) {


### PR DESCRIPTION
There currently is no way to run node interactively and pass arguments without
a file: `node -i foo bar baz` will instruct node to load `foo`.

This commit adds a `-` argument and modifies the behavior of the `-i` flag.
Informally, `-` means stdin and `-i` means run interactively.

When stdin is a tty (running directly without piping data into it):

1. `node - foo.js bar` will invoke the standard REPL without executing anything
beforehand.  `process.argv = ['node', '-', 'foo.js', 'bar']`

2. `node -i - foo.js bar` is the same as `node - foo.js bar`

3. `node -i foo.js bar` will run foo.js in the REPL context and then invoke the
standard REPL.  `process.argv = ['node', 'foo.js', 'bar']`

When stdin is a pipe or other file:

4. `| node - foo.js bar` will execute the commands piped into the shell.

5. `| node -i - foo.js bar` will execute the commands piped into the shell.

6. `| node -i foo.js bar` will first execute the commands in foo.js and then
execute the commands piped into the shell.

Note that this is slightly different from the behavior discussed in https://github.com/joyent/node/pull/5041.  It is possible to invoke behavior like the logic
in the `unbuffer` linux command, but that isn't implemented here.
