### PR TITLE
Removed date caching to fix delay in exit

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -39,16 +39,8 @@ var dateExpression = /Date/i;
 var expectExpression = /Expect/i;
 
 
-var dateCache;
 function utcDate() {
-  if (!dateCache) {
-    var d = new Date();
-    dateCache = d.toUTCString();
-    setTimeout(function() {
-      dateCache = undefined;
-    }, 1000 - d.getMilliseconds());
-  }
-  return dateCache;
+  return new Date().toUTCString();
 }
 
 

--- a/test/simple/test-http-process-exit-delay.js
+++ b/test/simple/test-http-process-exit-delay.js
@@ -1,0 +1,39 @@
+var assert = require('assert');
+var common = require('../common.js');
+var http = require('http');
+
+var start;
+var server = http.createServer(function(req, res) {
+  req.resume();
+  req.on('end', function() {
+    res.end('Success');
+  });
+
+  server.close(function() {
+    start = process.hrtime();
+  });
+});
+
+server.listen(common.PORT, 'localhost', function() {
+  var interval_id = setInterval(function() {
+    if (new Date().getMilliseconds() > 100)
+      return;
+
+    var req = http.request({
+      'host': 'localhost',
+      'port': common.PORT,
+      'agent': false,
+      'method': 'PUT'
+    });
+
+    req.end('Test');
+    clearInterval(interval_id);
+  }, 1);
+});
+
+process.on('exit', function() {
+  var d = process.hrtime(start);
+  assert.equal(d[0], 0);
+  assert(d[1] / 1e9 < 0.03);
+  console.log('ok');
+});


### PR DESCRIPTION
Without this patch, there can be up to a second delay between the time the
server is closed and the time the node process is exited, because the utcDate() function
in OutgoingMessage was doing a setTimeout() to update the cached
date/time.

This won't matter as much for production servers, but should have a bigger
impact on the tests.

If it turns out that the date/time caching was not a premature
optimization and should be retained, an `.unref()` should be added to the setTimeout() timer.

I worked on this during nodeconf2013 -- @isaacs nailed down the root problem and @piscisaureus helped quite a bit.
