### PR TITLE
`process.pid` now using getter (calling `getpid()` internally)

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2160,6 +2160,11 @@ static Handle<Value> EnvSetter(Local<String> property,
   return scope.Close(value);
 }
 
+static Handle<Value> ProcessPidGetter(Local<String> property,
+                                      const AccessorInfo& info) {
+  HandleScope scope(node_isolate);
+  return scope.Close(Integer::New(getpid()));
+}
 
 static Handle<Integer> EnvQuery(Local<String> property,
                                 const AccessorInfo& info) {
@@ -2420,7 +2425,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   Local<Object> env = envTemplate->NewInstance();
   process->Set(String::NewSymbol("env"), env);
 
-  process->Set(String::NewSymbol("pid"), Integer::New(getpid(), node_isolate));
+  process->SetAccessor(String::NewSymbol("pid"), ProcessPidGetter);
   process->Set(String::NewSymbol("features"), GetFeatures());
   process->SetAccessor(String::New("_needImmediateCallback"),
                        NeedImmediateCallbackGetter,


### PR DESCRIPTION
`process.pid` has been internally changed to use a getter instead of being simple property which is set at app startup. This change enables us to use posix `fork` & `daemonize` and still get correct process id. While this change may be considered as a source of possible performance impact, I personally don't think so, because we usually need PID just once or twice per app.
