### PR TITLE
buffer: return `this` in fill() for chainability

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -468,9 +468,10 @@ Buffer.prototype.fill = function fill(value, start, end) {
     throw new RangeError('end out of bounds');
   }
 
-  return this.parent.fill(value,
-                          start + this.offset,
-                          end + this.offset);
+  this.parent.fill(value,
+                   start + this.offset,
+                   end + this.offset);
+  return this;
 };
 
 


### PR DESCRIPTION
The parent fill() just returns undefined, so return something more useful for chaining purposes instead.
