### PR TITLE
docs: Remove broken links in community

### DIFF
--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -55,14 +55,6 @@
               node API.
             </p>
             <p>
-              <a href="http://www.nodemanual.org">Node Manual</a> offers
-              stylized API docs, as well as tutorials and live code samples
-            </p>
-            <p>
-              <a href="http://www.nodebits.org">Node Bits</a> provides sample
-              Node.js projects
-            </p>
-            <p>
               <a href="http://docs.nodejitsu.com/">docs.nodejitsu.com</a>
               answers many of the common problems people come across.
             </p>


### PR DESCRIPTION
Removing Node Manual and Node Bits
Links to Node Manual and Node Bits both
are broken, so this commit remove them
to the community's doc page.
