### PR TITLE
test: fix pummel/test-net-many-clients.js

### DIFF
--- a/test/pummel/test-net-many-clients.js
+++ b/test/pummel/test-net-many-clients.js
@@ -37,12 +37,11 @@ for (var i = 0; i < bytes; i++) {
 }
 
 var server = net.createServer(function(c) {
-  c.on('connect', function() {
-    total_connections++;
-    common.print('#');
-    c.write(body);
-    c.end();
-  });
+  console.log('connected');
+  total_connections++;
+  common.print('#');
+  c.write(body);
+  c.end();
 });
 
 function runClient(callback) {


### PR DESCRIPTION
client sockets no longer emit 'connect' event inside the
requestListener, update test-net-many-clients to reflect that
