### PR TITLE
(Docs) Use typographical quotation marks outside of code

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -22,7 +22,7 @@ knowledge of several libraries:
  - Others. Look in `deps/` for what else is available.
 
 Node statically compiles all its dependencies into the executable.
-When compiling your module, you don't need to worry about linking to
+When compiling your module, you don’t need to worry about linking to
 any of these libraries.
 
 All of the following examples are available for
@@ -31,7 +31,7 @@ used as a starting-point for your own Addon.
 
 ## Hello world
 
-To get started let's make a small Addon which is the C++ equivalent of
+To get started let’s make a small Addon which is the C++ equivalent of
 the following JavaScript code:
 
     module.exports.hello = function() { return 'world'; };
@@ -62,7 +62,7 @@ Note that all Node addons must export an initialization function:
     void Initialize (Handle<Object> exports);
     NODE_MODULE(module_name, Initialize)
 
-There is no semi-colon after `NODE_MODULE` as it's not a function (see `node.h`).
+There is no semi-colon after `NODE_MODULE` as it’s not a function (see `node.h`).
 
 The `module_name` needs to match the filename of the final binary (minus the
 .node suffix).
@@ -106,7 +106,7 @@ Please see patterns below for further information or
 
 Below are some addon patterns to help you get started. Consult the online
 [v8 reference](http://izs.me/v8-docs/main.html) for help with the various v8
-calls, and v8's [Embedder's Guide](http://code.google.com/apis/v8/embed.html)
+calls, and v8’s [Embedder’s Guide](http://code.google.com/apis/v8/embed.html)
 for an explanation of several concepts used such as handles, scopes,
 function templates, etc.
 
@@ -181,7 +181,7 @@ You can test it with the following JavaScript snippet:
 ### Callbacks
 
 You can pass JavaScript functions to a C++ function and execute them from
-there. Here's `addon.cc`:
+there. Here’s `addon.cc`:
 
     #define BUILDING_NODE_EXTENSION
     #include <node.h>
@@ -344,7 +344,7 @@ Then in `myobject.h` make your wrapper inherit from `node::ObjectWrap`:
     #endif
 
 And in `myobject.cc` implement the various methods that you want to expose.
-Here we expose the method `plusOne` by adding it to the constructor's
+Here we expose the method `plusOne` by adding it to the constructor’s
 prototype:
 
     #define BUILDING_NODE_EXTENSION
@@ -409,7 +409,7 @@ explicitly instantiating them with the `new` operator in JavaScript, e.g.
     // instead of:
     // var obj = new addon.Object();
 
-Let's register our `createObject` method in `addon.cc`:
+Let’s register our `createObject` method in `addon.cc`:
 
     #define BUILDING_NODE_EXTENSION
     #include <node.h>
@@ -533,7 +533,7 @@ Test it with:
 ### Passing wrapped objects around
 
 In addition to wrapping and returning C++ objects, you can pass them around
-by unwrapping them with Node's `node::ObjectWrap::Unwrap` helper function.
+by unwrapping them with Node’s `node::ObjectWrap::Unwrap` helper function.
 In the following `addon.cc` we introduce a function `add()` that can take on two
 `MyObject` objects:
 

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -3,7 +3,7 @@
     Stability: 3 - Stable
 
 Pure JavaScript is Unicode friendly but not nice to binary data.  When
-dealing with TCP streams or the file system, it's necessary to handle octet
+dealing with TCP streams or the file system, it’s necessary to handle octet
 streams. Node has several strategies for manipulating, creating, and
 consuming octet streams.
 
@@ -381,7 +381,7 @@ Reads a signed 8 bit integer from the buffer at the specified offset.
 Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.
 
-Works as `buffer.readUInt8`, except buffer contents are treated as two's
+Works as `buffer.readUInt8`, except buffer contents are treated as two’s
 complement signed values.
 
 ### buf.readInt16LE(offset, [noAssert])
@@ -397,7 +397,7 @@ specified endian format.
 Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.
 
-Works as `buffer.readUInt16*`, except buffer contents are treated as two's
+Works as `buffer.readUInt16*`, except buffer contents are treated as two’s
 complement signed values.
 
 ### buf.readInt32LE(offset, [noAssert])
@@ -413,7 +413,7 @@ specified endian format.
 Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.
 
-Works as `buffer.readUInt32*`, except buffer contents are treated as two's
+Works as `buffer.readUInt32*`, except buffer contents are treated as two’s
 complement signed values.
 
 ### buf.readFloatLE(offset, [noAssert])
@@ -572,7 +572,7 @@ that `value` may be too large for the specific function and `offset` may be
 beyond the end of the buffer leading to the values being silently dropped. This
 should not be used unless you are certain of correctness. Defaults to `false`.
 
-Works as `buffer.writeUInt8`, except value is written out as a two's complement
+Works as `buffer.writeUInt8`, except value is written out as a two’s complement
 signed integer into `buffer`.
 
 ### buf.writeInt16LE(value, offset, [noAssert])
@@ -590,7 +590,7 @@ that `value` may be too large for the specific function and `offset` may be
 beyond the end of the buffer leading to the values being silently dropped. This
 should not be used unless you are certain of correctness. Defaults to `false`.
 
-Works as `buffer.writeUInt16*`, except value is written out as a two's
+Works as `buffer.writeUInt16*`, except value is written out as a two’s
 complement signed integer into `buffer`.
 
 ### buf.writeInt32LE(value, offset, [noAssert])
@@ -608,7 +608,7 @@ that `value` may be too large for the specific function and `offset` may be
 beyond the end of the buffer leading to the values being silently dropped. This
 should not be used unless you are certain of correctness. Defaults to `false`.
 
-Works as `buffer.writeUInt32*`, except value is written out as a two's
+Works as `buffer.writeUInt32*`, except value is written out as a two’s
 complement signed integer into `buffer`.
 
 ### buf.writeFloatLE(value, offset, [noAssert])

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -5,9 +5,9 @@
 Node provides a tri-directional `popen(3)` facility through the
 `child_process` module.
 
-It is possible to stream data through a child's `stdin`, `stdout`, and
+It is possible to stream data through a child’s `stdin`, `stdout`, and
 `stderr` in a fully non-blocking way.  (Note that some programs use
-line-buffered I/O internally.  That doesn't affect node.js but it means
+line-buffered I/O internally.  That doesn’t affect node.js but it means
 data you send to the child process is not immediately consumed.)
 
 To create a child process use `require('child_process').spawn()` or
@@ -83,7 +83,7 @@ Messages send by `.send(message, [sendHandle])` are obtained using the
 
 * {Stream object}
 
-A `Writable Stream` that represents the child process's `stdin`.
+A `Writable Stream` that represents the child process’s `stdin`.
 Closing this stream via `end()` often causes the child process to terminate.
 
 If the child stdio streams are shared with the parent, then this will
@@ -93,7 +93,7 @@ not be set.
 
 * {Stream object}
 
-A `Readable Stream` that represents the child process's `stdout`.
+A `Readable Stream` that represents the child process’s `stdout`.
 
 If the child stdio streams are shared with the parent, then this will
 not be set.
@@ -102,7 +102,7 @@ not be set.
 
 * {Stream object}
 
-A `Readable Stream` that represents the child process's `stderr`.
+A `Readable Stream` that represents the child process’s `stderr`.
 
 If the child stdio streams are shared with the parent, then this will
 not be set.
@@ -142,7 +142,7 @@ May emit an `'error'` event when the signal cannot be delivered. Sending a
 signal to a child process that has already exited is not an error but may
 have unforeseen consequences: if the PID (the process ID) has been reassigned
 to another process, the signal will be delivered to that process instead.
-What happens next is anyone's guess.
+What happens next is anyone’s guess.
 
 Note that while the function is called `kill`, the signal delivered to the
 child process may not actually kill it.  `kill` really just sends a signal
@@ -278,7 +278,7 @@ there is no IPC channel keeping it alive. When calling this method the
 * `args` {Array} List of string arguments
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
-  * `stdio` {Array|String} Child's stdio configuration. (See below)
+  * `stdio` {Array|String} Child’s stdio configuration. (See below)
   * `customFds` {Array} **Deprecated** File descriptors for the child to use
     for stdio.  (See below)
   * `env` {Object} Environment key-value pairs
@@ -387,9 +387,9 @@ index corresponds to a fd in the child.  The value is one of the following:
    process.on('message').
 3. `'ignore'` - Do not set this file descriptor in the child. Note that Node
    will always open fd 0 - 2 for the processes it spawns. When any of these is
-   ignored node will open `/dev/null` and attach it to the child's fd.
+   ignored node will open `/dev/null` and attach it to the child’s fd.
 4. `Stream` object - Share a readable or writable stream that refers to a tty,
-   file, socket, or a pipe with the child process. The stream's underlying
+   file, socket, or a pipe with the child process. The stream’s underlying
    file descriptor is duplicated in the child process to the fd that 
    corresponds to the index in the `stdio` array.
 5. Positive integer - The integer value is interpreted as a file descriptor 
@@ -410,7 +410,7 @@ Example:
 
     var spawn = require('child_process').spawn;
 
-    // Child will use parent's stdios
+    // Child will use parent’s stdios
     spawn('prg', [], { stdio: 'inherit' });
 
     // Spawn child sharing only stderr
@@ -426,7 +426,7 @@ after the parent exits.
 
 By default, the parent will wait for the detached child to exit.  To prevent
 the parent from waiting for a given `child`, use the `child.unref()` method,
-and the parent's event loop will not include the child in its reference count.
+and the parent’s event loop will not include the child in its reference count.
 
 Example of detaching a long-running process and redirecting its output to a
 file:
@@ -445,7 +445,7 @@ file:
 
 When using the `detached` option to start a long-running process, the process
 will not stay running in the background unless it is provided with a `stdio`
-configuration that is not connected to the parent.  If the parent's `stdio` is
+configuration that is not connected to the parent.  If the parent’s `stdio` is
 inherited, the child will remain attached to the controlling terminal.
 
 There is a deprecated option called `customFds` which allows one to specify
@@ -466,7 +466,7 @@ See also: `child_process.exec()` and `child_process.fork()`
 * `command` {String} The command to run, with space-separated arguments
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
-  * `stdio` {Array|String} Child's stdio configuration. (See above)
+  * `stdio` {Array|String} Child’s stdio configuration. (See above)
     Only stdin is configurable, anything else will lead to unpredictable
     results.
   * `customFds` {Array} **Deprecated** File descriptors for the child to use
@@ -524,7 +524,7 @@ the child process is killed.
 * `args` {Array} List of string arguments
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
-  * `stdio` {Array|String} Child's stdio configuration. (See above)
+  * `stdio` {Array|String} Child’s stdio configuration. (See above)
   * `customFds` {Array} **Deprecated** File descriptors for the child to use
     for stdio.  (See above)
   * `env` {Object} Environment key-value pairs
@@ -560,10 +560,10 @@ instance, the returned object has a communication channel built-in. See
 `child.send(message, [sendHandle])` for details.
 
 By default the spawned Node process will have the stdout, stderr associated
-with the parent's. To change this behavior set the `silent` property in the
+with the parent’s. To change this behavior set the `silent` property in the
 `options` object to `true`.
 
-The child process does not automatically exit once it's done, you need to call
+The child process does not automatically exit once it’s done, you need to call
 `process.exit()` explicitly. This limitation may be lifted in the future.
 
 These child Nodes are still whole new instances of V8. Assume at least 30ms

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -55,7 +55,7 @@ handles back and forth.
 
 When you call `server.listen(...)` in a worker, it serializes the
 arguments and passes the request to the master process.  If the master
-process already has a listening server matching the worker's
+process already has a listening server matching the worker’s
 requirements, then it passes the handle to the worker.  If it does not
 already have a listening server matching that requirement, then it will
 create one, and pass the handle to the child.
@@ -64,11 +64,11 @@ This causes potentially surprising behavior in three edge cases:
 
 1. `server.listen({fd: 7})` Because the message is passed to the master,
    file descriptor 7 **in the parent** will be listened on, and the
-   handle passed to the worker, rather than listening to the worker's
+   handle passed to the worker, rather than listening to the worker’s
    idea of what the number 7 file descriptor references.
 2. `server.listen(handle)` Listening on handles explicitly will cause
    the worker to use the supplied handle, rather than talk to the master
-   process.  If the worker already has the handle, then it's presumed
+   process.  If the worker already has the handle, then it’s presumed
    that you know what you are doing.
 3. `server.listen(0)` Normally, this will cause servers to listen on a
    random port.  However, in a cluster, each worker will receive the
@@ -85,11 +85,11 @@ design your program such that it does not rely too heavily on in-memory
 data objects for things like sessions and login.
 
 Because workers are all separate processes, they can be killed or
-re-spawned depending on your program's needs, without affecting other
+re-spawned depending on your program’s needs, without affecting other
 workers.  As long as there are some workers still alive, the server will
 continue to accept connections.  Node does not automatically manage the
 number of workers for you, however.  It is your responsibility to manage
-the worker pool for your application's needs.
+the worker pool for your application’s needs.
 
 ## cluster.settings
 
@@ -97,7 +97,7 @@ the worker pool for your application's needs.
   * `exec` {String} file path to worker file.  (Default=`__filename`)
   * `args` {Array} string arguments passed to worker.
     (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
+  * `silent` {Boolean} whether or not to send output to parent’s stdio.
     (Default=`false`)
 
 All settings set by the `.setupMaster` is stored in this settings object.
@@ -221,7 +221,7 @@ call `.setupMaster()` with no arguments.
   * `exec` {String} file path to worker file.  (Default=`__filename`)
   * `args` {Array} string arguments passed to worker.
     (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
+  * `silent` {Boolean} whether or not to send output to parent’s stdio.
     (Default=`false`)
 
 `setupMaster` is used to change the default 'fork' behavior. The new settings
@@ -289,7 +289,7 @@ process.
     });
 
 Should you wish to reference a worker over a communication channel, using
-the worker's unique id is the easiest way to find the worker.
+the worker’s unique id is the easiest way to find the worker.
 
     socket.on('data', function(id) {
       var worker = cluster.workers[id];

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -8,7 +8,7 @@ Use `require('crypto')` to access this module.
 The crypto module offers a way of encapsulating secure credentials to be
 used as part of a secure HTTPS net or http connection.
 
-It also offers a set of wrappers for OpenSSL's hash, hmac, cipher,
+It also offers a set of wrappers for OpenSSL’s hash, hmac, cipher,
 decipher, sign and verify methods.
 
 
@@ -212,7 +212,7 @@ called.
 
 You can disable automatic padding of the input data to block size. If
 `auto_padding` is false, the length of the entire input data must be a
-multiple of the cipher's block size or `final` will fail.  Useful for
+multiple of the cipher’s block size or `final` will fail.  Useful for
 non-standard padding, e.g. using `0x0` instead of PKCS padding. You
 must call this before `cipher.final`.
 
@@ -261,7 +261,7 @@ called.
 
 You can disable auto padding if the data has been encrypted without
 standard block padding to prevent `decipher.final` from checking and
-removing it. Can only work if the input data's length is a multiple of
+removing it. Can only work if the input data’s length is a multiple of
 the ciphers block size. You must call this before streaming data to
 `decipher.update`.
 
@@ -364,7 +364,7 @@ or `'base64'`.  If no encoding is provided, then a buffer is returned.
 ### diffieHellman.computeSecret(other_public_key, [input_encoding], [output_encoding])
 
 Computes the shared secret using `other_public_key` as the other
-party's public key and returns the computed shared secret. Supplied
+party’s public key and returns the computed shared secret. Supplied
 key is interpreted using specified `input_encoding`, and secret is
 encoded using specified `output_encoding`. Encodings can be
 `'binary'`, `'hex'`, or `'base64'`. If the input encoding is not
@@ -417,7 +417,7 @@ supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in [RFC
 interface of objects created by [crypto.createDiffieHellman()][]
 above, but will not allow to change the keys (with
 [diffieHellman.setPublicKey()][] for example).  The advantage of using
-this routine is that the parties don't have to generate nor exchange
+this routine is that the parties don’t have to generate nor exchange
 group modulus beforehand, saving both processor and communication
 time.
 
@@ -491,7 +491,7 @@ The Crypto module was added to Node before there was the concept of a
 unified Stream API, and before there were Buffer objects for handling
 binary data.
 
-As such, the streaming classes don't have the typical methods found on
+As such, the streaming classes don’t have the typical methods found on
 other Node classes, and many methods accepted and returned
 Binary-encoded strings by default rather than Buffers.  This was
 changed to use Buffers by default instead.
@@ -502,7 +502,7 @@ For example, if you currently use the default arguments to the Sign
 class, and then pass the results to the Verify class, without ever
 inspecting the data, then it will continue to work as before.  Where
 you once got a binary string and then presented the binary string to
-the Verify object, you'll now get a Buffer, and present the Buffer to
+the Verify object, you’ll now get a Buffer, and present the Buffer to
 the Verify object.
 
 However, if you were doing things with the string data that will not

--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -18,7 +18,7 @@ Node has a built-in client for this debugger. To use this, start Node with the
       3   debugger;
     debug>
 
-Node's debugger client doesn't support the full range of commands, but
+Node’s debugger client doesn’t support the full range of commands, but
 simple step and inspection is possible. By putting the statement `debugger;`
 into the source code of your script, you will enable a breakpoint.
 
@@ -82,7 +82,7 @@ to come. Type `help` to see others.
 
 You can watch expression and variable values while debugging your code.
 On every breakpoint each expression from the watchers list will be evaluated
-in the current context and displayed just before the breakpoint's source code
+in the current context and displayed just before the breakpoint’s source code
 listing.
 
 To start watching an expression, type `watch("my_expression")`. `watchers`
@@ -118,11 +118,11 @@ after)
 * `unwatch(expr)` - Remove expression from watch list
 * `watchers` - List all watchers and their values (automatically listed on each
 breakpoint)
-* `repl` - Open debugger's repl for evaluation in debugging script's context
+* `repl` - Open debugger’s repl for evaluation in debugging script’s context
 
 ### Execution control
 
-* `run` - Run script (automatically runs on debugger's start)
+* `run` - Run script (automatically runs on debugger’s start)
 * `restart` - Restart script
 * `kill` - Kill script
 

--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -49,7 +49,7 @@ should be created via `dgram.createSocket(type, [callback])`.
 * `rinfo` Object. Remote address information
 
 Emitted when a new datagram is available on a socket.  `msg` is a `Buffer` and `rinfo` is
-an object with the sender's address information and the number of bytes in the datagram.
+an object with the sender’s address information and the number of bytes in the datagram.
 
 ### Event: 'listening'
 
@@ -84,7 +84,7 @@ re-used.  Note that DNS lookups will delay the time that a send takes place, at
 least until the next tick.  The only way to know for sure that a send has taken place
 is to use the callback.
 
-If the socket has not been previously bound with a call to `bind`, it's
+If the socket has not been previously bound with a call to `bind`, it’s
 assigned a random port number and bound to the "all interfaces" address
 (0.0.0.0 for `udp4` sockets, ::0 for `udp6` sockets).
 
@@ -118,9 +118,9 @@ and on the `Payload Length` field size.
   The value of `68` octets is very small, since most current link layer technologies have
   a minimum `MTU` of `1500` (like Ethernet).
 
-Note that it's impossible to know in advance the MTU of each link through which
+Note that it’s impossible to know in advance the MTU of each link through which
 a packet might travel, and that generally sending a datagram greater than
-the (receiver) `MTU` won't work (the packet gets silently dropped, without
+the (receiver) `MTU` won’t work (the packet gets silently dropped, without
 informing the source that the data did not reach its intended recipient).
 
 ### socket.bind(port, [address], [callback])
@@ -170,7 +170,7 @@ this object will contain `address` , `family` and `port`.
 * `flag` Boolean
 
 Sets or clears the `SO_BROADCAST` socket option.  When this option is set, UDP packets
-may be sent to a local interface's broadcast address.
+may be sent to a local interface’s broadcast address.
 
 ### socket.setTTL(ttl)
 
@@ -236,5 +236,5 @@ active socket in the event system. If the socket is already `unref`d calling
 ### socket.ref()
 
 Opposite of `unref`, calling `ref` on a previously `unref`d socket will *not*
-let the program exit if it's the only socket left (the default behavior). If
+let the program exit if it’s the only socket left (the default behavior). If
 the socket is `ref`d calling `ref` again will have no effect.

--- a/doc/api/documentation.markdown
+++ b/doc/api/documentation.markdown
@@ -16,7 +16,7 @@ experimental, and added for the benefit of IDEs and other utilities that
 wish to do programmatic things with the documentation.
 
 Every `.html` and `.json` file is generated based on the corresponding
-`.markdown` file in the `doc/api/` folder in node's source tree.  The
+`.markdown` file in the `doc/api/` folder in node’s source tree.  The
 documentation is generated using the `tools/doc/generate.js` program.
 The HTML template is located at `doc/template.html`.
 
@@ -24,7 +24,7 @@ The HTML template is located at `doc/template.html`.
 
 <!--type=misc-->
 
-Throughout the documentation, you will see indications of a section's
+Throughout the documentation, you will see indications of a section’s
 stability.  The Node.js API is still somewhat changing, and as it
 matures, certain parts are more reliable than others.  Some are so
 proven, and so relied upon, that they are unlikely to ever change at

--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -9,7 +9,7 @@ will be notified, rather than losing the context of the error in the
 `process.on('uncaughtException')` handler, or causing the program to
 exit immediately with an error code.
 
-## Warning: Don't Ignore Errors!
+## Warning: Don’t Ignore Errors!
 
 <!-- type=misc -->
 
@@ -42,7 +42,7 @@ For example, this is not a good idea:
 
 var d = require('domain').create();
 d.on('error', function(er) {
-  // The error won't crash the process, but what it does is worse!
+  // The error won’t crash the process, but what it does is worse!
   // Though we've prevented abrupt process restarting, we are leaking
   // resources like crazy if this ever happens.
   // This is no better than process.on('uncaughtException')!
@@ -101,9 +101,9 @@ if (cluster.isMaster) {
     d.on('error', function(er) {
       console.error('error', er.stack);
 
-      // Note: we're in dangerous territory!
+      // Note: we’re in dangerous territory!
       // By definition, something unexpected occurred,
-      // which we probably didn't want.
+      // which we probably didn’t want.
       // Anything can happen now!  Be very careful!
 
       try {
@@ -111,13 +111,13 @@ if (cluster.isMaster) {
         var killtimer = setTimeout(function() {
           process.exit(1);
         }, 30000);
-        // But don't keep the process open just for that!
+        // But don’t keep the process open just for that!
         killtimer.unref();
 
         // stop taking new requests.
         server.close();
 
-        // Let the master know we're dead.  This will trigger a
+        // Let the master know we’re dead.  This will trigger a
         // 'disconnect' in the cluster master, and then it will fork
         // a new worker.
         cluster.worker.disconnect();
@@ -146,7 +146,7 @@ if (cluster.isMaster) {
   server.listen(PORT);
 }
 
-// This part isn't important.  Just an example routing thing.
+// This part isn’t important.  Just an example routing thing.
 // You'd put your fancy application logic here.
 function handleRequest(req, res) {
   switch(req.url) {
@@ -200,7 +200,7 @@ If you *want* to nest Domain objects as children of a parent Domain,
 then you must explicitly add them.
 
 Implicit binding routes thrown errors and `'error'` events to the
-Domain's `error` event, but does not register the EventEmitter on the
+Domain’s `error` event, but does not register the EventEmitter on the
 Domain, so `domain.dispose()` will not shut down the EventEmitter.
 Implicit binding only takes care of thrown errors and `'error'` events.
 
@@ -305,7 +305,7 @@ to the domain.
 
 Explicitly adds an emitter to the domain.  If any event handlers called by
 the emitter throw an error, or if the emitter emits an `error` event, it
-will be routed to the domain's `error` event, just like with implicit
+will be routed to the domain’s `error` event, just like with implicit
 binding.
 
 This also works with timers that are returned from `setInterval` and
@@ -329,7 +329,7 @@ specified emitter.
 
 The returned function will be a wrapper around the supplied callback
 function.  When the returned function is called, any errors that are
-thrown will be routed to the domain's `error` event.
+thrown will be routed to the domain’s `error` event.
 
 #### Example
 

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -10,7 +10,7 @@ opened. All objects which emit events are instances of `events.EventEmitter`.
 You can access this module by doing: `require("events");`
 
 Typically, event names are represented by a camel-cased string, however,
-there aren't any strict restrictions on that, as any string will be accepted.
+there aren’t any strict restrictions on that, as any string will be accepted.
 
 Functions can then be attached to objects, to be executed when an event
 is emitted. These functions are called _listeners_.

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -228,7 +228,7 @@ linkString)`.
 
 ## fs.readlinkSync(path)
 
-Synchronous readlink(2). Returns the symbolic link's string value.
+Synchronous readlink(2). Returns the symbolic link’s string value.
 
 ## fs.realpath(path, [cache], callback)
 
@@ -311,10 +311,10 @@ An exception occurs if the file does not exist.
 
   This is primarily useful for opening files on NFS mounts as it allows you to
   skip the potentially stale local cache. It has a very real impact on I/O
-  performance so don't use this mode unless you need it.
+  performance so don’t use this mode unless you need it.
 
-  Note that this doesn't turn `fs.open()` into a synchronous blocking call.
-  If that's what you want then you should be using `fs.openSync()`
+  Note that this doesn’t turn `fs.open()` into a synchronous blocking call.
+  If that’s what you want then you should be using `fs.openSync()`
 
 * `'rs+'` - Open file for reading and writing, telling the OS to open it
   synchronously. See notes for `'rs'` about using this with caution.
@@ -345,7 +345,7 @@ Exclusive mode (`O_EXCL`) ensures that `path` is newly created. `fs.open()`
 fails if a file by that name already exists. On POSIX systems, symlinks are
 not followed. Exclusive mode may or may not work with network file systems.
 
-On Linux, positional writes don't work when the file is opened in append mode.
+On Linux, positional writes don’t work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
@@ -391,7 +391,7 @@ Note that it is unsafe to use `fs.write` multiple times on the same file
 without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.
 
-On Linux, positional writes don't work when the file is opened in append mode.
+On Linux, positional writes don’t work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
@@ -572,7 +572,7 @@ to be notified of filesystem changes.
 
 If the underlying functionality is not available for some reason, then
 `fs.watch` will not be able to function.  For example, watching files or
-directories on network file systems (NFS, SMB, etc.) often doesn't work
+directories on network file systems (NFS, SMB, etc.) often doesn’t work
 reliably or at all.
 
 You can still use `fs.watchFile`, which uses stat polling, but it is slower and
@@ -583,9 +583,9 @@ less reliable.
 <!--type=misc-->
 
 Providing `filename` argument in the callback is not supported
-on every platform (currently it's only supported on Linux and Windows).  Even
+on every platform (currently it’s only supported on Linux and Windows).  Even
 on supported platforms `filename` is not always guaranteed to be provided.
-Therefore, don't assume that `filename` argument is always provided in the
+Therefore, don’t assume that `filename` argument is always provided in the
 callback, and have some fallback logic if it is null.
 
     fs.watch('somedir', function (event, filename) {
@@ -603,7 +603,7 @@ Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
 
     fs.exists('/etc/passwd', function (exists) {
-      util.debug(exists ? "it's there" : "no passwd!");
+      util.debug(exists ? "it’s there" : "no passwd!");
     });
 
 
@@ -673,9 +673,9 @@ Returns a new ReadStream object (See `Readable Stream`).
 the file instead of the entire file.  Both `start` and `end` are inclusive and
 start at 0. The `encoding` can be `'utf8'`, `'ascii'`, or `'base64'`.
 
-If `autoClose` is false, then the file descriptor won't be closed, even if
-there's an error.  It is your responsibility to close it and make sure
-there's no file descriptor leak.  If `autoClose` is set to true (default
+If `autoClose` is false, then the file descriptor won’t be closed, even if
+there’s an error.  It is your responsibility to close it and make sure
+there’s no file descriptor leak.  If `autoClose` is set to true (default
 behavior), on `error` or `end` the file descriptor will be closed
 automatically.
 
@@ -692,7 +692,7 @@ An example to read the last 10 bytes of a file which is 100 bytes long:
 
 * `fd` {Integer} file descriptor used by the ReadStream.
 
-Emitted when the ReadStream's file is opened.
+Emitted when the ReadStream’s file is opened.
 
 
 ## fs.createWriteStream(path, [options])
@@ -718,7 +718,7 @@ default mode `w`.
 
 * `fd` {Integer} file descriptor used by the WriteStream.
 
-Emitted when the WriteStream's file is opened.
+Emitted when the WriteStream’s file is opened.
 
 ### file.bytesWritten
 

--- a/doc/api/globals.markdown
+++ b/doc/api/globals.markdown
@@ -2,7 +2,7 @@
 
 <!-- type=misc -->
 
-These objects are available in all modules. Some of these objects aren't
+These objects are available in all modules. Some of these objects aren’t
 actually in the global scope but in the module scope - this will be noted.
 
 ## global
@@ -12,7 +12,7 @@ actually in the global scope but in the module scope - this will be noted.
 * {Object} The global namespace object.
 
 In browsers, the top-level scope is the global scope. That means that in
-browsers if you're in the global scope `var something` will define a global
+browsers if you’re in the global scope `var something` will define a global
 variable. In Node this is different. The top-level scope is not the global
 scope; `var something` inside a Node module will be local to that module.
 
@@ -46,7 +46,7 @@ Used to handle binary data. See the [buffer section][]
 
 * {Function}
 
-To require modules. See the [Modules][] section.  `require` isn't actually a
+To require modules. See the [Modules][] section.  `require` isn’t actually a
 global but rather local to each module.
 
 ### require.resolve()
@@ -87,7 +87,7 @@ Example: running `node example.js` from `/Users/mjr`
     console.log(__filename);
     // /Users/mjr/example.js
 
-`__filename` isn't actually a global but rather local to each module.
+`__filename` isn’t actually a global but rather local to each module.
 
 ## __dirname
 
@@ -102,7 +102,7 @@ Example: running `node example.js` from `/Users/mjr`
     console.log(__dirname);
     // /Users/mjr
 
-`__dirname` isn't actually a global but rather local to each module.
+`__dirname` isn’t actually a global but rather local to each module.
 
 
 ## module
@@ -113,7 +113,7 @@ Example: running `node example.js` from `/Users/mjr`
 
 A reference to the current module. In particular
 `module.exports` is the same as the `exports` object.
-`module` isn't actually a global but rather local to each module.
+`module` isn’t actually a global but rather local to each module.
 
 See the [module system documentation][] for more information.
 
@@ -124,7 +124,7 @@ See the [module system documentation][] for more information.
 An object which is shared between all instances of the current module and
 made accessible through `require()`.
 `exports` is the same as the `module.exports` object.
-`exports` isn't actually a global but rather local to each module.
+`exports` isn’t actually a global but rather local to each module.
 
 See the [module system documentation][] for more information.
 
@@ -136,7 +136,7 @@ Run callback `cb` after *at least* `ms` milliseconds. The actual delay depends
 on external factors like OS timer granularity and system load.
 
 The timeout must be in the range of 1-2,147,483,647 inclusive. If the value is
-outside that range, it's changed to 1 millisecond. Broadly speaking, a timer
+outside that range, it’s changed to 1 millisecond. Broadly speaking, a timer
 cannot span more than 24.8 days.
 
 Returns an opaque value that represents the timer.
@@ -150,10 +150,10 @@ not execute.
 
 Run callback `cb` repeatedly every `ms` milliseconds. Note that the actual
 interval may vary, depending on external factors like OS timer granularity and
-system load. It's never less than `ms` but it may be longer.
+system load. It’s never less than `ms` but it may be longer.
 
 The interval must be in the range of 1-2,147,483,647 inclusive. If the value is
-outside that range, it's changed to 1 millisecond. Broadly speaking, a timer
+outside that range, it’s changed to 1 millisecond. Broadly speaking, a timer
 cannot span more than 24.8 days.
 
 Returns an opaque value that represents the timer.

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -19,7 +19,7 @@ HTTP message headers are represented by an object like this:
 
 Keys are lowercased. Values are not modified.
 
-In order to support the full spectrum of possible HTTP applications, Node's
+In order to support the full spectrum of possible HTTP applications, Node’s
 HTTP API is very low-level. It deals with stream handling and message
 parsing only. It parses a message into headers and body but it does not
 parse the actual headers or the body.
@@ -78,7 +78,7 @@ per connection (in the case of keep-alive connections).
 `function (request, response) { }`
 
 Emitted each time a request with an http Expect: 100-continue is received.
-If this event isn't listened for, the server will automatically respond
+If this event isn’t listened for, the server will automatically respond
 with a 100 Continue as appropriate.
 
 Handling this event involves calling `response.writeContinue` if the client
@@ -93,7 +93,7 @@ not be emitted.
 
 `function (request, socket, head) { }`
 
-Emitted each time a client requests a http CONNECT method. If this event isn't
+Emitted each time a client requests a http CONNECT method. If this event isn’t
 listened for, then clients requesting a CONNECT method will have their
 connections closed.
 
@@ -103,7 +103,7 @@ connections closed.
 * `head` is an instance of Buffer, the first packet of the tunneling stream,
   this may be empty.
 
-After this event is emitted, the request's socket will not have a `data`
+After this event is emitted, the request’s socket will not have a `data`
 event listener, meaning you will need to bind to it in order to handle data
 sent to the server on that socket.
 
@@ -111,7 +111,7 @@ sent to the server on that socket.
 
 `function (request, socket, head) { }`
 
-Emitted each time a client requests a http upgrade. If this event isn't
+Emitted each time a client requests a http upgrade. If this event isn’t
 listened for, then clients requesting an upgrade will have their connections
 closed.
 
@@ -121,7 +121,7 @@ closed.
 * `head` is an instance of Buffer, the first packet of the upgraded stream,
   this may be empty.
 
-After this event is emitted, the request's socket will not have a `data`
+After this event is emitted, the request’s socket will not have a `data`
 event listener, meaning you will need to bind to it in order to handle data
 sent to the server on that socket.
 
@@ -199,9 +199,9 @@ occurs.
 If there is a `'timeout'` event listener on the Server object, then it
 will be called with the timed-out socket as an argument.
 
-By default, the Server's timeout value is 2 minutes, and sockets are
+By default, the Server’s timeout value is 2 minutes, and sockets are
 destroyed automatically if they time out.  However, if you assign a
-callback to the Server's `'timeout'` event, then you are responsible
+callback to the Server’s `'timeout'` event, then you are responsible
 for handling socket timeouts.
 
 ### server.timeout
@@ -270,13 +270,13 @@ which has been transmitted are equal or not.
 * `msecs` {Number}
 * `callback` {Function}
 
-Sets the Socket's timeout value to `msecs`.  If a callback is
+Sets the Socket’s timeout value to `msecs`.  If a callback is
 provided, then it is added as a listener on the `'timeout'` event on
 the response object.
 
 If no `'timeout'` listener is added to the request, the response, or
 the server, then sockets are destroyed when they time out.  If you
-assign a handler on the request, the response, or the server's
+assign a handler on the request, the response, or the server’s
 `'timeout'` events, then it is your responsibility to handle timed out
 sockets.
 
@@ -321,7 +321,7 @@ in responses.
 
 ### response.getHeader(name)
 
-Reads out a header that's already been queued but not sent to the client.  Note
+Reads out a header that’s already been queued but not sent to the client.  Note
 that the name is case insensitive.  This can only be called before headers get
 implicitly flushed.
 
@@ -331,7 +331,7 @@ Example:
 
 ### response.removeHeader(name)
 
-Removes a header that's queued for implicit sending.
+Removes a header that’s queued for implicit sending.
 
 Example:
 
@@ -355,7 +355,7 @@ higher-level multi-part body encodings that may be used.
 
 The first time `response.write()` is called, it will send the buffered
 header information and the first body to the client. The second time
-`response.write()` is called, Node assumes you're going to be streaming
+`response.write()` is called, Node assumes you’re going to be streaming
 data, and sends that separately. That is, the response is buffered up to the
 first chunk of body.
 
@@ -454,7 +454,7 @@ Example:
     req.end();
 
 Note that in the example `req.end()` was called. With `http.request()` one
-must always call `req.end()` to signify that you're done with the request -
+must always call `req.end()` to signify that you’re done with the request -
 even if there is no data being written to the request body.
 
 If any error is encountered during the request (be that with DNS resolution,
@@ -501,13 +501,13 @@ current implementation now holds sockets for any number of hosts.
 
 The current HTTP Agent also defaults client requests to using
 Connection:keep-alive. If no pending HTTP requests are waiting on a socket
-to become free the socket is closed. This means that node's pool has the
+to become free the socket is closed. This means that node’s pool has the
 benefit of keep-alive when under load but still does not require developers
 to manually close the HTTP clients using keep-alive.
 
-Sockets are removed from the agent's pool when the socket emits either a
+Sockets are removed from the agent’s pool when the socket emits either a
 "close" event or a special "agentRemove" event. This means that if you intend
-to keep one HTTP request open for a long time and don't want it to stay in the
+to keep one HTTP request open for a long time and don’t want it to stay in the
 pool you can do something along the lines of:
 
     http.get(options, function(res) {
@@ -596,7 +596,7 @@ Emitted after a socket is assigned to this request.
 `function (response, socket, head) { }`
 
 Emitted each time a server responds to a request with a CONNECT method. If this
-event isn't being listened for, clients receiving a CONNECT method will have
+event isn’t being listened for, clients receiving a CONNECT method will have
 their connections closed.
 
 A client server pair that show you how to listen for the `connect` event.
@@ -659,7 +659,7 @@ A client server pair that show you how to listen for the `connect` event.
 `function (response, socket, head) { }`
 
 Emitted each time a server responds to a request with an upgrade. If this
-event isn't being listened for, clients receiving an upgrade header will have
+event isn’t being listened for, clients receiving an upgrade header will have
 their connections closed.
 
 A client server pair that show you how to listen for the `upgrade` event.
@@ -859,7 +859,7 @@ The 3-digit HTTP response status code. E.G. `404`.
 The `net.Socket` object associated with the connection.
 
 With HTTPS support, use request.connection.verifyPeer() and
-request.connection.getPeerCertificate() to obtain the client's
+request.connection.getPeerCertificate() to obtain the client’s
 authentication details.
 
 

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -76,7 +76,7 @@ loop an **unfinished copy** of the `a.js` exports object is returned to the
 `b.js` module.  `b.js` then finishes loading, and its exports object is
 provided to the `a.js` module.
 
-By the time `main.js` has loaded both modules, they're both finished.
+By the time `main.js` has loaded both modules, they’re both finished.
 The output of this program would thus be:
 
     $ node main.js
@@ -99,7 +99,7 @@ plan accordingly.
 Node has several modules compiled into the binary.  These modules are
 described in greater detail elsewhere in this documentation.
 
-The core modules are defined in node's source in the `lib/` folder.
+The core modules are defined in node’s source in the `lib/` folder.
 
 Core modules are always preferentially loaded if their identifier is
 passed to `require()`.  For instance, `require('http')` will always
@@ -174,7 +174,7 @@ If this was in a folder at `./some-library`, then
 `require('./some-library')` would attempt to load
 `./some-library/lib/some-library.js`.
 
-This is the extent of Node's awareness of package.json files.
+This is the extent of Node’s awareness of package.json files.
 
 If there is no package.json file present in the directory, then node
 will attempt to load an `index.js` or `index.node` file out of that
@@ -220,7 +220,7 @@ would resolve to different files.
 In each module, the `module` free variable is a reference to the object
 representing the current module.  In particular
 `module.exports` is the same as the `exports` object.
-`module` isn't actually a global but rather local to each module.
+`module` isn’t actually a global but rather local to each module.
 
 ### module.exports
 
@@ -274,7 +274,7 @@ The `module.require` method provides a way to load a module as if
 
 Note that in order to do this, you must get a reference to the `module`
 object.  Since `require()` returns the `exports`, and the `module` is
-typically *only* available within a specific module's code, it must be
+typically *only* available within a specific module’s code, it must be
 explicitly exported in order to be used.
 
 
@@ -382,7 +382,7 @@ Additionally, node will search in the following locations:
 * 2: `$HOME/.node_libraries`
 * 3: `$PREFIX/lib/node`
 
-Where `$HOME` is the user's home directory, and `$PREFIX` is node's
+Where `$HOME` is the user’s home directory, and `$PREFIX` is node’s
 configured `node_prefix`.
 
 These are mostly for historic reasons.  You are highly encouraged to
@@ -410,14 +410,14 @@ by checking `require.main.filename`.
 
 <!-- type=misc -->
 
-The semantics of Node's `require()` function were designed to be general
+The semantics of Node’s `require()` function were designed to be general
 enough to support a number of sane directory structures. Package manager
 programs such as `dpkg`, `rpm`, and `npm` will hopefully find it possible to
 build native packages from Node modules without modification.
 
 Below we give a suggested directory structure that could work:
 
-Let's say that we wanted to have the folder at
+Let’s say that we wanted to have the folder at
 `/usr/lib/node/<some-package>/<some-version>` hold the contents of a
 specific version of a package.
 
@@ -445,7 +445,7 @@ that it can use.
 
 When the code in the `foo` package does `require('bar')`, it will get the
 version that is symlinked into `/usr/lib/node/foo/1.2.3/node_modules/bar`.
-Then, when the code in the `bar` package calls `require('quux')`, it'll get
+Then, when the code in the `bar` package calls `require('quux')`, it’ll get
 the version that is symlinked into
 `/usr/lib/node/bar/4.3.2/node_modules/quux`.
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -16,7 +16,7 @@ automatically set as a listener for the ['connection'][] event.
     { allowHalfOpen: false
     }
 
-If `allowHalfOpen` is `true`, then the socket won't automatically send a FIN
+If `allowHalfOpen` is `true`, then the socket won’t automatically send a FIN
 packet when the other end of the socket sends a FIN packet. The socket becomes
 non-readable, but still writable. You should call the `end()` method explicitly.
 See ['end'][] event for more information.
@@ -70,7 +70,7 @@ For UNIX domain sockets, `options` argument should be an object which specifies:
 
 Common options are:
 
-  - `allowHalfOpen`: if `true`, the socket won't automatically send
+  - `allowHalfOpen`: if `true`, the socket won’t automatically send
     a FIN packet when the other end of the socket sends a FIN packet.
     Defaults to `false`.  See ['end'][] event for more information.
 
@@ -205,7 +205,7 @@ Example:
       console.log("opened server on %j", address);
     });
 
-Don't call `server.address()` until the `'listening'` event has been emitted.
+Don’t call `server.address()` until the `'listening'` event has been emitted.
 
 ### server.unref()
 
@@ -216,12 +216,12 @@ active server in the event system. If the server is already `unref`d calling
 ### server.ref()
 
 Opposite of `unref`, calling `ref` on a previously `unref`d server will *not*
-let the program exit if it's the only server left (the default behavior). If
+let the program exit if it’s the only server left (the default behavior). If
 the server is `ref`d calling `ref` again will have no effect.
 
 ### server.maxConnections
 
-Set this property to reject connections when the server's connection count gets
+Set this property to reject connections when the server’s connection count gets
 high.
 
 It is not recommended to use this option once a socket has been sent to a child
@@ -316,7 +316,7 @@ help users get up and running quickly. The computer cannot always keep up
 with the amount of data that is written to a socket - the network connection
 simply might be too slow. Node will internally queue up the data written to a
 socket and send it out over the wire when it is possible. (Internally it is
-polling on the socket's file descriptor for being writable).
+polling on the socket’s file descriptor for being writable).
 
 The consequence of this internal buffering is that memory may grow. This
 property shows the number of characters currently buffered to be written.
@@ -415,7 +415,7 @@ active socket in the event system. If the socket is already `unref`d calling
 ### socket.ref()
 
 Opposite of `unref`, calling `ref` on a previously `unref`d socket will *not*
-let the program exit if it's the only socket left (the default behavior). If
+let the program exit if it’s the only socket left (the default behavior). If
 the socket is `ref`d calling `ref` again will have no effect.
 
 ### socket.remoteAddress

--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -8,7 +8,7 @@ Use `require('os')` to access this module.
 
 ## os.tmpdir()
 
-Returns the operating system's default directory for temp files.
+Returns the operating system’s default directory for temp files.
 
 ## os.endianness()
 

--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -12,7 +12,7 @@ Use `require('path')` to use this module.  The following methods are provided:
 
 Normalize a string path, taking care of `'..'` and `'.'` parts.
 
-When multiple slashes are found, they're replaced by a single one;
+When multiple slashes are found, they’re replaced by a single one;
 when the path contains a trailing slash, it is preserved.
 On Windows backslashes are used.
 
@@ -43,7 +43,7 @@ Example:
 
 Resolves `to` to an absolute path.
 
-If `to` isn't already absolute `from` arguments are prepended in right to left
+If `to` isn’t already absolute `from` arguments are prepended in right to left
 order, until an absolute path is found. If after using all `from` paths still
 no absolute path is found, the current working directory is used as well. The
 resulting path is normalized, and trailing slashes are removed unless the path
@@ -61,7 +61,7 @@ Is similar to:
     cd a/../subfile
     pwd
 
-The difference is that the different paths don't need to exist and may also be
+The difference is that the different paths don’t need to exist and may also be
 files.
 
 Examples:

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -9,7 +9,7 @@ It is an instance of [EventEmitter][].
 ## Event: 'exit'
 
 Emitted when the process is about to exit.  This is a good hook to perform
-constant time checks of the module's state (like for unit tests).  The main
+constant time checks of the module’s state (like for unit tests).  The main
 event loop will no longer be run after the 'exit' callback finishes, so
 timers may not be scheduled.
 
@@ -38,14 +38,14 @@ Example of listening for `uncaughtException`:
       console.log('This will still run.');
     }, 500);
 
-    // Intentionally cause an exception, but don't catch it.
+    // Intentionally cause an exception, but don’t catch it.
     nonexistentFunc();
     console.log('This will not run.');
 
 Note that `uncaughtException` is a very crude mechanism for exception
 handling.
 
-Don't use it, use [domains](domain.html) instead. If you do use it, restart
+Don’t use it, use [domains](domain.html) instead. If you do use it, restart
 your application after every unhandled exception!
 
 Do *not* use it as the node.js equivalent of `On Error Resume Next`. An
@@ -67,7 +67,7 @@ standard POSIX signal names such as SIGINT, SIGUSR1, etc.
 
 Example of listening for `SIGINT`:
 
-    // Start reading from stdin so we don't exit.
+    // Start reading from stdin so we don’t exit.
     process.stdin.resume();
 
     process.on('SIGINT', function() {
@@ -404,7 +404,7 @@ Getter/setter to set what is displayed in 'ps'.
 When used as a setter, the maximum length is platform-specific and probably
 short.
 
-On Linux and OS X, it's limited to the size of the binary name plus the
+On Linux and OS X, it’s limited to the size of the binary name plus the
 length of the command line arguments because it overwrites the argv memory.
 
 v0.8 allowed for longer process title strings by also overwriting the environ
@@ -414,14 +414,14 @@ cases.
 
 ## process.arch
 
-What processor architecture you're running on: `'arm'`, `'ia32'`, or `'x64'`.
+What processor architecture you’re running on: `'arm'`, `'ia32'`, or `'x64'`.
 
     console.log('This processor architecture is ' + process.arch);
 
 
 ## process.platform
 
-What platform you're running on:
+What platform you’re running on:
 `'darwin'`, `'freebsd'`, `'linux'`, `'sunos'` or `'win32'`
 
     console.log('This platform is ' + process.platform);
@@ -448,7 +448,7 @@ This will generate:
 ## process.nextTick(callback)
 
 On the next loop around the event loop call this callback.
-This is *not* a simple alias to `setTimeout(fn, 0)`, it's much more
+This is *not* a simple alias to `setTimeout(fn, 0)`, it’s much more
 efficient.  It typically runs before any other I/O events fire, but there
 are some exceptions.  See `process.maxTickDepth` below.
 
@@ -493,7 +493,7 @@ This API is hazardous.  If you do this:
     });
     bar();
 
-then it's not clear whether `foo()` or `bar()` will be called first.
+then it’s not clear whether `foo()` or `bar()` will be called first.
 
 This approach is much better:
 
@@ -531,7 +531,7 @@ allowing other forms of I/O to occur.
 
 ## process.umask([mask])
 
-Sets or reads the process's file mode creation mask. Child processes inherit
+Sets or reads the process’s file mode creation mask. Child processes inherit
 the mask from the parent process. Returns the old mask if `mask` argument is
 given, otherwise returns the current mask.
 

--- a/doc/api/punycode.markdown
+++ b/doc/api/punycode.markdown
@@ -27,7 +27,7 @@ points.
 ## punycode.toUnicode(domain)
 
 Converts a Punycode string representing a domain name to Unicode. Only the
-Punycoded parts of the domain name will be converted, i.e. it doesn't matter if
+Punycoded parts of the domain name will be converted, i.e. it doesn’t matter if
 you call it on a string that has already been converted to Unicode.
 
     // decode domain names
@@ -37,8 +37,8 @@ you call it on a string that has already been converted to Unicode.
 ## punycode.toASCII(domain)
 
 Converts a Unicode string representing a domain name to Punycode. Only the
-non-ASCII parts of the domain name will be converted, i.e. it doesn't matter if
-you call it with a domain that's already in ASCII.
+non-ASCII parts of the domain name will be converted, i.e. it doesn’t matter if
+you call it with a domain that’s already in ASCII.
 
     // encode domain names
     punycode.toASCII('mañana.com'); // 'xn--maana-pta.com'

--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -29,7 +29,7 @@ Deserialize a query string to an object.
 Optionally override the default separator (`'&'`) and assignment (`'='`)
 characters.
 
-Options object may contain `maxKeys` property (equal to 1000 by default), it'll
+Options object may contain `maxKeys` property (equal to 1000 by default), it’ll
 be used to limit processed keys. Set it to 0 to remove key count limitation.
 
 Example:

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -6,7 +6,7 @@ To use this module, do `require('readline')`. Readline allows reading of a
 stream (such as `process.stdin`) on a line-by-line basis.
 
 Note that once you've invoked this module, your node program will not
-terminate until you've closed the interface. Here's how to allow your
+terminate until you've closed the interface. Here’s how to allow your
 program to gracefully exit:
 
     var readline = require('readline');
@@ -89,7 +89,7 @@ stream.
 ### rl.setPrompt(prompt)
 
 Sets the prompt, for example when you run `node` on the command line, you see
-`> `, which is node's prompt.
+`> `, which is node’s prompt.
 
 ### rl.prompt([preserveCursor])
 
@@ -102,9 +102,9 @@ been paused.
 
 ### rl.question(query, callback)
 
-Prepends the prompt with `query` and invokes `callback` with the user's
+Prepends the prompt with `query` and invokes `callback` with the user’s
 response. Displays the query to the user, and then invokes `callback`
-with the user's response after it has been typed.
+with the user’s response after it has been typed.
 
 This will also resume the `input` stream used with `createInterface` if
 it has been paused.
@@ -257,7 +257,7 @@ Example of listening for `SIGCONT`:
 
 ## Example: Tiny CLI
 
-Here's an example of how to use all these together to craft a tiny command
+Here’s an example of how to use all these together to craft a tiny command
 line interface:
 
     var readline = require('readline'),

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -49,13 +49,13 @@ takes the following values:
 
  - `useColors` - a boolean which specifies whether or not the `writer` function
    should output colors. If a different `writer` function is set then this does
-   nothing. Defaults to the repl's `terminal` value.
+   nothing. Defaults to the repl’s `terminal` value.
 
  - `useGlobal` - if set to `true`, then the repl will use the `global` object,
    instead of running scripts in a separate context. Defaults to `false`.
 
  - `ignoreUndefined` - if set to `true`, then the repl will not output the
-   return value of command if it's `undefined`. Defaults to `false`.
+   return value of command if it’s `undefined`. Defaults to `false`.
 
  - `writer` - the function to invoke for each command that gets evaluated which
    returns the formatting (including coloring) to display. Defaults to
@@ -139,7 +139,7 @@ Example of listening for `exit`:
 
 `function (context) {}`
 
-Emitted when the REPL's context is reset. This happens when you type `.clear`.
+Emitted when the REPL’s context is reset. This happens when you type `.clear`.
 If you start the repl with `{ useGlobal: true }` then this event will never
 be emitted.
 
@@ -191,7 +191,7 @@ Things in the `context` object appear as local within the REPL:
 There are a few special REPL commands:
 
   - `.break` - While inputting a multi-line expression, sometimes you get lost
-    or just don't care about completing it. `.break` will start over.
+    or just don’t care about completing it. `.break` will start over.
   - `.clear` - Resets the `context` object to an empty object and clears any
     multi-line expression.
   - `.exit` - Close the I/O stream, which will cause the REPL to exit.

--- a/doc/api/stdio.markdown
+++ b/doc/api/stdio.markdown
@@ -11,7 +11,7 @@ provided by most web browsers, here the output is sent to stdout or stderr.
 
 The console functions are synchronous when the destination is a terminal or
 a file (to avoid lost messages in case of premature exit) and asynchronous
-when it's a pipe (to avoid blocking for long periods of time).
+when it’s a pipe (to avoid blocking for long periods of time).
 
 That is, in the following example, stdout is non-blocking while stderr
 is blocking:

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -188,7 +188,7 @@ Note: **This function should usually be called by Readable consumers,
 NOT by implementors of Readable subclasses.**  It does not indicate
 the end of a `_read()` transaction in the way that
 `readable.push(chunk)` does.  If you find that you have to call
-`this.unshift(chunk)` in your Readable class, then there's a good
+`this.unshift(chunk)` in your Readable class, then there’s a good
 chance you ought to be using the
 [stream.Transform](#stream_class_stream_transform) class instead.
 
@@ -243,7 +243,7 @@ SimpleProtocol.prototype._read = function(n) {
   if (!this._inBody) {
     var chunk = this._source.read();
 
-    // if the source doesn't have data, we don't have data yet.
+    // if the source doesn’t have data, we don’t have data yet.
     if (chunk === null)
       return this.push('');
 
@@ -525,7 +525,7 @@ stream.
 
 ### Event: 'drain'
 
-Emitted when the stream's write queue empties and it's safe to write
+Emitted when the stream’s write queue empties and it’s safe to write
 without buffering again. Listen for it when `stream.write()` returns
 `false`.
 
@@ -543,14 +543,14 @@ event is emitted.
 
 * `source` {Readable Stream}
 
-Emitted when the stream is passed to a readable stream's pipe method.
+Emitted when the stream is passed to a readable stream’s pipe method.
 
 ### Event 'unpipe'
 
 * `source` {Readable Stream}
 
 Emitted when a previously established `pipe()` is removed using the
-source Readable stream's `unpipe()` method.
+source Readable stream’s `unpipe()` method.
 
 ## Class: stream.Duplex
 
@@ -564,7 +564,7 @@ extended with an underlying implementation of the `_read(size)`
 and `_write(chunk, encoding, callback)` methods as you would with a Readable or
 Writable stream class.
 
-Since JavaScript doesn't have multiple prototypal inheritance, this
+Since JavaScript doesn’t have multiple prototypal inheritance, this
 class prototypally inherits from Readable, and then parasitically from
 Writable.  It is thus up to the user to implement both the lowlevel
 `_read(n)` method as well as the lowlevel `_write(chunk, encoding, cb)` method

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -34,7 +34,7 @@ Stops a interval from triggering.
 
 The opaque value returned by `setTimeout` and `setInterval` also has the method
 `timer.unref()` which will allow you to create a timer that is active but if
-it is the only item left in the event loop won't keep the program running.
+it is the only item left in the event loop won’t keep the program running.
 If the timer is already `unref`d calling `unref` again will have no effect.
 
 In the case of `setTimeout` when you `unref` you create a separate timer that

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -57,10 +57,10 @@ exceeded. The limits are configurable:
   - `tls.CLIENT_RENEG_WINDOW`: renegotiation window in seconds, default is
                                10 minutes.
 
-Don't change the defaults unless you know what you are doing.
+Don’t change the defaults unless you know what you are doing.
 
 To test your server, connect to it with `openssl s_client -connect address:port`
-and tap `R<CR>` (that's the letter `R` followed by a carriage return) a few
+and tap `R<CR>` (that’s the letter `R` followed by a carriage return) a few
 times.
 
 
@@ -136,7 +136,7 @@ automatically set as a listener for the [secureConnection][] event.  The
     A `'clientError'` is emitted on the `tls.Server` object whenever a handshake
     times out.
 
-  - `honorCipherOrder` : When choosing a cipher, use the server's preferences
+  - `honorCipherOrder` : When choosing a cipher, use the server’s preferences
     instead of the client preferences.
 
     Note that if SSLv2 is used, the server will send its list of preferences
@@ -161,7 +161,7 @@ automatically set as a listener for the [secureConnection][] event.  The
     extension. Only one argument will be passed to it: `servername`. And
     `SNICallback` should return SecureContext instance.
     (You can use `crypto.createCredentials(...).context` to get proper
-    SecureContext). If `SNICallback` wasn't provided - default callback with
+    SecureContext). If `SNICallback` wasn’t provided - default callback with
     high-level API will be used (see below).
 
   - `sessionTimeout`: An integer specifying the seconds after which TLS
@@ -234,7 +234,7 @@ Size of slab buffer used by all tls servers and clients.
 Default: `10 * 1024 * 1024`.
 
 
-Don't change the defaults unless you know what you are doing.
+Don’t change the defaults unless you know what you are doing.
 
 
 ## tls.connect(options, [callback])
@@ -273,7 +273,7 @@ Creates a new client connection to the given `port` and `host` (old API) or
 
   - `NPNProtocols`: An array of string or `Buffer` containing supported NPN
     protocols. `Buffer` should have following format: `0x05hello0x05world`,
-    where first byte is next protocol name's length. (Passing array should
+    where first byte is next protocol name’s length. (Passing array should
     usually be much simpler: `['hello', 'world']`.)
 
   - `servername`: Servername for SNI (Server Name Indication) TLS extension.
@@ -418,8 +418,8 @@ storage.
 
 Emitted when client wants to resume previous TLS session. Event listener may
 perform lookup in external storage using given `sessionId`, and invoke
-`callback(null, sessionData)` once finished. If session can't be resumed
-(i.e. doesn't exist in storage) one may call `callback(null, null)`. Calling
+`callback(null, sessionData)` once finished. If session can’t be resumed
+(i.e. doesn’t exist in storage) one may call `callback(null, null)`. Calling
 `callback(err)` will terminate incoming connection and destroy socket.
 
 
@@ -449,13 +449,13 @@ more information.
 
 ### server.addContext(hostname, credentials)
 
-Add secure context that will be used if client request's SNI hostname is
+Add secure context that will be used if client request’s SNI hostname is
 matching passed `hostname` (wildcards can be used). `credentials` can contain
 `key`, `cert` and `ca`.
 
 ### server.maxConnections
 
-Set this property to reject connections when the server's connection count
+Set this property to reject connections when the server’s connection count
 gets high.
 
 ### server.connections
@@ -469,7 +469,7 @@ This is an encrypted stream.
 
 ### cryptoStream.bytesWritten
 
-A proxy to the underlying socket's bytesWritten accessor, this will return
+A proxy to the underlying socket’s bytesWritten accessor, this will return
 the total bytes written to the socket, *including the TLS overhead*.
 
 ## Class: tls.CleartextStream
@@ -485,7 +485,7 @@ A ClearTextStream is the `clear` member of a SecurePair object.
 ### Event: 'secureConnect'
 
 This event is emitted after a new connection has been successfully handshaked. 
-The listener will be called no matter if the server's certificate was
+The listener will be called no matter if the server’s certificate was
 authorized or not. It is up to the user to test `cleartextStream.authorized`
 to see if the server certificate was signed by one of the specified CAs.
 If `cleartextStream.authorized === false` then the error can be found in
@@ -499,12 +499,12 @@ specified CAs, otherwise `false`
 
 ### cleartextStream.authorizationError
 
-The reason why the peer's certificate has not been verified. This property
+The reason why the peer’s certificate has not been verified. This property
 becomes available only when `cleartextStream.authorized === false`.
 
 ### cleartextStream.getPeerCertificate()
 
-Returns an object representing the peer's certificate. The returned object has
+Returns an object representing the peer’s certificate. The returned object has
 some properties corresponding to the field of the certificate.
 
 Example:

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -73,7 +73,7 @@ Return a string representation of `object`, which is useful for debugging.
 An optional *options* object may be passed that alters certain aspects of the
 formatted string:
 
- - `showHidden` - if `true` then the object's non-enumerable properties will be
+ - `showHidden` - if `true` then the object’s non-enumerable properties will be
    shown too. Defaults to `false`.
 
  - `depth` - tells `inspect` how many times to recurse while formatting the
@@ -84,7 +84,7 @@ formatted string:
    Defaults to `false`. Colors are customizable, see below.
 
  - `customInspect` - if `false`, then custom `inspect()` functions defined on the
-   objects being inspected won't be called. Defaults to `true`.
+   objects being inspected won’t be called. Defaults to `true`.
 
 Example of inspecting all properties of the `util` object:
 

--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -32,7 +32,7 @@ available. Furthermore, the `this` expression within the global scope
 of the context evaluates to the empty object (`{}`) instead of to
 your sandbox.
 
-Your sandbox's properties are also not shared directly with the script.
+Your sandbox’s properties are also not shared directly with the script.
 Instead, the properties of the sandbox are copied into the context at
 the beginning of execution, and then after execution, the properties
 are copied back out in an attempt to propagate any changes.
@@ -52,7 +52,7 @@ the example problem with `Array`.
 ## vm.runInThisContext(code, [filename])
 
 `vm.runInThisContext()` compiles `code`, runs it and returns the result. Running
-code does not have access to local scope. `filename` is optional, it's used only
+code does not have access to local scope. `filename` is optional, it’s used only
 in stack traces.
 
 Example of using `vm.runInThisContext` and `eval` to run the same code:
@@ -115,7 +115,7 @@ result. A (V8) context comprises a global object, together with a set of
 built-in objects and functions. Running code does not have access to local scope
 and the global object held within `context` will be used as the global object
 for `code`.
-`filename` is optional, it's used only in stack traces.
+`filename` is optional, it’s used only in stack traces.
 
 Example: compile and execute code in a existing context.
 
@@ -155,7 +155,7 @@ to seed the initial contents of the global object used by the context.
 `vm.Script` object representing this compiled code. This script can be run
 later many times using methods below. The returned script is not bound to any
 global object. It is bound before each run, just for that run. `filename` is
-optional, it's only used in stack traces.
+optional, it’s only used in stack traces.
 
 In case of syntax error in `code`, `createScript` prints the syntax error to stderr
 and throws an exception.

--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -146,7 +146,7 @@ class of the compressor/decompressor classes.
 
 ### zlib.flush(callback)
 
-Flush pending data. Don't call this frivolously, premature flushes negatively
+Flush pending data. Don’t call this frivolously, premature flushes negatively
 impact the effectiveness of the compression algorithm.
 
 ### zlib.reset()
@@ -243,7 +243,7 @@ See the description of `deflateInit2` and `inflateInit2` at
 
 <!--type=misc-->
 
-From `zlib/zconf.h`, modified to node's usage:
+From `zlib/zconf.h`, modified to node’s usage:
 
 The memory requirements for deflate are (in bytes):
 
@@ -257,7 +257,7 @@ the default memory requirements from 256K to 128K, set the options to:
 
     { windowBits: 14, memLevel: 7 }
 
-Of course this will generally degrade compression (there's no free lunch).
+Of course this will generally degrade compression (there’s no free lunch).
 
 The memory requirements for inflate are (in bytes)
 
@@ -275,7 +275,7 @@ will take longer to complete.  A lower level will result in less
 compression, but will be much faster.
 
 In general, greater memory usage options will mean that node has to make
-fewer calls to zlib, since it'll be able to process more data in a
+fewer calls to zlib, since it’ll be able to process more data in a
 single `write` operation.  So, this is another factor that affects the
 speed, at the cost of memory usage.
 


### PR DESCRIPTION
- easier to read for humans
- easier to read for machines (parsers don’t confuse text-quotes with code-quotes)
