### PR TITLE
set isTTY to false if TERM is 'dumb'

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -129,7 +129,7 @@
           useGlobal: true,
           ignoreUndefined: false
         };
-        if (parseInt(process.env['NODE_NO_READLINE'], 10)) {
+        if (parseInt(process.env['NODE_NO_READLINE'], 10) || process.env['TERM'] === 'dumb') {
           opts.terminal = false;
         }
         if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {


### PR DESCRIPTION
This is to stop REPLs/logs from spitting ANSI control codes on terminals which don't support them. (issue #5344)

I'm not sure if this is the best approach (I'm new to node), but it does the job for me.
