### PR TITLE
Fix link to open issues on GitHub.

### DIFF
--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -14,7 +14,7 @@ JavaScript code can be compiled and run immediately or compiled, saved, and run 
 
 The `vm` module has many known issues and edge cases. If you run into
 issues or unexpected behavior, please consult
-[the open issues on GitHub](https://github.com/joyent/node/issues/search?q=vm).
+[the open issues on GitHub](https://github.com/joyent/node/search?q=vm+state%3Aopen&type=Issues).
 Some of the biggest problems are described below.
 
 ### Sandboxes


### PR DESCRIPTION
The link in the VM API docs to the open issues on GitHub no longer works due to the [recent changes to GitHub's search](https://github.com/blog/1492-repository-search-on-all-repositories).
