### PR TITLE
node: Add support for android

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export TOOLCHAIN=$PWD/android-toolchain
+mkdir -p $TOOLCHAIN
+$1/build/tools/make-standalone-toolchain.sh \
+    --toolchain=arm-linux-androideabi-4.7 \
+    --arch=arm \
+    --install-dir=$TOOLCHAIN \
+    --platform=android-9
+export PATH=$TOOLCHAIN/bin:$PATH
+export AR=arm-linux-androideabi-ar
+export CC=arm-linux-androideabi-gcc
+export CXX=arm-linux-androideabi-g++
+export LINK=arm-linux-androideabi-g++
+
+./configure \
+    --without-snapshot \
+    --dest-cpu=arm \
+    --dest-os=android

--- a/common.gypi
+++ b/common.gypi
@@ -161,10 +161,14 @@
           'BUILDING_UV_SHARED=1',
         ],
       }],
-      [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
-        'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-pthread', ],
+      [ 'OS in "linux freebsd openbsd solaris"', {
+        'cflags': [ '-pthread', ],
+        'ldflags': [ '-pthread' ],
+      }],
+      [ 'OS in "linux freebsd openbsd solaris android"', {
+        'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
-        'ldflags': [ '-pthread', '-rdynamic' ],
+        'ldflags': [ '-rdynamic' ],
         'target_conditions': [
           ['_type=="static_library"', {
             'standalone_static_library': 1, # disable thin archive which needs binutils >= 2.19
@@ -186,6 +190,10 @@
             'ldflags!': [ '-pthread' ],
           }],
         ],
+      }],
+      [ 'OS=="android"', {
+        'defines': ['_GLIBCXX_USE_C99_MATH'],
+        'libraries': [ '-llog' ],
       }],
       ['OS=="mac"', {
         'defines': ['_DARWIN_USE_64_BIT_INODE=1'],

--- a/configure
+++ b/configure
@@ -236,7 +236,7 @@ parser.add_option("--dest-os",
     action="store",
     dest="dest_os",
     help="Operating system to build for. Valid values are: "
-         "win, mac, solaris, freebsd, linux")
+         "win, mac, solaris, freebsd, linux, android")
 
 parser.add_option("--no-ifaddrs",
     action="store_true",
@@ -433,6 +433,8 @@ def configure_arm(o):
 
 
 def configure_node(o):
+  if options.dest_os == 'android':
+    o['variables']['OS'] = "android"
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
   o['variables']['v8_no_strict_aliasing'] = 1 # work around compiler bugs
   o['variables']['node_prefix'] = os.path.expanduser(options.prefix or '')
@@ -632,6 +634,7 @@ configure_libuv(output)
 configure_v8(output)
 configure_openssl(output)
 configure_winsdk(output)
+
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -213,7 +213,7 @@ The shell that executed node should see the exit code as 1.
 
 ## process.getgid()
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Gets the group identity of the process. (See getgid(2).)
 This is the numerical group id, not the group name.
@@ -225,7 +225,7 @@ This is the numerical group id, not the group name.
 
 ## process.setgid(id)
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Sets the group identity of the process. (See setgid(2).)  This accepts either
 a numerical ID or a groupname string. If a groupname is specified, this method
@@ -245,7 +245,7 @@ blocks while resolving it to a numerical ID.
 
 ## process.getuid()
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Gets the user identity of the process. (See getuid(2).)
 This is the numerical userid, not the username.
@@ -257,7 +257,7 @@ This is the numerical userid, not the username.
 
 ## process.setuid(id)
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Sets the user identity of the process. (See setuid(2).)  This accepts either
 a numerical ID or a username string.  If a username is specified, this method
@@ -277,7 +277,7 @@ blocks while resolving it to a numerical ID.
 
 ## process.getgroups()
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Returns an array with the supplementary group IDs. POSIX leaves it unspecified
 if the effective group ID is included but node.js ensures it always is.
@@ -285,7 +285,7 @@ if the effective group ID is included but node.js ensures it always is.
 
 ## process.setgroups(groups)
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Sets the supplementary group IDs. This is a privileged operation, meaning you
 need to be root or have the CAP_SETGID capability.
@@ -295,7 +295,7 @@ The list can contain group IDs, group names or both.
 
 ## process.initgroups(user, extra_group)
 
-Note: this function is only available on POSIX platforms (i.e. not Windows)
+Note: this function is only available on POSIX platforms (i.e. not Windows, Android)
 
 Reads /etc/group and initializes the group access list, using all groups of
 which the user is a member. This is a privileged operation, meaning you need

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -31,7 +31,8 @@
 #include "tree.h"
 #include "uv.h"
 
-#if defined(__OpenBSD__) || defined(__MINGW32__) || defined(_MSC_VER)
+#if defined(__OpenBSD__) || defined(__MINGW32__) \
+    || defined(_MSC_VER) || defined(__ANDROID__)
 # include <nameser.h>
 #else
 # include <arpa/nameser.h>

--- a/src/node.cc
+++ b/src/node.cc
@@ -61,7 +61,7 @@ typedef int mode_t;
 #include <sys/types.h>
 #include "zlib.h"
 
-#ifdef __POSIX__
+#if defined(__POSIX__) && !defined(__ANDROID__)
 # include <pwd.h> /* getpwnam() */
 # include <grp.h> /* getgrnam() */
 #endif
@@ -1413,7 +1413,7 @@ static Handle<Value> Umask(const Arguments& args) {
 }
 
 
-#ifdef __POSIX__
+#if defined(__POSIX__) && !defined(__ANDROID__)
 
 static const uid_t uid_not_found = static_cast<uid_t>(-1);
 static const gid_t gid_not_found = static_cast<gid_t>(-1);
@@ -1689,7 +1689,7 @@ static Handle<Value> InitGroups(const Arguments& args) {
   return Undefined(node_isolate);
 }
 
-#endif // __POSIX__
+#endif // __POSIX__ && !defined(__ANDROID__)
 
 
 v8::Handle<v8::Value> Exit(const v8::Arguments& args) {
@@ -2389,7 +2389,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
   NODE_SET_METHOD(process, "umask", Umask);
 
-#ifdef __POSIX__
+#if defined(__POSIX__) && !defined(__ANDROID__)
   NODE_SET_METHOD(process, "getuid", GetUid);
   NODE_SET_METHOD(process, "setuid", SetUid);
 
@@ -2399,7 +2399,7 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   NODE_SET_METHOD(process, "getgroups", GetGroups);
   NODE_SET_METHOD(process, "setgroups", SetGroups);
   NODE_SET_METHOD(process, "initgroups", InitGroups);
-#endif // __POSIX__
+#endif // __POSIX__ && !defined(__ANDROID__)
 
   NODE_SET_METHOD(process, "_kill", Kill);
 


### PR DESCRIPTION
Adds an ANDROID define and resolves minor discrepancies between
android and standard POSIX systems. In addition, some configure
parameters were added, and a helper-script for android configuration.
Ideally, this script should next be merged into the standard
configure script.

Note: This depends on the respective pull-requests in uv and cares:
https://github.com/joyent/libuv/pull/825
https://github.com/piscisaureus/cares/pull/2

To build for android, source the android-configure script
with an NDK path:

> source ./android-configure ~/android-ndk-r8d

This will create an android standalone toolchain and export the
necessary commands.

After that, build as normal:

> make -j8

After the build, you should now have android-compatible NodeJS
binaries.
