### PR TITLE
Fix missing namespace in NODE_PSYMBOL macro

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -98,7 +98,7 @@ void Load(v8::Handle<v8::Object> process);
 void EmitExit(v8::Handle<v8::Object> process);
 
 #define NODE_PSYMBOL(s) \
-  v8::Persistent<v8::String>::New(node_isolate, v8::String::NewSymbol(s))
+  v8::Persistent<v8::String>::New(node::node_isolate, v8::String::NewSymbol(s))
 
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(1000*static_cast<double>(t))


### PR DESCRIPTION
Added "node::" to node_isolate in the NODE_PSYMBOL macro because the current definition causes compile errors in projects that do not have "using namespace node;" prior to using this macro. This is because node_isolate is defined within the node namespace.

Similar to v8 namespace issue in https://github.com/joyent/node/pull/773

I have signed the CLA.
