### PR TITLE
readline: handle input starting with control chars

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -935,7 +935,7 @@ function emitKey(stream, s) {
     key.name = 'space';
     key.meta = (s.length === 2);
 
-  } else if (s <= '\x1a') {
+  } else if (s.length === 1 && s <= '\x1a') {
     // ctrl+letter
     key.name = String.fromCharCode(s.charCodeAt(0) + 'a'.charCodeAt(0) - 1);
     key.ctrl = true;

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -155,6 +155,18 @@ FakeInput.prototype.end = function() {};
   assert.equal(callCount, expectedLines.length - 1);
   rli.close();
 
+  // \r at start of input should output blank line
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: true });
+  expectedLines = ['', 'foo' ];
+  callCount = 0;
+  rli.on('line', function(line) {
+    assert.equal(line, expectedLines[callCount]);
+    callCount++;
+  });
+  fi.emit('data', '\rfoo\r');
+  assert.equal(callCount, expectedLines.length);
+  rli.close();
 
   // sending a multi-byte utf8 char over multiple writes
   var buf = Buffer('☮', 'utf8');


### PR DESCRIPTION
Handle control characters only when there is a single byte in the
stream, otherwise fall through to the standard multibyte handling.

Fixes #5508
