### PR TITLE
readline: move pause to fix #5927

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -264,10 +264,10 @@ Interface.prototype._refreshLine = function() {
 
 Interface.prototype.close = function() {
   if (this.closed) return;
+  this.pause();
   if (this.terminal) {
     this._setRawMode(false);
   }
-  this.pause();
   this.closed = true;
   this.emit('close');
 };

--- a/test/simple/test-regress-GH-5927.js
+++ b/test/simple/test-regress-GH-5927.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var readline = require('readline');
+
+var rl = readline.createInterface(process.stdin, process.stdout);
+rl.resume();
+
+var hasPaused = false;
+
+var origPause = rl.pause;
+rl.pause = function() {
+  hasPaused = true;
+  origPause.apply(this, arguments);
+}
+
+var origSetRawMode = rl._setRawMode;
+rl._setRawMode = function(mode) {
+  assert.ok(hasPaused);
+  origSetRawMode.apply(this, arguments);
+}
+
+rl.close();


### PR DESCRIPTION
Pause should be called before _setRawMode to prevent things going wonky
in windows (see #5927).

(sorry for messing up first pull request)
