### PR TITLE
cluster: Multiple calls to worker.disconnect() should still wait for server close events

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -480,14 +480,18 @@ if (cluster.isMaster) {
       for (var key in serverListeners) {
         server = serverListeners[key];
 
-        // in case the server is closed we won't close it again
-        if (server._handle === null) {
+        if (server._handle === null && server._connections === 0) {
+          // The server is closed and no connections remain
           progress.done();
           continue;
         }
 
+        // The server is still active
         server.on('close', progress.done.bind(progress));
-        server.close();
+
+        // in case the server is closing we won't close it again
+        if (server._handle !== null)
+          server.close();
       }
     });
 


### PR DESCRIPTION
The current worker.disconnect() code includes a check for server._handle to determine if the server is already closed.

This PR also checks server._connections to see if there are open connections remaining.  It also extends the simple/test-cluster-worker-disconnect.js test to check that open connections keep the worker alive.
