### PR TITLE
Buffer.write* operations now return reference to buffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -588,6 +588,7 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 1, 0xff, 0);
   this[offset] = value;
+  return this;
 };
 
 
@@ -599,6 +600,7 @@ function writeUInt16(buffer, value, offset, isBigEndian) {
     buffer[offset + 1] = (value & 0xff00) >>> 8;
     buffer[offset] = value & 0x00ff;
   }
+  return this;
 }
 
 
@@ -608,6 +610,7 @@ Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, false);
+  return this;
 };
 
 
@@ -617,6 +620,7 @@ Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, true);
+  return this;
 };
 
 
@@ -632,6 +636,7 @@ function writeUInt32(buffer, value, offset, isBigEndian) {
     buffer[offset + 1] = (value >>> 8) & 0xff;
     buffer[offset] = value & 0xff;
   }
+  return this;
 }
 
 
@@ -641,6 +646,7 @@ Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, false);
+  return this;
 };
 
 
@@ -650,6 +656,7 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, true);
+  return this;
 };
 
 
@@ -697,6 +704,7 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
     checkInt(this, value, offset, 1, 0x7f, -0x80);
   if (value < 0) value = 0xff + value + 1;
   this[offset] = value;
+  return this;
 };
 
 
@@ -707,6 +715,7 @@ Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, false);
+  return this;
 };
 
 
@@ -717,6 +726,7 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, true);
+  return this;
 };
 
 
@@ -727,6 +737,7 @@ Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, false);
+  return this;
 };
 
 
@@ -737,4 +748,5 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, true);
+  return this;
 };


### PR DESCRIPTION
Added `return this;` to the bottom of all write methods in order to increase readability:

```
new Buffer(4).writeUInt16BE(300, 0).writeUInt16BE(120, 2);
```
