### PR TITLE
Support $(PREFIX) install target directory prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PYTHON ?= python
 NINJA ?= ninja
 DESTDIR ?=
 SIGN ?=
+PREFIX ?= /usr/local
 
 NODE ?= ./node
 
@@ -55,10 +56,10 @@ config.gypi: configure
 	$(PYTHON) ./configure
 
 install: all
-	$(PYTHON) tools/install.py $@ $(DESTDIR)
+	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
 
 uninstall:
-	$(PYTHON) tools/install.py $@ $(DESTDIR)
+	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
 
 clean:
 	-rm -rf out/Makefile node node_g out/$(BUILDTYPE)/node blog.html email.md
@@ -266,17 +267,17 @@ pkg: $(PKG)
 $(PKG): release-only
 	rm -rf $(PKGDIR)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --prefix=$(PKGDIR)/32/usr/local --without-snapshot --dest-cpu=ia32 --tag=$(TAG)
+	$(PYTHON) ./configure --prefix=$(PKGDIR)/32$(PREFIX) --without-snapshot --dest-cpu=ia32 --tag=$(TAG)
 	$(MAKE) install V=$(V)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --prefix=$(PKGDIR)/usr/local --without-snapshot --dest-cpu=x64 --tag=$(TAG)
+	$(PYTHON) ./configure --prefix=$(PKGDIR)$(PREFIX) --without-snapshot --dest-cpu=x64 --tag=$(TAG)
 	$(MAKE) install V=$(V)
 	SIGN="$(SIGN)" PKGDIR="$(PKGDIR)" bash tools/osx-codesign.sh
-	lipo $(PKGDIR)/32/usr/local/bin/node \
-		$(PKGDIR)/usr/local/bin/node \
-		-output $(PKGDIR)/usr/local/bin/node-universal \
+	lipo $(PKGDIR)/32$(PREFIX)/bin/node \
+		$(PKGDIR)$(PREFIX)/bin/node \
+		-output $(PKGDIR)$(PREFIX)/bin/node-universal \
 		-create
-	mv $(PKGDIR)/usr/local/bin/node-universal $(PKGDIR)/usr/local/bin/node
+	mv $(PKGDIR)$(PREFIX)/bin/node-universal $(PKGDIR)$(PREFIX)/bin/node
 	rm -rf $(PKGDIR)/32
 	$(packagemaker) \
 		--id "org.nodejs.Node" \

--- a/tools/install.py
+++ b/tools/install.py
@@ -13,8 +13,8 @@ import shutil
 import sys
 
 # set at init time
-dst_dir = None
-node_prefix = None # dst_dir without DESTDIR prefix
+node_prefix = '/usr/local' # PREFIX variable from Makefile
+install_path = None # base target directory (DESTDIR + PREFIX from Makefile)
 target_defaults = None
 variables = None
 
@@ -47,7 +47,7 @@ def try_mkdir_r(path):
 
 def try_rmdir_r(path):
   path = abspath(path)
-  while path.startswith(dst_dir):
+  while path.startswith(install_path):
     try:
       os.rmdir(path)
     except OSError, e:
@@ -58,9 +58,9 @@ def try_rmdir_r(path):
 
 def mkpaths(path, dst):
   if dst.endswith('/'):
-    target_path = abspath(dst_dir, dst, os.path.basename(path))
+    target_path = abspath(install_path, dst, os.path.basename(path))
   else:
-    target_path = abspath(dst_dir, dst)
+    target_path = abspath(install_path, dst)
   return path, target_path
 
 def try_copy(path, dst):
@@ -90,7 +90,7 @@ def npm_files(action):
 
   # don't install npm if the target path is a symlink, it probably means
   # that a dev version of npm is installed there
-  if os.path.islink(abspath(dst_dir, target_path)): return
+  if os.path.islink(abspath(install_path, target_path)): return
 
   # npm has a *lot* of files and it'd be a pain to maintain a fixed list here
   # so we walk its source directory instead...
@@ -100,7 +100,7 @@ def npm_files(action):
     action(paths, target_path + dirname[9:] + '/')
 
   # create/remove symlink
-  link_path = abspath(dst_dir, 'bin/npm')
+  link_path = abspath(install_path, 'bin/npm')
   if action == uninstall:
     action([link_path], 'bin/npm')
   elif action == install:
@@ -113,7 +113,7 @@ def npm_files(action):
       # precompiled bundle should be able to be extracted anywhere and "just work"
       shebang = '/bin/sh\n// 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"'
     else:
-      shebang = os.path.join(node_prefix, 'bin/node')
+      shebang = os.path.join(node_prefix or '/', 'bin/node')
     update_shebang(link_path, shebang)
   else:
     assert(0) # unhandled action type
@@ -134,7 +134,7 @@ def files(action):
   if 'true' == variables.get('node_install_npm'): npm_files(action)
 
 def run(args):
-  global dst_dir, node_prefix, target_defaults, variables
+  global node_prefix, install_path, target_defaults, variables
 
   # chdir to the project's top-level directory
   os.chdir(abspath(os.path.dirname(__file__), '..'))
@@ -144,8 +144,15 @@ def run(args):
   target_defaults = conf['target_defaults']
 
   # argv[2] is a custom install prefix for packagers (think DESTDIR)
-  dst_dir = node_prefix = variables.get('node_prefix') or '/usr/local'
-  if len(args) > 2: dst_dir = abspath(args[2] + '/' + dst_dir)
+  # argv[3] is a custom install prefix (think PREFIX)
+  # Difference is that dst_dir won't be included in shebang lines etc.
+  if len(args) > 2:
+    dst_dir = args[2]
+  if len(args) > 3:
+    node_prefix = args[3]
+
+  # install_path thus becomes the base target directory.
+  install_path = dst_dir + node_prefix + '/'
 
   cmd = args[1] if len(args) > 1 else 'install'
   if cmd == 'install': return files(install)


### PR DESCRIPTION
This change introduces support for the common PREFIX variable in the Makefile and install.py, instead of having /usr/local hardcoded. This makes it much easier to install node to custom locations e.g. in a user's home directory.

The PREFIX variable defaults to /usr/local.

The change in install.py to introduce the install_path variable is probably not strictly necessary, but I thought it made it somewhat easier to separate the DESTDIR and PREFIX semantics. If you disagree I can of course update the patch.

See also #4551.
