### PR TITLE
module: fix for .foo.bar style multiple extensions

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -156,6 +156,25 @@ function tryExtensions(p, exts) {
   return false;
 }
 
+// Determine which entry in Module._extensions we should use for a given file
+function findExtension(filename) {
+  var extension = null;
+  var extensions = path.basename(filename).split('.');
+
+  // Remove initial dot from dotfiles
+  if (extensions[0] === '') extensions.shift();
+
+  // Start with the longest extension and work our way shortwards
+  while (extensions.shift()) {
+    var thisExtension = '.' + extensions.join('.');
+    if (Module._extensions[thisExtension]) {
+      extension = thisExtension;
+      break;
+    }
+  }
+  return extension || '.js';
+}
+
 
 Module._findPath = function(request, paths) {
   var exts = Object.keys(Module._extensions);
@@ -351,8 +370,8 @@ Module.prototype.load = function(filename) {
   this.filename = filename;
   this.paths = Module._nodeModulePaths(path.dirname(filename));
 
-  var extension = path.extname(filename) || '.js';
-  if (!Module._extensions[extension]) extension = '.js';
+  var extension = findExtension(filename);
+
   Module._extensions[extension](this, filename);
   this.loaded = true;
 };

--- a/test/fixtures/registerExt.test2.test
+++ b/test/fixtures/registerExt.test2.test
@@ -1,0 +1,1 @@
+throw("should not be called");

--- a/test/fixtures/registerExt.test3.test
+++ b/test/fixtures/registerExt.test3.test
@@ -1,0 +1,1 @@
+throw("should not be called");

--- a/test/simple/test-module-loading.js
+++ b/test/simple/test-module-loading.js
@@ -147,6 +147,20 @@ require.extensions['.test'] = function(module, filename) {
 
 assert.equal(require('../fixtures/registerExt2').custom, 'passed');
 
+common.debug('load custom file types with multiple extensions');
+require.extensions['.test2.test'] = function(module, filename) {
+  module._compile('exports.multiple = \'passed\'', filename);
+}
+
+require.extensions['.test'] = function(module, filename) {
+  module._compile('exports.fallback = \'passed\'', filename);
+}
+
+assert.equal(require('../fixtures/registerExt.test2.test').multiple, 'passed');
+
+assert.equal(require('../fixtures/registerExt.test3.test').fallback, 'passed');
+
+
 assert.equal(require('../fixtures/foo').foo, 'ok',
              'require module with no extension');
 
@@ -251,6 +265,8 @@ assert.deepEqual(children, {
   'fixtures/registerExt.test': {},
   'fixtures/registerExt.hello.world': {},
   'fixtures/registerExt2.test': {},
+  'fixtures/registerExt.test2.test': {},
+  'fixtures/registerExt.test3.test': {},
   'fixtures/empty.js': {},
   'fixtures/module-load-order/file1': {},
   'fixtures/module-load-order/file2.js': {},


### PR DESCRIPTION
Hi,

I ran into some strange behaviour recently when trying to require a file with a .foo.bar style extension that was defined in require.extensions. `tryExtensions` works fine since it just uses simple string concatenation, but `Module.load` only passes the last part of the extension (eg .bar) to require.extensions, so it barfs, usually with a cryptic parse error because it's trying to read the file as javascript.

I figured this qualified as a bug (and so pointed the commit at 0.10) because it's inconsistent behaviour between different parts of the module loader, and I can't imagine a situation where you'd add '.foo.bar' to require.extensions and expect it to not be called.
