### PR TITLE
console: console.dir takes options object: Fixes #5428

### DIFF
--- a/doc/api/stdio.markdown
+++ b/doc/api/stdio.markdown
@@ -44,10 +44,11 @@ Same as `console.log` but prints to stderr.
 
 Same as `console.error`.
 
-## console.dir(obj)
+## console.dir(obj, [options])
 
 Uses `util.inspect` on `obj` and prints resulting string to stdout. This function
-bypasses any custom `inspect()` function on `obj`.
+bypasses any custom `inspect()` function on `obj`.  `options` is passed through
+to `util.inspect`.
 
 ## console.time(label)
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -65,8 +65,9 @@ Console.prototype.warn = function() {
 Console.prototype.error = Console.prototype.warn;
 
 
-Console.prototype.dir = function(object) {
-  this._stdout.write(util.inspect(object, { customInspect: false }) + '\n');
+Console.prototype.dir = function(object, options) {
+  options = util._extend({ customInspect: false }, options);
+  this._stdout.write(util.inspect(object, options) + '\n');
 };
 
 

--- a/test/simple/test-console.js
+++ b/test/simple/test-console.js
@@ -50,6 +50,8 @@ console.log(custom_inspect);
 
 // test console.dir()
 console.dir(custom_inspect);
+console.dir(custom_inspect, { customInspect: true });
+console.dir({ foo: { bar: 'baz' }}, { depth: 0 });
 
 // test console.trace()
 console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
@@ -63,6 +65,8 @@ assert.equal('foo bar hop\n', strings.shift());
 assert.equal("{ slashes: '\\\\\\\\' }\n", strings.shift());
 assert.equal('inspect\n', strings.shift());
 assert.equal("{ foo: 'bar', inspect: [Function] }\n", strings.shift());
+assert.equal('inspect\n', strings.shift());
+assert.equal("{ foo: [Object] }\n", strings.shift());
 assert.equal('Trace: This is a {"formatted":"trace"} 10 foo',
              strings.shift().split('\n').shift());
 


### PR DESCRIPTION
`console.dir` will forward an `options` arg to `util.inspect`. `options.customInspect` will default to `false` if not specified, all other options use the `util.inspect` defaults.

Documentation and a test also updated.

Fixes #5428
