### PR TITLE
vm: fix race condition in watchdog cleanup

### DIFF
--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -38,12 +38,13 @@ class Watchdog {
   void Destroy();
 
   static void Run(void* arg);
+  static void Async(uv_async_t* async, int status);
   static void Timer(uv_timer_t* timer, int status);
 
   uv_thread_t thread_;
   uv_loop_t* loop_;
+  uv_async_t async_;
   uv_timer_t timer_;
-  bool timer_started_;
   bool thread_created_;
   bool destroyed_;
 };

--- a/test/simple/test-vm-run-timeout.js
+++ b/test/simple/test-vm-run-timeout.js
@@ -23,15 +23,35 @@ var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 
+// Test 1: Timeout of 100ms executing endless loop
 assert.throws(function() {
   vm.runInThisContext('while(true) {}', '', 100);
 });
 
+// Test 2: Timeout must be >= 0ms
 assert.throws(function() {
   vm.runInThisContext('', '', -1);
 });
 
-assert.doesNotThrow(function() {
-  vm.runInThisContext('', '', 0);
-  vm.runInThisContext('', '', 100);
-});
+// Test 3: Timeout of 0ms
+vm.runInThisContext('', '', 0);
+
+// Test 4: Timeout of 1000ms, script finishes first
+vm.runInThisContext('', '', 1000);
+
+// Test 5: Nested vm timeouts, inner timeout propagates out
+try {
+  var context = {
+    log: console.log,
+    runInVM: function(timeout) {
+      vm.runInNewContext('while(true) {}', context, '', timeout);
+    }
+  };
+  vm.runInNewContext('runInVM(10)', context, '', 100);
+  throw new Error('Test 5 failed');
+} catch (e) {
+  if (-1 === e.message.search(/Script execution timed out./)) {
+    throw e;
+  }
+}
+


### PR DESCRIPTION
Previous code was calling uv_loop_delete() directly on a running loop,
which led to race condition aborts/segfaults within libuv.  This change
changes the watchdog thread to call uv_run() with UV_RUN_ONCE so that
the call exits after either the timer times out or uv_async_send() is
called from the main thread in Watchdog::Destroy().  The timer/async
handles are then closed and uv_run() with UV_RUN_DEFAULT is called so
that libuv has a chance to cleanup before the thread exits.  The main
thread meanwhile calls uv_thread_join() and then uv_loop_delete() to
complete the cleanup.

Fixes #5564.
