### PR TITLE
configure: fix host_arch_cc() (cross-compilation case)

### DIFF
--- a/configure
+++ b/configure
@@ -296,11 +296,14 @@ def pkg_config(pkg):
   return (libs, cflags)
 
 
-def cc_macros():
-  """Checks predefined macros using the CC command."""
+def cc_macros(cc = None):
+  """Checks predefined macros using the C compiler command."""
+
+  if cc is None:
+    cc = CC
 
   try:
-    p = subprocess.Popen(shlex.split(CC) + ['-dM', '-E', '-'],
+    p = subprocess.Popen(shlex.split(cc) + ['-dM', '-E', '-'],
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
@@ -375,7 +378,9 @@ def arm_hard_float_abi():
 def host_arch_cc():
   """Host architecture check using the CC command."""
 
-  k = cc_macros()
+  # use 'cc', as CC may be set to a target arch compiler command
+  # in case of cross-compilation
+  k = cc_macros('cc')
 
   matchup = {
     '__x86_64__'  : 'x64',


### PR DESCRIPTION
In case of cross-compilation host_arch_cc() function could return
target arch if CC was set to target arch compiler. Host arch
compiler should always be used in this case. This was broken
by 707863c1fb13dacb48811b55801cdc83a4726904.
