### PR TITLE
crypto: do not move half-filled write head

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -315,6 +315,7 @@ void NodeBIO::Write(const char* data, size_t size) {
 
     // Go to next buffer if there still are some bytes to write
     if (left != 0) {
+      assert(write_head_->write_pos_ == kBufferLength);
       TryAllocateForWrite();
       write_head_ = write_head_->next_;
     }
@@ -342,7 +343,8 @@ void NodeBIO::Commit(size_t size) {
   // Allocate new buffer if write head is full,
   // and there're no other place to go
   TryAllocateForWrite();
-  write_head_ = write_head_->next_;
+  if (write_head_->write_pos_ == kBufferLength)
+    write_head_ = write_head_->next_;
 }
 
 


### PR DESCRIPTION
Might cause write head running over read head, when there were no
allocation and `Commit()` was called. Source of at least one test
failure on windows (`simple/test-https-drain.js`).

/cc @isaacs @tjfountaine @bnoordhuis
