### PR TITLE
Check __proto__ instead of .prototype in assert.deepEqual()

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -202,7 +202,7 @@ function objEquiv(a, b) {
   if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
     return false;
   // an identical 'prototype' property.
-  if (a.prototype !== b.prototype) return false;
+  if (a.__proto__ !== b.__proto__) return false;
   //~~~I've managed to break Object.keys through screwy arguments passing.
   //   Converting to array solves the problem.
   if (isArguments(a)) {

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -112,7 +112,6 @@ assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '2'}, {a: 4, b: '2'}));
 assert.doesNotThrow(makeBlock(a.deepEqual, [4], ['4']));
 assert.throws(makeBlock(a.deepEqual, {a: 4}, {a: 4, b: true}),
               a.AssertionError);
-assert.doesNotThrow(makeBlock(a.deepEqual, ['a'], {0: 'a'}));
 //(although not necessarily the same order),
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '1'}, {b: '1', a: 4}));
 var a1 = [1, 2, 3];
@@ -293,3 +292,7 @@ try {
   assert.equal(e.message, 'Missing expected exception..');
 }
 assert.ok(threw);
+
+// #4523
+assert.throws(makeBlock(a.deepEqual, [], {}), a.AssertionError, 'deepEqual prototypes');
+assert.doesNotThrow(makeBlock(a.deepEqual, [], []));


### PR DESCRIPTION
Fixes joyent/node#4523, but that might not be the right thing to do here.

A [test case](https://github.com/joyent/node/blob/master/test/simple/test-assert.js#L115) for the assert module depends on the [original bug](https://github.com/joyent/node/issues/4523). I remove it with this patch, but perhaps removing the prototype check altogether and leaving the test case and bug as they currently stand is a good idea. The docs do say the assert API is locked.
