### PR TITLE
Enable creating a Buffer with NULL data by relaxing an assert in smalloc.

### DIFF
--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -220,7 +220,7 @@ void Alloc(Handle<Object> obj,
            size_t length,
            FreeCallback fn,
            void* hint) {
-  assert(data != NULL);
+  assert(data != NULL || length == 0);
 
   if (smalloc_sym.IsEmpty()) {
     smalloc_sym = String::New("_smalloc_p");


### PR DESCRIPTION
This re-allows creating a NULL Buffer when there is no risk of dereferencing it in JS land.

It is required by the [ref module](https://github.com/TooTallNate/ref), which has a NULL "pointer" constant and also can read an arbitrary "pointer" (Buffer), NULL or otherwise, from memory.

I have come across this problem while updating the [ref module](https://github.com/TooTallNate/ref) to build against node.js master and v8 bleeding edge.
From [ref source](https://github.com/TooTallNate/ref/blob/master/src/binding.cc#L111-L124):

``` cc
/*
 * Creates the "null_pointer_buffer" Buffer instance that points to NULL.
 * It has a length of 0 so that you don't accidentally try to deref the NULL
 * pointer in JS-land by doing something like: `ref.NULL[0]`.
 */
```
