### PR TITLE
v8: fix build for mips32r2 architecture

### DIFF
--- a/deps/v8/build/common.gypi
+++ b/deps/v8/build/common.gypi
@@ -200,10 +200,11 @@
                   ['mips_arch_variant=="mips32r2"', {
                     'cflags': ['-mips32r2', '-Wa,-mips32r2'],
                   }],
+                  ['mips_arch_variant=="mips32r1"', {
+                    'cflags': ['-mips32', '-Wa,-mips32'],
+                  }],
                   ['mips_arch_variant=="loongson"', {
                     'cflags': ['-mips3', '-Wa,-mips3'],
-                  }, {
-                    'cflags': ['-mips32', '-Wa,-mips32'],
                   }],
                 ],
               }],


### PR DESCRIPTION
This is a floating patch as a backport from v8 3.15.0
Committed: https://code.google.com/p/v8/source/detail?r=12833
