### PR TITLE
Update docs to include `secureProtocol` parameter for `tls` and `https` modules

### DIFF
--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -134,6 +134,9 @@ The following options from [tls.connect()][] can also be specified. However, a
   the list of supplied CAs. An `'error'` event is emitted if verification
   fails. Verification happens at the connection level, *before* the HTTP
   request is sent. Default `true`.
+- `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
+    SSL version 3. The possible values depend on your installation of
+    OpenSSL and are defined in the constant [SSL_METHODS][].
 
 In order to specify these options, use a custom `Agent`.
 
@@ -217,3 +220,4 @@ Global instance of [https.Agent][] for all HTTPS client requests.
 [https.request()]: #https_https_request_options_callback
 [tls.connect()]: tls.html#tls_tls_connect_options_callback
 [tls.createServer()]: tls.html#tls_tls_createserver_options_secureconnectionlistener
+[SSL_METHOD]: http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -277,6 +277,10 @@ Creates a new client connection to the given `port` and `host` (old API) or
     usually be much simpler: `['hello', 'world']`.)
 
   - `servername`: Servername for SNI (Server Name Indication) TLS extension.
+  
+  - `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
+    SSL version 3. The possible values depend on your installation of
+    OpenSSL and are defined in the constant [SSL_METHODS][].
 
 The `callback` parameter will be added as a listener for the
 ['secureConnect'][] event.
@@ -566,3 +570,4 @@ The numeric representation of the remote port. For example, `443`.
 [Stream]: stream.html#stream_stream
 [tls.Server]: #tls_class_tls_server
 [SSL_CTX_set_timeout]: http://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+[SSL_METHODS]: http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS


### PR DESCRIPTION
There is an issue with some servers that cause SSL requests using the default SSL method to fail, for example:

http://webcache.googleusercontent.com/search?q=cache:_tRN2R7Awr0J:carnivore.it/2011/10/07/error_14077458_ssl_routines_ssl23_get_server_hello_reason_1112&hl=en&gl=us&strip=1

http://curl.haxx.se/mail/archive-2010-03/0069.html

Node provides an undocumented `secureProtocol` parameter to fix this, the code for which is here:

https://github.com/joyent/node/blob/179784e31e72fcdd0a2b1a596f7aebb43dc87913/lib/crypto.js#L60

This pull request adds documentation for that parameter to the `tls` and `https` modules so that it is easier to find for others. There is also a pull request open with Needle that is blocked on the parameter being properly documented at https://github.com/tomas/needle/pull/24#issuecomment-17956374

Thanks!
