### PR TITLE
crypto: change assertion to condition in bio

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -209,8 +209,7 @@ size_t NodeBIO::Read(char* out, size_t size) {
       read_head_->write_pos_ = 0;
 
       // But not get beyond write_head_
-      if (length_ != bytes_read) {
-        assert(read_head_ != write_head_);
+      if (length_ != bytes_read && read_head_ != write_head_) {
         read_head_ = read_head_->next_;
       }
     }


### PR DESCRIPTION
Read head can be the same as write head, even if there's some data to
read.

/cc @tjfontaine @bnoordhuis.

Should fix windows jenkins build.
