### PR TITLE
Proposing Object.setPrototypeOf() after V8 patch

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -27,14 +27,90 @@
 (function(process) {
   this.global = this;
 
+  (function(Object){
+    // https://code.google.com/p/v8/issues/detail?id=2645
+    // enrich Object with setPrototypeOf(target, proto):target
+    // if V8 is the patched one with
+    // --expose-proto-setter
+    // flag enabled, drops the prototype from the environment
+    // do nothing otherwise
+    var
+      deprecateInsteadOfThrowing = true,
+      bloodyProto = '__proto__',
+      setPrototypeOf = 'setPrototypeOf',
+      getPrototypeOf = 'getPrototypeOf',
+      ObjectPrototype = Object.prototype,
+      hasProto = bloodyProto in ObjectPrototype,
+      defineProperty = Object.defineProperty,
+      getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor,
+      descriptor = hasProto && getOwnPropertyDescriptor && getOwnPropertyDescriptor(
+        ObjectPrototype, bloodyProto
+      ),
+      set;
+    function addProperty(where, who, what) {
+      try {
+        defineProperty(
+          where,
+          who,
+          {
+            enumerable: false,
+            configurable: true,
+            writable: false,
+            value: what
+          }
+        );
+      } catch(o_O) {
+        where[who] = what;
+      }
+    }
+    if (!(setPrototypeOf in Object)) {
+      if (descriptor && descriptor.configurable && (set = descriptor.set)) {
+        try {
+          set.call(descriptor, ObjectPrototype);
+          addProperty(Object, setPrototypeOf, function (target, proto) {
+            set.call(target, proto);
+            return target;
+          });
+          delete ObjectPrototype[bloodyProto];
+          if (deprecateInsteadOfThrowing) {
+            defineProperty(
+              ObjectPrototype,
+              bloodyProto,
+              {
+                get: function () {
+                  console.warn('[DEPRECATED] use Object.getPrototypeOf(object) instead');
+                  return Object.getPrototypeOf(this);
+                },
+                set: function (proto) {
+                  console.warn('[DEPRECATED] use Object.setPrototypeOf(object, proto) instead');
+                  set.call(this, proto);
+                }
+              }
+            );
+          }
+        } catch(o_O) {}
+      }
+      if (hasProto && !(setPrototypeOf in Object)) {
+        addProperty(Object, setPrototypeOf, function (target, proto) {
+          target[bloodyProto] = proto;
+          return target;
+        });
+      }
+    }
+  }(Object));
+
   function startup() {
     var EventEmitter = NativeModule.require('events').EventEmitter;
 
-    process.__proto__ = Object.create(EventEmitter.prototype, {
-      constructor: {
-        value: process.constructor
-      }
-    });
+    Object.setPrototypeOf(
+      process,
+      Object.create(EventEmitter.prototype, {
+        constructor: {
+          value: process.constructor
+        }
+      })
+    );
+
     EventEmitter.call(process);
 
     process.EventEmitter = EventEmitter; // process.EventEmitter is deprecated

--- a/src/node.js
+++ b/src/node.js
@@ -78,11 +78,15 @@
               bloodyProto,
               {
                 get: function () {
-                  console.warn('[DEPRECATED] use Object.getPrototypeOf(object) instead');
+                  console.warn(
+                    '[DEPRECATED] use Object.getPrototypeOf(object) instead'
+                  );
                   return Object.getPrototypeOf(this);
                 },
                 set: function (proto) {
-                  console.warn('[DEPRECATED] use Object.setPrototypeOf(object, proto) instead');
+                  console.warn(
+                    '[DEPRECATED] use Object.setPrototypeOf(o, proto) instead'
+                  );
                   set.call(this, proto);
                 }
               }

--- a/src/node.js
+++ b/src/node.js
@@ -42,8 +42,8 @@
       ObjectPrototype = Object.prototype,
       hasProto = bloodyProto in ObjectPrototype,
       defineProperty = Object.defineProperty,
-      getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor,
-      descriptor = hasProto && getOwnPropertyDescriptor && getOwnPropertyDescriptor(
+      getOPD = Object.getOwnPropertyDescriptor,
+      descriptor = hasProto && getOPD && getOPD(
         ObjectPrototype, bloodyProto
       ),
       set;

--- a/src/node.js
+++ b/src/node.js
@@ -64,12 +64,14 @@
       }
     }
     if (!(setPrototypeOf in Object)) {
-      if (descriptor && descriptor.configurable && (set = descriptor.set)) {
+      if (descriptor && descriptor.configurable && (
+        set = descriptor.set
+      )) {
         try {
           set.call(descriptor, ObjectPrototype);
-          addProperty(Object, setPrototypeOf, function (target, proto) {
-            set.call(target, proto);
-            return target;
+          addProperty(Object, setPrototypeOf, function (t, proto) {
+            set.call(t, proto);
+            return t;
           });
           delete ObjectPrototype[bloodyProto];
           if (deprecateInsteadOfThrowing) {
@@ -79,13 +81,15 @@
               {
                 get: function () {
                   console.warn(
-                    '[DEPRECATED] use Object.getPrototypeOf(object) instead'
+                    '[DEPRECATED] use ' +
+                    'Object.getPrototypeOf(object) instead'
                   );
                   return Object.getPrototypeOf(this);
                 },
                 set: function (proto) {
                   console.warn(
-                    '[DEPRECATED] use Object.setPrototypeOf(o, proto) instead'
+                    '[DEPRECATED] use ' +
+                    'Object.setPrototypeOf(o, proto) instead'
                   );
                   set.call(this, proto);
                 }


### PR DESCRIPTION
[here the request in V8 repository with a patch](https://code.google.com/p/v8/issues/detail?id=2645)

The feature/bug request has a working patch attached so it should be straight forward for V8 to implement the change.

Once the patch will be in it is possible for node.js to promote a better/cleaner environment simply warning the deprecated **proto** for a while and then drop it, hopefully, in V 1.0.0

I've pushed that request in V8 with a patch hoping before 0.12 is out it can be usable already but I have no idea about node.js position on it.

I don't want credits, I don't care about the code, I can sign any paper that says this stuff is not mine.

What node should do, as soon as that patch is in V8, is to use `--expose-proto-setter` flag in `d8` when launched ... obviously, if that's possible.

Thanks for the consideration and any sort of outcome this request will have.
