### PR TITLE
test: reap children when cluster-bind-twice fails

### DIFF
--- a/test/simple/test-cluster-bind-twice.js
+++ b/test/simple/test-cluster-bind-twice.js
@@ -51,13 +51,17 @@ if (!id) {
   var b = fork(__filename, ['two']);
 
   a.on('exit', function(c) {
-    if (c)
+    if (c) {
+      b.send('QUIT');
       throw new Error('A exited with ' + c);
+    }
   });
 
   b.on('exit', function(c) {
-    if (c)
+    if (c) {
+      a.send('QUIT');
       throw new Error('B exited with ' + c);
+    }
   });
 
 


### PR DESCRIPTION
As of 45ed546 cluster-bind-twice no longer indiscriminately kills its children on exiting, however when the grandparent fails (reliably on windows #4966) this results in orphaned processes.

If a child exits uncleanly, kill the other side of the tree.

cc @isaacs @bnoordhuis
