### PR TITLE
crypto: pbkdf2 should keep current domain

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -560,9 +560,9 @@ exports.pbkdf2Sync = function(password, salt, iterations, keylen) {
 function pbkdf2(password, salt, iterations, keylen, callback) {
   password = toBuf(password);
   salt = toBuf(salt);
-
+  var domain = (process) ? process.domain : undefined;
   if (exports.DEFAULT_ENCODING === 'buffer')
-    return binding.PBKDF2(password, salt, iterations, keylen, callback);
+    return binding.PBKDF2(password, salt, iterations, keylen, callback, domain);
 
   // at this point, we need to handle encodings.
   var encoding = exports.DEFAULT_ENCODING;
@@ -571,9 +571,9 @@ function pbkdf2(password, salt, iterations, keylen, callback) {
       if (ret)
         ret = ret.toString(encoding);
       callback(er, ret);
-    });
+    }, domain);
   } else {
-    var ret = binding.PBKDF2(password, salt, iterations, keylen);
+    var ret = binding.PBKDF2(password, salt, iterations, keylen, undefined, domain);
     return ret.toString(encoding);
   }
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3848,7 +3848,7 @@ Handle<Value> PBKDF2(const Arguments& args) {
   ssize_t iter = -1;
   pbkdf2_req* req = NULL;
 
-  if (args.Length() != 4 && args.Length() != 5) {
+  if (args.Length() != 6) {
     type_error = "Bad parameter";
     goto err;
   }
@@ -3910,6 +3910,7 @@ Handle<Value> PBKDF2(const Arguments& args) {
   if (args[4]->IsFunction()) {
     req->obj = Persistent<Object>::New(Object::New());
     req->obj->Set(String::New("ondone"), args[4]);
+    req->obj->Set(String::New("domain"), args[5]);
     uv_queue_work(uv_default_loop(),
                   &req->work_req,
                   EIO_PBKDF2,

--- a/test/simple/test-crypto-pbkdf2-domain-error.js
+++ b/test/simple/test-crypto-pbkdf2-domain-error.js
@@ -1,0 +1,41 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var crypto = require('crypto');
+var domain = require('domain');
+var assert = require('assert');
+
+var d = domain.create();
+var gotError = false;
+
+process.on('exit', function() {
+  assert(gotError);
+});
+
+d.on('error', function () { 
+  gotError = true; 
+});
+
+d.run(function () {
+  crypto.pbkdf2('a', 'b', 1, 8, function () {
+    throw new Error('x');
+  });
+});


### PR DESCRIPTION
Passes the active domain into the callback for crypto.pbkdf2 function, so that any
exceptions are thrown to the domain handler.

Fixes issue #5801.  Please review.
