### PR TITLE
have events module exports EventEmitter, substack style.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -21,11 +21,9 @@
 
 var domain;
 
-exports.usingDomains = false;
-
 function EventEmitter() {
   this.domain = null;
-  if (exports.usingDomains) {
+  if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
     domain = domain || require('domain');
     if (domain.active && !(this instanceof domain.Domain)) {
@@ -35,7 +33,12 @@ function EventEmitter() {
   this._events = this._events || {};
   this._maxListeners = this._maxListeners || undefined;
 }
-exports.EventEmitter = EventEmitter;
+module.exports = EventEmitter;
+
+// Backwards-compat with node 0.10.x
+EventEmitter.EventEmitter = EventEmitter;
+
+EventEmitter.usingDomains = false;
 
 
 // By default EventEmitters will print a warning if more than 10 listeners are


### PR DESCRIPTION
This change is 100% backwards compatible.

This change will make using `EventEmitter` slightly simpler / nicer and adheres to the best practice set forth by substack.

``` js
var EventEmitter = require("events")

var emitter = new EventEmitter()
```

I know the API is frozen however this isn't an API change as much as it is just a "what do we export change".

The only difference is that we now have to set `EventEmitter` as a property of `EventEmitter` for backwards compatibility like we do with [`Stream`][1]

We have also set the `usingDomains` property on the `EventEmitter` constructor itself because that aligns with it's current usage of `require("events").usingDomains = true`

There are other internals that would benefit from this change as well like `StringDecoder`

**advantages:**
- makes code using EventEmitter slightly simpler
- adheres to common practice of export one thing

**disadvantages:**
- The API is frozen, we can't do this.
- Allows for 0.12 only code using EventEmitter that will break in 0.10
