### PR TITLE
http: Send GET request with a body as chunked

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -389,6 +389,8 @@ Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
 
 OutgoingMessage.prototype.write = function(chunk, encoding) {
   if (!this._header) {
+    if (this.method === 'GET' && chunk.length !== 0)
+      this.useChunkedEncodingByDefault = true;
     this._implicitHeader();
   }
 
@@ -471,6 +473,8 @@ OutgoingMessage.prototype.end = function(data, encoding) {
     return false;
   }
   if (!this._header) {
+    if (this.method === 'GET' && data && data.length !== 0)
+      this.useChunkedEncodingByDefault = true;
     this._implicitHeader();
   }
 

--- a/test/simple/test-http-get-body.js
+++ b/test/simple/test-http-get-body.js
@@ -1,0 +1,41 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common.js');
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  req.resume();
+  req.on('end', function() {
+    res.end('ok');
+    console.log('ok');
+  });
+  server.close();
+});
+
+server.listen(common.PORT, 'localhost', function() {
+    var req = http.request({
+      'host': 'localhost',
+      'port': common.PORT
+    });
+    req.end('ok');
+});


### PR DESCRIPTION
If a GET with a body is being sent and it is in implicit headers mode,
the body will be sent chunked by default (if a Content-Length is
not specified). Otherwise it would result in a request with a body and
no Content-Length header, which is invalid and causes a socket hang up
error.

The HTTP 1.1 spec allows sending a body with a GET request, but the
server isn't allowed to attach meaning to it because GET requests are
idempotent.

Fixes #5767 (more discussion there as well).
