### PR TITLE
Small doc heading fix

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -572,7 +572,7 @@ which has been transmitted are equal or not.
 The request implements the [Writable Stream][] interface. This is an
 [EventEmitter][] with the following events:
 
-### Event 'response'
+### Event: 'response'
 
 `function (response) { }`
 


### PR DESCRIPTION
Fix event response heading to follow pattern of other events. (Also, shouldn't http.IncomingMessage be listed as a class instead of a property?)
