### PR TITLE
crypto: free excessive memory in NodeBIO

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -210,7 +210,31 @@ size_t NodeBIO::Read(char* out, size_t size) {
   assert(expected == bytes_read);
   length_ -= bytes_read;
 
+  // Free all empty buffers, but write_head's child
+  FreeEmpty();
+
   return bytes_read;
+}
+
+
+void NodeBIO::FreeEmpty() {
+  Buffer* child = write_head_->next_;
+  if (child == write_head_ || child == read_head_)
+    return;
+  Buffer* cur = child->next_;
+  if (cur == write_head_ || cur == read_head_)
+    return;
+
+  while (cur != read_head_) {
+    assert(cur != write_head_);
+    assert(cur->write_pos_ == cur->read_pos_);
+
+    Buffer* next = cur->next_;
+    child->next_ = next;
+    delete cur;
+
+    cur = next;
+  }
 }
 
 

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -62,6 +62,10 @@ class NodeBIO {
   // Read `len` bytes maximum into `out`, return actual number of read bytes
   size_t Read(char* out, size_t size);
 
+  // Memory optimization:
+  // Deallocate children of write head's child if they're empty
+  void FreeEmpty();
+
   // Find first appearance of `delim` in buffer or `limit` if `delim`
   // wasn't found.
   size_t IndexOf(char delim, size_t limit);


### PR DESCRIPTION
Before this commit NodeBIO never shrank, possibly consuming a lot of
memory (depending on reader's haste).

All buffers between write_head's child and read_head should be
deallocated on read, leaving only space left in write_head and in the
next buffer.

/cc @bnoordhuis @trevnorris
