### PR TITLE
doc: add description of legacy buf.write() format

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -98,6 +98,9 @@ The method will not write partial characters.
     len = buf.write('\u00bd + \u00bc = \u00be', 0);
     console.log(len + " bytes: " + buf.toString('utf8', 0, len));
 
+For some historical reason, the `encoding` can be placed at other position too
+so that it makes following forms legal: `buf.write(string, [offset], [encoding])`
+or `buf.write(string, [encoding], [offset], [length])`.
 
 ### buf.toString([encoding], [start], [end])
 


### PR DESCRIPTION
The buf.write() method also supports undocumented legacy style invocation.
As the example of buf.length property uses this form, a reader can be confused
with it.  Add description of these styles at the end.
