### PR TITLE
https: implement https.Server#setTimeout()

### DIFF
--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -10,6 +10,14 @@ separate module.
 This class is a subclass of `tls.Server` and emits events same as
 `http.Server`. See `http.Server` for more information.
 
+### server.setTimeout(msecs, callback)
+
+See [http.Server#setTimeout()][].
+
+### server.timeout
+
+See [http.Server#timeout][].
+
 ## https.createServer(options, [requestListener])
 
 Returns a new HTTPS web server object. The `options` is similar to
@@ -197,6 +205,8 @@ for more information.
 
 Global instance of [https.Agent][] for all HTTPS client requests.
 
+[http.Server#setTimeout()]: http.html#http_server_settimeout_msecs_callback
+[http.Server#timeout]: http.html#http_server_timeout
 [Agent]: #https_class_https_agent
 [globalAgent]: #https_https_globalagent
 [http.listen()]: http.html#http_server_listen_port_hostname_backlog_callback

--- a/lib/https.js
+++ b/lib/https.js
@@ -43,12 +43,13 @@ function Server(opts, requestListener) {
   this.addListener('clientError', function(err, conn) {
     conn.destroy(err);
   });
+
+  this.timeout = 2 * 60 * 1000;
 }
 inherits(Server, tls.Server);
-
-
 exports.Server = Server;
 
+Server.prototype.setTimeout = http.Server.prototype.setTimeout;
 
 exports.createServer = function(opts, requestListener) {
   return new Server(opts, requestListener);

--- a/test/simple/test-https-set-timeout-server.js
+++ b/test/simple/test-https-set-timeout-server.js
@@ -1,0 +1,208 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var assert = require('assert');
+var https = require('https');
+var tls = require('tls');
+var fs = require('fs');
+
+var tests = [];
+
+var serverOptions = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+function test(fn) {
+  if (!tests.length)
+    process.nextTick(run);
+  tests.push(fn);
+}
+
+function run() {
+  var fn = tests.shift();
+  if (fn) {
+    console.log('# %s', fn.name);
+    fn(run);
+  } else
+    console.log('ok');
+}
+
+test(function serverTimeout(cb) {
+  var caughtTimeout = false;
+  process.on('exit', function() {
+    assert(caughtTimeout);
+  });
+  var server = https.createServer(serverOptions, function(req, res) {
+    // just do nothing, we should get a timeout event.
+  });
+  server.listen(common.PORT);
+  server.setTimeout(50, function(socket) {
+    caughtTimeout = true;
+    socket.destroy();
+    server.close();
+    cb();
+  });
+  https.get({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }).on('error', function() {});
+});
+
+test(function serverRequestTimeout(cb) {
+  var caughtTimeout = false;
+  process.on('exit', function() {
+    assert(caughtTimeout);
+  });
+  var server = https.createServer(serverOptions, function(req, res) {
+    // just do nothing, we should get a timeout event.
+    req.setTimeout(50, function() {
+      caughtTimeout = true;
+      req.socket.destroy();
+      server.close();
+      cb();
+    });
+  });
+  server.listen(common.PORT);
+  var req = https.request({
+    port: common.PORT,
+    method: 'POST',
+    rejectUnauthorized: false
+  });
+  req.on('error', function() {});
+  req.write('Hello');
+  // req is in progress
+});
+
+test(function serverResponseTimeout(cb) {
+  var caughtTimeout = false;
+  process.on('exit', function() {
+    assert(caughtTimeout);
+  });
+  var server = https.createServer(serverOptions, function(req, res) {
+    // just do nothing, we should get a timeout event.
+    res.setTimeout(50, function() {
+      caughtTimeout = true;
+      res.socket.destroy();
+      server.close();
+      cb();
+    });
+  });
+  server.listen(common.PORT);
+  https.get({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }).on('error', function() {});
+});
+
+test(function serverRequestNotTimeoutAfterEnd(cb) {
+  var caughtTimeoutOnRequest = false;
+  var caughtTimeoutOnResponse = false;
+  process.on('exit', function() {
+    assert(!caughtTimeoutOnRequest);
+    assert(caughtTimeoutOnResponse);
+  });
+  var server = https.createServer(serverOptions, function(req, res) {
+    // just do nothing, we should get a timeout event.
+    req.setTimeout(50, function(socket) {
+      caughtTimeoutOnRequest = true;
+    });
+    res.on('timeout', function(socket) {
+      caughtTimeoutOnResponse = true;
+    });
+  });
+  server.on('timeout', function(socket) {
+    socket.destroy();
+    server.close();
+    cb();
+  });
+  server.listen(common.PORT);
+  https.get({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }).on('error', function() {});
+});
+
+test(function serverResponseTimeoutWithPipeline(cb) {
+  var caughtTimeout = '';
+  process.on('exit', function() {
+    assert.equal(caughtTimeout, '/2');
+  });
+  var server = https.createServer(serverOptions, function(req, res) {
+    res.setTimeout(50, function() {
+      caughtTimeout += req.url;
+    });
+    if (req.url === '/1') res.end();
+  });
+  server.on('timeout', function(socket) {
+    socket.destroy();
+    server.close();
+    cb();
+  });
+  server.listen(common.PORT);
+  var options = {
+    port: common.PORT,
+    allowHalfOpen: true,
+    rejectUnauthorized: false
+  };
+  var c = tls.connect(options, function() {
+    c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+    c.write('GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+    c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+  });
+});
+
+test(function idleTimeout(cb) {
+  var caughtTimeoutOnRequest = false;
+  var caughtTimeoutOnResponse = false;
+  var caughtTimeoutOnServer = false;
+  process.on('exit', function() {
+    assert(!caughtTimeoutOnRequest);
+    assert(!caughtTimeoutOnResponse);
+    assert(caughtTimeoutOnServer);
+  });
+  var server = https.createServer(serverOptions, function(req, res) {
+    req.on('timeout', function(socket) {
+      caughtTimeoutOnRequest = true;
+    });
+    res.on('timeout', function(socket) {
+      caughtTimeoutOnResponse = true;
+    });
+    res.end();
+  });
+  server.setTimeout(50, function(socket) {
+    caughtTimeoutOnServer = true;
+    socket.destroy();
+    server.close();
+    cb();
+  });
+  server.listen(common.PORT);
+  var options = {
+    port: common.PORT,
+    allowHalfOpen: true,
+    rejectUnauthorized: false
+  };
+  tls.connect(options, function() {
+    this.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+    // Keep-Alive
+  });
+});


### PR DESCRIPTION
Like commit d258fb0 ("http: More useful setTimeout API on server") but
this time for the https module.

Fixes #5361.

Suggested reviewer: @isaacs.  The PR is against master but the patch should apply cleanly to v0.10, in case you want to back-port it.
