### PR TITLE
readline: add setEcho function to readline

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -100,6 +100,11 @@ to `true` to prevent the cursor placement being reset to `0`.
 This will also resume the `input` stream used with `createInterface` if it has
 been paused.
 
+### rl.setEcho([enable])
+
+Enables or disables echoing (visibility) of input as it is typed in by user. Useful for
+password input and other stealthy appliances. Available if the terminal is a TTY.
+
 ### rl.question(query, callback)
 
 Prepends the prompt with `query` and invokes `callback` with the user's

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -155,12 +155,12 @@ Interface.prototype.setPrompt = function(prompt) {
 
 //enable or disable input visibility in terminal
 Interface.prototype.setEcho = function(enable) {
-	if(!arguments.length){
-		enable = true
-	}
-	//this does not make sense when input is not terminal, however, throwing
-	//an error when somebody pipes a file into the app would not be good
-	this._echo = !!enable;
+  if (!arguments.length) {
+    enable = true;
+  }
+  //this does not make sense when input is not terminal, however, throwing
+  //an error when somebody pipes a file into the app would not be good
+  this._echo = !!enable;
 };
 
 
@@ -227,7 +227,7 @@ Interface.prototype._refreshLine = function() {
   var columns = this.columns;
 
   // line length
-  var line = this._prompt + (this._echo?this.line:'');
+  var line = this._prompt + (this._echo ? this.line : '');
   var dispPos = this._getDisplayPos(line);
   var lineCols = dispPos.cols;
   var lineRows = dispPos.rows;
@@ -347,7 +347,7 @@ Interface.prototype._insertString = function(c) {
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
-    } else if(this._echo) {
+    } else if (this._echo) {
       this.output.write(c);
     }
 
@@ -592,7 +592,7 @@ Interface.prototype._getDisplayPos = function(str) {
 Interface.prototype._getCursorPos = function() {
   var columns = this.columns;
   var strBeforeCursor;
-  if(this._echo){
+  if (this._echo) {
     strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
   } else {
     strBeforeCursor = this._prompt;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -50,6 +50,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   this._sawReturn = false;
+  this._echo = true;
 
   EventEmitter.call(this);
 
@@ -152,6 +153,16 @@ Interface.prototype.setPrompt = function(prompt) {
   this._prompt = prompt;
 };
 
+//enable or disable input visibility in terminal
+Interface.prototype.setEcho = function(enable) {
+	if(!arguments.length){
+		enable = true
+	}
+	//this does not make sense when input is not terminal, however, throwing
+	//an error when somebody pipes a file into the app would not be good
+	this._echo = !!enable;
+};
+
 
 Interface.prototype._setRawMode = function(mode) {
   if (typeof this.input.setRawMode === 'function') {
@@ -216,7 +227,7 @@ Interface.prototype._refreshLine = function() {
   var columns = this.columns;
 
   // line length
-  var line = this._prompt + this.line;
+  var line = this._prompt + (this._echo?this.line:'');
   var dispPos = this._getDisplayPos(line);
   var lineCols = dispPos.cols;
   var lineRows = dispPos.rows;
@@ -336,7 +347,7 @@ Interface.prototype._insertString = function(c) {
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
-    } else {
+    } else if(this._echo) {
       this.output.write(c);
     }
 
@@ -580,7 +591,12 @@ Interface.prototype._getDisplayPos = function(str) {
 // Returns current cursor's position and line
 Interface.prototype._getCursorPos = function() {
   var columns = this.columns;
-  var strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
+  var strBeforeCursor;
+  if(this._echo){
+    strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
+  } else {
+    strBeforeCursor = this._prompt;
+  }
   var dispPos = this._getDisplayPos(strBeforeCursor);
   var cols = dispPos.cols;
   var rows = dispPos.rows;


### PR DESCRIPTION
setEcho allows disabling (or enabling) input echoing (visibility) in readline as
user types it into the terminal

backward compatibility preserved
