### PR TITLE
buffer: return offset for end of last write

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -574,6 +574,7 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 1, 0xff, 0);
   this[offset] = value;
+  return offset + 1;
 };
 
 
@@ -594,6 +595,7 @@ Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, false);
+  return offset + 2;
 };
 
 
@@ -603,6 +605,7 @@ Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
   writeUInt16(this, value, offset, true);
+  return offset + 2;
 };
 
 
@@ -627,6 +630,7 @@ Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, false);
+  return offset + 4;
 };
 
 
@@ -636,6 +640,7 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
   writeUInt32(this, value, offset, true);
+  return offset + 4;
 };
 
 
@@ -683,6 +688,7 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
     checkInt(this, value, offset, 1, 0x7f, -0x80);
   if (value < 0) value = 0xff + value + 1;
   this[offset] = value;
+  return offset + 1;
 };
 
 
@@ -693,6 +699,7 @@ Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, false);
+  return offset + 2;
 };
 
 
@@ -703,6 +710,7 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
   if (value < 0) value = 0xffff + value + 1;
   writeUInt16(this, value, offset, true);
+  return offset + 2;
 };
 
 
@@ -713,6 +721,7 @@ Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, false);
+  return offset + 4;
 };
 
 
@@ -723,4 +732,5 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
   if (value < 0) value = 0xffffffff + value + 1;
   writeUInt32(this, value, offset, true);
+  return offset + 4;
 };

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -778,6 +778,14 @@ assert.equal(buf[3], 0xFF);
   assert.equal(buf[3], 0xFF);
 });
 
+// test offset returns are correct
+var b = new Buffer(16);
+assert.equal(4, b.writeUInt32LE(0, 0));
+assert.equal(6, b.writeUInt16LE(0, 4));
+assert.equal(7, b.writeUInt8(0, 6));
+assert.equal(8, b.writeInt8(0, 7));
+assert.equal(16, b.writeDoubleLE(0, 8));
+
 // test for buffer overrun
 buf = new Buffer([0, 0, 0, 0, 0]); // length: 5
 var sub = buf.slice(0, 4);         // length: 4


### PR DESCRIPTION
Users asked to have `Buffer#write*` methods return last offset. Now the do.

Fixes #3597
