### PR TITLE
Modify gethostname buf from 255 to 256

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -51,8 +51,8 @@ static Handle<Value> GetEndianness(const Arguments& args) {
 
 static Handle<Value> GetHostname(const Arguments& args) {
   HandleScope scope(node_isolate);
-  char s[255];
-  int r = gethostname(s, 255);
+  char s[256];
+  int r = gethostname(s, sizeof(s));
 
   if (r < 0) {
 #ifdef __POSIX__
@@ -62,6 +62,7 @@ static Handle<Value> GetHostname(const Arguments& args) {
 #endif // __MINGW32__
   }
 
+  s[sizeof(s)-1] = 0;
   return scope.Close(String::New(s));
 }
 


### PR DESCRIPTION
1. SUSv2 gurantees hostnames are limited to 255 bytes, if the size of buffer is 255, the last char will be truncated in some platforms
2. If the hostname length exceeds the buf length(255), there may not contain null char in the buf, the following String::New will have problem
