### PR TITLE
Whitelist support

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -62,6 +62,11 @@ and servers.
 
   --max-stack-size=val   set max v8 stack size (bytes)
 
+  --whitelist arg        control native function access
+
+  --show-whitelist-err   show values that are resolved but
+                         fail to pass the whitelist filter.
+
 
 .SH ENVIRONMENT VARIABLES
 
@@ -438,6 +443,80 @@ If set to 1 then colors will not be used in the REPL.
         type: string  default: v8.log
   --ll_prof (Enable low-level linux profiler.)
         type: bool  default: false
+
+.SH WHITELIST
+
+Whitelists are an attack vector reduction strategy
+implemented as a list of fully-qualified native value
+names that may be accessed from Javascript.
+
+If used, any natively generated value that is not in
+the defined whitelist will be reset to a default
+value for that datatype.
+
+In the whitelist, value names are terminated by ';',
+and no spacing or formatting is permitted in the
+whitelist string.
+
+Note that whitelisting is an advanced functionality
+that gives you detailed control over all interactions
+between the native and javascript components within
+NodeJS. If used incorrectly, a faulty whitelist may 
+cause errors within NodeJS internals or result in 
+NodeJS refusing to start altogether.
+
+.SH WHITELIST EXAMPLES
+
+To allow access to values in a module explicitly,
+identify the values with a fully-qualified name:
+
+  node --whitelist "evals.Context;evals.NodeScript;"
+
+To allow access to all values defined in a native module,
+use a wildcard for that module path:
+
+  node --whitelist "constants.*;"
+
+A minimal non-wildcarded list of values to get nodeJS
+to start in repl-mode is as follows:
+
+  buffer.setFastBufferConstructor;
+  buffer.SlowBuffer.makeFastBuffer;
+  evals.NodeScript.runInThisContext;
+  natives._linklist;
+  natives._stream_duplex;
+  natives._stream_readable;
+  natives._stream_writable;
+  natives.assert;
+  natives.buffer;
+  natives.config;
+  natives.console;
+  natives.domain;
+  natives.events;
+  natives.fs;
+  natives.module;
+  natives.net;
+  natives.path;
+  natives.repl;
+  natives.readline;
+  natives.stream;
+  natives.string_decoder;
+  natives.timers;
+  natives.tty;
+  natives.util;
+  natives.vm;
+  process._needTickCallback;
+  process._setupDomainUse;
+  process.argv;
+  process.binding;
+  process.cwd;
+  signal_wrap.Signal;
+  tty_wrap.isTTY;
+  tty_wrap.guessHandleType;
+  tty_wrap.TTY;
+
+It is not guaranteed that this set is sufficient to
+allow NodeJS to execute as expected in all use cases.
 
 .SH RESOURCES AND DOCUMENTATION
 

--- a/test/simple/test-whitelist-flags.js
+++ b/test/simple/test-whitelist-flags.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var execFile = require('child_process').execFile;
+var node = process.execPath;
+
+var normal = ["-e", "console.log(\"ok\");"];
+var binding = ["-e", "require(\"http\");"];
+var whiteOk = ['--whitelist', 'natives.*;evals.*;process.*;'
+    +'buffer.*;tty_wrap.*;pipe_wrap.*;constants.*;timer_wrap.*'
+    +';cares_wrap.*;signal_wrap.*;'].concat(normal);
+var whiteShow = ['--show-whitelist-err', '--whitelist', whiteOk[1]]
+        .concat(binding);
+var whiteShowSub = ['--show-whitelist-err', '--whitelist',
+    whiteOk[1]+'http_parser.HTTPParser;'].concat(binding);
+
+//Since this is a whitelist test, it relies on which native modules are
+//loaded during the startup process. If the startup chain or the
+//http_parser value order changes, these tests may need to be updated..
+
+execFile(node, normal, function(er, stdout, stderr) {
+  console.error('normal: show normal output');
+  assert.equal(er, null);
+  assert.equal(stdout, 'ok\n');
+  assert.equal(stderr, '');
+  console.log('normal ok');
+});
+execFile(node, whiteOk, function(er, stdout, stderr) {
+  console.error('--whitelist: function is whitelisted');
+  assert.equal(er, null);
+  assert.equal(stdout, 'ok\n');
+  assert.equal(stderr, '');
+  console.log('whiteok ok');
+});
+execFile(node, whiteShow, function(er, stdout, stderr) {
+  console.error('--show-whitelist-err: identify blacklisted values');
+  assert.equal(er, null);
+  assert.equal(stdout, '');
+  assert.equal(stderr, 'Value http_parser.HTTPParser not in whitelist.\n');
+  console.log('whiteshow ok');
+});
+execFile(node, whiteShowSub, function(er, stdout, stderr) {
+  console.error('--show-whitelist-err: whitelist single element');
+  console.log(whiteOk[1]+'http_parser.HTTPParser;');
+  assert.equal(er, null);
+  assert.equal(stdout, '');
+  assert.equal(stderr, 'Value http_parser.HTTPParser.REQUEST not in whitelist.\n'+
+                       'Value http_parser.HTTPParser.RESPONSE not in whitelist.\n');
+  console.log('whiteshowsub ok');
+});


### PR DESCRIPTION
This patch provides granular native API-whitelisting support to NodeJS, which can be used to implement attack vector minimization solutions for both core NodeJS APIs and extension APIs, to reduce volatility when insecure scripts are executed in a NodeJS environment, or when parts of a NodeJS environment is compromised due to unresolved security issues.

The whitelist is activated by use of a "--whitelist arg" flag, and will prevent access to any native API not specified in the whitelist. 

The whitelist itself is a set of semi-colon delimited value names or wildcards on the form "a.b.c;a.c.*;" and covers all APIs constructed via Binding, DLOpen, and SetupProcessObject by traversing the returned export object and matching value names to the provided filter specification.
