### PR TITLE
test: test sending a handle twice

### DIFF
--- a/test/simple/test-cluster-send-handle-twice.js
+++ b/test/simple/test-cluster-send-handle-twice.js
@@ -1,0 +1,56 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Testing to send an handle twice to the parent process.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+var workers = {
+  toStart: 8
+};
+
+if (cluster.isMaster) {
+  for (var i = 0; i < workers.toStart; ++i) {
+    var worker = cluster.fork();
+    worker.on('exit', function(code, signal) {
+      assert.equal(code, 0, 'Worker exited with an error code');
+      assert(!signal, 'Worker exited by a signal');
+    });
+  }
+} else {
+  var server = net.createServer(function(socket) {
+    process.send('send-handle-1', socket);
+    process.send('send-handle-2', socket);
+  });
+
+  server.listen(common.PORT, function () {
+    var client = net.connect({ host: 'localhost', port: common.PORT });
+    client.on('close', function () { cluster.worker.disconnect(); });
+    setTimeout(function () { client.end(); }, 50);
+  }).on('error', function (e) {
+    console.error(e);
+    assert(false, 'server.listen failed');
+    cluster.worker.disconnect();
+  });
+}

--- a/test/simple/test-cluster-send-handle-twice.js
+++ b/test/simple/test-cluster-send-handle-twice.js
@@ -44,11 +44,11 @@ if (cluster.isMaster) {
     process.send('send-handle-2', socket);
   });
 
-  server.listen(common.PORT, function () {
+  server.listen(common.PORT, function() {
     var client = net.connect({ host: 'localhost', port: common.PORT });
-    client.on('close', function () { cluster.worker.disconnect(); });
-    setTimeout(function () { client.end(); }, 50);
-  }).on('error', function (e) {
+    client.on('close', function() { cluster.worker.disconnect(); });
+    setTimeout(function() { client.end(); }, 50);
+  }).on('error', function(e) {
     console.error(e);
     assert(false, 'server.listen failed');
     cluster.worker.disconnect();


### PR DESCRIPTION
Added [test-cluster-send-handle-twice.js](https://github.com/kunnix/node/blob/80b2557c513ff6d682e6a0fba728bfd462e17fc5/test/simple/test-cluster-send-handle-twice.js) testing to send a handle twice to the parent process.

This currently leads to a crash on Linux 32-bit (Ubuntu), see [issue 5469](https://github.com/joyent/node/issues/5469).
