### PR TITLE
smalloc: call callback if set on AllocDispose

### DIFF
--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -180,14 +180,15 @@ void AllocDispose(Handle<Object> obj) {
   char* data = static_cast<char*>(obj->GetIndexedPropertiesExternalArrayData());
   size_t length = obj->GetIndexedPropertiesExternalArrayDataLength();
 
-  if (data == NULL || length == 0)
-    return;
-
-  obj->SetIndexedPropertiesToExternalArrayData(NULL,
-                                               kExternalUnsignedByteArray,
-                                               0);
-  free(data);
-  node_isolate->AdjustAmountOfExternalAllocatedMemory(-length);
+  if (data != NULL) {
+    obj->SetIndexedPropertiesToExternalArrayData(NULL,
+                                                 kExternalUnsignedByteArray,
+                                                 0);
+    free(data);
+  }
+  if (length != 0) {
+    node_isolate->AdjustAmountOfExternalAllocatedMemory(-length);
+  }
 }
 
 


### PR DESCRIPTION
Fix bug where if dev passed a callback to Alloc then called AllocDispose
it wouldn't bother to pass the data to the callback and instead would
just free it.
