### PR TITLE
assert: put info in err.message, not err.name

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -38,13 +38,12 @@ var assert = module.exports = ok;
 //                             expected: expected })
 
 assert.AssertionError = function AssertionError(options) {
-  this.message = options.message;
+  this.name = 'AssertionError';
   this.actual = options.actual;
   this.expected = options.expected;
   this.operator = options.operator;
+  this.message = options.message || getMessage(this)
   var stackStartFunction = options.stackStartFunction || fail;
-
-  this.name = getName(this, options.message);
   Error.captureStackTrace(this, stackStartFunction);
 };
 
@@ -72,15 +71,10 @@ function truncate(s, n) {
   }
 }
 
-function getName(self, message) {
-  if (message) {
-    return 'AssertionError: ' + message;
-  } else {
-    return 'AssertionError: ' +
-           truncate(JSON.stringify(self.actual, replacer), 128) + ' ' +
-           self.operator + ' ' +
-           truncate(JSON.stringify(self.expected, replacer), 128);
-  }
+function getMessage(self) {
+  return truncate(JSON.stringify(self.actual, replacer), 128) + ' ' +
+         self.operator + ' ' +
+         truncate(JSON.stringify(self.expected, replacer), 128);
 }
 
 // At present only the three keys mentioned above are used and

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -293,3 +293,16 @@ try {
   assert.equal(e.message, 'Missing expected exception..');
 }
 assert.ok(threw);
+
+// #5292
+try {
+  assert.equal(1, 2);
+} catch (e) {
+  assert.equal(e.toString().split('\n')[0], 'AssertionError: 1 == 2')
+}
+
+try {
+  assert.equal(1, 2, 'oh no');
+} catch (e) {
+  assert.equal(e.toString().split('\n')[0], 'AssertionError: oh no')
+}


### PR DESCRIPTION
(fixes #5292)

4716dc6 made assert.equal() and related functions work better by generating a better toString() from the expected, actual, and operator values passed to fail(). Unfortunately, this was accomplished by putting the generated message into the error's `name` property. When you passed in a custom error message, the error would put the custom error into `name` _and_ `message`, resulting in helpful string representations like `"AssertionError: Oh no: Oh no"`.

This commit resolves that issue by storing the generated message in the `message` property and leaving the error's name alone.
