### PR TITLE
crypto: do not throw error if one isn't set

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2622,7 +2622,7 @@ class Decipher : public ObjectWrap {
     if (out_len <= 0 || r == 0) {
       delete [] out_value; // allocated even if out_len == 0
       out_value = NULL;
-      if (r == 0) return ThrowCryptoTypeError(ERR_get_error());
+      if (r == 0 && ERR_peek_error()) return ThrowCryptoTypeError(ERR_get_error());
     }
 
     outString = Encode(out_value, out_len, BUFFER);

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -915,3 +915,19 @@ assert.throws(function() {
   c.update('update', 'utf-8');
   c.final('utf8');  // Should not throw.
 })();
+
+// Decipher#final should not throw an error when both
+// EVP_CipherFinal_ex returns 0 and ERR_get_error() returns 0
+assert.doesNotThrow(function() {
+  var key = 'foo', input = 'hello world';
+
+  var c = crypto.createCipher('aes-256-gcm', key);
+  var result = c.update(input, 'utf8', 'base64');
+  result += c.final('base64');
+
+  var dc = crypto.createDecipher('aes-256-gcm', key);
+  var dresult = dc.update(result, 'base64', 'utf8');
+  dresult += dc.final('utf8');
+
+  assert.equal(input, dresult);
+});


### PR DESCRIPTION
An issue was reported by cipherboy on IRC where calling final() with the gcm cipher would result in EVP_CipherFinal_ex() returning 0, but ERR_get_error() also returned 0 (indicating no error is in the queue).

The condition I've modified specifically for DecipherFinal should probably also be done for anywhere else we check the return value of an OpenSSL function.
