### PR TITLE
Adding warning about issues from not reading response

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -566,7 +566,9 @@ entirely discarded.  However, if you add a `'response'` event handler,
 then you **must** consume the data from the response object, either by
 calling `response.read()` whenever there is a `'readable'` event, or
 by adding a `'data'` handler, or by calling the `.resume()` method.
-Until the data is consumed, the `'end'` event will not fire.
+Until the data is consumed, the `'end'` event will not fire.  Also, until 
+the data is read it will consume memory that can eventually lead to a 
+'process out of memory' error.
 
 Note: Node does not check whether Content-Length and the length of the body
 which has been transmitted are equal or not.


### PR DESCRIPTION
Added a note to ClientRequest about memory issues that can result when a response that is handled is not consumed.
