### PR TITLE
Util: Removed duplicated isArray check

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -430,8 +430,7 @@ function reduceToSingleString(output, base, braces) {
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
 function isArray(ar) {
-  return Array.isArray(ar) ||
-         (typeof ar === 'object' && objectToString(ar) === '[object Array]');
+  return Array.isArray(ar);
 }
 exports.isArray = isArray;
 


### PR DESCRIPTION
The extra check for typeof and toString is duplicating the work that `Array.isArray` already does (http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.3.2 and https://github.com/v8/v8/blob/8ae7cef19427362d2fb1c1fa4951050df6fe2e61/src/array.js#L1583).  As a result, any check to `util.isArray` that isn't an array will be checked twice.

Let me know if this should be deprecated and I will update the PR.
