### PR TITLE
Fix issue #5647 - always use $(PYTHON) when building

### DIFF
--- a/deps/v8/tools/gyp/v8.gyp
+++ b/deps/v8/tools/gyp/v8.gyp
@@ -815,7 +815,7 @@
             '<(SHARED_INTERMEDIATE_DIR)/libraries.cc',
           ],
           'action': [
-            'python',
+            '$(PYTHON)',
             '../../tools/js2c.py',
             '<@(_outputs)',
             'CORE',
@@ -833,7 +833,7 @@
             '<(SHARED_INTERMEDIATE_DIR)/experimental-libraries.cc',
           ],
           'action': [
-            'python',
+            '$(PYTHON)',
             '../../tools/js2c.py',
             '<@(_outputs)',
             'EXPERIMENTAL',
@@ -863,7 +863,7 @@
               '<(SHARED_INTERMEDIATE_DIR)/debug-support.cc',
             ],
             'action': [
-              'python',
+              '$(PYTHON)',
               '../../tools/gen-postmortem-metadata.py',
               '<@(_outputs)',
               '<@(heapobject_files)'


### PR DESCRIPTION
Fixes issue #5647 by changing the explicit use of python to $(PYTHON).
