### PR TITLE
child_process: Set additional fds as read/write

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -62,16 +62,11 @@ function createPipe(ipc) {
   return new handleWraps.Pipe(ipc);
 }
 
-function createSocket(pipe, readable) {
+function createSocket(pipe, readable, writable) {
   var s = new net.Socket({ handle: pipe });
 
-  if (readable) {
-    s.writable = false;
-    s.readable = true;
-  } else {
-    s.writable = true;
-    s.readable = false;
-  }
+  s.writable = writable;
+  s.readable = readable;
 
   return s;
 }
@@ -938,9 +933,11 @@ ChildProcess.prototype.spawn = function(options) {
     }
 
     if (stdio.handle) {
-      // when i === 0 - we're dealing with stdin
-      // (which is the only one writable pipe)
-      stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, i > 0);
+      // when i === 0 - we're dealing with stdin (only writable)
+      // when i === 1 - we're dealing with stdout (only readable)
+      // when i === 2 - we're dealing with stderr (only readable)
+      // when i > 2 - we're dealing with custom fds (read/write)
+      stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, i > 0, i < 1 || i > 2);
 
       if (i > 0 && self.pid !== 0) {
         self._closesNeeded++;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -933,11 +933,23 @@ ChildProcess.prototype.spawn = function(options) {
     }
 
     if (stdio.handle) {
-      // when i === 0 - we're dealing with stdin (only writable)
-      // when i === 1 - we're dealing with stdout (only readable)
-      // when i === 2 - we're dealing with stderr (only readable)
-      // when i > 2 - we're dealing with custom fds (read/write)
-      stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, i > 0, i < 1 || i > 2);
+      switch (i) {
+        case 0: // stdin
+          // only writable
+          stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, false, true);
+          break;
+
+        case 1: // stdout
+        case 2: // stderr
+          // only readable
+          stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, true, false);
+          break;
+
+        default: // custom fd
+          // read/write
+          stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, true, true);
+          break;
+      }
 
       if (i > 0 && self.pid !== 0) {
         self._closesNeeded++;

--- a/lib/net.js
+++ b/lib/net.js
@@ -206,8 +206,13 @@ function onSocketFinish() {
 
   var shutdownReq = this._handle.shutdown();
 
-  if (!shutdownReq)
+  if (!shutdownReq) {
+    if (process._errno === 'ENOTCONN') {
+      return this._destroy();
+    }
+
     return this._destroy(errnoException(process._errno, 'shutdown'));
+  }
 
   shutdownReq.oncomplete = afterShutdown;
 }

--- a/test/simple/test-child-process-stdio.js
+++ b/test/simple/test-child-process-stdio.js
@@ -34,3 +34,8 @@ child = common.spawnPwd(options);
 
 assert.equal(child.stdout, null);
 assert.equal(child.stderr, null);
+
+options = {stdio: ['pipe', 'pipe', 'pipe', 'pipe']};
+child = common.spawnPwd(options);
+
+child.stdio[3].end();

--- a/test/simple/test-child-process-stdio.js
+++ b/test/simple/test-child-process-stdio.js
@@ -38,4 +38,7 @@ assert.equal(child.stderr, null);
 options = {stdio: ['pipe', 'pipe', 'pipe', 'pipe']};
 child = common.spawnPwd(options);
 
+assert.ok(child.stdio[3].readable);
+assert.ok(child.stdio[3].writable);
+
 child.stdio[3].end();


### PR DESCRIPTION
When a `ChildProcess`'s `stdio` configuration includes additional file descriptors, those fds should be set as read/write to prevent `uv_shutdown from setting`ENOTCONN`when calling end() on the`Socket` wrapper.

Pre-libuv handling: https://github.com/joyent/node/blob/8417870f513e6f1ab98e07fe95d3430dbec48b87/lib/net.js#L851-L853

Where `uv_shutdown` sets `ENOTCONN`: https://github.com/joyent/libuv/blob/3ee4d3f183331a123ce35edd0d32268a2bb22aa5/src/unix/stream.c#L1090-L1095

This still needs tests, but I'm curious what y'all think (and to put my thinking down).

I'm seeing it when I pipe multiple `Buffer`s to ImageMagick via additional fds using `Socket#end()`.  (See "STDIN, STDOUT, and file descriptors" in http://www.imagemagick.org/script/command-line-processing.php)
