### PR TITLE
tls: retry writing after hello parse error

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -253,6 +253,7 @@ function CryptoStream(pair, options) {
   this._pendingEncoding = '';
   this._pendingCallback = null;
   this._doneFlag = false;
+  this._retryAfterPartial = false;
   this._resumingSession = false;
   this._reading = true;
   this._destroyed = false;
@@ -361,7 +362,13 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
 
       return cb(null);
     }
-    assert(written === 0 || written === -1);
+    if (written !== 0 && written !== -1) {
+      assert(!this._retryAfterPartial);
+      this._retryAfterPartial = true;
+      this._write(data.slice(written), encoding, cb);
+      this._retryAfterPartial = false;
+      return;
+    }
   } else {
     debug('cleartext.write queue is full');
 

--- a/test/simple/test-tls-hello-parser-failure.js
+++ b/test/simple/test-tls-hello-parser-failure.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var tls = require('tls');
+var net = require('net');
+var fs = require('fs');
+var assert = require('assert');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/test_key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem')
+};
+
+var server = tls.createServer(options, function(c) {
+
+}).listen(common.PORT, function() {
+  var client = net.connect(common.PORT, function() {
+    var bonkers = new Buffer(1024 * 1024);
+    bonkers.fill(42);
+    client.end(bonkers);
+  });
+
+  var once = false;
+  client.on('error', function() {
+    if (!once) {
+      once = true;
+      client.destroy();
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
When writing bad data to EncryptedStream it'll first get to the
ClientHello parser, and, only after it will refuse it, to the OpenSSL.
But ClientHello parser has limited buffer and therefore write could
return `bytes_written` < `incoming_bytes`, which is not the case when
working with OpenSSL.

After such errors ClientHello parser disables itself and will
pass-through all data to the OpenSSL. So just trying to write data one
more time will throw the rest into OpenSSL and let it handle it.

/cc @bnoordhuis @piscisaureus
