### PR TITLE
doc: fs.watch should document throwing error

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -542,6 +542,8 @@ no-op, not an error.
 Watch for changes on `filename`, where `filename` is either a file or a
 directory.  The returned object is a [fs.FSWatcher](#fs_class_fs_fswatcher).
 
+If the `FSWatcher` object cannot be created, an `ErrnoException` is thrown.
+
 The second argument is optional. The `options` if provided should be an object
 containing a boolean member `persistent`, which indicates whether the process
 should continue to run as long as files are being watched. The default is


### PR DESCRIPTION
error is thrown here:
https://github.com/joyent/node/blob/master/lib/fs.js#L1038

I was caught off-guard that this method would throw errors, and wanted to put it in the docs. Simply wrapping things in a try/catch solved my issues, but I had no heads up that the method could throw errors.
