### PR TITLE
doc: Update doc for http.IncomingMessage.socket

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -858,10 +858,12 @@ The 3-digit HTTP response status code. E.G. `404`.
 
 ### message.socket
 
-The `net.Socket` object associated with the connection.
+For HTTP, the `net.Socket` object associated with the connection.
 
-With HTTPS support, use request.connection.verifyPeer() and
-request.connection.getPeerCertificate() to obtain the client's
+For HTTPS, the `tls.CleartextStream` object associated with the connection.
+
+With HTTPS support, use request.socket.authorized and
+request.socket.getPeerCertificate() to obtain the client's
 authentication details.
 
 


### PR DESCRIPTION
For HTTPS servers, the socket property of the IncomingMessage is a
tls.CleartextStream rather than a net.Socket.  Update the documentation
to reflect this and note that the underlying socket can be accessed
through the socket property of the tls.CleartextStream.

Also update the documentation for getting the client authentication
details.  verifyPeer was removed in df46c8e6 2.5 years ago and
request.connection is a now-undocumented alias for request.socket.
Update these to the current names.

**Reviewer Note:**  The socket property of `tls.CleartextStream` is not currently documented elsewhere (that I am aware of).  If this is not intended to be part of the public API, is there an alternate way to get commonly used socket information (e.g. local and remote address and port) for HTTPS requests?  If so, I can update and re-send the pull request using that method.

Thanks for considering,
Kevin
