### PR TITLE
fs: write strings directly to disk

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -373,19 +373,18 @@ to the completion callback.
 
 Synchronous fsync(2).
 
-## fs.write(fd, buffer, offset, length, position, callback)
+## fs.write(fd, buffer, offset, length[, position], callback)
 
 Write `buffer` to the file specified by `fd`.
 
 `offset` and `length` determine the part of the buffer to be written.
 
 `position` refers to the offset from the beginning of the file where this data
-should be written. If `position` is `null`, the data will be written at the
-current position.
-See pwrite(2).
+should be written. If `typeof position !== 'number'`, the data will be written
+at the current position. See pwrite(2).
 
-The callback will be given three arguments `(err, written, buffer)` where `written`
-specifies how many _bytes_ were written from `buffer`.
+The callback will be given three arguments `(err, written, buffer)` where
+`written` specifies how many _bytes_ were written from `buffer`.
 
 Note that it is unsafe to use `fs.write` multiple times on the same file
 without waiting for the callback. For this scenario,
@@ -395,9 +394,39 @@ On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
-## fs.writeSync(fd, buffer, offset, length, position)
+## fs.write(fd, data[, position[, encoding]], callback)
 
-Synchronous version of `fs.write()`. Returns the number of bytes written.
+Write `data` to the file specified by `fd`.  If `data` is not a Buffer instance
+then the value will be coerced to a string.
+
+`position` refers to the offset from the beginning of the file where this data
+should be written. If `typeof position !== 'number'` the data will be written at
+the current position. See pwrite(2).
+
+`encoding` is the expected string encoding.
+
+The callback will receive the arguments `(err, written, string)` where `written`
+specifies how many _bytes_ the passed string required to be written. Note that
+bytes written is not the same as string characters. See
+[Buffer.byteLength](buffer.html#buffer_class_method_buffer_bytelength_string_encoding).
+
+Unlike when writing `buffer`, the entire string must be written. No substring
+may be specified. This is because the byte offset of the resulting data may not
+be the same as the string offset.
+
+Note that it is unsafe to use `fs.write` multiple times on the same file
+without waiting for the callback. For this scenario,
+`fs.createWriteStream` is strongly recommended.
+
+On Linux, positional writes don't work when the file is opened in append mode.
+The kernel ignores the position argument and always appends the data to
+the end of the file.
+
+## fs.writeSync(fd, buffer, offset, length[, position])
+
+## fs.writeSync(fd, data[, position[, encoding]])
+
+Synchronous versions of `fs.write()`. Returns the number of bytes written.
 
 ## fs.read(fd, buffer, offset, length, position, callback)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -462,50 +462,59 @@ fs.readSync = function(fd, buffer, offset, length, position) {
   return [str, r];
 };
 
+// usage:
+//  fs.write(fd, buffer, offset, length[, position], callback);
+// OR
+//  fs.write(fd, string[, position[, encoding]], callback);
 fs.write = function(fd, buffer, offset, length, position, callback) {
-  if (!IS_BUFFER(buffer)) {
-    // legacy string interface (fd, data, position, encoding, callback)
-    callback = arguments[4];
-    position = arguments[2];
-    assertEncoding(arguments[3]);
-
-    buffer = new Buffer('' + arguments[1], arguments[3]);
-    offset = 0;
-    length = buffer.length;
-  }
-
-  if (!length) {
-    if (IS_FUNCTION(callback)) {
-      process.nextTick(function() {
-        callback(undefined, 0);
-      });
+  if (IS_BUFFER(buffer)) {
+    // if no position is passed then assume null
+    if (IS_FUNCTION(position)) {
+      callback = position;
+      position = null;
     }
-    return;
+    callback = maybeCallback(callback);
+    var wrapper = function(err, written) {
+      // Retain a reference to buffer so that it can't be GC'ed too soon.
+      callback(err, written || 0, buffer);
+    };
+    return binding.writeBuffer(fd, buffer, offset, length, position, wrapper);
   }
 
-  callback = maybeCallback(callback);
-
-  function wrapper(err, written) {
-    // Retain a reference to buffer so that it can't be GC'ed too soon.
+  if (IS_STRING(buffer))
+    buffer += '';
+  if (!IS_FUNCTION(position)) {
+    if (IS_FUNCTION(offset)) {
+      position = offset;
+      offset = null;
+    } else {
+      position = length;
+    }
+    length = 'utf8';
+  }
+  callback = maybeCallback(position);
+  position = function(err, written) {
+    // retain reference to string in case it's external
     callback(err, written || 0, buffer);
-  }
-
-  binding.write(fd, buffer, offset, length, position, wrapper);
+  };
+  return binding.writeString(fd, buffer, offset, length, position);
 };
 
+// usage:
+//  fs.writeSync(fd, buffer, offset, length[, position]);
+// OR
+//  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
-  if (!IS_BUFFER(buffer)) {
-    // legacy string interface (fd, data, position, encoding)
-    position = arguments[2];
-    assertEncoding(arguments[3]);
-
-    buffer = new Buffer('' + arguments[1], arguments[3]);
-    offset = 0;
-    length = buffer.length;
+  if (IS_BUFFER(buffer)) {
+    if (IS_UNDEFINED(position))
+      position = null;
+    return binding.writeBuffer(fd, buffer, offset, length, position);
   }
-  if (!length) return 0;
-
-  return binding.write(fd, buffer, offset, length, position);
+  if (!IS_STRING(buffer))
+    buffer += '';
+  if (IS_UNDEFINED(offset))
+    offset = null;
+  return binding.writeString(fd, buffer, offset, length, position);
 };
 
 fs.rename = function(oldPath, newPath, callback) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -230,12 +230,13 @@ size_t hex_decode(char* buf,
 }
 
 
-bool GetExternalParts(Handle<Value> val, const char** data, size_t* len) {
+bool StringBytes::GetExternalParts(Handle<Value> val,
+                                   const char** data,
+                                   size_t* len) {
   if (Buffer::HasInstance(val)) {
     *data = Buffer::Data(val);
     *len = Buffer::Length(val);
     return true;
-
   }
 
   assert(val->IsString());

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -239,7 +239,9 @@ bool StringBytes::GetExternalParts(Handle<Value> val,
     return true;
   }
 
-  assert(val->IsString());
+  if (!val->IsString())
+    return false;
+
   Local<String> str = Local<String>::New(val.As<String>());
 
   if (str->IsExternalAscii()) {

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -44,6 +44,12 @@ class StringBytes {
   // very much slower for UTF-8
   static size_t Size(v8::Handle<v8::Value> val, enum encoding enc);
 
+  // If the string is external then assign external properties to data and len,
+  // then return true. If not return false.
+  static bool GetExternalParts(v8::Handle<v8::Value> val,
+                               const char** data,
+                               size_t* len);
+
   // Write the bytes from the string or buffer into the char*
   // returns the number of bytes written, which will always be
   // <= buflen.  Use StorageSize/Size first to know how much


### PR DESCRIPTION
Instead of first converting the string to a `Buffer` instance, use the string data directly to write to disk.

This partially addresses #5607
