### PR TITLE
http: forbid double 'close' event

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -355,6 +355,7 @@ Socket.prototype._destroy = function(exception, cb) {
   fireErrorCallbacks();
 
   process.nextTick(function() {
+    self._hangupClose = true;
     self.emit('close', exception ? true : false);
   });
 

--- a/test/simple/test-http-net-close-twice.js
+++ b/test/simple/test-http-net-close-twice.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var connectionClose = 0;
+var responseClose = 0;
+
+var server = http.createServer(function(req, res) {
+  req.connection.on('close', function () {
+    connectionClose += 1;
+  });
+  req.on('close', function() {
+    res.writeHead(500);
+    res.write('a');
+    server.close();
+  });
+  res.on('close', function() {
+    responseClose += 1;
+  });
+});
+server.on('listening', function() {
+  var req = http.request({
+    method: 'PUT',
+    port: common.PORT
+  });
+  req.on('error', function () {});
+  req.write('a');
+  setTimeout(function () {
+    req.abort();
+  }, 150);
+});
+server.listen(common.PORT);
+
+process.on('exit', function() {
+  assert.equal(connectionClose, 1);
+  assert.equal(responseClose, 1);
+});


### PR DESCRIPTION
In 0.8 branch there is this corner case when 'close' event is emitted twice from both ServerResponse and underlying Socket (response is written after socket is already closed by the client).
The same test case works fine in v0.10 or master without any fixes.
