### PR TITLE
doc: Remove `bufferSize` option

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -650,7 +650,6 @@ Returns a new ReadStream object (See `Readable Stream`).
       encoding: null,
       fd: null,
       mode: 0666,
-      bufferSize: 64 * 1024,
       autoClose: true
     }
 


### PR DESCRIPTION
`bufferSize` option has been removed
in b0f6789a78dbb14778769d1d76b195c2fcd8a340
