### PR TITLE
crypto: fix utf8/utf-8 encoding check

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -236,6 +236,7 @@ Hmac.prototype._transform = Hash.prototype._transform;
 
 
 function getDecoder(decoder, encoding) {
+  if (encoding === 'utf-8') encoding = 'utf8';  // Normalize encoding.
   decoder = decoder || new StringDecoder(encoding);
   assert(decoder.encoding === encoding, 'Cannot change encoding');
   return decoder;

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -900,3 +900,14 @@ assert.throws(function() {
   c.update('update');
   c.final();
 })();
+
+// #5655 regression tests, 'utf-8' and 'utf8' are identical.
+(function() {
+  var c = crypto.createCipher('aes192', '0123456789abcdef');
+  c.update('update', '')  // Defaults to "utf8".
+  c.final('utf-8');  // Should not throw.
+
+  c = crypto.createCipher('aes192', '0123456789abcdef')
+  c.update('update', 'utf8')
+  c.final('utf-8');  // Should not throw.
+})();


### PR DESCRIPTION
Normalize the encoding in getEncoding() before using it. Fixes a
"AssertionError: Cannot change encoding" exception when the caller
mixes "utf8" and "utf-8".

Fixes #5655.

Suggested reviewer: @indutny. This time for real.
