### PR TITLE
add path.isAbsolute(path)

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -78,6 +78,25 @@ Examples:
     // if currently in /home/myself/node, it returns
     '/home/myself/node/wwwroot/static_files/gif/image.gif'
 
+## path.isAbsolute(path)
+
+Determines whether `path` is an absolute path. An absolute path will always
+resolve to the same location, regardless of the working directory.
+
+Posix examples:
+
+    path.isAbsolute('/foo/bar') // true
+    path.isAbsolute('/baz/..')  // true
+    path.isAbsolute('qux/')     // false
+    path.isAbsolute('.')        // false
+
+Windows examples:
+
+    path.isAbsolute('//server')  // true
+    path.isAbsolute('C:/foo/..') // true
+    path.isAbsolute('bar\baz')   // false
+    path.isAbsolute('.')         // false
+
 ## path.relative(from, to)
 
 Solve the relative path from `from` to `to`.

--- a/lib/path.js
+++ b/lib/path.js
@@ -121,7 +121,7 @@ if (isWindows) {
       var result = splitDeviceRe.exec(path),
           device = result[1] || '',
           isUnc = device && device.charAt(1) !== ':',
-          isAbsolute = !!result[2] || isUnc, // UNC paths are always absolute
+          isAbsolute = exports.isAbsolute(path),
           tail = result[3];
 
       if (device &&
@@ -172,7 +172,7 @@ if (isWindows) {
     var result = splitDeviceRe.exec(path),
         device = result[1] || '',
         isUnc = device && device.charAt(1) !== ':',
-        isAbsolute = !!result[2] || isUnc, // UNC paths are always absolute
+        isAbsolute = exports.isAbsolute(path),
         tail = result[3],
         trailingSlash = /[\\\/]$/.test(tail);
 
@@ -200,6 +200,15 @@ if (isWindows) {
     }
 
     return device + (isAbsolute ? '\\' : '') + tail;
+  };
+
+  // windows version
+  exports.isAbsolute = function(path) {
+    var result = splitDeviceRe.exec(path),
+        device = result[1] || '',
+        isUnc = device && device.charAt(1) !== ':';
+    // UNC paths are always absolute
+    return !!result[2] || isUnc;
   };
 
   // windows version
@@ -338,7 +347,7 @@ if (isWindows) {
   // path.normalize(path)
   // posix version
   exports.normalize = function(path) {
-    var isAbsolute = path.charAt(0) === '/',
+    var isAbsolute = exports.isAbsolute(path),
         trailingSlash = path.substr(-1) === '/';
 
     // Normalize the path
@@ -356,6 +365,10 @@ if (isWindows) {
     return (isAbsolute ? '/' : '') + path;
   };
 
+  // posix version
+  exports.isAbsolute = function(path) {
+    return path.charAt(0) === '/';
+  };
 
   // posix version
   exports.join = function() {
@@ -415,7 +428,6 @@ if (isWindows) {
   exports.sep = '/';
   exports.delimiter = ':';
 }
-
 
 exports.dirname = function(path) {
   var result = splitPath(path),

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -351,6 +351,23 @@ resolveTests.forEach(function(test) {
 });
 assert.equal(failures.length, 0, failures.join(''));
 
+// path.isAbsolute tests
+if (isWindows) {
+  assert.equal(path.isAbsolute('//server/file'), true);
+  assert.equal(path.isAbsolute('\\\\server\\file'), true);
+  assert.equal(path.isAbsolute('C:/Users/'), true);
+  assert.equal(path.isAbsolute('C:\\Users\\'), true);
+  assert.equal(path.isAbsolute('C:cwd/another'), false);
+  assert.equal(path.isAbsolute('C:cwd\\another'), false);
+  assert.equal(path.isAbsolute('directory/directory'), false);
+  assert.equal(path.isAbsolute('directory\\directory'), false);
+} else {
+  assert.equal(path.isAbsolute('/home/foo'), true);
+  assert.equal(path.isAbsolute('/home/foo/..'), true);
+  assert.equal(path.isAbsolute('bar/'), false);
+  assert.equal(path.isAbsolute('./baz'), false);
+}
+
 // path.relative tests
 if (isWindows) {
   // windows


### PR DESCRIPTION
Nothing more than `return exports.resolve(path) === path` -- with documentation, too! EDIT: No, it's a check to see if a path is _absolute_. On POSIX this means path.charAt(0) === '/' and other more complicated things on Windows.

Fixes joyent/node#5299.
