### PR TITLE
vm: Correctly pass through syntax errors.

### DIFF
--- a/src/node_script.cc
+++ b/src/node_script.cc
@@ -342,15 +342,6 @@ void WrappedScript::EvalMachine(const FunctionCallbackInfo<Value>& args) {
     timeout = args[timeout_index]->Uint32Value();
   }
 
-  const int display_error_index = timeout_index +
-                                  (timeout_flag == noTimeout ? 0 : 1);
-  bool display_error = false;
-  if (args.Length() > display_error_index &&
-      args[display_error_index]->IsBoolean() &&
-      args[display_error_index]->BooleanValue() == true) {
-    display_error = true;
-  }
-
   Local<Context> context = Context::GetCurrent();
 
   Local<Array> keys;
@@ -389,10 +380,6 @@ void WrappedScript::EvalMachine(const FunctionCallbackInfo<Value>& args) {
     script = output_flag == returnResult ? Script::Compile(code, filename)
                                          : Script::New(code, filename);
     if (script.IsEmpty()) {
-      // FIXME UGLY HACK TO DISPLAY SYNTAX ERRORS.
-      if (display_error) DisplayExceptionLine(try_catch.Message());
-
-      // Hack because I can't get a proper stacktrace on SyntaxError
       try_catch.ReThrow();
       return;
     }
@@ -420,7 +407,6 @@ void WrappedScript::EvalMachine(const FunctionCallbackInfo<Value>& args) {
       return ThrowError("Script execution timed out.");
     }
     if (result.IsEmpty()) {
-      if (display_error) DisplayExceptionLine(try_catch.Message());
       try_catch.ReThrow();
       return;
     }

--- a/test/message/vm_syntax_error.js
+++ b/test/message/vm_syntax_error.js
@@ -1,0 +1,31 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var vm = require('vm');
+
+var context = {
+    run: function() {
+        vm.runInNewContext('invalid ?= 1', context, 'bar');
+    }
+};
+vm.runInNewContext('run()', context, 'foo');

--- a/test/message/vm_syntax_error.out
+++ b/test/message/vm_syntax_error.out
@@ -1,0 +1,6 @@
+bar:1
+invalid ?= 1
+         ^
+SyntaxError: Unexpected token =
+    at context.run (*test*message*vm_syntax_error.js:*:*)
+    at foo:1:1


### PR DESCRIPTION
My V8 patch to fix C++ `TryThrow` to restore message script location when `ReThrow`-ing landed in 704fd8f3. Now that this is in place, the `display_error` hack in `node_script.cc` can be removed since syntax errors within `vm` calls are correctly reported as a `SyntaxError` at the actual error site instead of at the outer-most `vm` call.

Fixes #3452
