### PR TITLE
Fixed missing backtick in docs

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -166,4 +166,4 @@ with the node debugger. Either connect to the `pid` or the URI to the debugger.
 The syntax is:
 
 * `node debug -p <pid>` - Connects to the process via the `pid`
-* `node debug <URI> - Connects to the process via the URI such as localhost:5858
+* `node debug <URI>` - Connects to the process via the URI such as localhost:5858


### PR DESCRIPTION
The debugging docs here is missing a backtick:

http://nodejs.org/api/debugger.html#debugger_advanced_usage
