### PR TITLE
Event return doc and cleanup

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -80,6 +80,7 @@ added for a particular event. This is a useful default which helps finding
 memory leaks. Obviously not all Emitters should be limited to 10. This function
 allows that to be increased. Set to zero for unlimited.
 
+Returns emitter, so calls can be chained.
 
 ### EventEmitter.defaultMaxListeners
 

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -39,6 +39,8 @@ Adds a listener to the end of the listeners array for the specified event.
       console.log('someone connected!');
     });
 
+Returns emitter, so calls can be chained.
+
 ### emitter.once(event, listener)
 
 Adds a **one time** listener for the event. This listener is
@@ -48,6 +50,8 @@ it is removed.
     server.once('connection', function (stream) {
       console.log('Ah, we have our first user!');
     });
+
+Returns emitter, so calls can be chained.
 
 ### emitter.removeListener(event, listener)
 
@@ -61,11 +65,13 @@ Remove a listener from the listener array for the specified event.
     // ...
     server.removeListener('connection', callback);
 
+Returns emitter, so calls can be chained.
 
 ### emitter.removeAllListeners([event])
 
 Removes all listeners, or those of the specified event.
 
+Returns emitter, so calls can be chained.
 
 ### emitter.setMaxListeners(n)
 
@@ -98,6 +104,8 @@ Returns an array of listeners for the specified event.
 ### emitter.emit(event, [arg1], [arg2], [...])
 
 Execute each of the listeners in order with the supplied arguments.
+
+Returns `true` if event had listeners, `false` otherwise.
 
 
 ### Class Method: EventEmitter.listenerCount(emitter, event)

--- a/lib/events.js
+++ b/lib/events.js
@@ -49,6 +49,8 @@ EventEmitter.prototype.setMaxListeners = function(n) {
   if (typeof n !== 'number' || n < 0)
     throw TypeError('n must be a positive number');
   this._maxListeners = n;
+
+  return this;
 };
 
 EventEmitter.prototype.emit = function(type) {


### PR DESCRIPTION
Return values of event methods were not all documented, and one was simply missing a return. I noticed when reading node http code, which was using the undocumented return value of .emit().
