### PR TITLE
src: increment NODE_MODULE_VERSION

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -208,7 +208,7 @@ node_module_struct* get_builtin_module(const char *name);
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 0x000C /* v0.12 */
+#define NODE_MODULE_VERSION 0x000D /* v0.13 */
 
 #define NODE_STANDARD_MODULE_STUFF \
           NODE_MODULE_VERSION,     \


### PR DESCRIPTION
Due to the unexporting of node_isolate in 4bb4f734b3

I was already using this in [leveldown](https://github.com/rvagg/node-leveldown/blob/master/src/leveldown.h#L60-L62)
