### PR TITLE
buffer: integer write methods return the buffer (this)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -795,6 +795,7 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 1, 0xff, 0);
   this[offset] = value;
+  return this;
 };
 
 
@@ -813,6 +814,7 @@ Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, false);
+  return this;
 };
 
 
@@ -820,6 +822,7 @@ Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, true);
+  return this;
 };
 
 
@@ -842,6 +845,7 @@ Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, false);
+  return this;
 };
 
 
@@ -849,6 +853,7 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, true);
+  return this;
 };
 
 
@@ -894,6 +899,7 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
     checkInt(this, value, offset, 1, 0x7f, -0x80);
   if (value < 0) value = 0xff + value + 1;
   this[offset] = value;
+  return this;
 };
 
 
@@ -902,6 +908,7 @@ Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, false);
+  return this;
 };
 
 
@@ -910,6 +917,7 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, true);
+  return this;
 };
 
 
@@ -918,6 +926,7 @@ Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, false);
+  return this;
 };
 
 
@@ -926,6 +935,7 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, true);
+  return this;
 };
 
 
@@ -933,6 +943,7 @@ Buffer.prototype.writeFloatLE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
   this.parent.writeFloatLE(value, this.offset + offset, !!noAssert);
+  return this;
 };
 
 
@@ -940,6 +951,7 @@ Buffer.prototype.writeFloatBE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
   this.parent.writeFloatBE(value, this.offset + offset, !!noAssert);
+  return this;
 };
 
 
@@ -947,6 +959,7 @@ Buffer.prototype.writeDoubleLE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 8, this.length);
   this.parent.writeDoubleLE(value, this.offset + offset, !!noAssert);
+  return this;
 };
 
 
@@ -954,4 +967,5 @@ Buffer.prototype.writeDoubleBE = function(value, offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 8, this.length);
   this.parent.writeDoubleBE(value, this.offset + offset, !!noAssert);
+  return this;
 };


### PR DESCRIPTION
This is great for chaining and inline Buffer initialization.
`(new Buffer(2)).writeUInt16BE(0x1234)` --> `<Buffer 12 34>`
