### PR TITLE
stream: unshift('') is a noop

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -166,7 +166,7 @@ function readableAddChunk(stream, state, chunk, encoding, addToFront) {
 
       maybeReadMore(stream, state);
     }
-  } else {
+  } else if (!addToFront) {
     state.reading = false;
   }
 

--- a/test/simple/test-stream-unshift-empty-chunk.js
+++ b/test/simple/test-stream-unshift-empty-chunk.js
@@ -1,0 +1,81 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+// This test verifies that stream.unshift(Buffer(0)) or 
+// stream.unshift('') does not set state.reading=false.
+var Readable = require('stream').Readable;
+
+var r = new Readable();
+var nChunks = 10;
+var chunk = new Buffer(10);
+chunk.fill('x');
+
+r._read = function(n) {
+  setTimeout(function() {
+    r.push(--nChunks === 0 ? null : chunk);
+  });
+};
+
+var readAll = false;
+var seen = [];
+r.on('readable', function() {
+  var chunk;
+  while (chunk = r.read()) {
+    seen.push(chunk.toString());
+    // simulate only reading a certain amount of the data,
+    // and then putting the rest of the chunk back into the
+    // stream, like a parser might do.  We just fill it with
+    // 'y' so that it's easy to see which bits were touched,
+    // and which were not.
+    var putBack = new Buffer(readAll ? 0 : 5);
+    putBack.fill('y');
+    readAll = !readAll;
+    r.unshift(putBack);
+  }
+});
+
+var expect =
+  [ 'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy',
+    'xxxxxxxxxx',
+    'yyyyy' ];
+
+r.on('end', function() {
+  assert.deepEqual(seen, expect);
+  console.log('ok');
+});


### PR DESCRIPTION
In some cases, the http CONNECT/Upgrade API is unshifting an empty
bodyHead buffer onto the socket.

Normally, stream.unshift(chunk) does not set state.reading=false.
However, this check was not being done for the case when the chunk was
empty (either `''` or `Buffer(0)`), and as a result, it was causing the
socket to think that a read had completed, and to stop providing data.

This bug is not limited to http or web sockets, but rather would affect
any parser that unshifts data back onto the source stream without being
very careful to never unshift an empty chunk.  Since the intent of
unshift is to _not_ change the state.reading property, this is a bug.

Fixes #5557
Fixes LearnBoost/socket.io#1242
