### PR TITLE
IncomingMessage.destroy now dumps the response

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -356,6 +356,7 @@ IncomingMessage.prototype._read = function(n) {
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
 IncomingMessage.prototype.destroy = function(error) {
+  this._dump();
   if (this.socket)
     this.socket.destroy(error);
 };


### PR DESCRIPTION
subsystem: IncomingMessage.destroy now dumps the response

If _'destroy'_ only wraps the _'socket.destroy_' I am not sure there is much use for it to exist in a public form.  Alternatively, _'.destroy'_ could become _'._destroy'_.
