### PR TITLE
debugger: `restart` with custom debug port (bugfix)

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1601,7 +1601,8 @@ Interface.prototype.trySpawn = function(cb) {
   var self = this,
       breakpoints = this.breakpoints || [],
       port = exports.port,
-      host = 'localhost';
+      host = 'localhost',
+      childArgs = this.args;
 
   this.killChild();
 
@@ -1634,13 +1635,13 @@ Interface.prototype.trySpawn = function(cb) {
         // Start debugger on custom port
         // `node debug --port=5858 app.js`
         port = parseInt(match[1], 10);
-        this.args.splice(0, 2, '--debug-brk=' + port);
+        childArgs = ['--debug-brk=' + port].concat(this.args.slice(2));
       }
     }
   }
 
   if (!this.child) {
-    this.child = spawn(process.execPath, this.args);
+    this.child = spawn(process.execPath, childArgs);
 
     this.child.stdout.on('data', this.childPrint.bind(this));
     this.child.stderr.on('data', this.childPrint.bind(this));
@@ -1701,7 +1702,7 @@ Interface.prototype.trySpawn = function(cb) {
   }
 
   setTimeout(function() {
-    self.print('connecting..', true);
+    self.print('connecting to port ' + port + '..', true);
     attemptConnect();
   }, 50);
 };

--- a/test/simple/helper-debugger-repl.js
+++ b/test/simple/helper-debugger-repl.js
@@ -1,0 +1,141 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+process.env.NODE_DEBUGGER_TIMEOUT = 2000;
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+var port = common.PORT + 1337;
+
+var child;
+var buffer = '';
+var expected = [];
+
+function startDebugger(scriptToDebug) {
+  scriptToDebug = process.env.NODE_DEBUGGER_TEST_SCRIPT ||
+                  common.fixturesDir + '/' + scriptToDebug;
+
+  child = spawn(process.execPath, ['debug', '--port=' + port, scriptToDebug]);
+
+  console.error('./node', 'debug', '--port=' + port, scriptToDebug);
+
+  child.stdout.setEncoding('utf-8');
+  child.stdout.on('data', function(data) {
+    data = (buffer + data).split('\n');
+    buffer = data.pop();
+    data.forEach(function(line) {
+      child.emit('line', line);
+    });
+  });
+  child.stderr.pipe(process.stderr);
+
+  child.on('line', function(line) {
+    line = line.replace(/^(debug> *)+/, '');
+    console.log(line);
+    assert.ok(expected.length > 0, 'Got unexpected line: ' + line);
+
+    var expectedLine = expected[0].lines.shift();
+    assert.ok(line.match(expectedLine) !== null, line + ' != ' + expectedLine);
+
+    if (expected[0].lines.length === 0) {
+      var callback = expected[0].callback;
+      expected.shift();
+      callback && callback();
+    }
+  });
+
+  var childClosed = false;
+  child.on('close', function(code) {
+    assert(!code);
+    childClosed = true;
+  });
+
+  var quitCalled = false;
+  function quit() {
+    if (quitCalled || childClosed) return;
+    quitCalled = true;
+    child.stdin.write('quit');
+    child.kill('SIGTERM');
+  }
+
+  setTimeout(function() {
+    console.error('dying badly buffer=%j', buffer);
+    var err = 'Timeout';
+    if (expected.length > 0 && expected[0].lines) {
+      err = err + '. Expected: ' + expected[0].lines.shift();
+    }
+
+    child.on('close', function() {
+      console.error('child is closed');
+      throw new Error(err);
+    });
+
+    quit();
+  }, 5000).unref();
+
+  process.once('uncaughtException', function(e) {
+    console.error('UncaughtException', e, e.stack);
+    quit();
+    console.error(e.toString());
+    process.exit(1);
+  });
+
+  process.on('exit', function(code) {
+    console.error('process exit', code);
+    quit();
+    if (code === 0)
+      assert(childClosed);
+  });
+}
+
+function addTest(input, output) {
+  function next() {
+    if (expected.length > 0) {
+      console.log('debug> ' + expected[0].input);
+      child.stdin.write(expected[0].input + '\n');
+
+      if (!expected[0].lines) {
+        var callback = expected[0].callback;
+        expected.shift();
+
+        callback && callback();
+      }
+    } else {
+      quit();
+    }
+  };
+  expected.push({input: input, lines: output, callback: next});
+}
+
+var initialLines = [
+  /listening on port \d+/,
+  /connecting.* ok/,
+  /break in .*:1/,
+  /1/, /2/, /3/
+];
+
+// Process initial lines
+addTest(null, initialLines);
+
+exports.startDebugger = startDebugger;
+exports.addTest = addTest;
+exports.initialLines = initialLines;

--- a/test/simple/test-debugger-repl-restart.js
+++ b/test/simple/test-debugger-repl-restart.js
@@ -23,55 +23,9 @@ var repl = require('./helper-debugger-repl.js');
 
 repl.startDebugger('breakpoints.js');
 
-var addTest = repl.addTest;
+// Restart the debugged script
+repl.addTest('restart', [
+  /terminated/,
+].concat(repl.initialLines));
 
-// Next
-addTest('n', [
-  /break in .*:11/,
-  /9/, /10/, /11/, /12/, /13/
-]);
-
-// Watch
-addTest('watch("\'x\'")');
-
-// Continue
-addTest('c', [
-  /break in .*:5/,
-  /Watchers/,
-  /0:\s+'x' = "x"/,
-  /()/,
-  /3/, /4/, /5/, /6/, /7/
-]);
-
-// Show watchers
-addTest('watchers', [
-  /0:\s+'x' = "x"/
-]);
-
-// Unwatch
-addTest('unwatch("\'x\'")');
-
-// Step out
-addTest('o', [
-  /break in .*:12/,
-  /10/, /11/, /12/, /13/, /14/
-]);
-
-// Continue
-addTest('c', [
-  /break in .*:5/,
-  /3/, /4/, /5/, /6/, /7/
-]);
-
-// Set breakpoint by function name
-addTest('sb("setInterval()", "!(setInterval.flag++)")', [
-  /1/, /2/, /3/, /4/, /5/, /6/, /7/, /8/, /9/, /10/
-]);
-
-// Continue
-addTest('c', [
-  /break in node.js:\d+/,
-  /\d/, /\d/, /\d/, /\d/, /\d/
-]);
-
-addTest('quit', []);
+repl.addTest('quit', []);


### PR DESCRIPTION
Fixed a bug in debugger repl where `restart` command did not work
when a custom debug port was specified via command-line option
`--port={number}`.

To improve troubleshooting of similar problems in the future, debugger repl
now prints the port it is connecting to.

File `test/simple/helper-debugger-repl.js` was extracted from `test/simple/test-debugger-repl.js`
