### PR TITLE
build: libv8_base.a is now libv8_base.<arch>.a

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -450,7 +450,7 @@
             {
               'action_name': 'node_dtrace_ustack_constants',
               'inputs': [
-                '<(PRODUCT_DIR)/obj.target/deps/v8/tools/gyp/libv8_base.a'
+                '<(PRODUCT_DIR)/obj.target/deps/v8/tools/gyp/libv8_base.<(target_arch).a'
               ],
               'outputs': [
                 '<(SHARED_INTERMEDIATE_DIR)/v8constants.h'


### PR DESCRIPTION
This fixes generating the v8 contstants for dtrace on smartos, and the build in general for smartos
