### PR TITLE
Add .travis.yml file back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+
+before_script:
+  - "./configure"
+  - "make"
+
+script:
+  - "make test"
+
+notifications:
+  email: false
+  irc:
+    - secure: "h8AOh/k2u3nsBfhvnn6poBLbG7PN9OKm2xoZSs7+/QfuxgxB4V4VSYQEYWc+\neKbBa870H/mW+pL+2aWz6vtmmD6V01ii/4Q5A8V03ztFAOg25URdAUAmgpO8\n7JXM9xKYhvczk/dBxb6yIlRrqyWnwc2usKGL57z+IQ884qaW7CY="
+


### PR DESCRIPTION
This was removed in 9c7078cea2b719defbb6519d10a14ab15e733822 because
forks sent notifications to the IRC channel. By encrypting it (`travis
encrypt "irc.freenode.net#libuv"`), only the main repo can decrypt it
and send notifications to the IRC channel.

I'm sorry that this isn't really obvious, we're working on making the notifications config better, see travis-ci/travis-ci#1094.
