### PR TITLE
util.log to handle non strings like console.log

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -490,11 +490,10 @@ function timestamp() {
   return [d.getDate(), months[d.getMonth()], time].join(' ');
 }
 
-
-exports.log = function(msg) {
-  exports.puts(timestamp() + ' - ' + msg.toString());
+// log is just a thin wrapper to console.log that prepends a timestamp
+exports.log = function() {
+  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
 };
-
 
 exports.exec = exports.deprecate(function() {
   return require('child_process').exec.apply(this, arguments);

--- a/lib/util.js
+++ b/lib/util.js
@@ -490,10 +490,12 @@ function timestamp() {
   return [d.getDate(), months[d.getMonth()], time].join(' ');
 }
 
+
 // log is just a thin wrapper to console.log that prepends a timestamp
 exports.log = function() {
   console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
 };
+
 
 exports.exec = exports.deprecate(function() {
   return require('child_process').exec.apply(this, arguments);

--- a/test/simple/test-util-log.js
+++ b/test/simple/test-util-log.js
@@ -34,24 +34,25 @@ global.process.stdout.write = function(string) {
 console._stderr = process.stdout;
 
 var tests = [
-    {input: 'foo', output: 'foo'},
-    {input: undefined, output: 'undefined'},
-    {input: null, output: 'null'},
-    {input: false, output: 'false'},
-    {input: 42, output: '42'},
-    {input: function(){}, output: '[Function]'},
-    {input: parseInt('not a number', 10), output: 'NaN'},
-    {input: {answer: 42}, output: '{ answer: 42 }'},
-    {input: [1,2,3], output: '[ 1, 2, 3 ]'}
+  {input: 'foo', output: 'foo'},
+  {input: undefined, output: 'undefined'},
+  {input: null, output: 'null'},
+  {input: false, output: 'false'},
+  {input: 42, output: '42'},
+  {input: function(){}, output: '[Function]'},
+  {input: parseInt('not a number', 10), output: 'NaN'},
+  {input: {answer: 42}, output: '{ answer: 42 }'},
+  {input: [1,2,3], output: '[ 1, 2, 3 ]'}
 ];
 
 // test util.log()
 tests.forEach(function(test) {
-    util.log(test.input);
-    var result = strings.shift().trim();
-    var match = (/[0-9]{1,2} [A-Z][a-z]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} - (.+)$/).exec(result);
-    assert.ok(match);
-    assert.equal(match[1], test.output);
+  util.log(test.input);
+  var result = strings.shift().trim(),
+      re = (/[0-9]{1,2} [A-Z][a-z]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} - (.+)$/),
+      match = re.exec(result);
+  assert.ok(match);
+  assert.equal(match[1], test.output);
 });
 
 global.process.stdout.write = stdout_write;

--- a/test/simple/test-util-log.js
+++ b/test/simple/test-util-log.js
@@ -1,0 +1,57 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var assert = require('assert');
+var util = require('../../lib/util.js');
+
+assert.ok(process.stdout.writable);
+assert.ok(process.stderr.writable);
+
+var stdout_write = global.process.stdout.write;
+var strings = [];
+global.process.stdout.write = function(string) {
+  strings.push(string);
+};
+console._stderr = process.stdout;
+
+var tests = [
+    {input: 'foo', output: 'foo'},
+    {input: undefined, output: 'undefined'},
+    {input: null, output: 'null'},
+    {input: false, output: 'false'},
+    {input: 42, output: '42'},
+    {input: function(){}, output: '[Function]'},
+    {input: parseInt('not a number', 10), output: 'NaN'},
+    {input: {answer: 42}, output: '{ answer: 42 }'},
+    {input: [1,2,3], output: '[ 1, 2, 3 ]'}
+];
+
+// test util.log()
+tests.forEach(function(test) {
+    util.log(test.input);
+    var result = strings.shift().trim();
+    var match = (/[0-9]{1,2} [A-Z][a-z]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} - (.+)$/).exec(result);
+    assert.ok(match);
+    assert.equal(match[1], test.output);
+});
+
+global.process.stdout.write = stdout_write;

--- a/test/simple/test-util-log.js
+++ b/test/simple/test-util-log.js
@@ -21,7 +21,7 @@
 
 
 var assert = require('assert');
-var util = require('../../lib/util.js');
+var util = require('util');
 
 assert.ok(process.stdout.writable);
 assert.ok(process.stderr.writable);


### PR DESCRIPTION
util.log will fail on input that does not support .toString(). Have it
use console.log() instead. Includes tests for hairy data types.

Fixes joyent/node#5349.
