### PR TITLE
repl: fix JSON.parse error check

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -923,6 +923,5 @@ function isSyntaxError(e) {
       // "strict mode" syntax errors
       !e.match(/^SyntaxError: .*strict mode.*/i) &&
       // JSON.parse() error
-      !(e.match(/^SyntaxError: Unexpected (token .*|end of input)/) &&
-      e.match(/\n {4}at Object.parse \(native\)\n/));
+      !e.match(/\n {4}at Object.parse \(native\)\n/);
 }

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -134,6 +134,9 @@ function error_test() {
       expect: /^SyntaxError: Unexpected token i/ },
     // end of input to JSON.parse error is special case of syntax error,
     // should throw
+    { client: client_unix, send: 'JSON.parse(\'066\');',
+      expect: /^SyntaxError: Unexpected number/ },
+    // should throw
     { client: client_unix, send: 'JSON.parse(\'{\');',
       expect: /^SyntaxError: Unexpected end of input/ },
     // invalid RegExps are a special case of syntax error,


### PR DESCRIPTION
Before this, entering something like:

```
> JSON.parse('066');
```

resulted in the "..." prompt instead of displaying the expected "SyntaxError: Unexpected number"
