### PR TITLE
Fix crash when passing invalid hex strings to cipher.update or decipher.update

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2271,6 +2271,11 @@ Handle<Value> CipherBase::Update(const Arguments& args) {
   // Only copy the data if we have to, because it's a string
   if (args[0]->IsString()) {
     enum encoding encoding = ParseEncoding(args[1], BINARY);
+
+    Local<String> str = args[0]->ToString();
+    if (encoding == HEX && str->Length() % 2 != 0)
+      return ThrowTypeError("Invalid hex string");
+
     size_t buflen = StringBytes::StorageSize(args[0], encoding);
     char* buf = new char[buflen];
     size_t written = StringBytes::Write(buf, buflen, args[0], encoding);

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -670,6 +670,12 @@ assert.throws(function() {
 }, /buffer/);
 
 
+// Regression test for #5725: should throw but not assert in C++ land.
+assert.throws(function() {
+  crypto.createDecipher('aes-256-cbc', 'foo').update('0', 'hex');
+}, TypeError);
+
+
 // Test Diffie-Hellman with two parties sharing a secret,
 // using various encodings as we go along
 var dh1 = crypto.createDiffieHellman(256);


### PR DESCRIPTION
Passing invalid hex strings to `cipher.update` or `decipher.update` made node crash. Here is a demo:

```
Freyr:jolimerdier pierre$ node
> require('crypto').createDecipher('aes-256-cbc', 'foo').update('000', 'hex');
Assertion failed: (str->Length() % 2 == 0 && "invalid hex string length"), function StorageSize, file ../src/string_bytes.cc, line 301.
Abort trap: 6
Freyr:jolimerdier pierre$ node -v
v0.10.12
```

This has been tested on both Linux and Mac environments.
A simple workaround is to use `update(Buffer(somevar, 'hex'))` instead of `update(somevar, 'hex')`.

This pull request fixes the crash, and makes this throw a TypeError instead.
