### PR TITLE
Fix for detection of multiple protocols

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -29,17 +29,17 @@ exports.format = urlFormat;
 exports.Url = Url;
 
 function Url() {
-  this.protocol = null;
-  this.slashes = null;
-  this.auth = null;
-  this.host = null;
-  this.port = null;
-  this.hostname = null;
-  this.hash = null;
-  this.search = null;
-  this.query = null;
-  this.pathname = null;
-  this.path = null;
+	this.protocol = null;
+	this.slashes = null;
+	this.auth = null;
+	this.host = null;
+	this.port = null;
+	this.hostname = null;
+	this.hash = null;
+	this.search = null;
+	this.query = null;
+	this.pathname = null;
+	this.path = null;
 }
 
 // Reference: RFC 3986, RFC 1808, RFC 2396
@@ -47,642 +47,724 @@ function Url() {
 // define these here so at least they only have to be
 // compiled once on the first module load.
 var protocolPattern = /^([a-z0-9.+-]+:)/i,
-    portPattern = /:[0-9]*$/,
+		portPattern = /:[0-9]*$/,
 
-    // RFC 2396: characters reserved for delimiting URLs.
-    // We actually just auto-escape these.
-    delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
+		// RFC 2396: characters reserved for delimiting URLs.
+		// We actually just auto-escape these.
+		delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
 
-    // RFC 2396: characters not allowed for various reasons.
-    unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims),
+		// RFC 2396: characters not allowed for various reasons.
+		unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims),
 
-    // Allowed by RFCs, but cause of XSS attacks.  Always escape these.
-    autoEscape = ['\''].concat(unwise),
-    // Characters that are never ever allowed in a hostname.
-    // Note that any invalid chars are also handled, but these
-    // are the ones that are *expected* to be seen, so we fast-path
-    // them.
-    nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
-    nonAuthChars = ['/', '@', '?', '#'].concat(delims),
-    hostnameMaxLen = 255,
-    hostnamePartPattern = /^[a-z0-9A-Z_-]{0,63}$/,
-    hostnamePartStart = /^([a-z0-9A-Z_-]{0,63})(.*)$/,
-    // protocols that can allow "unsafe" and "unwise" chars.
-    unsafeProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that never have a hostname.
-    hostlessProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that always have a path component.
-    pathedProtocol = {
-      'http': true,
-      'https': true,
-      'ftp': true,
-      'gopher': true,
-      'file': true,
-      'http:': true,
-      'ftp:': true,
-      'gopher:': true,
-      'file:': true
-    },
-    // protocols that always contain a // bit.
-    slashedProtocol = {
-      'http': true,
-      'https': true,
-      'ftp': true,
-      'gopher': true,
-      'file': true,
-      'http:': true,
-      'https:': true,
-      'ftp:': true,
-      'gopher:': true,
-      'file:': true
-    },
-    querystring = require('querystring');
+		// Allowed by RFCs, but cause of XSS attacks.  Always escape these.
+		autoEscape = ['\''].concat(unwise),
+		// Characters that are never ever allowed in a hostname.
+		// Note that any invalid chars are also handled, but these
+		// are the ones that are *expected* to be seen, so we fast-path
+		// them.
+		nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
+		nonAuthChars = ['/', '@', '?', '#'].concat(delims),
+		hostnameMaxLen = 255,
+		hostnamePartPattern = /^[a-z0-9A-Z_-]{0,63}$/,
+		hostnamePartStart = /^([a-z0-9A-Z_-]{0,63})(.*)$/,
+		// protocols that can allow "unsafe" and "unwise" chars.
+		unsafeProtocol = {
+			'javascript': true,
+			'javascript:': true
+		},
+		// protocols that never have a hostname.
+		hostlessProtocol = {
+			'javascript': true,
+			'javascript:': true
+		},
+		// protocols that always have a path component.
+		pathedProtocol = {
+			'http': true,
+			'https': true,
+			'ftp': true,
+			'gopher': true,
+			'file': true,
+			'monogodb' : true,
+			'acap' : true,
+			'adiumxtra' : true,
+			'aw' : true,
+			'bolo' : true,
+			'chrome' : true,
+			'chrome-extension' : true,
+			'content' : true,
+			'crid' : true,
+			'cvs' :  true,
+			'feed' : true,
+			'imap' : true,
+			'irc' : true,
+			'jar' : true,
+			'lastfm' : true,
+			'ldap' : true,
+			'mumble' : true,
+			'nntp' : true,
+			'psyc' : true,
+			'reload' : true,
+			'res' : true,
+			'resource' : true,
+			'rmi' : true,
+			'rsync' : true,
+			'rtmp' : true,
+			'secondlife' : true,
+			'sgn' : true,
+			'smb' : true,
+			'snmp' : true,
+			'soldat' : true,
+			'ssh' : true,
+		},
+		// protocols that always contain a // bit.
+		slashedProtocol = {
+			'http': true,
+			'https': true,
+			'ftp': true,
+			'gopher': true,
+			'file': true,
+			'mongodb' : true,
+			'chrome' : true,
+			'bolo' : true,
+			'chrome-extension' : true,
+			'aaa' : true,
+			'acap' : true,
+			'adiumxtra' : true,
+			'aw' : true,
+			'beshare' : true,
+			'content' : true,
+			'crid' : true,
+			'cvs' :  true,
+			'dict' : true,
+			'ed2k' : true,
+			'facetime' : true,
+			'feed' : true,
+			'finger' : true,
+			'fish' : true,
+			'git' : true,
+			'go' : true,
+			'hcp' : true,
+			'imap' : true,
+			'irc' : true,
+			'irc6' : true,
+			'ircs' : true,
+			'jar' : true,
+			'lastfm' : true,
+			'ldap' : true,
+			'ldaps' : true,
+			'market' : true,
+			'ms-help' : true,
+			'mumble' : true,
+			'nntp' : true,
+			'pop' : true,
+			'reload' : true,
+			'res' : true,
+			'resource' : true,
+			'rmi' : true,
+			'rsync' : true,
+			'rtmp' : true,
+			'secondlife' : true,
+			'sgn' : true,
+			'smb' : true,
+			'snmp' : true,
+			'soldat' : true,
+			'ssh' : true,
+			'teamspeak' : true,
+			'telnet' : true,
+			'udp' : true,
+			'unreal' : true,
+			'ut2004' : true,
+			'ventrilo' : true,
+			'wais' : true,
+			'wtai' : true,
+			'wyciwyg' : true,
+			'xri' : true,
+			'z39.50r' : true,
+			'z39.50s' : true,
+			'coap' : true,
+		},
+		querystring = require('querystring');
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (url && typeof(url) === 'object' && url instanceof Url) return url;
+	if (url && typeof(url) === 'object' && url instanceof Url) return url;
 
-  var u = new Url;
-  u.parse(url, parseQueryString, slashesDenoteHost);
-  return u;
+	var u = new Url;
+	u.parse(url, parseQueryString, slashesDenoteHost);
+	return u;
 }
 
 Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
-  if (typeof url !== 'string') {
-    throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
-  }
+	if (typeof url !== 'string') {
+		throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
+	}
 
-  var rest = url;
+	var rest = url;
 
-  // trim before proceeding.
-  // This is to support parse stuff like "  http://foo.com  \n"
-  rest = rest.trim();
+	// trim before proceeding.
+	// This is to support parse stuff like "  http://foo.com  \n"
+	rest = rest.trim();
 
-  var proto = protocolPattern.exec(rest);
-  if (proto) {
-    proto = proto[0];
-    var lowerProto = proto.toLowerCase();
-    this.protocol = lowerProto;
-    rest = rest.substr(proto.length);
-  }
+	var proto = protocolPattern.exec(rest);
 
-  // figure out if it's got a host
-  // user@server is *always* interpreted as a hostname, and url
-  // resolution will treat //foo/bar as host=foo,path=bar because that's
-  // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
-    var slashes = rest.substr(0, 2) === '//';
-    if (slashes && !(proto && hostlessProtocol[proto])) {
-      rest = rest.substr(2);
-      this.slashes = true;
-    }
-  }
+	if (proto) {
+		proto = proto[0];
+		var lowerProto = proto.toLowerCase();
+		this.protocol = lowerProto;
+		rest = rest.substr(proto.length);
+	}
 
-  if (!hostlessProtocol[proto] &&
-      (slashes || (proto && !slashedProtocol[proto]))) {
-    // there's a hostname.
-    // the first instance of /, ?, ;, or # ends the host.
-    // don't enforce full RFC correctness, just be unstupid about it.
+	// figure out if it's got a host
+	// user@server is *always* interpreted as a hostname, and url
+	// resolution will treat //foo/bar as host=foo,path=bar because that's
+	// how the browser resolves relative URLs.
+	if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
+		var slashes = rest.substr(0, 2) === '//';
+		if (slashes && !(proto && hostlessProtocol[proto])) {
+			rest = rest.substr(2);
+			this.slashes = true;
+		}
+	}
 
-    // If there is an @ in the hostname, then non-host chars *are* allowed
-    // to the left of the first @ sign, unless some non-auth character
-    // comes *before* the @-sign.
-    // URLs are obnoxious.
-    var atSign = rest.indexOf('@');
-    if (atSign !== -1) {
-      var auth = rest.slice(0, atSign);
+	if (!hostlessProtocol[proto] &&
+			(slashes || (proto && !slashedProtocol[proto.replace(":", "") ]))) {
+		// there's a hostname.
+		// the first instance of /, ?, ;, or # ends the host.
+		// don't enforce full RFC correctness, just be unstupid about it.
 
-      // there *may be* an auth
-      var hasAuth = true;
-      for (var i = 0, l = nonAuthChars.length; i < l; i++) {
-        if (auth.indexOf(nonAuthChars[i]) !== -1) {
-          // not a valid auth.  Something like http://foo.com/bar@baz/
-          hasAuth = false;
-          break;
-        }
-      }
+		// If there is an @ in the hostname, then non-host chars *are* allowed
+		// to the left of the first @ sign, unless some non-auth character
+		// comes *before* the @-sign.
+		// URLs are obnoxious.
+		var atSign = rest.indexOf('@');
+		if (atSign !== -1) {
+			var auth = rest.slice(0, atSign);
 
-      if (hasAuth) {
-        // pluck off the auth portion.
-        this.auth = decodeURIComponent(auth);
-        rest = rest.substr(atSign + 1);
-      }
-    }
+			// there *may be* an auth
+			var hasAuth = true;
+			for (var i = 0, l = nonAuthChars.length; i < l; i++) {
+				if (auth.indexOf(nonAuthChars[i]) !== -1) {
+					// not a valid auth.  Something like http://foo.com/bar@baz/
+					hasAuth = false;
+					break;
+				}
+			}
 
-    var firstNonHost = -1;
-    for (var i = 0, l = nonHostChars.length; i < l; i++) {
-      var index = rest.indexOf(nonHostChars[i]);
-      if (index !== -1 &&
-          (firstNonHost < 0 || index < firstNonHost)) firstNonHost = index;
-    }
+			if (hasAuth) {
+				// pluck off the auth portion.
+				this.auth = decodeURIComponent(auth);
+				rest = rest.substr(atSign + 1);
+			}
+		}
 
-    if (firstNonHost !== -1) {
-      this.host = rest.substr(0, firstNonHost);
-      rest = rest.substr(firstNonHost);
-    } else {
-      this.host = rest;
-      rest = '';
-    }
+		var firstNonHost = -1;
+		for (var i = 0, l = nonHostChars.length; i < l; i++) {
+			var index = rest.indexOf(nonHostChars[i]);
+			if (index !== -1 &&
+					(firstNonHost < 0 || index < firstNonHost)) firstNonHost = index;
+		}
 
-    // pull out port.
-    this.parseHost();
+		if (firstNonHost !== -1) {
+			this.host = rest.substr(0, firstNonHost);
+			rest = rest.substr(firstNonHost);
+		} else {
+			this.host = rest;
+			rest = '';
+		}
 
-    // we've indicated that there is a hostname,
-    // so even if it's empty, it has to be present.
-    this.hostname = this.hostname || '';
+		// pull out port.
+		this.parseHost();
 
-    // if hostname begins with [ and ends with ]
-    // assume that it's an IPv6 address.
-    var ipv6Hostname = this.hostname[0] === '[' &&
-        this.hostname[this.hostname.length - 1] === ']';
+		// we've indicated that there is a hostname,
+		// so even if it's empty, it has to be present.
+		this.hostname = this.hostname || '';
 
-    // validate a little.
-    if (!ipv6Hostname) {
-      var hostparts = this.hostname.split(/\./);
-      for (var i = 0, l = hostparts.length; i < l; i++) {
-        var part = hostparts[i];
-        if (!part) continue;
-        if (!part.match(hostnamePartPattern)) {
-          var newpart = '';
-          for (var j = 0, k = part.length; j < k; j++) {
-            if (part.charCodeAt(j) > 127) {
-              // we replace non-ASCII char with a temporary placeholder
-              // we need this to make sure size of hostname is not
-              // broken by replacing non-ASCII by nothing
-              newpart += 'x';
-            } else {
-              newpart += part[j];
-            }
-          }
-          // we test again with ASCII char only
-          if (!newpart.match(hostnamePartPattern)) {
-            var validParts = hostparts.slice(0, i);
-            var notHost = hostparts.slice(i + 1);
-            var bit = part.match(hostnamePartStart);
-            if (bit) {
-              validParts.push(bit[1]);
-              notHost.unshift(bit[2]);
-            }
-            if (notHost.length) {
-              rest = '/' + notHost.join('.') + rest;
-            }
-            this.hostname = validParts.join('.');
-            break;
-          }
-        }
-      }
-    }
+		// if hostname begins with [ and ends with ]
+		// assume that it's an IPv6 address.
+		var ipv6Hostname = this.hostname[0] === '[' &&
+				this.hostname[this.hostname.length - 1] === ']';
 
-    if (this.hostname.length > hostnameMaxLen) {
-      this.hostname = '';
-    } else {
-      // hostnames are always lower case.
-      this.hostname = this.hostname.toLowerCase();
-    }
+		// validate a little.
+		if (!ipv6Hostname) {
+			var hostparts = this.hostname.split(/\./);
+			for (var i = 0, l = hostparts.length; i < l; i++) {
+				var part = hostparts[i];
+				if (!part) continue;
+				if (!part.match(hostnamePartPattern)) {
+					var newpart = '';
+					for (var j = 0, k = part.length; j < k; j++) {
+						if (part.charCodeAt(j) > 127) {
+							// we replace non-ASCII char with a temporary placeholder
+							// we need this to make sure size of hostname is not
+							// broken by replacing non-ASCII by nothing
+							newpart += 'x';
+						} else {
+							newpart += part[j];
+						}
+					}
+					// we test again with ASCII char only
+					if (!newpart.match(hostnamePartPattern)) {
+						var validParts = hostparts.slice(0, i);
+						var notHost = hostparts.slice(i + 1);
+						var bit = part.match(hostnamePartStart);
+						if (bit) {
+							validParts.push(bit[1]);
+							notHost.unshift(bit[2]);
+						}
+						if (notHost.length) {
+							rest = '/' + notHost.join('.') + rest;
+						}
+						this.hostname = validParts.join('.');
+						break;
+					}
+				}
+			}
+		}
 
-    if (!ipv6Hostname) {
-      // IDNA Support: Returns a puny coded representation of "domain".
-      // It only converts the part of the domain name that
-      // has non ASCII characters. I.e. it dosent matter if
-      // you call it with a domain that already is in ASCII.
-      var domainArray = this.hostname.split('.');
-      var newOut = [];
-      for (var i = 0; i < domainArray.length; ++i) {
-        var s = domainArray[i];
-        newOut.push(s.match(/[^A-Za-z0-9_-]/) ?
-            'xn--' + punycode.encode(s) : s);
-      }
-      this.hostname = newOut.join('.');
-    }
+		if (this.hostname.length > hostnameMaxLen) {
+			this.hostname = '';
+		} else {
+			// hostnames are always lower case.
+			this.hostname = this.hostname.toLowerCase();
+		}
 
-    var p = this.port ? ':' + this.port : '';
-    var h = this.hostname || '';
-    this.host = h + p;
-    this.href += this.host;
+		if (!ipv6Hostname) {
+			// IDNA Support: Returns a puny coded representation of "domain".
+			// It only converts the part of the domain name that
+			// has non ASCII characters. I.e. it dosent matter if
+			// you call it with a domain that already is in ASCII.
+			var domainArray = this.hostname.split('.');
+			var newOut = [];
+			for (var i = 0; i < domainArray.length; ++i) {
+				var s = domainArray[i];
+				newOut.push(s.match(/[^A-Za-z0-9_-]/) ?
+						'xn--' + punycode.encode(s) : s);
+			}
+			this.hostname = newOut.join('.');
+		}
 
-    // strip [ and ] from the hostname
-    // the host field still retains them, though
-    if (ipv6Hostname) {
-      this.hostname = this.hostname.substr(1, this.hostname.length - 2);
-      if (rest[0] !== '/') {
-        rest = '/' + rest;
-      }
-    }
-  }
+		var p = this.port ? ':' + this.port : '';
+		var h = this.hostname || '';
+		this.host = h + p;
+		this.href += this.host;
 
-  // now rest is set to the post-host stuff.
-  // chop off any delim chars.
-  if (!unsafeProtocol[lowerProto]) {
+		// strip [ and ] from the hostname
+		// the host field still retains them, though
+		if (ipv6Hostname) {
+			this.hostname = this.hostname.substr(1, this.hostname.length - 2);
+			if (rest[0] !== '/') {
+				rest = '/' + rest;
+			}
+		}
+	}
 
-    // First, make 100% sure that any "autoEscape" chars get
-    // escaped, even if encodeURIComponent doesn't think they
-    // need to be.
-    for (var i = 0, l = autoEscape.length; i < l; i++) {
-      var ae = autoEscape[i];
-      var esc = encodeURIComponent(ae);
-      if (esc === ae) {
-        esc = escape(ae);
-      }
-      rest = rest.split(ae).join(esc);
-    }
-  }
+	// now rest is set to the post-host stuff.
+	// chop off any delim chars.
+	if (!unsafeProtocol[lowerProto]) {
+
+		// First, make 100% sure that any "autoEscape" chars get
+		// escaped, even if encodeURIComponent doesn't think they
+		// need to be.
+		for (var i = 0, l = autoEscape.length; i < l; i++) {
+			var ae = autoEscape[i];
+			var esc = encodeURIComponent(ae);
+			if (esc === ae) {
+				esc = escape(ae);
+			}
+			rest = rest.split(ae).join(esc);
+		}
+	}
 
 
-  // chop off from the tail first.
-  var hash = rest.indexOf('#');
-  if (hash !== -1) {
-    // got a fragment string.
-    this.hash = rest.substr(hash);
-    rest = rest.slice(0, hash);
-  }
-  var qm = rest.indexOf('?');
-  if (qm !== -1) {
-    this.search = rest.substr(qm);
-    this.query = rest.substr(qm + 1);
-    if (parseQueryString) {
-      this.query = querystring.parse(this.query);
-    }
-    rest = rest.slice(0, qm);
-  } else if (parseQueryString) {
-    // no query string, but parseQueryString still requested
-    this.search = '';
-    this.query = {};
-  }
-  if (rest) this.pathname = rest;
-  if (slashedProtocol[proto] &&
-      this.hostname && !this.pathname) {
-    this.pathname = '/';
-  }
+	// chop off from the tail first.
+	var hash = rest.indexOf('#');
+	if (hash !== -1) {
+		// got a fragment string.
+		this.hash = rest.substr(hash);
+		rest = rest.slice(0, hash);
+	}
+	var qm = rest.indexOf('?');
+	if (qm !== -1) {
+		this.search = rest.substr(qm);
+		this.query = rest.substr(qm + 1);
+		if (parseQueryString) {
+			this.query = querystring.parse(this.query);
+		}
+		rest = rest.slice(0, qm);
+	} else if (parseQueryString) {
+		// no query string, but parseQueryString still requested
+		this.search = '';
+		this.query = {};
+	}
+	if (rest) this.pathname = rest;
+	if (slashedProtocol[proto.replace(":", "")] &&
+			this.hostname && !this.pathname) {
+		this.pathname = '/';
+	}
 
-  //to support http.request
-  if (this.pathname || this.search) {
-    var p = this.pathname || '';
-    var s = this.search || '';
-    this.path = p + s;
-  }
+	//to support http.request
+	if (this.pathname || this.search) {
+		var p = this.pathname || '';
+		var s = this.search || '';
+		this.path = p + s;
+	}
 
-  // finally, reconstruct the href based on what has been validated.
-  this.href = this.format();
-  return this;
+	// finally, reconstruct the href based on what has been validated.
+	this.href = this.format();
+	return this;
 };
 
 // format a parsed object into a url string
 function urlFormat(obj) {
-  // ensure it's an object, and not a string url.
-  // If it's an obj, this is a no-op.
-  // this way, you can call url_format() on strings
-  // to clean up potentially wonky urls.
-  if (typeof(obj) === 'string') obj = urlParse(obj);
-  if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
-  return obj.format();
+	// ensure it's an object, and not a string url.
+	// If it's an obj, this is a no-op.
+	// this way, you can call url_format() on strings
+	// to clean up potentially wonky urls.
+	if (typeof(obj) === 'string') obj = urlParse(obj);
+	if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
+	return obj.format();
 }
 
 Url.prototype.format = function() {
-  var auth = this.auth || '';
-  if (auth) {
-    auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ':');
-    auth += '@';
-  }
+	var auth = this.auth || '';
+	if (auth) {
+		auth = encodeURIComponent( auth );
+		auth = auth.replace(/%3A/i, ':');
+		auth += '@';
+	}
 
-  var protocol = this.protocol || '',
-      pathname = this.pathname || '',
-      hash = this.hash || '',
-      host = false,
-      query = '';
+	var protocol = this.protocol || '',
+		pathname = this.pathname || '',
+		hash = this.hash || '',
+		host = false,
+		query = '';
 
-  if (this.host) {
-    host = auth + this.host;
-  } else if (this.hostname) {
-    host = auth + (this.hostname.indexOf(':') === -1 ?
-        this.hostname :
-        '[' + this.hostname + ']');
-    if (this.port) {
-      host += ':' + this.port;
-    }
-  }
+	if (this.host) {
+		host = auth + this.host;
+	} else if ( this.hostname ) {
+		host = auth + ( this.hostname.indexOf(':') === -1 ?
+				this.hostname :
+				'[' + this.hostname + ']'); // Ha??
+		if (this.port) {
+			host += ':' + this.port;
+		}
+	}
 
-  if (this.query && typeof this.query === 'object' &&
-      Object.keys(this.query).length) {
-    query = querystring.stringify(this.query);
-  }
+	if (this.query && typeof this.query === 'object' &&
+			Object.keys(this.query).length) {
+		query = querystring.stringify(this.query);
+	}
 
-  var search = this.search || (query && ('?' + query)) || '';
+	var search = this.search || (query && ('?' + query)) || '';
 
-  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
+	if (protocol && protocol.substr(-1) !== ':') protocol += ':';
 
-  // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
-  // unless they had them to begin with.
-  if (this.slashes ||
-      (!protocol || slashedProtocol[protocol]) && host !== false) {
-    host = '//' + (host || '');
-    if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
-  } else if (!host) {
-    host = '';
-  }
+	// only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
+	// unless they had them to begin with.
+	if (this.slashes ||
+			(!protocol || slashedProtocol[ protocol.replace(":", "") ]) && host !== false) {
+		host = '//' + (host || '');
+		if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
+	} else if (!host) {
+		host = '';
+	}
 
-  if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
-  if (search && search.charAt(0) !== '?') search = '?' + search;
+	if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
+	if (search && search.charAt(0) !== '?') search = '?' + search;
 
-  pathname = pathname.replace(/[?#]/g, function(match) {
-    return encodeURIComponent(match);
-  });
-  search = search.replace('#', '%23');
+	pathname = pathname.replace(/[?#]/g, function(match) {
+		return encodeURIComponent(match);
+	});
+	search = search.replace('#', '%23');
 
-  return protocol + host + pathname + search + hash;
+	return protocol + host + pathname + search + hash;
 };
 
 function urlResolve(source, relative) {
-  return urlParse(source, false, true).resolve(relative);
+	return urlParse(source, false, true).resolve(relative);
 }
 
 Url.prototype.resolve = function(relative) {
-  return this.resolveObject(urlParse(relative, false, true)).format();
+	return this.resolveObject(urlParse(relative, false, true)).format();
 };
 
 function urlResolveObject(source, relative) {
-  if (!source) return relative;
-  return urlParse(source, false, true).resolveObject(relative);
+	if (!source) return relative;
+	return urlParse(source, false, true).resolveObject(relative);
 }
 
 Url.prototype.resolveObject = function(relative) {
-  if (typeof relative === 'string') {
-    var rel = new Url();
-    rel.parse(relative, false, true);
-    relative = rel;
-  }
+	if (typeof relative === 'string') {
+		var rel = new Url();
+		rel.parse(relative, false, true);
+		relative = rel;
+	}
 
-  var result = new Url();
-  Object.keys(this).forEach(function(k) {
-    result[k] = this[k];
-  }, this);
+	var result = new Url();
+	Object.keys(this).forEach(function(k) {
+		result[k] = this[k];
+	}, this);
 
-  // hash is always overridden, no matter what.
-  // even href="" will remove it.
-  result.hash = relative.hash;
+	// hash is always overridden, no matter what.
+	// even href="" will remove it.
+	result.hash = relative.hash;
 
-  // if the relative url is empty, then there's nothing left to do here.
-  if (relative.href === '') {
-    result.href = result.format();
-    return result;
-  }
+	// if the relative url is empty, then there's nothing left to do here.
+	if (relative.href === '') {
+		result.href = result.format();
+		return result;
+	}
 
-  // hrefs like //foo/bar always cut to the protocol.
-  if (relative.slashes && !relative.protocol) {
-    // take everything except the protocol from relative
-    Object.keys(relative).forEach(function(k) {
-      if (k !== 'protocol')
-        result[k] = relative[k];
-    });
+	// hrefs like //foo/bar always cut to the protocol.
+	if (relative.slashes && !relative.protocol) {
+		// take everything except the protocol from relative
+		Object.keys(relative).forEach(function(k) {
+			if (k !== 'protocol')
+				result[k] = relative[k];
+		});
 
-    //urlParse appends trailing / to urls like http://www.example.com
-    if (slashedProtocol[result.protocol] &&
-        result.hostname && !result.pathname) {
-      result.path = result.pathname = '/';
-    }
+		//urlParse appends trailing / to urls like http://www.example.com
+		if (slashedProtocol[result.protocol.replace(":", "")] &&
+				result.hostname && !result.pathname) {
+			result.path = result.pathname = '/';
+		}
 
-    result.href = result.format();
-    return result;
-  }
+		result.href = result.format();
+		return result;
+	}
 
-  if (relative.protocol && relative.protocol !== result.protocol) {
-    // if it's a known url protocol, then changing
-    // the protocol does weird things
-    // first, if it's not file:, then we MUST have a host,
-    // and if there was a path
-    // to begin with, then we MUST have a path.
-    // if it is file:, then the host is dropped,
-    // because that's known to be hostless.
-    // anything else is assumed to be absolute.
-    if (!slashedProtocol[relative.protocol]) {
-      Object.keys(relative).forEach(function(k) {
-        result[k] = relative[k];
-      });
-      result.href = result.format();
-      return result;
-    }
+	if (relative.protocol && relative.protocol !== result.protocol) {
+		// if it's a known url protocol, then changing
+		// the protocol does weird things
+		// first, if it's not file:, then we MUST have a host,
+		// and if there was a path
+		// to begin with, then we MUST have a path.
+		// if it is file:, then the host is dropped,
+		// because that's known to be hostless.
+		// anything else is assumed to be absolute.
+		if (!slashedProtocol[relative.protocol.replace(":", "")]) {
+			Object.keys(relative).forEach(function(k) {
+				result[k] = relative[k];
+			});
+			result.href = result.format();
+			return result;
+		}
 
-    result.protocol = relative.protocol;
-    if (!relative.host && !hostlessProtocol[relative.protocol]) {
-      var relPath = (relative.pathname || '').split('/');
-      while (relPath.length && !(relative.host = relPath.shift()));
-      if (!relative.host) relative.host = '';
-      if (!relative.hostname) relative.hostname = '';
-      if (relPath[0] !== '') relPath.unshift('');
-      if (relPath.length < 2) relPath.unshift('');
-      result.pathname = relPath.join('/');
-    } else {
-      result.pathname = relative.pathname;
-    }
-    result.search = relative.search;
-    result.query = relative.query;
-    result.host = relative.host || '';
-    result.auth = relative.auth;
-    result.hostname = relative.hostname || relative.host;
-    result.port = relative.port;
-    // to support http.request
-    if (result.pathname || result.search) {
-      var p = result.pathname || '';
-      var s = result.search || '';
-      result.path = p + s;
-    }
-    result.slashes = result.slashes || relative.slashes;
-    result.href = result.format();
-    return result;
-  }
+		result.protocol = relative.protocol;
+		if (!relative.host && !hostlessProtocol[relative.protocol]) {
+			var relPath = (relative.pathname || '').split('/');
+			while (relPath.length && !(relative.host = relPath.shift()));
+			if (!relative.host) relative.host = '';
+			if (!relative.hostname) relative.hostname = '';
+			if (relPath[0] !== '') relPath.unshift('');
+			if (relPath.length < 2) relPath.unshift('');
+			result.pathname = relPath.join('/');
+		} else {
+			result.pathname = relative.pathname;
+		}
+		result.search = relative.search;
+		result.query = relative.query;
+		result.host = relative.host || '';
+		result.auth = relative.auth;
+		result.hostname = relative.hostname || relative.host;
+		result.port = relative.port;
+		// to support http.request
+		if (result.pathname || result.search) {
+			var p = result.pathname || '';
+			var s = result.search || '';
+			result.path = p + s;
+		}
+		result.slashes = result.slashes || relative.slashes;
+		result.href = result.format();
+		return result;
+	}
 
-  var isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/'),
-      isRelAbs = (
-          relative.host ||
-          relative.pathname && relative.pathname.charAt(0) === '/'
-      ),
-      mustEndAbs = (isRelAbs || isSourceAbs ||
-                    (result.host && relative.pathname)),
-      removeAllDots = mustEndAbs,
-      srcPath = result.pathname && result.pathname.split('/') || [],
-      relPath = relative.pathname && relative.pathname.split('/') || [],
-      psychotic = result.protocol && !slashedProtocol[result.protocol];
+	var isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/'),
+			isRelAbs = (
+					relative.host ||
+					relative.pathname && relative.pathname.charAt(0) === '/'
+			),
+			mustEndAbs = (isRelAbs || isSourceAbs ||
+										(result.host && relative.pathname)),
+			removeAllDots = mustEndAbs,
+			srcPath = result.pathname && result.pathname.split('/') || [],
+			relPath = relative.pathname && relative.pathname.split('/') || [],
+			psychotic = result.protocol && !slashedProtocol[result.protocol.replace(":", "")];
 
-  // if the url is a non-slashed url, then relative
-  // links like ../.. should be able
-  // to crawl up to the hostname, as well.  This is strange.
-  // result.protocol has already been set by now.
-  // Later on, put the first path part into the host field.
-  if (psychotic) {
-    result.hostname = '';
-    result.port = null;
-    if (result.host) {
-      if (srcPath[0] === '') srcPath[0] = result.host;
-      else srcPath.unshift(result.host);
-    }
-    result.host = '';
-    if (relative.protocol) {
-      relative.hostname = null;
-      relative.port = null;
-      if (relative.host) {
-        if (relPath[0] === '') relPath[0] = relative.host;
-        else relPath.unshift(relative.host);
-      }
-      relative.host = null;
-    }
-    mustEndAbs = mustEndAbs && (relPath[0] === '' || srcPath[0] === '');
-  }
+	// if the url is a non-slashed url, then relative
+	// links like ../.. should be able
+	// to crawl up to the hostname, as well.  This is strange.
+	// result.protocol has already been set by now.
+	// Later on, put the first path part into the host field.
+	if (psychotic) {
+		result.hostname = '';
+		result.port = null;
+		if (result.host) {
+			if (srcPath[0] === '') srcPath[0] = result.host;
+			else srcPath.unshift(result.host);
+		}
+		result.host = '';
+		if (relative.protocol) {
+			relative.hostname = null;
+			relative.port = null;
+			if (relative.host) {
+				if (relPath[0] === '') relPath[0] = relative.host;
+				else relPath.unshift(relative.host);
+			}
+			relative.host = null;
+		}
+		mustEndAbs = mustEndAbs && (relPath[0] === '' || srcPath[0] === '');
+	}
 
-  if (isRelAbs) {
-    // it's absolute.
-    result.host = (relative.host || relative.host === '') ?
-                  relative.host : result.host;
-    result.hostname = (relative.hostname || relative.hostname === '') ?
-                      relative.hostname : result.hostname;
-    result.search = relative.search;
-    result.query = relative.query;
-    srcPath = relPath;
-    // fall through to the dot-handling below.
-  } else if (relPath.length) {
-    // it's relative
-    // throw away the existing file, and take the new path instead.
-    if (!srcPath) srcPath = [];
-    srcPath.pop();
-    srcPath = srcPath.concat(relPath);
-    result.search = relative.search;
-    result.query = relative.query;
-  } else if (relative.search !== null && relative.search !== undefined) {
-    // just pull out the search.
-    // like href='?foo'.
-    // Put this after the other two cases because it simplifies the booleans
-    if (psychotic) {
-      result.hostname = result.host = srcPath.shift();
-      //occationaly the auth can get stuck only in host
-      //this especialy happens in cases like
-      //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-      var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                       result.host.split('@') : false;
-      if (authInHost) {
-        result.auth = authInHost.shift();
-        result.host = result.hostname = authInHost.shift();
-      }
-    }
-    result.search = relative.search;
-    result.query = relative.query;
-    //to support http.request
-    if (result.pathname !== null || result.search !== null) {
-      result.path = (result.pathname ? result.pathname : '') +
-                    (result.search ? result.search : '');
-    }
-    result.href = result.format();
-    return result;
-  }
+	if (isRelAbs) {
+		// it's absolute.
+		result.host = (relative.host || relative.host === '') ?
+									relative.host : result.host;
+		result.hostname = (relative.hostname || relative.hostname === '') ?
+											relative.hostname : result.hostname;
+		result.search = relative.search;
+		result.query = relative.query;
+		srcPath = relPath;
+		// fall through to the dot-handling below.
+	} else if (relPath.length) {
+		// it's relative
+		// throw away the existing file, and take the new path instead.
+		if (!srcPath) srcPath = [];
+		srcPath.pop();
+		srcPath = srcPath.concat(relPath);
+		result.search = relative.search;
+		result.query = relative.query;
+	} else if (relative.search !== null && relative.search !== undefined) {
+		// just pull out the search.
+		// like href='?foo'.
+		// Put this after the other two cases because it simplifies the booleans
+		if (psychotic) {
+			result.hostname = result.host = srcPath.shift();
+			//occationaly the auth can get stuck only in host
+			//this especialy happens in cases like
+			//url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+			var authInHost = result.host && result.host.indexOf('@') > 0 ?
+											 result.host.split('@') : false;
+			if (authInHost) {
+				result.auth = authInHost.shift();
+				result.host = result.hostname = authInHost.shift();
+			}
+		}
+		result.search = relative.search;
+		result.query = relative.query;
+		//to support http.request
+		if (result.pathname !== null || result.search !== null) {
+			result.path = (result.pathname ? result.pathname : '') +
+										(result.search ? result.search : '');
+		}
+		result.href = result.format();
+		return result;
+	}
 
-  if (!srcPath.length) {
-    // no path at all.  easy.
-    // we've already handled the other stuff above.
-    result.pathname = null;
-    //to support http.request
-    if (result.search) {
-      result.path = '/' + result.search;
-    } else {
-      result.path = null;
-    }
-    result.href = result.format();
-    return result;
-  }
+	if (!srcPath.length) {
+		// no path at all.  easy.
+		// we've already handled the other stuff above.
+		result.pathname = null;
+		//to support http.request
+		if (result.search) {
+			result.path = '/' + result.search;
+		} else {
+			result.path = null;
+		}
+		result.href = result.format();
+		return result;
+	}
 
-  // if a url ENDs in . or .., then it must get a trailing slash.
-  // however, if it ends in anything else non-slashy,
-  // then it must NOT get a trailing slash.
-  var last = srcPath.slice(-1)[0];
-  var hasTrailingSlash = (
-      (result.host || relative.host) && (last === '.' || last === '..') ||
-      last === '');
+	// if a url ENDs in . or .., then it must get a trailing slash.
+	// however, if it ends in anything else non-slashy,
+	// then it must NOT get a trailing slash.
+	var last = srcPath.slice(-1)[0];
+	var hasTrailingSlash = (
+			(result.host || relative.host) && (last === '.' || last === '..') ||
+			last === '');
 
-  // strip single dots, resolve double dots to parent dir
-  // if the path tries to go above the root, `up` ends up > 0
-  var up = 0;
-  for (var i = srcPath.length; i >= 0; i--) {
-    last = srcPath[i];
-    if (last == '.') {
-      srcPath.splice(i, 1);
-    } else if (last === '..') {
-      srcPath.splice(i, 1);
-      up++;
-    } else if (up) {
-      srcPath.splice(i, 1);
-      up--;
-    }
-  }
+	// strip single dots, resolve double dots to parent dir
+	// if the path tries to go above the root, `up` ends up > 0
+	var up = 0;
+	for (var i = srcPath.length; i >= 0; i--) {
+		last = srcPath[i];
+		if (last == '.') {
+			srcPath.splice(i, 1);
+		} else if (last === '..') {
+			srcPath.splice(i, 1);
+			up++;
+		} else if (up) {
+			srcPath.splice(i, 1);
+			up--;
+		}
+	}
 
-  // if the path is allowed to go above the root, restore leading ..s
-  if (!mustEndAbs && !removeAllDots) {
-    for (; up--; up) {
-      srcPath.unshift('..');
-    }
-  }
+	// if the path is allowed to go above the root, restore leading ..s
+	if (!mustEndAbs && !removeAllDots) {
+		for (; up--; up) {
+			srcPath.unshift('..');
+		}
+	}
 
-  if (mustEndAbs && srcPath[0] !== '' &&
-      (!srcPath[0] || srcPath[0].charAt(0) !== '/')) {
-    srcPath.unshift('');
-  }
+	if (mustEndAbs && srcPath[0] !== '' &&
+			(!srcPath[0] || srcPath[0].charAt(0) !== '/')) {
+		srcPath.unshift('');
+	}
 
-  if (hasTrailingSlash && (srcPath.join('/').substr(-1) !== '/')) {
-    srcPath.push('');
-  }
+	if (hasTrailingSlash && (srcPath.join('/').substr(-1) !== '/')) {
+		srcPath.push('');
+	}
 
-  var isAbsolute = srcPath[0] === '' ||
-      (srcPath[0] && srcPath[0].charAt(0) === '/');
+	var isAbsolute = srcPath[0] === '' ||
+			(srcPath[0] && srcPath[0].charAt(0) === '/');
 
-  // put the host back
-  if (psychotic) {
-    result.hostname = result.host = isAbsolute ? '' :
-                                    srcPath.length ? srcPath.shift() : '';
-    //occationaly the auth can get stuck only in host
-    //this especialy happens in cases like
-    //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-    var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                     result.host.split('@') : false;
-    if (authInHost) {
-      result.auth = authInHost.shift();
-      result.host = result.hostname = authInHost.shift();
-    }
-  }
+	// put the host back
+	if (psychotic) {
+		result.hostname = result.host = isAbsolute ? '' :
+																		srcPath.length ? srcPath.shift() : '';
+		//occationaly the auth can get stuck only in host
+		//this especialy happens in cases like
+		//url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+		var authInHost = result.host && result.host.indexOf('@') > 0 ?
+										 result.host.split('@') : false;
+		if (authInHost) {
+			result.auth = authInHost.shift();
+			result.host = result.hostname = authInHost.shift();
+		}
+	}
 
-  mustEndAbs = mustEndAbs || (result.host && srcPath.length);
+	mustEndAbs = mustEndAbs || (result.host && srcPath.length);
 
-  if (mustEndAbs && !isAbsolute) {
-    srcPath.unshift('');
-  }
+	if (mustEndAbs && !isAbsolute) {
+		srcPath.unshift('');
+	}
 
-  if (!srcPath.length) {
-    result.pathname = null;
-    result.path = null;
-  } else {
-    result.pathname = srcPath.join('/');
-  }
+	if (!srcPath.length) {
+		result.pathname = null;
+		result.path = null;
+	} else {
+		result.pathname = srcPath.join('/');
+	}
 
-  //to support request.http
-  if (result.pathname !== null || result.search !== null) {
-    result.path = (result.pathname ? result.pathname : '') +
-                  (result.search ? result.search : '');
-  }
-  result.auth = relative.auth || result.auth;
-  result.slashes = result.slashes || relative.slashes;
-  result.href = result.format();
-  return result;
+	//to support request.http
+	if (result.pathname !== null || result.search !== null) {
+		result.path = (result.pathname ? result.pathname : '') +
+									(result.search ? result.search : '');
+	}
+	result.auth = relative.auth || result.auth;
+	result.slashes = result.slashes || relative.slashes;
+	result.href = result.format();
+	return result;
 };
 
 Url.prototype.parseHost = function() {
-  var host = this.host;
-  var port = portPattern.exec(host);
-  if (port) {
-    port = port[0];
-    if (port !== ':') {
-      this.port = port.substr(1);
-    }
-    host = host.substr(0, host.length - port.length);
-  }
-  if (host) this.hostname = host;
+	var host = this.host;
+	var port = portPattern.exec(host);
+	if (port) {
+		port = port[0];
+		if (port !== ':') {
+			this.port = port.substr(1);
+		}
+		host = host.substr(0, host.length - port.length);
+	}
+	if (host) this.hostname = host;
 };


### PR DESCRIPTION
There is a problem of detecting multiple protocols in the library URL. With a small, changes will be solved here are the changes. These are the protocols, which were given support

http, http, ftp, gophe, file, mongodb, chrome, bolo, chrome-extension, aaa, acap, adiumxtra, aw, beshare, content, crid, cvs, dict, ed2k, facetime, feed, finger, fish, git, go, hcp, imap, irc, irc6, ircs, jar, lastfm, ldap, ldaps, market, ms-help, mumble, nntp, pop, reload, res, resource, rmi, rsync, rtmp, secondlife, sgn, smb, snmp, soldat, ssh, teamspeak, telnet, udp, unreal, ut2004, ventrilo, wais, wtai, wyciwyg, xri, z39.50r, z39.50s and coap.

The truth is not whether to place the support for "Git", or that would modify but with this commit it would improve a lot the Library URL.
