### PR TITLE
buffer: return `this` in write*Int/Float/Double methods for chainability

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -794,6 +794,7 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 1, 0xff, 0);
   this[offset] = value;
+  return this;
 };
 
 
@@ -812,6 +813,7 @@ Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, false);
+  return this;
 };
 
 
@@ -819,6 +821,7 @@ Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, true);
+  return this;
 };
 
 
@@ -841,6 +844,7 @@ Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, false);
+  return this;
 };
 
 
@@ -848,6 +852,7 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, true);
+  return this;
 };
 
 
@@ -893,6 +898,7 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
     checkInt(this, value, offset, 1, 0x7f, -0x80);
   if (value < 0) value = 0xff + value + 1;
   this[offset] = value;
+  return this;
 };
 
 
@@ -901,6 +907,7 @@ Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, false);
+  return this;
 };
 
 
@@ -909,6 +916,7 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, true);
+  return this;
 };
 
 
@@ -917,6 +925,7 @@ Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, false);
+  return this;
 };
 
 
@@ -925,6 +934,7 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, true);
+  return this;
 };
 
 
@@ -932,6 +942,7 @@ Buffer.prototype.writeFloatLE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
   this.parent.writeFloatLE(value, this.offset + offset, !!noAssert);
+  return this;
 };
 
 
@@ -939,6 +950,7 @@ Buffer.prototype.writeFloatBE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
   this.parent.writeFloatBE(value, this.offset + offset, !!noAssert);
+  return this;
 };
 
 
@@ -946,6 +958,7 @@ Buffer.prototype.writeDoubleLE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 8, this.length);
   this.parent.writeDoubleLE(value, this.offset + offset, !!noAssert);
+  return this;
 };
 
 
@@ -953,4 +966,5 @@ Buffer.prototype.writeDoubleBE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 8, this.length);
   this.parent.writeDoubleBE(value, this.offset + offset, !!noAssert);
+  return this;
 };


### PR DESCRIPTION
Return something useful for chaining purposes.
