### PR TITLE
REPL should not capture aborted statements

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -272,8 +272,6 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
     function finish(e, ret) {
 
-      self.memory(cmd);
-
       // If error was SyntaxError and not JSON.parse error
       if (isSyntaxError(e)) {
         if (!self.bufferedCommand && cmd.trim().match(/^npm /)) {
@@ -295,6 +293,8 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       } else if (e) {
         self._domain.emit('error', e);
       }
+
+      self.lines = self.memoryResetLevel(cmd, self.lines);
 
       // Clear buffer if no SyntaxErrors
       self.bufferedCommand = '';
@@ -425,17 +425,21 @@ REPLServer.prototype.complete = function(line, callback) {
   if (this.bufferedCommand != undefined && this.bufferedCommand.length) {
     // Get a new array of inputed lines
     var tmp = this.lines.slice();
+    tmp.level = this.lines.level.slice();
+    // append pending bufferedCommand
+    tmp = this.memory(this.bufferedCommand, tmp);
     // Kill off all function declarations to push all local variables into
     // global scope
-    this.lines.level.forEach(function(kill) {
+    tmp.level.forEach(function(kill) {
       if (kill.isFunction) {
         tmp[kill.line] = '';
       }
     });
-    var flat = new ArrayStream();         // make a new "input" stream
-    var magic = new REPLServer('', flat); // make a nested REPL
-    magic.context = magic.createContext();
-    flat.run(tmp);                        // eval the flattened code
+    var flat = new ArrayStream();               // make a new "input" stream
+    var magic = new REPLServer({prompt   : '',  // make a nested REPL
+                                stream   : flat,
+                                useGlobal: false });
+    flat.run(tmp);                              // eval the flattened code
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand
     if (!magic.bufferedCommand) {
@@ -700,19 +704,49 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   this.commands['.' + keyword] = cmd;
 };
 
-REPLServer.prototype.memory = function memory(cmd) {
-  var self = this;
 
-  self.lines = self.lines || [];
-  self.lines.level = self.lines.level || [];
+/**
+ * Same as memory, except that it will reset the level array
+ * that is used to calculate scope.  Better than having a
+ * mystical boolean appended to the other function.
+ *
+ * @param {String} cmd The command entered to check.
+ * @param {Array} lines the array of lines to add the cmd to
+ * @return {Array} The modified lines array.
+ */
+REPLServer.prototype.memoryResetLevel = function memory(cmd, lines) {
+  lines.level = [];
+  return this.memory(cmd, lines);
+};
+
+/**
+ * Used to remember every line entered into the REPL.
+ * Also used to build a list of lines that have scope,
+ * e.g. function() {.  These lines can then be removed
+ * to evaluate local scope.
+ *
+ * @param {String} cmd The command entered to check.
+ * @param {Array} lines the array of lines to add the cmd to
+ * @return {Array} The modified lines array.
+ */
+REPLServer.prototype.memory = function memory(cmd, lines) {
+
+  lines = lines || [];
+  lines.level = lines.level || [];
 
   // save the line so I can do magic later
   if (cmd) {
-    // TODO should I tab the level?
-    self.lines.push(new Array(self.lines.level.length).join('  ') + cmd);
+    if (cmd.search('\n') >= 0) {
+      // multipule lines, split on \n and eval each line
+      cmd.split('\n').forEach(function(cmd) {
+        lines = memory(cmd, lines);
+      });
+      return lines;
+    }
+    lines.push(new Array(lines.level.length).join('  ') + cmd);
   } else {
     // I don't want to not change the format too much...
-    self.lines.push('');
+    lines.push('');
   }
 
   // I need to know "depth."
@@ -737,14 +771,14 @@ REPLServer.prototype.memory = function memory(cmd) {
           // "function()
           // {" but nothing should break, only tab completion for local
           // scope will not work for this function.
-          self.lines.level.push({
-            line: self.lines.length - 1,
+          lines.level.push({
+            line: lines.length - 1,
             depth: depth,
             isFunction: /\s*function\s*/.test(cmd)
           });
         } else if (depth < 0) {
           // going... up.
-          var curr = self.lines.level.pop();
+          var curr = lines.level.pop();
           if (curr) {
             var tmp = curr.depth + depth;
             if (tmp < 0) {
@@ -754,7 +788,7 @@ REPLServer.prototype.memory = function memory(cmd) {
             } else if (tmp > 0) {
               //remove and push back
               curr.depth += depth;
-              self.lines.level.push(curr);
+              lines.level.push(curr);
             }
           }
         }
@@ -766,11 +800,11 @@ REPLServer.prototype.memory = function memory(cmd) {
     // self.lines.level.length === 0
     // TODO? keep a log of level so that any syntax breaking lines can
     // be cleared on .break and in the case of a syntax error?
-    // TODO? if a log was kept, then I could clear the bufferedComand and
+    // TODO? if a log was kept, then I could clear the bufferedCommand and
     // eval these lines and throw the syntax error
-  } else {
-    self.lines.level = [];
   }
+
+  return lines;
 };
 
 function addStandardGlobals(completionGroups, filter) {
@@ -846,7 +880,9 @@ function defineDefaultCommands(repl) {
     help: 'Save all evaluated commands in this REPL session to a file',
     action: function(file) {
       try {
-        fs.writeFileSync(file, this.lines.join('\n') + '\n');
+        var putOut = this.lines.slice();
+        putOut.push(this.bufferedCommand);
+        fs.writeFileSync(file, putOut.join('\n') + '\n');
         this.outputStream.write('Session saved to:' + file + '\n');
       } catch (e) {
         this.outputStream.write('Failed to save:' + file + '\n');

--- a/test/simple/test-repl-.save.load.js
+++ b/test/simple/test-repl-.save.load.js
@@ -61,7 +61,8 @@ putIn.run(testFile);
 putIn.run(['.save ' + saveFileName]);
 
 // the file should have what I wrote
-assert.equal(fs.readFileSync(saveFileName, 'utf8'), testFile.join('\n') + '\n');
+assert.equal(fs.readFileSync(saveFileName, 'utf8')
+             , testFile.join('\n') + '\n\n');
 
 // make sure that the REPL data is "correct"
 // so when I load it back I know I'm good


### PR DESCRIPTION
The "memory" for the REPL was "saved" even in the case of a `bufferedCommand`.  This causes `.save` to write out aborted multi-line statements e.g.

```
>var top = function() {
>.. var something = 1;
>.. CTRL-C
```

This is a problem in two cases.
1. The REPL will save these lines and write them out during the `.save` function
2. The REPL will remember these lines and potentially inject nonexistent variables into other local tab completions.

The basic fix is to move the `memory` call from the top of `finish` to below the bufferedCommand check.

The fallout was to remove the side effects from the `memory` function.  So it could be used in the `complete` function to append the `bufferedCommand`.

I also updated the nested "magic" REPL to pass the useGlobal:false param instead of injecting my own context.

This should fix #4514

The part I really don't like about this is I don't know how to test the CTRL-C business.  I wanted to append a test to `.save` that would verify that the first part, but I can't figure out how to send it... `'\x03'` does not work :(.  If anyone could give me suggestions I'll write the two tests and all will be right with the world.
