### PR TITLE
Callback with Buffers from child_process.exec

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -607,11 +607,14 @@ exports.execFile = function(file /* args, options, callback */) {
   var child = spawn(file, args, {
     cwd: options.cwd,
     env: options.env,
+    encoding: options.encoding,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 
-  var stdout = '';
-  var stderr = '';
+  var _stdout = [];
+  var _stderr = [];
+  var stdoutLen = 0;
+  var stderrLen = 0;
   var killed = false;
   var exited = false;
   var timeoutId;
@@ -628,6 +631,16 @@ exports.execFile = function(file /* args, options, callback */) {
     }
 
     if (!callback) return;
+
+    // merge chunks
+    var stdout = Buffer.concat(_stdout);
+    var stderr = Buffer.concat(_stderr);
+
+    if (options.encoding) {
+      // convert to strings
+      stdout = stdout.toString(options.encoding);
+      stderr = stderr.toString(options.encoding);
+    }
 
     if (err) {
       callback(err, stdout, stderr);
@@ -669,20 +682,21 @@ exports.execFile = function(file /* args, options, callback */) {
     }, options.timeout);
   }
 
-  child.stdout.setEncoding(options.encoding);
-  child.stderr.setEncoding(options.encoding);
-
   child.stdout.addListener('data', function(chunk) {
-    stdout += chunk;
-    if (stdout.length > options.maxBuffer) {
+    _stdout.push(chunk);
+    stdoutLen += chunk.length;
+
+    if (stdoutLen > options.maxBuffer) {
       err = new Error('stdout maxBuffer exceeded.');
       kill();
     }
   });
 
   child.stderr.addListener('data', function(chunk) {
-    stderr += chunk;
-    if (stderr.length > options.maxBuffer) {
+    _stderr.push(chunk);
+    stderrLen += chunk.length;
+
+    if (stderrLen > options.maxBuffer) {
       err = new Error('stderr maxBuffer exceeded.');
       kill();
     }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -636,7 +636,7 @@ exports.execFile = function(file /* args, options, callback */) {
     var stdout = Buffer.concat(_stdout);
     var stderr = Buffer.concat(_stderr);
 
-    if (options.encoding) {
+    if (Buffer.isEncoding(options.encoding)) {
       // convert to strings
       stdout = stdout.toString(options.encoding);
       stderr = stderr.toString(options.encoding);

--- a/test/simple/test-child-process-exec-buffer.js
+++ b/test/simple/test-child-process-exec-buffer.js
@@ -1,0 +1,52 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require('../common');
+var assert = require('assert');
+var exec = require('child_process').exec;
+
+var success_count = 0;
+
+var str = 'hello';
+
+// default encoding
+var child = exec("echo " + str, function(err, stdout, stderr) {
+  assert.ok('string', typeof(stdout), 'Expected stdout to be a string');
+  assert.ok('string', typeof(stderr), 'Expected stderr to be a string');
+  assert.equal(str + '\n', stdout);
+
+  success_count++;
+});
+
+// no encoding (Buffers expected)
+var child = exec("echo " + str, {
+  encoding: null
+}, function(err, stdout, stderr) {
+  assert.ok(stdout instanceof Buffer, 'Expected stdout to be a Buffer');
+  assert.ok(stderr instanceof Buffer, 'Expected stderr to be a Buffer');
+  assert.equal(str + '\n', stdout.toString());
+
+  success_count++;
+});
+
+process.on('exit', function() {
+  assert.equal(2, success_count);
+});


### PR DESCRIPTION
The [`child_process` docs](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) say that `child_process.exec`'s callback should be passed stdout and stderr as `Buffers`. However, even when a `null` `encoding` is provided, `stdout` and `stderr` are both strings.

This patch modifies `child_process.execFile` so that it only returns strings when `encoding` isn't `null`.
