### PR TITLE
build: vcbuild.bat fix for Visual Studio 2012

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -99,9 +99,6 @@ ENDLOCAL
 @rem Skip project generation if requested.
 if defined nobuild goto sign
 
-@rem Bail out early if not running in VS build env.
-if defined VCINSTALLDIR goto msbuild-found
-
 @rem Look for Visual Studio 2012
 if not defined VS110COMNTOOLS goto vc-set-2010
 if not exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2010


### PR DESCRIPTION
The commit adding support for VS2012 build (0602fbb49c159fe5eded343a0fbb447979d757ba ) does not work correctly, it generates project files in old format that is not supported by VS2012.

The new commit (14bd2304d1cb4c53cf29de2ba2894e36c089ba7f) fixes this problem.

/cc: @piscisaureus
