### PR TITLE
timers: setImmediate process full queue each turn

### DIFF
--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -54,11 +54,10 @@ callbacks and before `setTimeout` and `setInterval` . Returns an
 `immediateId` for possible use with `clearImmediate()`. Optionally you
 can also pass arguments to the callback.
 
-Immediates are queued in the order created, and are popped off the queue once
-per loop iteration. `setImmediate` will yield to the event loop after firing a
-queued callback to make sure I/O is not being starved. While order is preserved
-for execution, other I/O events may fire between any two scheduled immediate
-callbacks.
+Callbacks for immediates are queued in the order in which they were created.
+The entire callback queue is processed every event loop iteration. If you queue
+an immediate from a inside an executing callback that immediate won't fire
+until the next event loop iteration.
 
 ## clearImmediate(immediateId)
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -313,18 +313,24 @@ L.init(immediateQueue);
 
 
 function processImmediate() {
-  var immediate = L.shift(immediateQueue);
+  var queue = immediateQueue;
 
-  if (L.isEmpty(immediateQueue)) {
-    process._needImmediateCallback = false;
+  immediateQueue = {};
+  L.init(immediateQueue);
+
+  while (L.isEmpty(queue) === false) {
+    var immediate = L.shift(queue);
+    var domain = immediate.domain;
+    if (domain) domain.enter();
+    immediate._onImmediate();
+    if (domain) domain.exit();
   }
 
-  if (immediate._onImmediate) {
-    if (immediate.domain) immediate.domain.enter();
-
-    immediate._onImmediate();
-
-    if (immediate.domain) immediate.domain.exit();
+  // Only round-trip to C++ land if we have to. Calling clearImmediate() on an
+  // immediate that's in |queue| is okay. Worst case is we make a superfluous
+  // call to NeedImmediateCallbackSetter().
+  if (L.isEmpty(immediateQueue)) {
+    process._needImmediateCallback = false;
   }
 }
 

--- a/test/simple/test-timers-immediate-queue.js
+++ b/test/simple/test-timers-immediate-queue.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+// setImmediate should run clear its queued cbs once per event loop turn
+// but immediates queued while processing the current queue should happen
+// on the next turn of the event loop.
+
+// in v0.10 hit should be 1, because we only process one cb per turn
+// in v0.11 and beyond it should be the exact same size of QUEUE
+// if we're letting things recursively add to the immediate QUEUE hit will be
+// > QUEUE
+
+var ticked = false;
+
+var hit = 0;
+var QUEUE = 1000;
+
+function run() {
+  if (hit === 0)
+    process.nextTick(function() { ticked = true; });
+
+  if (ticked) return;
+
+  hit += 1;
+  setImmediate(run);
+}
+
+for (var i = 0; i < QUEUE; i++)
+  setImmediate(run);
+
+process.on('exit', function() {
+  console.log('hit', hit);
+  assert.strictEqual(hit, QUEUE, 'We ticked between the immediate queue');
+});


### PR DESCRIPTION
Previously only one cb per turn of the event loop was processed at a
time, which is not exactly what is meant by immediate

fixes #5798

/cc @bnoordhuis
