### PR TITLE
Disable chunked response in test_standard_http

### DIFF
--- a/test/simple/test-http-upgrade-server.js
+++ b/test/simple/test-http-upgrade-server.js
@@ -44,8 +44,9 @@ function testServer() {
   });
 
   server.on('request', function(req, res) {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.write('okay');
+    var okay = 'okay';
+    res.writeHead(200, {'Content-Type': 'text/plain', 'Content-Length': okay.length});
+    res.write(okay);
     res.end();
   });
 


### PR DESCRIPTION
In some cases the test fails because it receives data in two chunks (data + '0\r\n\r\n')
