### PR TITLE
src: preliminary update to new Persistent API

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -275,7 +275,8 @@ class QueryWrap {
   QueryWrap() {
     HandleScope scope(node_isolate);
 
-    object_ = Persistent<Object>::New(node_isolate, Object::New());
+    Persistent<Object> o_(node_isolate, Object::New());
+    object_ = o_;
   }
 
   virtual ~QueryWrap() {

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -74,9 +74,8 @@ void FSEventWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "start", Start);
   NODE_SET_PROTOTYPE_METHOD(t, "close", Close);
 
-  target->Set(String::NewSymbol("FSEvent"),
-              Persistent<FunctionTemplate>::New(node_isolate,
-                                                t)->GetFunction());
+  Persistent<FunctionTemplate> tft(node_isolate, t);
+  target->Set(String::NewSymbol("FSEvent"), tft->GetFunction());
 
   change_sym = NODE_PSYMBOL("change");
   onchange_sym = NODE_PSYMBOL("onchange");

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -113,7 +113,8 @@ HandleWrap::HandleWrap(Handle<Object> object, uv_handle_t* h) {
   HandleScope scope(node_isolate);
   assert(object_.IsEmpty());
   assert(object->InternalFieldCount() > 0);
-  object_ = v8::Persistent<v8::Object>::New(node_isolate, object);
+  Persistent<Object> o_(node_isolate, object);
+  object_ = o_;
   object_->SetAlignedPointerInInternalField(0, this);
   ngx_queue_insert_tail(&handle_wrap_queue, &handle_wrap_queue_);
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -878,7 +878,8 @@ Handle<Value> SetupDomainUse(const Arguments& args) {
   Local<Function> ndt = ndt_v.As<Function>();
   process->Set(String::New("_tickCallback"), tdc);
   process->Set(String::New("nextTick"), ndt);
-  process_tickCallback = Persistent<Function>::New(node_isolate, tdc);
+  Persistent<Function> ptc(node_isolate, tdc);
+  process_tickCallback = ptc;
   return Undefined(node_isolate);
 }
 
@@ -972,7 +973,8 @@ MakeCallback(const Handle<Object> object,
       abort();
     }
     Local<Function> cb = cb_v.As<Function>();
-    process_tickCallback = Persistent<Function>::New(node_isolate, cb);
+    Persistent<Function> ptc(node_isolate, cb);
+    process_tickCallback = ptc;
   }
 
   TryCatch try_catch;
@@ -1913,7 +1915,8 @@ static Handle<Value> Binding(const Arguments& args) {
   node_module_struct* modp;
 
   if (binding_cache.IsEmpty()) {
-    binding_cache = Persistent<Object>::New(node_isolate, Object::New());
+    Persistent<Object> bc(node_isolate, Object::New());
+    binding_cache = bc;
   }
 
   Local<Object> exports;
@@ -2200,8 +2203,9 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
   process_template->SetClassName(String::NewSymbol("process"));
 
-  process = Persistent<Object>::New(node_isolate,
-                                process_template->GetFunction()->NewInstance());
+  Persistent<Object> p(node_isolate,
+                       process_template->GetFunction()->NewInstance());
+  process = p;
 
   process->SetAccessor(String::New("title"),
                        ProcessTitleGetter,
@@ -2211,7 +2215,8 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   process->Set(String::NewSymbol("version"), String::New(NODE_VERSION));
 
   // process.moduleLoadList
-  module_load_list = Persistent<Array>::New(node_isolate, Array::New());
+  Persistent<Array> mll(node_isolate, Array::New());
+  module_load_list = mll;
   process->Set(String::NewSymbol("moduleLoadList"), module_load_list);
 
   // process.versions

--- a/src/node.h
+++ b/src/node.h
@@ -97,6 +97,7 @@ v8::Handle<v8::Object> SetupProcessObject(int argc, char *argv[]);
 void Load(v8::Handle<v8::Object> process);
 void EmitExit(v8::Handle<v8::Object> process);
 
+// TODO(trevnorris): not sure how to handle this case
 #define NODE_PSYMBOL(s) \
   v8::Persistent<v8::String>::New(node_isolate, v8::String::NewSymbol(s))
 
@@ -152,6 +153,7 @@ NODE_EXTERN ssize_t DecodeWrite(char *buf,
 v8::Local<v8::Object> BuildStatsObject(const uv_stat_t* s);
 
 
+// TODO(trevnorris): this isn't used. can it be removed?
 static inline v8::Persistent<v8::Function>* cb_persist(
     const v8::Local<v8::Value> &v) {
   v8::Persistent<v8::Function> *fn = new v8::Persistent<v8::Function>();

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -145,7 +145,7 @@ Buffer::Buffer(Handle<Object> wrapper, size_t length) : ObjectWrap() {
 
   length_ = 0;
   callback_ = NULL;
-  handle_.SetWrapperClassId(node_isolate, BUFFER_CLASS_ID);
+  handle_.SetWrapperClassId(BUFFER_CLASS_ID);
 
   Replace(NULL, length, NULL, NULL);
 }
@@ -567,8 +567,8 @@ bool Buffer::HasInstance(Handle<Value> val) {
 
 Handle<Value> SetFastBufferConstructor(const Arguments& args) {
   assert(args[0]->IsFunction());
-  fast_buffer_constructor = Persistent<Function>::New(node_isolate,
-                                                      args[0].As<Function>());
+  Persistent<Function> fbc(node_isolate, args[0].As<Function>());
+  fast_buffer_constructor = fbc;
   return Undefined(node_isolate);
 }
 
@@ -634,7 +634,8 @@ void Buffer::Initialize(Handle<Object> target) {
   length_symbol = NODE_PSYMBOL("length");
 
   Local<FunctionTemplate> t = FunctionTemplate::New(Buffer::New);
-  constructor_template = Persistent<FunctionTemplate>::New(node_isolate, t);
+  Persistent<FunctionTemplate> ct(node_isolate, t);
+  constructor_template = ct;
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("SlowBuffer"));
 

--- a/src/node_counters.cc
+++ b/src/node_counters.cc
@@ -122,9 +122,10 @@ void InitPerfCounters(Handle<Object> target) {
   };
 
   for (int i = 0; i < ARRAY_SIZE(tab); i++) {
-    tab[i].templ = Persistent<FunctionTemplate>::New(node_isolate,
-        FunctionTemplate::New(tab[i].func));
-    target->Set(String::NewSymbol(tab[i].name), tab[i].templ->GetFunction());
+    Persistent<FunctionTemplate> tabi(node_isolate,
+                                      FunctionTemplate::New(tab[i].func));
+    tab[i].templ = tabi;
+    target->Set(String::NewSymbol(tab[i].name), tabi->GetFunction());
   }
 
   // Only Windows performance counters supported

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -157,8 +157,8 @@ void SecureContext::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(SecureContext::New);
-  secure_context_constructor = Persistent<FunctionTemplate>::New(node_isolate,
-                                                                 t);
+  Persistent<FunctionTemplate> scc(node_isolate, t);
+  secure_context_constructor = scc;
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(String::NewSymbol("SecureContext"));
@@ -1142,8 +1142,8 @@ int Connection::SelectNextProtoCallback_(SSL *s,
     *outlen = 8;
 
     // set status unsupported
-    p->selectedNPNProto_ = Persistent<Value>::New(node_isolate,
-                                                  False(node_isolate));
+    Persistent<Value> psp(node_isolate, False(node_isolate));
+    p->selectedNPNProto_ = psp;
 
     return SSL_TLSEXT_ERR_OK;
   }
@@ -1154,6 +1154,7 @@ int Connection::SelectNextProtoCallback_(SSL *s,
   int status = SSL_select_next_proto(out, outlen, in, inlen, npnProtos,
                                      Buffer::Length(p->npnProtos_));
 
+  // TODO(trevnorris): compiler complains when creating a Persistent here
   switch (status) {
     case OPENSSL_NPN_UNSUPPORTED:
       p->selectedNPNProto_ = Persistent<Value>::New(node_isolate,
@@ -1188,8 +1189,8 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
     if (!p->servername_.IsEmpty()) {
       p->servername_.Dispose(node_isolate);
     }
-    p->servername_ = Persistent<String>::New(node_isolate,
-                                             String::New(servername));
+    Persistent<String> ps_(node_isolate, String::New(servername));
+    p->servername_ = ps_;
 
     // Call the SNI callback and use its return value as context
     if (!p->sniObject_.IsEmpty()) {
@@ -1209,7 +1210,8 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
 
       // If ret is SecureContext
       if (secure_context_constructor->HasInstance(ret)) {
-        p->sniContext_ = Persistent<Value>::New(node_isolate, ret);
+        Persistent<Value> psc_(node_isolate, ret);
+        p->sniContext_ = psc_;
         SecureContext *sc = ObjectWrap::Unwrap<SecureContext>(
                                 Local<Object>::Cast(ret));
         SSL_set_SSL_CTX(s, sc->ctx_);
@@ -2040,7 +2042,8 @@ Handle<Value> Connection::SetNPNProtocols(const Arguments& args) {
   if (!ss->npnProtos_.IsEmpty()) {
     ss->npnProtos_.Dispose(node_isolate);
   }
-  ss->npnProtos_ = Persistent<Object>::New(node_isolate, args[0]->ToObject());
+  Persistent<Object> ssnp_(node_isolate, args[0]->ToObject());
+  ss->npnProtos_ = ssnp_;
 
   return True(node_isolate);
 };
@@ -2073,7 +2076,8 @@ Handle<Value> Connection::SetSNICallback(const Arguments& args) {
   if (!ss->sniObject_.IsEmpty()) {
     ss->sniObject_.Dispose(node_isolate);
   }
-  ss->sniObject_ = Persistent<Object>::New(node_isolate, Object::New());
+  Persistent<Object> sso_(node_isolate, Object::New());
+  ss->sniObject_ = sso_;
   ss->sniObject_->Set(String::New("onselect"), args[0]);
 
   return True(node_isolate);
@@ -3502,7 +3506,8 @@ Handle<Value> PBKDF2(const Arguments& args) {
   req->keylen = keylen;
 
   if (args[4]->IsFunction()) {
-    req->obj = Persistent<Object>::New(node_isolate, Object::New());
+    Persistent<Object> ro(node_isolate, Object::New());
+    req->obj = ro;
     req->obj->Set(String::New("ondone"), args[4]);
     uv_queue_work(uv_default_loop(),
                   &req->work_req,
@@ -3624,7 +3629,8 @@ Handle<Value> RandomBytes(const Arguments& args) {
   req->size_ = size;
 
   if (args[1]->IsFunction()) {
-    req->obj_ = Persistent<Object>::New(node_isolate, Object::New());
+    Persistent<Object> ro_(node_isolate, Object::New());
+    req->obj_ = ro_;
     req->obj_->Set(String::New("ondone"), args[1]);
 
     uv_queue_work(uv_default_loop(),

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -344,9 +344,10 @@ void InitDTrace(Handle<Object> target) {
   };
 
   for (unsigned int i = 0; i < ARRAY_SIZE(tab); i++) {
-    tab[i].templ = Persistent<FunctionTemplate>::New(node_isolate,
+    Persistent<FunctionTemplate> tabi(node_isolate,
         FunctionTemplate::New(tab[i].func));
-    target->Set(String::NewSymbol(tab[i].name), tab[i].templ->GetFunction());
+    tab[i].templ = tabi;
+    target->Set(String::NewSymbol(tab[i].name), tabi->GetFunction());
   }
 
 #ifdef HAVE_ETW

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -956,8 +956,8 @@ void InitFs(Handle<Object> target) {
   HandleScope scope(node_isolate);
   // Initialize the stats object
   Local<FunctionTemplate> stat_templ = FunctionTemplate::New();
-  stats_constructor_template = Persistent<FunctionTemplate>::New(node_isolate,
-                                                                 stat_templ);
+  Persistent<FunctionTemplate> sct(node_isolate, stat_templ);
+  stats_constructor_template = sct;
   target->Set(String::NewSymbol("Stats"),
                stats_constructor_template->GetFunction());
   File::Initialize(target);

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -48,10 +48,10 @@ class NODE_EXTERN ObjectWrap {
 
   virtual ~ObjectWrap ( ) {
     if (!handle_.IsEmpty()) {
-      assert(handle_.IsNearDeath(node_isolate));
-      handle_.ClearWeak(node_isolate);
+      assert(handle_.IsNearDeath());
+      handle_.ClearWeak();
       handle_->SetAlignedPointerInInternalField(0, 0);
-      handle_.Dispose(node_isolate);
+      handle_.Dispose();
       handle_.Clear();
     }
   }
@@ -71,7 +71,8 @@ class NODE_EXTERN ObjectWrap {
   inline void Wrap (v8::Handle<v8::Object> handle) {
     assert(handle_.IsEmpty());
     assert(handle->InternalFieldCount() > 0);
-    handle_ = v8::Persistent<v8::Object>::New(node_isolate, handle);
+    v8::Persistent<v8::Object> h_(node_isolate, handle);
+    handle_ = h_;
     handle_->SetAlignedPointerInInternalField(0, this);
     MakeWeak();
   }
@@ -79,7 +80,7 @@ class NODE_EXTERN ObjectWrap {
 
   inline void MakeWeak (void) {
     handle_.MakeWeak(node_isolate, this, WeakCallback);
-    handle_.MarkIndependent(node_isolate);
+    handle_.MarkIndependent();
   }
 
   /* Ref() marks the object as being attached to an event loop.
@@ -89,7 +90,7 @@ class NODE_EXTERN ObjectWrap {
   virtual void Ref() {
     assert(!handle_.IsEmpty());
     refs_++;
-    handle_.ClearWeak(node_isolate);
+    handle_.ClearWeak();
   }
 
   /* Unref() marks an object as detached from the event loop.  This is its
@@ -103,7 +104,7 @@ class NODE_EXTERN ObjectWrap {
    */
   virtual void Unref() {
     assert(!handle_.IsEmpty());
-    assert(!handle_.IsWeak(node_isolate));
+    assert(!handle_.IsWeak());
     assert(refs_ > 0);
     if (--refs_ == 0) { MakeWeak(); }
   }

--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -128,8 +128,8 @@ void CloneObject(Handle<Object> recv,
         })"
       ), String::New("binding:script"))->Run()
     );
-    cloneObjectMethod = Persistent<Function>::New(node_isolate,
-                                                  cloneObjectMethod_);
+    Persistent<Function> com(node_isolate, cloneObjectMethod_);
+    cloneObjectMethod = com;
   }
 
   cloneObjectMethod->Call(recv, 2, args);
@@ -140,7 +140,8 @@ void WrappedContext::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(WrappedContext::New);
-  constructor_template = Persistent<FunctionTemplate>::New(node_isolate, t);
+  Persistent<FunctionTemplate> ct(node_isolate, t);
+  constructor_template = ct;
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("Context"));
 
@@ -165,7 +166,8 @@ Handle<Value> WrappedContext::New(const Arguments& args) {
 
 
 WrappedContext::WrappedContext() : ObjectWrap() {
-  context_ = Persistent<Context>::New(node_isolate, Context::New(node_isolate));
+  Persistent<Context> c_(node_isolate, Context::New(node_isolate));
+  context_ = c_;
 }
 
 
@@ -192,7 +194,8 @@ void WrappedScript::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(WrappedScript::New);
-  constructor_template = Persistent<FunctionTemplate>::New(node_isolate, t);
+  Persistent<FunctionTemplate> ct(node_isolate, t);
+  constructor_template = ct;
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   // Note: We use 'NodeScript' instead of 'Script' so that we do not
   // conflict with V8's Script class defined in v8/src/messages.js
@@ -454,7 +457,8 @@ Handle<Value> WrappedScript::EvalMachine(const Arguments& args) {
       return ThrowException(Exception::Error(
             String::New("Must be called as a method of Script.")));
     }
-    n_script->script_ = Persistent<Script>::New(node_isolate, script);
+    Persistent<Script> ns_(node_isolate, script);
+    n_script->script_ = ns_;
     result = args.This();
   }
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -38,7 +38,8 @@ void StatWatcher::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(StatWatcher::New);
-  constructor_template = Persistent<FunctionTemplate>::New(node_isolate, t);
+  Persistent<FunctionTemplate> ct(node_isolate, t);
+  constructor_template = ct;
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("StatWatcher"));
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -114,7 +114,8 @@ void PipeWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "setPendingInstances", SetPendingInstances);
 #endif
 
-  pipeConstructor = Persistent<Function>::New(node_isolate, t->GetFunction());
+  Persistent<Function> pc(node_isolate, t->GetFunction());
+  pipeConstructor = pc;
 
   target->Set(String::NewSymbol("Pipe"), pipeConstructor);
 }

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -37,7 +37,8 @@ class ReqWrap {
  public:
   ReqWrap() {
     v8::HandleScope scope(node_isolate);
-    object_ = v8::Persistent<v8::Object>::New(node_isolate, v8::Object::New());
+    v8::Persistent<v8::Object> o_(node_isolate, v8::Object::New());
+    object_ = o_;
 
     if (using_domains) {
       v8::Local<v8::Value> domain = v8::Context::GetCurrent()

--- a/src/slab_allocator.cc
+++ b/src/slab_allocator.cc
@@ -65,7 +65,8 @@ void SlabAllocator::Initialize() {
   offset_ = 0;
   last_ptr_ = NULL;
   initialized_ = true;
-  slab_sym_ = Persistent<String>::New(node_isolate, String::New(sym));
+  Persistent<String> ss_(node_isolate, String::NewSymbol(sym));
+  slab_sym_ = ss_;
 }
 
 
@@ -96,7 +97,8 @@ char* SlabAllocator::Allocate(Handle<Object> obj, unsigned int size) {
   if (slab_.IsEmpty() || offset_ + size > size_) {
     slab_.Dispose(node_isolate);
     slab_.Clear();
-    slab_ = Persistent<Object>::New(node_isolate, NewSlab(size_));
+    Persistent<Object> s_(node_isolate, NewSlab(size_));
+    slab_ = s_;
     offset_ = 0;
     last_ptr_ = NULL;
   }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -120,7 +120,8 @@ void TCPWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
 #endif
 
-  tcpConstructor = Persistent<Function>::New(node_isolate, t->GetFunction());
+  Persistent<Function> tc(node_isolate, t->GetFunction());
+  tcpConstructor = tc;
 
   onconnection_sym = NODE_PSYMBOL("onconnection");
   oncomplete_sym = NODE_PSYMBOL("oncomplete");

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -119,8 +119,9 @@ void UDPWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "ref", HandleWrap::Ref);
   NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
 
-  constructor = Persistent<Function>::New(node_isolate,
-      Persistent<FunctionTemplate>::New(node_isolate, t)->GetFunction());
+  Persistent<FunctionTemplate> cft(node_isolate, t);
+  Persistent<Function> c(node_isolate, cft->GetFunction());
+  constructor = c;
   target->Set(String::NewSymbol("UDP"), constructor);
 }
 


### PR DESCRIPTION
Large changes are coming down the pipe from v8 for how Persistents are
handled. These changes are preparing node for these.

This is still a WIP, and actually not completely sure these are the absolute correct syntax changes. Just going by the `// TODO(dcarney): remove before cutover` comments found in `include/v8.h`.

/cc @bnoordhuis @isaacs
