### PR TITLE
events: Add EventEmitter::prependListener

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -173,6 +173,15 @@ EventEmitter.prototype.addListener = function(type, listener) {
 
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
+EventEmitter.prototype.prependListener = (type, listener) {
+  this.addListener(type, listener);
+  if (typeof this._events[type] !== 'function') {
+    var listeners = this._events[type];
+    listeners.unshift(listeners.pop());
+  }
+  return this;
+}
+
 EventEmitter.prototype.once = function(type, listener) {
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');

--- a/test/simple/test-events-prepend-listener.js
+++ b/test/simple/test-events-prepend-listener.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var events = require('events');
+
+var e = new events.EventEmitter();
+
+var orderAdded = [];
+
+e.on('newListener', function (event, listener) {
+  orderAdded.push(listener);
+});
+
+var originalFirst = function () {};
+var newFirst = function () {};
+
+assert.notEqual(originalFirst, newFirst);
+
+e.addListener('event', originalFirst);
+e.prependListener('event', newFirst);
+
+process.on('exit', function () {
+  var orderCalled = e.listeners('event');
+  assert.equal(orderCalled[0], newFirst);
+  assert.equal(orderCalled[1], originalFirst);
+  assert.equal(orderAdded[0], orderCalled[1]);
+  assert.equal(orderAdded[1], orderCalled[0]);
+});


### PR DESCRIPTION
Currently there is no way to ensure a newly added handler will be called first without accessing `_events[type]`. This used to be possible using `emitter.listeners('type').unshift(...)` but #3442 changed that.

I currently poke at `_events` from my own user-land code to accomplish this, which I'd rather avoid.
