### PR TITLE
crypto: fix default encoding regression

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -220,7 +220,8 @@ size_t StringBytes::Write(char* buf,
       break;
     }
 
-    case BINARY: {
+    case BINARY:
+    case BUFFER: {
       // TODO(isaacs): THIS IS AWFUL!!!
       uint16_t* twobytebuf = new uint16_t[buflen];
 
@@ -248,10 +249,6 @@ size_t StringBytes::Write(char* buf,
       break;
     }
 
-    case BUFFER:
-      assert(0 && "buffer encoding specified, but string provided");
-      break;
-
     default:
       assert(0 && "unknown encoding");
       break;
@@ -277,6 +274,7 @@ size_t StringBytes::StorageSize(Handle<Value> val, enum encoding encoding) {
 
   switch (encoding) {
     case BINARY:
+    case BUFFER:
     case ASCII:
       data_size = str->Length();
       break;
@@ -305,10 +303,6 @@ size_t StringBytes::StorageSize(Handle<Value> val, enum encoding encoding) {
       data_size = str->Length() / 2;
       break;
 
-    case BUFFER:
-      assert(0 && "buffer encoding specified but string provided");
-      break;
-
     default:
       assert(0 && "unknown encoding");
       break;
@@ -331,6 +325,7 @@ size_t StringBytes::Size(Handle<Value> val, enum encoding encoding) {
 
   switch (encoding) {
     case BINARY:
+    case BUFFER:
     case ASCII:
       data_size = str->Length();
       break;
@@ -355,10 +350,6 @@ size_t StringBytes::Size(Handle<Value> val, enum encoding encoding) {
 
     case HEX:
       data_size = str->Length() / 2;
-      break;
-
-    case BUFFER:
-      assert(0 && "buffer encoding specified by string provided");
       break;
 
     default:

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -979,3 +979,8 @@ assert.throws(function() {
     assert.equal(buf.slice(0, -i), s.slice(0, -i));
   }
 })();
+
+// Regression test for #5482: should throw but not assert in C++ land.
+assert.throws(function() {
+  Buffer('', 'buffer');
+}, TypeError);

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -887,3 +887,10 @@ assert.throws(function() {
   try { d.final('xxx') } catch (e) { /* Ignore. */ }
   try { d.final('xxx') } catch (e) { /* Ignore. */ }
 })();
+
+// Regression test for #5482: string to Cipher#update() should not assert.
+(function() {
+  var c = crypto.createCipher('aes192', '0123456789abcdef');
+  c.update('update');
+  c.final();
+})();


### PR DESCRIPTION
The default encoding is 'buffer'. When the input is a string, treat it
as 'binary'. Fixes the following assertion:

```
  node: ../src/string_bytes.cc:309: static size_t
  node::StringBytes::StorageSize(v8::Handle<v8::Value>, node::encoding):
  Assertion `0 && "buffer encoding specified but string provided"'
  failed.
```

Fixes #5482.

Suggested reviewers: @isaacs @piscisaureus
