### PR TITLE
stream_wrap: Remove unused arg from WriteBuffer

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -284,9 +284,7 @@ void StreamWrap::OnRead2(uv_pipe_t* handle, ssize_t nread, uv_buf_t buf,
 }
 
 
-size_t StreamWrap::WriteBuffer(WriteWrap* req,
-                               Handle<Value> val,
-                               uv_buf_t* buf) {
+size_t StreamWrap::WriteBuffer(Handle<Value> val, uv_buf_t* buf) {
   assert(Buffer::HasInstance(val));
 
   // Simple non-writev case
@@ -401,7 +399,7 @@ Handle<Value> StreamWrap::WriteBuffer(const Arguments& args) {
   req_wrap->object_->SetHiddenValue(buffer_sym, args[0]);
 
   uv_buf_t buf;
-  WriteBuffer(req_wrap, args[0], &buf);
+  WriteBuffer(args[0], &buf);
 
   int r = uv_write(&req_wrap->req_,
                    wrap->stream_,
@@ -591,7 +589,7 @@ Handle<Value> StreamWrap::Writev(const Arguments& args) {
 
     // Write buffer
     if (Buffer::HasInstance(chunk)) {
-      bytes += WriteBuffer(req_wrap, chunk, &bufs[i]);
+      bytes += WriteBuffer(chunk, &bufs[i]);
       continue;
     }
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -62,9 +62,7 @@ class StreamWrap : public HandleWrap {
   static v8::Handle<v8::Value> WriteUcs2String(const v8::Arguments& args);
 
  protected:
-  static size_t WriteBuffer(WriteWrap* req,
-                            v8::Handle<v8::Value> val,
-                            uv_buf_t* buf);
+  static size_t WriteBuffer(v8::Handle<v8::Value> val, uv_buf_t* buf);
   template <enum WriteEncoding encoding>
   static size_t WriteStringImpl(char* storage,
                                 size_t storage_size,


### PR DESCRIPTION
WriteBuffer was changed in the cork/uncork implementation (60ed2c54).
The unused argument has been removed.

Simple change. just a little code cleanup.
