### PR TITLE
http: fix chunk length calculation if write was called with encoding.

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -560,9 +560,9 @@ exports.pbkdf2Sync = function(password, salt, iterations, keylen) {
 function pbkdf2(password, salt, iterations, keylen, callback) {
   password = toBuf(password);
   salt = toBuf(salt);
-
+  var domain = (process) ? process.domain : undefined;
   if (exports.DEFAULT_ENCODING === 'buffer')
-    return binding.PBKDF2(password, salt, iterations, keylen, callback);
+    return binding.PBKDF2(password, salt, iterations, keylen, callback, domain);
 
   // at this point, we need to handle encodings.
   var encoding = exports.DEFAULT_ENCODING;
@@ -571,9 +571,9 @@ function pbkdf2(password, salt, iterations, keylen, callback) {
       if (ret)
         ret = ret.toString(encoding);
       callback(er, ret);
-    });
+    }, domain);
   } else {
-    var ret = binding.PBKDF2(password, salt, iterations, keylen);
+    var ret = binding.PBKDF2(password, salt, iterations, keylen, undefined, domain);
     return ret.toString(encoding);
   }
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -814,7 +814,11 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
       ret = this._send(chunk, encoding);
     } else {
       // buffer, or a non-toString-friendly encoding
-      len = chunk.length;
+      if(encoding !== undefined) {
+        len = Buffer.byteLength(chunk, encoding);
+      } else {
+        len = chunk.length;
+      }
       this._send(len.toString(16) + CRLF);
       this._send(chunk, encoding);
       ret = this._send(CRLF);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3848,7 +3848,7 @@ Handle<Value> PBKDF2(const Arguments& args) {
   ssize_t iter = -1;
   pbkdf2_req* req = NULL;
 
-  if (args.Length() != 4 && args.Length() != 5) {
+  if (args.Length() != 6) {
     type_error = "Bad parameter";
     goto err;
   }
@@ -3910,6 +3910,7 @@ Handle<Value> PBKDF2(const Arguments& args) {
   if (args[4]->IsFunction()) {
     req->obj = Persistent<Object>::New(Object::New());
     req->obj->Set(String::New("ondone"), args[4]);
+    req->obj->Set(String::New("domain"), args[5]);
     uv_queue_work(uv_default_loop(),
                   &req->work_req,
                   EIO_PBKDF2,

--- a/test/simple/test-crypto-pbkdf2-domain-error.js
+++ b/test/simple/test-crypto-pbkdf2-domain-error.js
@@ -1,0 +1,41 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var crypto = require('crypto');
+var domain = require('domain');
+var assert = require('assert');
+
+var d = domain.create();
+var gotError = false;
+
+process.on('exit', function() {
+  assert(gotError);
+});
+
+d.on('error', function () { 
+  gotError = true; 
+});
+
+d.run(function () {
+  crypto.pbkdf2('a', 'b', 1, 8, function () {
+    throw new Error('x');
+  });
+});

--- a/test/simple/test-http-server-encoding-length.js
+++ b/test/simple/test-http-server-encoding-length.js
@@ -1,0 +1,72 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var util = require('util');
+
+var buf  = new Buffer(43);
+var port = common.PORT;
+
+var data = "R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+
+var server = http.createServer(function(req, res) {
+    req.resume();
+    res.writeHeader(200, {"Content-type": "image/gif"});
+    if (req.url == "/buf") {
+        buf.write(data, 0, 43, "base64")
+        res.write(buf);
+    } else {
+        res.write(data, "base64");
+    }
+    res.end();
+}).listen(port, function() {
+    var offset = 0;
+    var paths = ['/buf', '/'];
+    
+    function do_request(offset) {
+	      var options = {
+	          host: 'localhost',
+	          port: port,
+	          path: paths[offset],
+	          headers: {},
+	      };
+	      var req = http.request(options, function(res) {
+	          var chunks = [];
+	          
+	          res.on('data', function(chunk) {
+		            chunks.push(chunk);
+	          });
+	          res.on('end', function() {
+		            var concat = Buffer.concat(chunks);
+		            assert.ok(concat.toString('base64') === data, "Did not get expected data");
+		            if(++offset === paths.length) {
+		                server.close();
+		            } else {
+		                do_request(offset);
+		            }
+	          });
+	      });
+	      req.end();
+    }
+    do_request(0);
+});


### PR DESCRIPTION
The chunk length calculation when using chunked transfer encoding
and a string encoding of Base64 was incorrect.  This patch properly
calculates the chunk length, by getting the number of bytes when
the string is decoded rather then just the length of the string.

Patch is for v0.10.

Fixes issue: #5777
