### PR TITLE
add ability to add more stdio channels in child_process.fork and cluster.fork

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -1,4 +1,4 @@
-# Child Process
+ Child Process
 
     Stability: 3 - Stable
 
@@ -544,6 +544,7 @@ leaner than `child_process.exec`. It has the same options.
   * `env` {Object} Environment key-value pairs
   * `encoding` {String} (Default: 'utf8')
   * `execPath` {String} Executable used to create the child process
+  * `addStdio` {Array} Additional child stdio fds / channels.
 * Return: ChildProcess object
 
 This is a special case of the `spawn()` functionality for spawning Node
@@ -567,5 +568,10 @@ created for the child rather than the current `node` executable. This should be
 done with care and by default will talk over the fd represented an
 environmental variable `NODE_CHANNEL_FD` on the child process. The input and
 output on this fd is expected to be line delimited JSON objects.
+
+For valid types for the `addStdio` option, see the `stdio` options at
+ [`ChildProcess#spawn()`](#child_process_child_process_spawn_command_args_options)
+'ipc' must not be used here, as there may be at most *one* IPC stdio per ChildProcess,
+and `fork` already creates one internally.
 
 [EventEmitter]: events.html#events_class_events_eventemitter

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -264,7 +264,7 @@ Example:
     });
     cluster.fork();
 
-## cluster.fork([env], [options])
+## cluster.fork(env, [options])
 
 * `env` {Object} Key/value pairs to add to child process environment.
 * `options` {Object} 

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -264,12 +264,17 @@ Example:
     });
     cluster.fork();
 
-## cluster.fork([env])
+## cluster.fork([env], [options])
 
 * `env` {Object} Key/value pairs to add to child process environment.
+* `options` {Object} 
+  * `addStdio` {Array} Additional child stdio fds / channels.
 * return {Worker object}
 
 Spawn a new worker process. This can only be called from the master process.
+
+For the `addStdio` options, see [ChildProcess#fork()](child_process.html#child_process_child_process_fork_modulepath_args_options).
+
 
 ## cluster.disconnect([callback])
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -528,6 +528,11 @@ exports.fork = function(modulePath /*, args, options*/) {
   options.stdio = options.silent ? ['pipe', 'pipe', 'pipe', 'ipc'] :
       [0, 1, 2, 'ipc'];
 
+  // Additional stdio channels
+  if (options.addStdio) {
+    options.stdio = options.stdio.concat(options.addStdio);
+  }
+
   options.execPath = options.execPath || process.execPath;
 
   return spawn(options.execPath, args, options);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -257,18 +257,21 @@ function masterInit() {
   };
 
   var ids = 0;
-  cluster.fork = function(env) {
+  cluster.fork = function(env, options) {
     cluster.setupMaster();
     var worker = new Worker;
     worker.id = ++ids;
     var workerEnv = util._extend({}, process.env);
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + worker.id;
-    worker.process = fork(settings.exec, settings.args, {
+    var forkOptions = {
       env: workerEnv,
       silent: settings.silent,
       execArgv: createWorkerExecArgv(settings.execArgv, worker)
-    });
+    };
+    if (options && options.addStdio)
+      forkOptions.addStdio = options.addStdio;
+    worker.process = fork(settings.exec, settings.args, forkOptions);
     worker.process.once('exit', function(exitCode, signalCode) {
       worker.suicide = !!worker.suicide;
       worker.state = 'dead';


### PR DESCRIPTION
Export ability (partly) of `child_process.spawn()` to specify fds / channels between parent and child to `child_process.fork()` and `cluster.fork()`, in reference to issue #5727
