### PR TITLE
docs: Adding a link to Brazilian community of Node

### DIFF
--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -187,9 +187,11 @@
               <a href="http://nodejskr.org">OctoberSkyJs</a> Korea Node.js
               community<br>
               <a href="https://plus.google.com/communities/113346206415381691435">FR . Node.js</a>
-              Google+ Community of Node.js French users
+              Google+ Community of Node.js French users<br>
               <a href="http://www.nodejstr.com/">Node.js Türkiye</a>
-              Node.js in Turkish
+              Node.js in Turkish<br>
+              <a href="http://www.nodebr.com/">NodeBR.com</a>
+              Brazilian community of Node.js
             </p>
           </div>
         </div>


### PR DESCRIPTION
Adding a link to nodebr.com Brazilian community.
We are adding a link to Brazilian community portal with docs in portuguese.
