### PR TITLE
buffer: throw when writing beyond buffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -339,6 +339,9 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
   }
   encoding = String(encoding || 'utf8').toLowerCase();
 
+  if (string.length > 0 && (length < 0 || offset < 0))
+    throw new RangeError('attempt to write beyond buffer bounds');
+
   var ret;
   switch (encoding) {
     case 'hex':

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -221,6 +221,16 @@ new Buffer(0);
 b.write('', 1024);
 b.write('', 2048);
 
+// throw when writing past bounds from the pool
+assert.throws(function() {
+  b.write('a', 2048);
+}, RangeError);
+
+// throw when writing to negative offset
+assert.throws(function() {
+  b.write('a', -1);
+}, RangeError);
+
 // try to copy 0 bytes worth of data into an empty buffer
 b.copy(new Buffer(0), 0, 0, 0);
 


### PR DESCRIPTION
Previously one could write anywhere in a buffer pool if they accidently
got their offset wrong. Mainly because the cc level checks only test
against the parent slow buffer and not against the js object properties.
So now we check to make sure values won't go beyond bounds without
letting the dev know.

Fix for #5498

/cc @isaacs
