### PR TITLE
child_process: add 'shell' option to .exec()

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -464,6 +464,9 @@ See also: `child_process.exec()` and `child_process.fork()`
   * `cwd` {String} Current working directory of the child process
   * `env` {Object} Environment key-value pairs
   * `encoding` {String} (Default: 'utf8')
+  * `shell` {String} Shell to execute the command with
+    (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,  The shell should
+     understand the `-c` switch on UNIX or `/s /c` on Windows.)
   * `timeout` {Number} (Default: 0)
   * `maxBuffer` {Number} (Default: 200*1024)
   * `killSignal` {String} (Default: 'SIGTERM')

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -576,6 +576,10 @@ exports.exec = function(command /*, options, callback */) {
     file = '/bin/sh';
     args = ['-c', command];
   }
+
+  if (options && options.shell)
+    file = options.shell;
+
   return exports.execFile(file, args, options, callback);
 };
 


### PR DESCRIPTION
Fixes #5935.

No test, I don't see a good way to test it.

Suggested reviewer: @piscisaureus
