### PR TITLE
stream: fixed Readable.prototype.wrap to support objectMode

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -767,7 +767,7 @@ Readable.prototype.wrap = function(stream) {
   stream.on('data', function(chunk) {
     if (state.decoder)
       chunk = state.decoder.write(chunk);
-    if (!chunk || !chunk.length)
+    if (!chunk || !state.objectMode && !chunk.length)
       return;
 
     var ret = self.push(chunk);

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -759,7 +759,6 @@ Readable.prototype.wrap = function(stream) {
       if (chunk && chunk.length)
         self.push(chunk);
     }
-    state.ended = true;
 
     self.push(null);
   });

--- a/test/simple/test-stream2-readable-wrap-empty.js
+++ b/test/simple/test-stream2-readable-wrap-empty.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var Readable = require('_stream_readable');
+var EE = require('events').EventEmitter;
+
+var oldStream = new EE();
+oldStream.pause = function(){};
+oldStream.resume = function(){};
+
+var newStream = new Readable().wrap(oldStream);
+
+var ended = false;
+newStream
+  .on('readable', function(){})
+  .on('end', function(){ ended = true; });
+
+oldStream.emit('end');
+
+process.on('exit', function(){
+  assert.ok(ended);
+});


### PR DESCRIPTION
Added a check to see if the stream is in objectMode before deciding
whether to include or exclude data from an old-style wrapped stream.
