### PR TITLE
Buffer.concat does not error on nulls

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -486,7 +486,7 @@ Buffer.concat = function(list, length) {
     length = 0;
     for (var i = 0; i < list.length; i++) {
       var buf = list[i];
-      length += buf.length;
+      length += (buf ? buf.length : 0);
     }
   }
 
@@ -494,8 +494,10 @@ Buffer.concat = function(list, length) {
   var pos = 0;
   for (var i = 0; i < list.length; i++) {
     var buf = list[i];
-    buf.copy(buffer, pos);
-    pos += buf.length;
+    if (buf) {
+      buf.copy(buffer, pos);
+      pos += buf.length;
+    }
   }
   return buffer;
 };


### PR DESCRIPTION
If null (or falsey) values are passed to Buffer.concat they will be skipped rather than throw an error.

Thus Buffer.concat([buff1,null,buff2]) would be handled identically to Buffer.concat([buff1,buff2]) instead of throwing an error.
