### PR TITLE
child_process: emit 'disconnect' asynchronously

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -498,7 +498,7 @@ function setupChannel(target, channel) {
       return;
     }
 
-    finish();
+    process.nextTick(finish);
   };
 
   channel.readStart();

--- a/test/simple/test-child-process-disconnect.js
+++ b/test/simple/test-child-process-disconnect.js
@@ -27,6 +27,16 @@ var net = require('net');
 // child
 if (process.argv[2] === 'child') {
 
+  // Check that the 'disconnect' event is deferred to the next event loop tick.
+  var disconnect = process.disconnect;
+  process.disconnect = function() {
+    disconnect.apply(this, arguments);
+    // If the event is emitted synchronously, we're too late by now.
+    process.once('disconnect', common.mustCall(disconnectIsNotAsync));
+    // The funky function name makes it show up legible in mustCall errors.
+    function disconnectIsNotAsync() {}
+  };
+
   var server = net.createServer();
 
   server.on('connection', function(socket) {


### PR DESCRIPTION
Deferring I/O-triggered events to the next event loop tick is not just
a good idea, IT'S THE LAW!

(Yes, I'll amend the commit log before landing this.)
