### PR TITLE
allow escaping buffers in querystring.stringify and a little improvement...

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -36,6 +36,19 @@ function charCode(c) {
   return c.charCodeAt(0);
 }
 
+var escapeTokens = {
+  percent: '%'.charCodeAt(0),
+  plus: '+'.charCodeAt(0),
+  space: ' '.charCodeAt(0),
+  zero: '0'.charCodeAt(0),
+  nine: '9'.charCodeAt(0),
+  a: 'a'.charCodeAt(0),
+  f: 'f'.charCodeAt(0),
+  z: 'z'.charCodeAt(0),
+  A: 'A'.charCodeAt(0),
+  F: 'F'.charCodeAt(0),
+  Z: 'Z'.charCodeAt(0)
+};
 
 // a safe fast alternative to decodeURIComponent
 QueryString.unescapeBuffer = function(s, decodeSpaces) {
@@ -48,13 +61,13 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
     switch (state) {
       case 'CHAR':
         switch (c) {
-          case charCode('%'):
+          case escapeTokens.percent:
             n = 0;
             m = 0;
             state = 'HEX0';
             break;
-          case charCode('+'):
-            if (decodeSpaces) c = charCode(' ');
+          case escapeTokens.plus:
+            if (decodeSpaces) c = escapeTokens.space;
             // pass thru
           default:
             out[outIndex++] = c;
@@ -65,14 +78,14 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
       case 'HEX0':
         state = 'HEX1';
         hexchar = c;
-        if (charCode('0') <= c && c <= charCode('9')) {
-          n = c - charCode('0');
-        } else if (charCode('a') <= c && c <= charCode('f')) {
-          n = c - charCode('a') + 10;
-        } else if (charCode('A') <= c && c <= charCode('F')) {
-          n = c - charCode('A') + 10;
+        if (escapeTokens.zero <= c && c <= escapeTokens.nine) {
+          n = c - escapeTokens.zero;
+        } else if (escapeTokens.a <= c && c <= escapeTokens.f) {
+          n = c - escapeTokens.a + 10;
+        } else if (escapeTokens.A <= c && c <= escapeTokens.F) {
+          n = c - escapeTokens.A + 10;
         } else {
-          out[outIndex++] = charCode('%');
+          out[outIndex++] = escapeTokens.percent;
           out[outIndex++] = c;
           state = 'CHAR';
           break;
@@ -81,14 +94,14 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
 
       case 'HEX1':
         state = 'CHAR';
-        if (charCode('0') <= c && c <= charCode('9')) {
-          m = c - charCode('0');
-        } else if (charCode('a') <= c && c <= charCode('f')) {
-          m = c - charCode('a') + 10;
-        } else if (charCode('A') <= c && c <= charCode('F')) {
-          m = c - charCode('A') + 10;
+        if (escapeTokens.zero <= c && c <= escapeTokens.nine) {
+          m = c - escapeTokens.zero;
+        } else if (escapeTokens.a <= c && c <= escapeTokens.f) {
+          m = c - escapeTokens.a + 10;
+        } else if (escapeTokens.A <= c && c <= escapeTokens.F) {
+          m = c - escapeTokens.A + 10;
         } else {
-          out[outIndex++] = charCode('%');
+          out[outIndex++] = escapeTokens.percent;
           out[outIndex++] = hexchar;
           out[outIndex++] = c;
           break;
@@ -103,14 +116,47 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
   return out.slice(0, outIndex - 1);
 };
 
-
 QueryString.unescape = function(s, decodeSpaces) {
   return QueryString.unescapeBuffer(s, decodeSpaces).toString();
 };
 
+QueryString.escapeBuffer = function(s, encodeSpaces) {
+  var r;
 
-QueryString.escape = function(str) {
-  return encodeURIComponent(str);
+  if (!(s instanceof Buffer)) {
+    r = encodeURIComponent(s);
+    if (encodeSpaces) r = r.replace('%20', '+');
+    return r;
+  }
+
+  var i, len, et = escapeTokens;
+  len = s.length;
+  r = Array(len);
+
+  for (i = 0; i < len; i++) {
+    var n = s[i];
+    switch (true) {
+      // alphanumerics can be passed as is
+      case et.zero <= n && n <= et.nine:
+      case et.a <= n && n <= et.z:
+      case et.A <= n && n <= et.Z:
+        r[i] = String.fromCharCode(n);
+        break;
+      // space can be converted to plus if needed
+      case encodeSpaces && n === et.space:
+        r[i] = '+';
+        break;
+      // convert all other characters to %hh notation
+      default:
+        r[i] = '%' + (n.toString(16));
+    }
+  }
+
+  return r.join('');
+};
+
+QueryString.escape = function(s, encodeSpaces) {
+  return QueryString.escapeBuffer(s, encodeSpaces);
 };
 
 var stringifyPrimitive = function(v) {
@@ -123,6 +169,11 @@ var stringifyPrimitive = function(v) {
 
     case 'number':
       return isFinite(v) ? v : '';
+
+    case 'object':
+      if (v instanceof Buffer) {
+        return v;
+      }
 
     default:
       return '';
@@ -137,7 +188,7 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
     obj = undefined;
   }
 
-  if (typeof obj === 'object') {
+  if (typeof obj === 'object' && !(obj instanceof Buffer)) {
     return Object.keys(obj).map(function(k) {
       var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
       if (Array.isArray(obj[k])) {


### PR DESCRIPTION
... in unescapeBuffer

Check please line 108. Do we really need toString() there?
