### PR TITLE
SNICallback regression.

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1038,7 +1038,7 @@ function Server(/* [options], listener */) {
   // Handle option defaults:
   this.setOptions(options);
 
-  if (!self.pfx && (!self.cert || !self.key)) {
+  if (!self.pfx && (!self.cert || !self.key) && !self.SNICallback) {
     throw new Error('Missing PFX or certificate + private key.');
   }
 


### PR DESCRIPTION
in v0.8 the following used to work

``` js
var server = https.createServer({
    SNICallback: function(hostname) {
        return certs[hostname] || certs["www.colingo.com"]
    }
}, function (req, res) { ... })
```

Doing this is probably unwise (I don't actually understand why?)

We maybe should not throw an error here for back compat?
