### PR TITLE
crypto: fix return Local Handle w/o scope.Close()

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1962,7 +1962,7 @@ Handle<Value> Connection::GetNegotiatedProto(const Arguments& args) {
       return False();
     }
 
-    return String::New((const char*) npn_proto, npn_proto_len);
+    return scope.Close(String::New((const char*) npn_proto, npn_proto_len));
   } else {
     return ss->selectedNPNProto_;
   }


### PR DESCRIPTION
A New String was being created and returned, but was not sent through
the scope.Close(), which caused it to be cleaned up before being
returned.

Partial fix for #5319

@indutny, if we want a unit test I'll need your assistance. Now sure how to trigger this in a timely manner.
