### PR TITLE
Http more corking

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -460,6 +460,10 @@ var crlf_buf = new Buffer('\r\n');
 
 
 OutgoingMessage.prototype.end = function(data, encoding) {
+  if (data && typeof data !== 'string' && !Buffer.isBuffer(data)) {
+    throw new TypeError('first argument must be a string or Buffer');
+  }
+
   if (this.finished) {
     return false;
   }
@@ -473,112 +477,24 @@ OutgoingMessage.prototype.end = function(data, encoding) {
     data = false;
   }
 
+  if (this.connection && data)
+    this.connection.cork();
+
   var ret;
-
-  var hot = this._headerSent === false &&
-            (data && data.length > 0) &&
-            this.output.length === 0 &&
-            this.connection &&
-            this.connection.writable &&
-            this.connection._httpMessage === this;
-
-  // The benefits of the hot-path optimization below start to fall
-  // off when the buffer size gets up near 128KB, because the cost
-  // of the copy is more than the cost of the extra write() call.
-  // Switch to the write/end method at that point.  Heuristics and
-  // magic numbers are awful, but slow http responses are worse.
-  if (hot && Buffer.isBuffer(data) && data.length > 120 * 1024)
-    hot = false;
-
-  if (hot) {
-    // Hot path. They're doing
-    //   res.writeHead();
-    //   res.end(blah);
-    // HACKY.
-
-    if (typeof data === 'string') {
-      if (this.chunkedEncoding) {
-        var l = Buffer.byteLength(data, encoding).toString(16);
-        ret = this.connection.write(this._header + l + CRLF +
-                                    data + '\r\n0\r\n' +
-                                    this._trailer + '\r\n', encoding);
-      } else {
-        ret = this.connection.write(this._header + data, encoding);
-      }
-    } else if (Buffer.isBuffer(data)) {
-      if (this.chunkedEncoding) {
-        var chunk_size = data.length.toString(16);
-
-        // Skip expensive Buffer.byteLength() calls; only ISO-8859-1 characters
-        // are allowed in HTTP headers. Therefore:
-        //
-        //   this._header.length == Buffer.byteLength(this._header.length)
-        //   this._trailer.length == Buffer.byteLength(this._trailer.length)
-        //
-        var header_len = this._header.length;
-        var chunk_size_len = chunk_size.length;
-        var data_len = data.length;
-        var trailer_len = this._trailer.length;
-
-        var len = header_len +
-                  chunk_size_len +
-                  2 + // '\r\n'.length
-                  data_len +
-                  5 + // '\r\n0\r\n'.length
-                  trailer_len +
-                  2;  // '\r\n'.length
-
-        var buf = new Buffer(len);
-        var off = 0;
-
-        buf.write(this._header, off, header_len, 'ascii');
-        off += header_len;
-
-        buf.write(chunk_size, off, chunk_size_len, 'ascii');
-        off += chunk_size_len;
-
-        crlf_buf.copy(buf, off);
-        off += 2;
-
-        data.copy(buf, off);
-        off += data_len;
-
-        zero_chunk_buf.copy(buf, off);
-        off += 5;
-
-        if (trailer_len > 0) {
-          buf.write(this._trailer, off, trailer_len, 'ascii');
-          off += trailer_len;
-        }
-
-        crlf_buf.copy(buf, off);
-
-        ret = this.connection.write(buf);
-      } else {
-        var header_len = this._header.length;
-        var buf = new Buffer(header_len + data.length);
-        buf.write(this._header, 0, header_len, 'ascii');
-        data.copy(buf, header_len);
-        ret = this.connection.write(buf);
-      }
-    } else {
-      throw new TypeError('first argument must be a string or Buffer');
-    }
-    this._headerSent = true;
-
-  } else if (data) {
+  if (data) {
     // Normal body write.
     ret = this.write(data, encoding);
   }
 
-  if (!hot) {
-    if (this.chunkedEncoding) {
-      ret = this._send('0\r\n' + this._trailer + '\r\n'); // Last chunk.
-    } else {
-      // Force a flush, HACK.
-      ret = this._send('');
-    }
+  if (this.chunkedEncoding) {
+    ret = this._send('0\r\n' + this._trailer + '\r\n'); // Last chunk.
+  } else {
+    // Force a flush, HACK.
+    ret = this._send('');
   }
+
+  if (this.connection && data)
+    this.connection.uncork();
 
   this.finished = true;
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -125,7 +125,7 @@ function Transform(options) {
   // sync guard flag.
   this._readableState.sync = false;
 
-  this.once('finish', function() {
+  this.once('prefinish', function() {
     if ('function' === typeof this._flush)
       this._flush(function(er) {
         done(stream, er);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -102,6 +102,14 @@ function WritableState(options, stream) {
   this.writelen = 0;
 
   this.buffer = [];
+
+  // number of pending user-supplied write callbacks
+  // this must be 0 before 'finish' can be emitted
+  this.pendingcb = 0;
+
+  // emit prefinish if the only thing we're waiting for is _write cbs
+  // This is relevant for synchronous Transform streams
+  this.prefinished = false;
 }
 
 function Writable(options) {
@@ -171,8 +179,10 @@ Writable.prototype.write = function(chunk, encoding, cb) {
 
   if (state.ended)
     writeAfterEnd(this, state, cb);
-  else if (validChunk(this, state, chunk, cb))
+  else if (validChunk(this, state, chunk, cb)) {
+    state.pendingcb++;
     ret = writeOrBuffer(this, state, chunk, encoding, cb);
+  }
 
   return ret;
 };
@@ -241,10 +251,13 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
 function onwriteError(stream, state, sync, er, cb) {
   if (sync)
     process.nextTick(function() {
+      state.pendingcb--;
       cb(er);
     });
-  else
+  else {
+    state.pendingcb--;
     cb(er);
+  }
 
   stream.emit('error', er);
 }
@@ -289,9 +302,9 @@ function onwrite(stream, er) {
 function afterWrite(stream, state, finished, cb) {
   if (!finished)
     onwriteDrain(stream, state);
+  state.pendingcb--;
   cb();
-  if (finished)
-    finishMaybe(stream, state);
+  finishMaybe(stream, state);
 }
 
 // Must force callback to be called on nextTick, so that we don't
@@ -315,9 +328,14 @@ function clearBuffer(stream, state) {
     for (var c = 0; c < state.buffer.length; c++)
       cbs.push(state.buffer[c].callback);
 
+    // count the one we are adding, as well.
+    // TODO(isaacs) clean this up
+    state.pendingcb++;
     doWrite(stream, state, true, state.length, state.buffer, '', function(err) {
-      for (var i = 0; i < cbs.length; i++)
+      for (var i = 0; i < cbs.length; i++) {
+        state.pendingcb--;
         cbs[i](err);
+      }
     });
 
     // Clear buffer
@@ -390,11 +408,22 @@ function needFinish(stream, state) {
           !state.writing);
 }
 
+function prefinish(stream, state) {
+  if (!state.prefinished) {
+    state.prefinished = true;
+    stream.emit('prefinish');
+  }
+}
+
 function finishMaybe(stream, state) {
   var need = needFinish(stream, state);
   if (need) {
-    state.finished = true;
-    stream.emit('finish');
+    if (state.pendingcb === 0) {
+      prefinish(stream, state);
+      state.finished = true;
+      stream.emit('finish');
+    } else
+      prefinish(stream, state);
   }
   return need;
 }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -77,7 +77,7 @@ function WritableState(options, stream) {
   this.writing = false;
 
   // when true all writes will be buffered until .uncork() call
-  this.corked = false;
+  this.corked = 0;
 
   // a flag to be able to tell if the onwrite cb is called immediately,
   // or on a later tick.  We set this to true at first, becuase any
@@ -190,16 +190,17 @@ Writable.prototype.write = function(chunk, encoding, cb) {
 Writable.prototype.cork = function() {
   var state = this._writableState;
 
-  state.corked = true;
+  state.corked++;
 };
 
 Writable.prototype.uncork = function() {
   var state = this._writableState;
 
   if (state.corked) {
-    state.corked = false;
+    state.corked--;
 
     if (!state.writing &&
+        !state.corked &&
         !state.finished &&
         !state.bufferProcessing &&
         state.buffer.length)
@@ -221,6 +222,8 @@ function decodeChunk(state, chunk, encoding) {
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, chunk, encoding, cb) {
   chunk = decodeChunk(state, chunk, encoding);
+  if (Buffer.isBuffer(chunk))
+    encoding = 'buffer';
   var len = state.objectMode ? 1 : chunk.length;
 
   state.length += len;
@@ -392,8 +395,11 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   if (typeof chunk !== 'undefined' && chunk !== null)
     this.write(chunk, encoding);
 
-  // .end() should .uncork()
-  this.uncork();
+  // .end() fully uncorks
+  if (state.corked) {
+    state.corked = 1;
+    this.uncork();
+  }
 
   // ignore unnecessary end() calls.
   if (!state.ending && !state.finished)

--- a/test/simple/test-stream-writev.js
+++ b/test/simple/test-stream-writev.js
@@ -1,0 +1,121 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var stream = require('stream');
+
+var queue = [];
+for (var decode = 0; decode < 2; decode++) {
+  for (var uncork = 0; uncork < 2; uncork++) {
+    for (var multi = 0; multi < 2; multi++) {
+      queue.push([!!decode, !!uncork, !!multi]);
+    }
+  }
+}
+
+run();
+
+function run() {
+  var t = queue.pop();
+  if (t)
+    test(t[0], t[1], t[2], run);
+  else
+    console.log('ok');
+}
+
+function test(decode, uncork, multi, next) {
+  console.log('# decode=%j uncork=%j multi=%j', decode, uncork, multi);
+  var counter = 0;
+  var expectCount = 0;
+  function cnt(msg) {
+    expectCount++;
+    var expect = expectCount;
+    var called = false;
+    return function(er) {
+      if (er)
+        throw er;
+      called = true;
+      counter++;
+      assert.equal(counter, expect);
+    };
+  }
+
+  var w = new stream.Writable({ decodeStrings: decode });
+  w._write = function(chunk, e, cb) {
+    assert(false, 'Should not call _write');
+  };
+
+  var expectChunks = decode ?
+      [{ encoding: 'buffer',
+         chunk: [104, 101, 108, 108, 111, 44, 32] },
+       { encoding: 'buffer', chunk: [119, 111, 114, 108, 100] },
+       { encoding: 'buffer', chunk: [33] },
+       { encoding: 'buffer',
+         chunk: [10, 97, 110, 100, 32, 116, 104, 101, 110, 46, 46, 46] },
+       { encoding: 'buffer',
+         chunk: [250, 206, 190, 167, 222, 173, 190, 239, 222, 202, 251, 173] }] :
+      [{ encoding: 'ascii', chunk: 'hello, ' },
+       { encoding: 'utf8', chunk: 'world' },
+       { encoding: 'buffer', chunk: [33] },
+       { encoding: 'binary', chunk: '\nand then...' },
+       { encoding: 'hex', chunk: 'facebea7deadbeefdecafbad' }];
+
+  var actualChunks;
+  w._writev = function(chunks, cb) {
+    actualChunks = chunks.map(function(chunk) {
+      return {
+        encoding: chunk.encoding,
+        chunk: Buffer.isBuffer(chunk.chunk) ?
+            Array.prototype.slice.call(chunk.chunk) : chunk.chunk
+      };
+    });
+    cb();
+  };
+
+  w.cork();
+  w.write('hello, ', 'ascii', cnt('hello'));
+  w.write('world', 'utf8', cnt('world'));
+
+  if (multi)
+    w.cork();
+
+  w.write(new Buffer('!'), 'buffer', cnt('!'));
+  w.write('\nand then...', 'binary', cnt('and then'));
+
+  if (multi)
+    w.uncork();
+
+  w.write('facebea7deadbeefdecafbad', 'hex', cnt('hex'));
+
+  if (uncork)
+    w.uncork();
+
+  w.end(cnt('end'));
+
+  w.on('finish', function() {
+    // make sure finish comes after all the write cb
+    cnt('finish')();
+    assert.deepEqual(expectChunks, actualChunks);
+    next();
+  });
+}

--- a/test/simple/test-stream2-writable.js
+++ b/test/simple/test-stream2-writable.js
@@ -375,3 +375,19 @@ test('finish does not come before write cb', function(t) {
   w.write(Buffer(0));
   w.end();
 });
+
+test('finish does not come before sync _write cb', function(t) {
+  var w = new W();
+  var writeCb = false;
+  w._write = function(chunk, e, cb) {
+    cb();
+  };
+  w.on('finish', function() {
+    assert(writeCb);
+    t.end();
+  });
+  w.write(Buffer(0), function(er) {
+    writeCb = true;
+  });
+  w.end();
+});


### PR DESCRIPTION
Depends on #5434, hence the duplicate commit.

Make the `corked` flag a counter, so that you can cork multiple times and then uncork that many times to release the flow to _writev.

Then get rid of the http "hacky hot path" code in http.OutgoingMessage.end, instead using cork/uncork.

Significant improvements in a few benchmarks, and no statistically significant diffs in the others.  Note that http benchmarks exhibit around 5% jitter.  This could be improved by setting NODE_BENCH_RUNS higher to run it more times, but that takes literally forever.

```
http/chunked.js num=1 size=1 c=100: ./node: 9384.8 ./node-master: 9000.6 ............................ 4.27%
http/chunked.js num=1 size=64 c=100: ./node: 9169.6 ./node-master: 9125.9 ........................... 0.48%
http/chunked.js num=1 size=256 c=100: ./node: 9315.2 ./node-master: 8826.8 .......................... 5.53%
http/chunked.js num=4 size=1 c=100: ./node: 5553.3 ./node-master: 5354.9 ............................ 3.71%
http/chunked.js num=4 size=64 c=100: ./node: 5105.9 ./node-master: 5260.3 .......................... -2.94%
http/chunked.js num=4 size=256 c=100: ./node: 4880.2 ./node-master: 5165.1 ......................... -5.52%
http/chunked.js num=8 size=1 c=100: ./node: 3239.6 ./node-master: 3311.8 ........................... -2.18%
http/chunked.js num=8 size=64 c=100: ./node: 3121.4 ./node-master: 3190.8 .......................... -2.18%
http/chunked.js num=8 size=256 c=100: ./node: 3201.4 ./node-master: 3124.4 .......................... 2.46%
http/chunked.js num=16 size=1 c=100: ./node: 1649.9 ./node-master: 1607 ............................. 2.67%
http/chunked.js num=16 size=64 c=100: ./node: 1556.8 ./node-master: 1449.3 .......................... 7.42%
http/chunked.js num=16 size=256 c=100: ./node: 1562.3 ./node-master: 1391.2 ........................ 12.30%
http/cluster.js type=bytes length=4 c=50: ./node: 16043 ./node-master: 16527 ....................... -2.93%
http/cluster.js type=bytes length=4 c=500: ./node: 14294 ./node-master: 14168 ....................... 0.89%
http/cluster.js type=bytes length=1024 c=50: ./node: 14343 ./node-master: 14084 ..................... 1.84%
http/cluster.js type=bytes length=1024 c=500: ./node: 12926 ./node-master: 12841 .................... 0.66%
http/cluster.js type=bytes length=102400 c=50: ./node: 499.5 ./node-master: 491.18 .................. 1.69%
http/cluster.js type=bytes length=102400 c=500: ./node: 445.96 ./node-master: 440.62 ................ 1.21%
http/cluster.js type=buffer length=4 c=50: ./node: 14809 ./node-master: 14491 ....................... 2.19%
http/cluster.js type=buffer length=4 c=500: ./node: 13428 ./node-master: 13276 ...................... 1.14%
http/cluster.js type=buffer length=1024 c=50: ./node: 14589 ./node-master: 14378 .................... 1.47%
http/cluster.js type=buffer length=1024 c=500: ./node: 12380 ./node-master: 12813 .................. -3.38%
http/cluster.js type=buffer length=102400 c=50: ./node: 9315.5 ./node-master: 6970.6 ............... 33.64%
http/cluster.js type=buffer length=102400 c=500: ./node: 8596.4 ./node-master: 6123 ................ 40.40%
http/end-vs-write-end.js type=asc kb=64 c=100 method=write: ./node: 3194.7 ./node-master: 3024.3 .... 5.63%
http/end-vs-write-end.js type=asc kb=64 c=100 method=end  : ./node: 2747 ./node-master: 3091.5 .... -11.14%
http/end-vs-write-end.js type=asc kb=128 c=100 method=write: ./node: 1659.8 ./node-master: 1532.6 ... 8.30%
http/end-vs-write-end.js type=asc kb=128 c=100 method=end  : ./node: 1509.5 ./node-master: 1647.2 .. -8.36%
http/end-vs-write-end.js type=asc kb=256 c=100 method=write: ./node: 987.42 ./node-master: 930.36 ... 6.13%
http/end-vs-write-end.js type=asc kb=256 c=100 method=end  : ./node: 812.56 ./node-master: 934.77 . -13.07%
http/end-vs-write-end.js type=asc kb=1024 c=100 method=write: ./node: 218.22 ./node-master: 207.8 ... 5.01%
http/end-vs-write-end.js type=asc kb=1024 c=100 method=end  : ./node: 233.61 ./node-master: 212.11 . 10.14%
http/end-vs-write-end.js type=utf kb=64 c=100 method=write: ./node: 4679.5 ./node-master: 4583.4 .... 2.10%
http/end-vs-write-end.js type=utf kb=64 c=100 method=end  : ./node: 4692.1 ./node-master: 4648.7 .... 0.93%
http/end-vs-write-end.js type=utf kb=128 c=100 method=write: ./node: 2203.3 ./node-master: 2093.8 ... 5.23%
http/end-vs-write-end.js type=utf kb=128 c=100 method=end  : ./node: 2275.7 ./node-master: 2219.6 ... 2.53%
http/end-vs-write-end.js type=utf kb=256 c=100 method=write: ./node: 1338.3 ./node-master: 1292.9 ... 3.51%
http/end-vs-write-end.js type=utf kb=256 c=100 method=end  : ./node: 1223.2 ./node-master: 1350.8 .. -9.45%
http/end-vs-write-end.js type=utf kb=1024 c=100 method=write: ./node: 388.35 ./node-master: 373.6 ... 3.95%
http/end-vs-write-end.js type=utf kb=1024 c=100 method=end  : ./node: 342.19 ./node-master: 379.1 .. -9.74%
http/end-vs-write-end.js type=buf kb=64 c=100 method=write: ./node: 7215.8 ./node-master: 6983.3 .... 3.33%
http/end-vs-write-end.js type=buf kb=64 c=100 method=end  : ./node: 7728.8 ./node-master: 6221.9 ... 24.22%
http/end-vs-write-end.js type=buf kb=128 c=100 method=write: ./node: 5427.4 ./node-master: 5194.9 ... 4.48%
http/end-vs-write-end.js type=buf kb=128 c=100 method=end  : ./node: 5968 ./node-master: 4833.7 .... 23.47%
http/end-vs-write-end.js type=buf kb=256 c=100 method=write: ./node: 3862.2 ./node-master: 3527.2 ... 9.50%
http/end-vs-write-end.js type=buf kb=256 c=100 method=end  : ./node: 4163.1 ./node-master: 3439 .... 21.06%
http/end-vs-write-end.js type=buf kb=1024 c=100 method=write: ./node: 1380.7 ./node-master: 1308.4 .. 5.53%
http/end-vs-write-end.js type=buf kb=1024 c=100 method=end  : ./node: 1249.7 ./node-master: 1316.2 . -5.05%
http/simple.js type=bytes length=4 c=50: ./node: 11778 ./node-master: 12410 ........................ -5.09%
http/simple.js type=bytes length=4 c=500: ./node: 10282 ./node-master: 9883.1 ....................... 4.04%
http/simple.js type=bytes length=1024 c=50: ./node: 10550 ./node-master: 10559 ..................... -0.09%
http/simple.js type=bytes length=1024 c=500: ./node: 9650.6 ./node-master: 9221.9 ................... 4.65%
http/simple.js type=bytes length=102400 c=50: ./node: 354.34 ./node-master: 354.57 ................. -0.06%
http/simple.js type=bytes length=102400 c=500: ./node: 321.55 ./node-master: 317.76 ................. 1.19%
http/simple.js type=buffer length=4 c=50: ./node: 10775 ./node-master: 10818 ....................... -0.40%
http/simple.js type=buffer length=4 c=500: ./node: 10446 ./node-master: 10253 ....................... 1.88%
http/simple.js type=buffer length=1024 c=50: ./node: 10939 ./node-master: 11292 .................... -3.13%
http/simple.js type=buffer length=1024 c=500: ./node: 10585 ./node-master: 10801 ................... -2.00%
http/simple.js type=buffer length=102400 c=50: ./node: 7027.6 ./node-master: 5200.6 ................ 35.13%
http/simple.js type=buffer length=102400 c=500: ./node: 6100.7 ./node-master: 4523.5 ............... 34.87%
```
