### PR TITLE
stream - add firstBufferLength property to readable streams

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -383,6 +383,27 @@ a future `'readable'` event will be emitted when more is available.
 Calling `stream.read(0)` will always return `null`, and will trigger a
 refresh of the internal buffer, but otherwise be a no-op.
 
+### readable.firstBufferSize
+
+Note: **This property SHOULD be accessed by Readable stream users.**
+If a readable stream implementer changes how data is buffered in the
+readable object, the implementer should override the getter for this
+property.
+
+Equal to the length of the buffer at the front of the internal buffer
+list, or 0 if the internal buffer list is empty. Calling
+`stream.read(stream.firstBufferSize)` will return the first internal
+buffer without any buffer copies.
+
+Internally, readable streams keep a list of Buffer objects that are
+used to return the desired amount of data synchronously when read()
+is called. Calls to `read()` are most efficient if they do not require
+any buffer copies. If a caller of `read()` is able to handle an arbitrary
+amount of data, then it can be more efficient to call
+`stream.read(stream.firstBufferSize)` rather than `read()` with no
+arguments. (The latter will join all buffers in the buffer list,
+resulting in data copy.)
+
 ### readable.pipe(destination, [options])
 
 * `destination` {Writable Stream}

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -248,6 +248,13 @@ function howMuchToRead(n, state) {
   return n;
 }
 
+Readable.prototype.__defineGetter__('firstBufferLength', function() {
+  return this._readableState &&
+         this._readableState.buffer &&
+         this._readableState.buffer.length > 0 ?
+             this._readableState.buffer[0].length : 0;
+});
+
 // you can override either this method, or the async _read(n) below.
 Readable.prototype.read = function(n) {
   var state = this._readableState;

--- a/test/simple/test-stream2-basic.js
+++ b/test/simple/test-stream2-basic.js
@@ -473,3 +473,60 @@ test('adding readable triggers data flow', function(t) {
     t.end();
   });
 });
+
+test('first buffer length', function(t) {
+  var r = new R();
+
+  r._read = function () {};
+  r.on("end", function () {
+    t.equal(r.firstBufferLength, 0);
+    t.end();
+  });
+
+  t.equal(r.firstBufferLength, 0);
+
+  r.push('xxx');
+  t.equal(r.firstBufferLength, 3);
+  r.push('xx');
+  t.equal(r.firstBufferLength, 3);
+  t.ok(r.read(2));
+  t.equal(r.firstBufferLength, 1);
+  t.ok(r.read(1));
+  t.equal(r.firstBufferLength, 2);
+  t.ok(r.read(r.firstBufferLength));
+  t.equal(r.firstBufferLength, 0);
+
+  r.push('xxxx');
+  r.push('xxx');
+  r.push(null);
+
+  t.equal(r.firstBufferLength, 4);
+  t.ok(r.read());
+  t.equal(r.firstBufferLength, 0);
+});
+
+test('first buffer length in object mode', function(t) {
+  var r = new R({objectMode: true});
+  var n, b, count;
+
+  r._read = function () {};
+  r.on("end", function () {
+    t.equal(r.firstBufferLength, 0);
+    t.end();
+  });
+
+  t.equal(r.firstBufferLength, 0);
+
+  r.push('xxx');
+  r.push('xxxxx');
+  r.push('xx');
+  r.push(null);
+
+  count = 0;
+  while (n = r.firstBufferLength, b = r.read()) {
+    count++;
+    t.equal(n, b.length);
+  }
+  t.equal(count, 3);
+  t.equal(n, 0);
+});


### PR DESCRIPTION
Adds a firstBufferLength property to stream.Readable objects, as well as tests and documentation.

I really like the new stream API. However, I've run into a number of situations where my code is able to handle arbitrary amounts of data, and I want to call `read()` in a way that avoids unnecessary buffer copies.

One way to do this is to use objectMode. Unfortunately, many streams don't support objectMode. For example, there's no documented way of putting a Socket that comes from a `connection` event into objectMode.

Another way to do this is to always call `read()` (with no arguments) synchronously whenever a `readable` event occurs, and then keep a list of these buffer objects in userland code. However, this introduces two problems:
1. if the user is not actually ready to read the data, then the user has to keep these buffers around in a list. This messes up back pressure -- node will never tell the kernel that it has all the data it can handle.
2. Managing a list of buffers in userland code results in duplicating functionality that is already in `Readable.prototype.read`

This small change introduces a getter on Readable that returns the length of the first buffer (so that a call to `stream.read(stream.firstBufferLength)` will read exactly the first buffer with no copies).

Using this (as opposed to `read()` with no arguments or `read([some fixed length])`) can result in significant speed-ups in some cases. I created a benchmark, available here:
  https://gist.github.com/joelrbrandt/5995120

This benchmark first pushes buffers sized between 10K and 20K onto a Readable stream until the stream contains 10MB of buffers (this part is not timed). Then, the buffers are read in a number of ways:
- All at once by calling `stream.read()`
- Iteratively by calling `stream.read(10000)`
- Iteratively by calling `stream.read(stream.firstBufferLength)`
- Iteratively by calling `stream.read()` when the stream is in object mode

On my machine (Late 2010 MacBook Air with 2.13 GHz Core 2 Duo), I get the following results when running each test 400 times:

```
Read entire contents test done, read 4000000000 total bytes in 400 read calls. Total time 5.31244938 seconds
Read MIN_BLOCK_SIZE test done, read 4000000000 total bytes in 4000000 read calls. Total time 10.935569675 seconds
Read firstBufferLength test done, read 4000000000 total bytes in 2667167 read calls. Total time 0.636731486 seconds
Object mode test done, read 4000000000 total bytes in 2667747 read calls. Total time 0.464432509 seconds
```

In other words, using `stream.read(stream.firstBufferLength)` is 8x faster than `read()` and 17x faster than `read(10000)` under these conditions. It's also only a 1.4x slowdown over using object mode (probably due mostly to function call overhead for the getter).
