### PR TITLE
tls: only wait for finish if we haven't seen it

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -645,12 +645,15 @@ CryptoStream.prototype.destroySoon = function(err) {
     // Wait for both `finish` and `end` events to ensure that all data that
     // was written on this side was read from the other side.
     var self = this;
-    var waiting = 2;
+    var waiting = 1;
     function finish() {
       if (--waiting === 0) self.destroy();
     }
     this._opposite.once('end', finish);
-    this.once('finish', finish);
+    if (!this._finished) {
+      this.once('finish', finish);
+      ++waiting;
+    }
   }
 };
 


### PR DESCRIPTION
A pooled https agent may get a Connection: close, but never finish
destroying the socket as the prior request had already emitted finish
likely from a pipe.

Since the socket is not marked as destroyed it may get reused by the
agent pool and result in an ECONNRESET.

re: #5712 #5739
