### PR TITLE
debugger: fixed bug in breakpoint regex escaping.

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1398,8 +1398,8 @@ Interface.prototype.setBreakpoint = function(script, line,
       };
     } else {
       this.print('Warning: script \'' + script + '\' was not loaded yet.');
-      var normalizedPath = script.replace('([/.?*])', '\\$1');
-      var scriptPathRegex = '^(.*[\\/\\\\])?' + normalizedPath + '$';
+      var escapedPath = script.replace(/([\/\\.?*()^${}|[\]])/g, '\\$1');
+      var scriptPathRegex = '^(.*[\\/\\\\])?' + escapedPath + '$';
       req = {
         type: 'scriptRegExp',
         target: scriptPathRegex,

--- a/test/simple/test-debugger-repl-break-in-module.js
+++ b/test/simple/test-debugger-repl-break-in-module.js
@@ -31,6 +31,12 @@ repl.addTest('sb("mod.js", 23)', [
   /1/, /2/, /3/, /4/, /5/, /6/
 ]);
 
+// Check escaping of regex characters
+repl.addTest('sb(")^$*+?}{|][(.js\\\\", 1)', [
+  /Warning: script '[^']+' was not loaded yet\./,
+  /1/, /2/, /3/, /4/, /5/, /6/
+]);
+
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
     /break in .*[\\\/]mod\.js:23/,
@@ -47,7 +53,9 @@ repl.addTest('restart', [].concat(
   repl.handshakeLines,
   [
     /Restoring breakpoint mod.js:23/,
-    /Warning: script 'mod\.js' was not loaded yet\./
+    /Warning: script 'mod\.js' was not loaded yet\./,
+    /Restoring breakpoint \).*:\d+/,
+    /Warning: script '\)[^']*' was not loaded yet\./
   ],
   repl.initialBreakLines));
 


### PR DESCRIPTION
Fixed a bug in setBreakpoint() where not all regex characters were
escaped while constructing scriptRegEx for V8.

See also commits
- bajtos/node@7d68aa23333917a48fc26f99cfb8a148a457a679
- joyent/node@5db936d2aecaddb5d539855a150813e36df45b66
