### PR TITLE
docs: Updates dgram doc with optional port for socket.bind()

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -123,13 +123,15 @@ a packet might travel, and that generally sending a datagram greater than
 the (receiver) `MTU` won't work (the packet gets silently dropped, without
 informing the source that the data did not reach its intended recipient).
 
-### socket.bind(port, [address], [callback])
+### socket.bind([port], [address], [callback])
 
-* `port` Integer
+* `port` Integer, Optional
 * `address` String, Optional
 * `callback` Function, Optional
 
 For UDP sockets, listen for datagrams on a named `port` and optional `address`.
+If `port` is not specified, the OS will try to assign a random port (it does the right thing for
+both `udp4` and `udp6` sockets).
 If `address` is not specified, the OS will try to listen on all addresses.
 
 The `callback` argument, if provided, is added as a one-shot `'listening'`

--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -130,8 +130,7 @@ informing the source that the data did not reach its intended recipient).
 * `callback` Function, Optional
 
 For UDP sockets, listen for datagrams on a named `port` and optional `address`.
-If `port` is not specified, the OS will try to assign a random port (it does the right thing for
-both `udp4` and `udp6` sockets).
+If `port` is not specified, the OS will try to assign a random port.
 If `address` is not specified, the OS will try to listen on all addresses.
 
 The `callback` argument, if provided, is added as a one-shot `'listening'`


### PR DESCRIPTION
As explained several times throughout this document already:

> `socket.bind()` will bind to the "all interfaces" address on a random port (it does the right thing for both `udp4` and `udp6` sockets).

and

> If the socket has not been previously bound with a call to `bind`, it's assigned a random port number and bound to the "all interfaces" address (0.0.0.0 for `udp4` sockets, ::0 for `udp6` sockets).

I felt for an API lookup, it is a good idea to repeat this in `socket.bind` itself.
