### PR TITLE
timers, net: use single unref'd timer for internal timeouts

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -307,7 +307,7 @@ Socket.prototype.listen = function() {
 Socket.prototype.setTimeout = function(msecs, callback) {
   if (msecs > 0 && !isNaN(msecs) && isFinite(msecs)) {
     timers.enroll(this, msecs);
-    timers.active(this);
+    timers._unrefActive(this);
     if (callback) {
       this.once('timeout', callback);
     }
@@ -481,7 +481,7 @@ function onread(buffer, offset, length) {
   var self = handle.owner;
   assert(handle === self._handle, 'handle != self._handle');
 
-  timers.active(self);
+  timers._unrefActive(self);
 
   var end = offset + length;
   debug('onread', process._errno, offset, length, end);
@@ -612,7 +612,7 @@ Socket.prototype._write = function(data, encoding, cb) {
   this._pendingData = null;
   this._pendingEncoding = '';
 
-  timers.active(this);
+  timers._unrefActive(this);
 
   if (!this._handle) {
     this._destroy(new Error('This socket is closed.'), cb);
@@ -702,7 +702,7 @@ function afterWrite(status, handle, req) {
     return;
   }
 
-  timers.active(self);
+  timers._unrefActive(self);
 
   if (self !== process.stderr && self !== process.stdout)
     debug('afterWrite call cb');
@@ -783,7 +783,7 @@ Socket.prototype.connect = function(options, cb) {
     self.once('connect', cb);
   }
 
-  timers.active(this);
+  timers._unrefActive(this);
 
   self._connecting = true;
   self.writable = true;
@@ -814,7 +814,7 @@ Socket.prototype.connect = function(options, cb) {
           self._destroy();
         });
       } else {
-        timers.active(self);
+        timers._unrefActive(self);
 
         addressType = addressType || 4;
 
@@ -861,7 +861,7 @@ function afterConnect(status, handle, req, readable, writable) {
   if (status == 0) {
     self.readable = readable;
     self.writable = writable;
-    timers.active(self);
+    timers._unrefActive(self);
 
     self.emit('connect');
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -373,3 +373,111 @@ exports.clearImmediate = function(immediate) {
     process._needImmediateCallback = false;
   }
 };
+
+
+// Internal APIs that need timeouts should use timers._unrefActive isntead of
+// timers.active as internal timeouts shouldn't hold the loop open
+
+var unrefList, unrefTimer;
+
+
+function unrefTimeout() {
+  var now = Date.now();
+
+  debug('unrefTimer fired');
+
+  var first;
+  while (first = L.peek(unrefList)) {
+    var diff = now - first._idleStart;
+
+    if (diff < first._idleTimeout) {
+      diff = first._idleTimeout - diff;
+      unrefTimer.start(diff, 0);
+      unrefTimer.when = now + diff;
+      debug('unrefTimer rescheudling for later');
+      return;
+    }
+
+    L.remove(first);
+
+    var domain = first.domain;
+
+    if (!first._onTimeout) continue;
+    if (domain && domain._disposed) continue;
+
+    try {
+      if (domain) domain.enter();
+      var threw = true;
+      debug('unreftimer firing timeout');
+      first._onTimeout();
+      threw = false;
+      if (domain) domain.exit();
+    } finally {
+      if (threw) process.nextTick(unrefTimeout);
+    }
+  }
+
+  debug('unrefList is empty');
+  unrefTimer.when = -1;
+}
+
+
+exports._unrefActive = function(item) {
+  var msecs = item._idleTimeout;
+  if (!msecs || msecs < 0) return;
+  assert(msecs >= 0);
+
+  L.remove(item);
+
+  if (!unrefList) {
+    debug('unrefList initialized');
+    unrefList = {};
+    L.init(unrefList);
+
+    debug('unrefTimer initialized');
+    unrefTimer = new Timer();
+    unrefTimer.unref();
+    unrefTimer.when = -1;
+    unrefTimer.ontimeout = unrefTimeout;
+  }
+
+  var now = Date.now();
+  item._idleStart = now;
+
+  if (L.isEmpty(unrefList)) {
+    debug('unrefList empty');
+    L.append(unrefList, item);
+
+    unrefTimer.start(msecs, 0);
+    unrefTimer.when = now + msecs;
+    debug('unrefTimer scheduled');
+    return;
+  }
+
+  var when = now + msecs;
+
+  debug('unrefList find where we can insert');
+
+  var cur, them;
+
+  for (cur = unrefList._idlePrev; cur != unrefList; cur = cur._idlePrev) {
+    them = cur._idleStart + cur._idleTimeout;
+
+    if (when < them) {
+      debug('unrefList inserting into middle of list');
+
+      L.append(cur, item);
+
+      if (unrefTimer.when > when) {
+        debug('unrefTimer is scheduled to fire too late, reschedule');
+        unrefTimer.start(msecs, 0);
+        unrefTimer.when = when;
+      }
+
+      return;
+    }
+  }
+
+  debug('unrefList append to end');
+  L.append(unrefList, item);
+};

--- a/test/simple/test-net-socket-timeout-unref.js
+++ b/test/simple/test-net-socket-timeout-unref.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var server = net.createServer(function (c) {
+  c.write('hello');
+  c.unref();
+});
+server.listen(common.PORT);
+server.unref();
+
+var timedout = false;
+
+[8, 5, 3, 6, 2, 4].forEach(function (T) {
+  var socket = net.createConnection(common.PORT, 'localhost');
+  socket.setTimeout(T * 1000, function () {
+    console.log(process._getActiveHandles());
+    timedout = true;
+    socket.destroy();
+  });
+  socket.unref();
+});
+
+process.on('exit', function () {
+  assert.strictEqual(timedout, false, 'Socket timeout should not hold loop open');
+});


### PR DESCRIPTION
If you were to `socket.unref` and also `socket.setTimeout` your loop would stay open until the timeout fired.

This alleviates that problem by making internal timeouts subscribe to a single timer that has already been unref'd
