### PR TITLE
Buffer dispose

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -37,12 +37,12 @@ buffer.setupBufferJS(Buffer);
 Buffer.poolSize = 8 * 1024;
 var poolSize = Buffer.poolSize;
 var poolOffset = 0;
-var allocPool = alloc({}, poolSize);
+var allocPool = alloc({ __refs: 0 }, poolSize);
 
 
 function createPool() {
   poolSize = Buffer.poolSize;
-  allocPool = alloc({}, poolSize);
+  allocPool = alloc({ __refs: 0 }, poolSize);
   poolOffset = 0;
 }
 
@@ -77,8 +77,10 @@ function Buffer(subject, encoding) {
                             this,
                             poolOffset,
                             poolOffset + this.length);
+    this.parent.__refs++;
     poolOffset += this.length;
   } else {
+    this.__refs = 0;
     alloc(this, this.length);
   }
 
@@ -100,6 +102,7 @@ function Buffer(subject, encoding) {
 function SlowBuffer(length) {
   length = ~~length;
   var b = new Buffer(undefined, length);
+  b.__refs = 0;
   alloc(b, length);
   return b;
 }
@@ -167,6 +170,25 @@ Buffer.concat = function(list, length) {
 // pre-set for values that may exist in the future
 Buffer.prototype.length = undefined;
 Buffer.prototype.parent = undefined;
+Buffer.prototype.__refs = undefined;
+
+
+Buffer.prototype.dispose = function() {
+  var parent = this.parent || this;
+
+  if (parent.__refs <= 1) {
+    smalloc.dispose(this);
+    parent.__refs = 0;
+  } else {
+    buffer.disposeSlice(this);
+    parent.__refs--;
+  }
+
+  if (this.parent)
+    this.parent = undefined;
+
+  this.length = 0;
+};
 
 
 // toString(encoding, start=0, end=buffer.length)
@@ -360,8 +382,10 @@ Buffer.prototype.slice = function(start, end) {
   var buf = new Buffer();
   sliceOnto(this, buf, start, end);
   buf.length = end - start;
-  if (buf.length > 0)
+  if (buf.length > 0) {
     buf.parent = util.isUndefined(this.parent) ? this : this.parent;
+    buf.parent.__refs++;
+  }
 
   return buf;
 };

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -228,6 +228,22 @@ Local<Object> Use(char* data, uint32_t length) {
 }
 
 
+void DisposeSlice(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(node_isolate);
+
+  assert(args[0]->IsObject());
+
+  Local<Object> obj = args[0].As<Object>();
+  char* data = static_cast<char*>(obj->GetIndexedPropertiesExternalArrayData());
+  size_t length = obj->GetIndexedPropertiesExternalArrayDataLength();
+
+  if (data != NULL || length > 0)
+    obj->SetIndexedPropertiesToExternalArrayData(NULL,
+                                                 v8::kExternalUnsignedByteArray,
+                                                 0);
+}
+
+
 template <encoding encoding>
 void StringSlice(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
@@ -608,6 +624,8 @@ void Initialize(Handle<Object> target) {
 
   target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "setupBufferJS"),
               FunctionTemplate::New(SetupBufferJS)->GetFunction());
+  target->Set(String::New("disposeSlice"),
+              FunctionTemplate::New(DisposeSlice)->GetFunction());
 }
 
 

--- a/test/simple/test-buffer-dispose-segfault.js
+++ b/test/simple/test-buffer-dispose-segfault.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var spawn = require('child_process').spawn;
+var SlowBuffer = require('buffer').SlowBuffer;
+
+
+// child
+if (process.argv[2] === 'child') {
+  var b = new SlowBuffer(5).fill(0xf);
+  var c = b.slice(0, 2);
+  var d = b.slice(0, 4);
+
+  b.dispose();
+
+  for (var i = 0; i < 1e3; i++) {
+    b = new SlowBuffer(5).fill(0xa);
+    c[0] += c[1];
+    d[2] += d[3];
+    b.dispose();
+    if (i % 10 === 0) gc();
+  }
+} else {
+  // test case
+  var child = spawn(process.execPath,
+                ['--expose_gc', __filename, 'child']);
+
+  child.on('exit', function(code, signal) {
+    assert.equal(code, 0, signal);
+    console.log('dispose didn\'t segfault');
+  });
+}


### PR DESCRIPTION
This may be a controversial piece of functionality. While it does offer some awesome advantages for scenarios like the following:

``` javascript
net.createServer(function(socket) {
  socket.on('data', function(chunk) {
    fs.write(anFsFd, chunk, function() {
      chunk.dispose();
    });
  });
});
```

This is riddled with opportunities for developers to kick themselves in the crotch. IMO the advantages are enough where finding the right balance is well worth it. In some cases were raw throughput is key I've been able to increase throughput upwards of 30%.
