### PR TITLE
path: add depth argument to dirname (recursion)

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -117,15 +117,21 @@ Examples:
     // returns
     '../../impl/bbb'
 
-## path.dirname(p)
+## path.dirname(p, [n])
 
 Return the directory name of a path.  Similar to the Unix `dirname` command.
+If `n` is specified, `dirname` is called `n` times with the given path.
+Defaults to 1.
 
 Example:
 
     path.dirname('/foo/bar/baz/asdf/quux')
     // returns
     '/foo/bar/baz/asdf'
+    
+   path.dirname('/foo/bar/baz/asdf/quux', 2)
+   // returns
+   '/foo/bar/baz'
 
 ## path.basename(p, [ext])
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -429,7 +429,11 @@ if (isWindows) {
   exports.delimiter = ':';
 }
 
-exports.dirname = function(path) {
+exports.dirname = function(path, depth) {
+  if (depth < 1) {
+    return path;
+  }
+
   var result = splitPath(path),
       root = result[0],
       dir = result[1];
@@ -442,6 +446,11 @@ exports.dirname = function(path) {
   if (dir) {
     // It has a dirname, strip trailing slash
     dir = dir.substr(0, dir.length - 1);
+  }
+  
+  if (depth > 1) {
+    // Process again until depth == 1
+    return arguments.callee(root + dir, --depth);
   }
 
   return root + dir;


### PR DESCRIPTION
path.dirname('/foo/bar/baz/asdf/quux')
// returns
'/foo/bar/baz/asdf'

path.dirname('/foo/bar/baz/asdf/quux', 2)
// returns
'/foo/bar/baz'
