### PR TITLE
assert: display failing assert expression in assertion messages

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -24,7 +24,9 @@
 
 // UTILITY
 var util = require('util');
-var pSlice = Array.prototype.slice;
+var Ap = Array.prototype;
+var pSlice = Ap.slice;
+var pMap = Ap.map;
 
 // 1. The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
@@ -71,10 +73,14 @@ function truncate(s, n) {
   }
 }
 
+function stringify(value) {
+  return truncate(JSON.stringify(value, replacer), 128);
+}
+
 function getMessage(self) {
-  return truncate(JSON.stringify(self.actual, replacer), 128) + ' ' +
+  return stringify(self.actual) + ' ' +
          self.operator + ' ' +
-         truncate(JSON.stringify(self.expected, replacer), 128);
+         stringify(self.expected);
 }
 
 // At present only the three keys mentioned above are used and
@@ -101,6 +107,19 @@ function fail(actual, expected, message, operator, stackStartFunction) {
 // EXTENSION! allows for well behaved errors defined elsewhere.
 assert.fail = fail;
 
+function check(result, args) {
+  if (!result) {
+    var stackStartFunction = args.callee;
+    var testName = stackStartFunction.name;
+    var argList = pMap.call(args, stringify).join(", ");
+    var message = "assert." + testName + "(" + argList + ")";
+    fail(result, true, message, testName, stackStartFunction);
+  }
+}
+// EXTENSION! Export the check function so that external code can define
+// its own easy-to-read assertion methods.
+assert._checkResult = check;
+
 // 4. Pure assertion tests whether a value is truthy, as determined
 // by !!guard.
 // assert.ok(guard, message_opt);
@@ -109,7 +128,7 @@ assert.fail = fail;
 // assert.strictEqual(true, guard, message_opt);.
 
 function ok(value, message) {
-  if (!!!value) fail(value, true, message, '==', assert.ok);
+  check(!!value, arguments);
 }
 assert.ok = ok;
 
@@ -118,25 +137,21 @@ assert.ok = ok;
 // assert.equal(actual, expected, message_opt);
 
 assert.equal = function equal(actual, expected, message) {
-  if (actual != expected) fail(actual, expected, message, '==', assert.equal);
+  check(actual == expected, arguments);
 };
 
 // 6. The non-equality assertion tests for whether two objects are not equal
 // with != assert.notEqual(actual, expected, message_opt);
 
 assert.notEqual = function notEqual(actual, expected, message) {
-  if (actual == expected) {
-    fail(actual, expected, message, '!=', assert.notEqual);
-  }
+  check(actual != expected, arguments);
 };
 
 // 7. The equivalence assertion tests a deep equality relation.
 // assert.deepEqual(actual, expected, message_opt);
 
 assert.deepEqual = function deepEqual(actual, expected, message) {
-  if (!_deepEqual(actual, expected)) {
-    fail(actual, expected, message, 'deepEqual', assert.deepEqual);
-  }
+  check(_deepEqual(actual, expected), arguments);
 };
 
 function _deepEqual(actual, expected) {
@@ -239,27 +254,21 @@ function objEquiv(a, b) {
 // assert.notDeepEqual(actual, expected, message_opt);
 
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
-  if (_deepEqual(actual, expected)) {
-    fail(actual, expected, message, 'notDeepEqual', assert.notDeepEqual);
-  }
+  check(!_deepEqual(actual, expected), arguments);
 };
 
 // 9. The strict equality assertion tests strict equality, as determined by ===.
 // assert.strictEqual(actual, expected, message_opt);
 
 assert.strictEqual = function strictEqual(actual, expected, message) {
-  if (actual !== expected) {
-    fail(actual, expected, message, '===', assert.strictEqual);
-  }
+  check(actual === expected, arguments);
 };
 
 // 10. The strict non-equality assertion tests for strict inequality, as
 // determined by !==.  assert.notStrictEqual(actual, expected, message_opt);
 
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
-  if (actual === expected) {
-    fail(actual, expected, message, '!==', assert.notStrictEqual);
-  }
+  check(actual !== expected, arguments);
 };
 
 function expectedException(actual, expected) {
@@ -278,11 +287,10 @@ function expectedException(actual, expected) {
   return false;
 }
 
-function _throws(shouldThrow, block, expected, message) {
+function _throws(shouldThrow, block, expected) {
   var actual;
 
   if (typeof expected === 'string') {
-    message = expected;
     expected = null;
   }
 
@@ -292,33 +300,32 @@ function _throws(shouldThrow, block, expected, message) {
     actual = e;
   }
 
-  message = (expected && expected.name ? ' (' + expected.name + ').' : '.') +
-            (message ? ' ' + message : '.');
-
   if (shouldThrow && !actual) {
-    fail(actual, expected, 'Missing expected exception' + message);
+    return false;
   }
 
   if (!shouldThrow && expectedException(actual, expected)) {
-    fail(actual, expected, 'Got unwanted exception' + message);
+    return false;
   }
 
   if ((shouldThrow && actual && expected &&
       !expectedException(actual, expected)) || (!shouldThrow && actual)) {
     throw actual;
   }
+
+  return true;
 }
 
 // 11. Expected to throw an error:
 // assert.throws(block, Error_opt, message_opt);
 
-assert.throws = function(block, /*optional*/error, /*optional*/message) {
-  _throws.apply(this, [true].concat(pSlice.call(arguments)));
+assert.throws = function throws(block, /*optional*/error, /*optional*/message) {
+  check(_throws(true, block, error), arguments);
 };
 
 // EXTENSION! This is annoying to write outside this module.
-assert.doesNotThrow = function(block, /*optional*/message) {
-  _throws.apply(this, [false].concat(pSlice.call(arguments)));
+assert.doesNotThrow = function doesNotThrow(block, /*optional*/error, /*optional*/message) {
+  check(_throws(false, block, error), arguments);
 };
 
-assert.ifError = function(err) { if (err) {throw err;}};
+assert.ifError = function ifError(err) { if (err) {throw err;}};

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -3,7 +3,7 @@ Exiting with code=1
 assert.js:*
   throw new assert.AssertionError({
         ^
-AssertionError: 1 == 2
+AssertionError: assert.equal(1, 2)
     at Object.<anonymous> (*test*message*error_exit.js:*:*)
     at Module._compile (module.js:*:*)
     at Object.Module._extensions..js (module.js:*:*)

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -258,8 +258,10 @@ function testAssertionMessage(actual, expected) {
   try {
     assert.equal(actual, '');
   } catch (e) {
-    assert.equal(e.toString(),
-        ['AssertionError:', expected, '==', '""'].join(' '));
+    assert.equal(
+      e.toString(),
+      'AssertionError: assert.equal(' + expected + ', "")'
+    );
   }
 }
 testAssertionMessage(undefined, '"undefined"');
@@ -285,12 +287,16 @@ testAssertionMessage({a: NaN, b: Infinity, c: -Infinity},
 
 // #2893
 try {
-  assert.throws(function () {
+  function block() {
     assert.ifError(null);
-  });
+  }
+  assert.throws(block);
 } catch (e) {
   threw = true;
-  assert.equal(e.message, 'Missing expected exception..');
+  assert.equal(
+    e.message,
+    'assert.throws(' + JSON.stringify(block.toString()) + ')'
+  );
 }
 assert.ok(threw);
 
@@ -298,11 +304,17 @@ assert.ok(threw);
 try {
   assert.equal(1, 2);
 } catch (e) {
-  assert.equal(e.toString().split('\n')[0], 'AssertionError: 1 == 2')
+  assert.equal(
+    e.toString().split('\n')[0],
+    'AssertionError: assert.equal(1, 2)'
+  );
 }
 
 try {
   assert.equal(1, 2, 'oh no');
 } catch (e) {
-  assert.equal(e.toString().split('\n')[0], 'AssertionError: oh no')
+  assert.equal(
+    e.toString().split('\n')[0],
+    'AssertionError: assert.equal(1, 2, "oh no")'
+  );
 }


### PR DESCRIPTION
This is a less hairy alternative to a previous proposal to display C-style assertion messages: https://github.com/joyent/node/pull/2444

Whereas C's `#define assert` displays the original source of the condition argument, I am proposing to display the resulting/computed values of all the arguments, including any provided message arguments.

Consider the following failing assertion:

``` js
function getObject() {
  return { mark: 333 * 2 }
}

require("assert").notDeepEqual(getObject(), { mark: 666 }, getObject.name +
  " returned the forbidden value");
```

With my proposed changes, the first line of the resulting error message would be:

```
AssertionError: assert.notDeepEqual({"mark":666}, {"mark":666}, "getObject returned the forbidden value")
```

This output is more helpful than what is currently displayed:

```
AssertionError: getObject returned the forbidden value
```

because it mentions the `notDeepEqual` method and displays a the final values that were expected to be unequal, along with any other arguments that were passed. In other words, you can now pass as many or as few trailing message arguments as you like.

The new behavior is also slightly less confusing when no message is provided:

``` js
assert.notEqual("hello", "hel" + "lo");
```

Compare the new output:

```
AssertionError: assert.notEqual("hello", "hello")
```

to the old:

```
AssertionError: "hello" != "hello"
```

This treatment of error messages paves the way for more sophisticated assertions, such as

``` js
assert.every(isEven, [a(), b(), c()], "some values were odd")
```

The `require("assert")._checkResult` function is exported so that external code can easily augment the assertion module:

``` js
var assert = require("assert");

assert.every = function every(predicate, list) {
   return assert._checkResult(list.every(predicate), arguments);
};
```
