### PR TITLE
module: use path.sep instead of a custom solution

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -212,15 +212,13 @@ Module._nodeModulePaths = function(from) {
   // to be absolute.  Doing a fully-edge-case-correct path.split
   // that works on both Windows and Posix is non-trivial.
   var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
-  // yes, '/' works on both, but let's be a little canonical.
-  var joiner = process.platform === 'win32' ? '\\' : '/';
   var paths = [];
   var parts = from.split(splitRe);
 
   for (var tip = parts.length - 1; tip >= 0; tip--) {
     // don't search in .../node_modules/node_modules
     if (parts[tip] === 'node_modules') continue;
-    var dir = parts.slice(0, tip + 1).concat('node_modules').join(joiner);
+    var dir = parts.slice(0, tip + 1).concat('node_modules').join(path.sep);
     paths.push(dir);
   }
 

--- a/test/simple/test-module-nodemodulepaths.js
+++ b/test/simple/test-module-nodemodulepaths.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var module = require('module');
+
+var isWindows = process.platform === 'win32';
+
+var file, delimiter, paths;
+
+if (isWindows) {
+  file = 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo';
+  delimiter = '\\'
+} else {
+  file = '/usr/test/lib/node_modules/npm/foo';
+  delimiter = '/'
+}
+
+paths = module._nodeModulePaths(file);
+
+assert.ok(paths.indexOf(file + delimiter + 'node_modules') !== -1);
+assert.ok(Array.isArray(paths));


### PR DESCRIPTION
I did some cleanup and added a test.

Instead of using a custom solution we can use path.sep in
Module._nodeModulePaths
