### PR TITLE
fs: readFile and readFileSync throw EISDIR on a directory.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -198,6 +198,8 @@ fs.readFile = function(path, options, callback_) {
 
     fs.fstat(fd, function(er, st) {
       if (er) return callback(er);
+      // some platforms do not throw EISDIR.
+      if (st.isDirectory()) return callback(errnoException(-constants.EISDIR, 'read'));
       size = st.size;
       if (size === 0) {
         // the kernel lies about many files.
@@ -275,7 +277,10 @@ fs.readFileSync = function(path, options) {
   var size;
   var threw = true;
   try {
-    size = fs.fstatSync(fd).size;
+    var st = fs.fstatSync(fd);
+    // some platforms do not throw EISDIR.
+    if (st && st.isDirectory && st.isDirectory()) throw errnoException(-constants.EISDIR, 'read');
+    size = st.size;
     threw = false;
   } finally {
     if (threw) fs.closeSync(fd);


### PR DESCRIPTION
Some OSes (freebsd) allow to read a directory.
