### PR TITLE
url: Fix edge-case in parse where protocol is non-lowercase

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -318,7 +318,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     this.query = {};
   }
   if (rest) this.pathname = rest;
-  if (slashedProtocol[proto] &&
+  if (slashedProtocol[lowerProto] &&
       this.hostname && !this.pathname) {
     this.pathname = '/';
   }

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -44,6 +44,16 @@ var parseTests = {
     'path': '/'
   },
 
+  'HTTP://www.example.com' : {
+    'href': 'http://www.example.com/',
+    'protocol': 'http:',
+    'slashes': true,
+    'host': 'www.example.com',
+    'hostname': 'www.example.com',
+    'pathname': '/',
+    'path': '/'
+  },
+
   'http://www.ExAmPlE.com/' : {
     'href': 'http://www.example.com/',
     'protocol': 'http:',


### PR DESCRIPTION
When using url.parse(), path and pathname usually return '/' when
there is no path available. However when you have a protocol that
contains non-lowercase letters and the input string does not have a
trailing slash, both path and pathname will be undefined.

---

I based this off v0.10.13 since that was the latest stable branch.
Fixes #5861
