### PR TITLE
crypto: Make Decipher._flush() emit errors.

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -253,7 +253,12 @@ Cipher.prototype._transform = function(chunk, encoding, callback) {
 };
 
 Cipher.prototype._flush = function(callback) {
-  this.push(this._binding.final());
+  try {
+    this.push(this._binding.final());
+  } catch (e) {
+    callback(e);
+    return;
+  }
   callback();
 };
 

--- a/test/simple/test-crypto-stream.js
+++ b/test/simple/test-crypto-stream.js
@@ -60,3 +60,18 @@ crypto.createHash('md5').unpipe({});
 crypto.createHash('md5').setEncoding('utf8');
 crypto.createHash('md5').pause();
 crypto.createHash('md5').resume();
+
+// Decipher._flush() should emit an error event, not an exception.
+var key = new Buffer('48fb56eb10ffeb13fc0ef551bbca3b1b', 'hex'),
+    badkey = new Buffer('12341234123412341234123412341234', 'hex'),
+    iv = new Buffer('6d358219d1f488f5f4eb12820a66d146', 'hex'),
+    cipher = crypto.createCipheriv('aes-128-cbc', key, iv),
+    decipher = crypto.createDecipheriv('aes-128-cbc', badkey, iv);
+
+cipher.pipe(decipher)
+  .on('error', common.mustCall(function end(err) {
+    // TypeError: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt
+    assert(/:06065064:/.test(err));
+  }));
+
+cipher.end('Papaya!');  // Should not cause an unhandled exception.


### PR DESCRIPTION
When Decipher processes a stream using an incorrect key, the DecipherFinal()
method throws an unhandled exception at the end of the stream.
