### PR TITLE
doc: update JSON output of API docs to unstable

### DIFF
--- a/doc/api/documentation.markdown
+++ b/doc/api/documentation.markdown
@@ -74,9 +74,7 @@ change.  Please do not suggest changes in this area; they will be refused.
 
 ## JSON Output
 
-    Stability: 1 - Experimental
+    Stability: 2 - Unstable
 
 Every HTML file in the markdown has a corresponding JSON file with the
 same data.
-
-This feature is new as of node v0.6.12.  It is experimental.


### PR DESCRIPTION
Minor doc change, moving from Experimental to Unstable for 
JSON output and removing reference to node v0.6.12.
