### PR TITLE
net: emit dns 'lookup' event before connect

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -450,6 +450,15 @@ The amount of bytes sent.
 
 `net.Socket` instances are [EventEmitter][] with the following events:
 
+### Event: 'lookup'
+
+Emitted after resolving the hostname but before connecting.
+Not applicable to UNIX sockets.
+
+* `err` {Error | Null} The error object.  See [dns.lookup()][].
+* `address` {String} The IP address.
+* `family` {String | Null} The address type.  See [dns.lookup()][].
+
 ### Event: 'connect'
 
 Emitted when a socket connection is successfully established.

--- a/lib/net.js
+++ b/lib/net.js
@@ -860,6 +860,8 @@ Socket.prototype.connect = function(options, cb) {
     var host = options.host;
     debug('connect: find host ' + host);
     require('dns').lookup(host, function(err, ip, addressType) {
+      self.emit('lookup', err, ip, addressType);
+
       // It's possible we were destroyed while looking this up.
       // XXX it would be great if we could cancel the promise returned by
       // the look up.

--- a/test/simple/test-net-dns-lookup.js
+++ b/test/simple/test-net-dns-lookup.js
@@ -21,35 +21,23 @@
 
 var common = require('../common');
 var assert = require('assert');
-
 var net = require('net');
+var ok = false;
 
-var expected_bad_connections = 1;
-var actual_bad_connections = 0;
-
-var host = '********';
-host += host;
-host += host;
-host += host;
-host += host;
-host += host;
-
-function do_not_call() {
-  throw new Error('This function should not have been called.');
-}
-
-var socket = net.connect(42, host, do_not_call);
-socket.on('error', function(err) {
-  assert.equal(err.code, 'ENOTFOUND');
-  actual_bad_connections++;
+var server = net.createServer(function(client) {
+  client.end();
+  server.close();
 });
-socket.on('lookup', function(err, ip, type) {
-  assert(err instanceof Error);
-  assert.equal(err.code, 'ENOTFOUND');
-  assert.equal(ip, undefined);
-  assert.equal(type, undefined);
+
+server.listen(common.PORT, '127.0.0.1', function() {
+  net.connect(common.PORT, '127.0.0.1').on('lookup', function(err, ip, type) {
+    assert.equal(err, null);
+    assert.equal(ip, '127.0.0.1');
+    assert.equal(type, '4');
+    ok = true;
+  });
 });
 
 process.on('exit', function() {
-  assert.equal(actual_bad_connections, expected_bad_connections);
+  assert(ok);
 });


### PR DESCRIPTION
net.connect() and net.createConnection() now emit a 'lookup' event
after resolving the hostname but before connecting.

Fixes #5418.

Suggested reviewer: @isaacs
