### PR TITLE
test: run test faster

### DIFF
--- a/test/simple/test-fs-watch.js
+++ b/test/simple/test-fs-watch.js
@@ -76,13 +76,12 @@ assert.doesNotThrow(
         watcher.close();
         ++watchSeenOne;
       });
+      watcher.on('ready', function() {
+        fs.writeFileSync(filepathOne, 'world');
+      });
+      watcher.emit('ready');
     }
 );
-
-setTimeout(function() {
-  fs.writeFileSync(filepathOne, 'world');
-}, 1000);
-
 
 process.chdir(testDir);
 
@@ -103,12 +102,12 @@ assert.doesNotThrow(
         watcher.close();
         ++watchSeenTwo;
       });
+      watcher.on('ready', function() {
+        fs.writeFileSync(filepathTwoAbs, 'pardner');
+      });
+      watcher.emit('ready');
     }
 );
-
-setTimeout(function() {
-  fs.writeFileSync(filepathTwoAbs, 'pardner');
-}, 1000);
 
 try { fs.unlinkSync(filepathThree); } catch (e) {}
 try { fs.mkdirSync(testsubdir, 0700); } catch (e) {}
@@ -126,13 +125,13 @@ assert.doesNotThrow(
         watcher.close();
         ++watchSeenThree;
       });
+      watcher.on('ready', function() {
+        var fd = fs.openSync(filepathThree, 'w');
+        fs.closeSync(fd);
+      });
+      watcher.emit('ready');
     }
 );
-
-setTimeout(function() {
-  var fd = fs.openSync(filepathThree, 'w');
-  fs.closeSync(fd);
-}, 1000);
 
 // https://github.com/joyent/node/issues/2293 - non-persistent watcher should
 // not block the event loop


### PR DESCRIPTION
instead of using a timeout events are emitted which resulted in a 0.7s
runtime instead of a 1.3s lasting one
