### PR TITLE
trace: remove macro usage for probe points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,8 @@ CPPLINT_EXCLUDE += src/queue.h
 CPPLINT_EXCLUDE += src/tree.h
 CPPLINT_EXCLUDE += src/v8abbr.h
 
-CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard src/*.cc src/*.h src/*.c))
+CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard src/**.cc src/**.h src/**.c))
+CPPLINT_FILES += $(filter-out $(CPPLINT_EXCLUDE), $(wildcard src/dtrace-provider/*.cc src/dtrace-provider/*.h src/dtrace-provider/*.c))
 
 cpplint:
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_FILES)

--- a/deps/libusdt/LICENCE
+++ b/deps/libusdt/LICENCE
@@ -1,0 +1,21 @@
+Copyright 2012 Chris Andrews. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY CHRIS ANDREWS ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL CHRIS ANDREWS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/deps/libusdt/Makefile
+++ b/deps/libusdt/Makefile
@@ -1,0 +1,156 @@
+CC = gcc
+CFLAGS = -O2 -Wall
+
+# MAC_BUILD - set this to "universal" to build a 2-way fat library 
+MAC_BUILD = universal
+
+# if ARCH set, disable universal build on the mac
+ifdef ARCH
+MAC_BUILD =
+else
+ARCH = $(shell uname -m)
+endif
+
+UNAME = $(shell uname -s)
+
+ifeq ($(UNAME), Linux)
+RANLIB=ranlib
+CFLAGS+=-D_GNU_SOURCE -fPIC
+endif
+
+ifeq ($(UNAME), SunOS)
+RANLIB=/bin/true
+PATH +=:/usr/perl5/5.10.0/bin:/usr/perl5/5.12/bin
+CFLAGS += -fPIC
+ifeq ($(ARCH), i86pc)
+ARCH = $(shell isainfo -k)
+ifeq ($(ARCH), amd64)
+ARCH = x86_64
+else
+ARCH = i386
+endif
+endif 
+ifeq ($(ARCH), x86_64)
+CFLAGS += -m64
+endif
+endif
+
+ifeq ($(UNAME), FreeBSD)
+RANLIB=ranlib
+CFLAGS += -Wno-error=unknown-pragmas -I/usr/src/sys/cddl/compat/opensolaris -I/usr/src/sys/cddl/contrib/opensolaris/uts/common
+CFLAGS += -fPIC
+ifeq ($(ARCH), i386)
+CFLAGS += -m32
+endif
+ifeq ($(ARCH), amd64)
+ARCH = x86_64
+endif
+endif
+
+ifeq ($(UNAME), Darwin)
+RANLIB=ranlib
+ifeq ($(MAC_BUILD), universal)
+CFLAGS += -arch i386 -arch x86_64
+else
+CFLAGS += -arch $(ARCH)
+endif
+endif
+
+# main library build
+objects = usdt.o usdt_dof_file.o usdt_tracepoints.o usdt_probe.o usdt_dof.o usdt_dof_sections.o
+headers = usdt.h usdt_internal.h
+
+.c.o: $(headers)
+
+all: libusdt.a
+
+libusdt.a: $(objects) $(headers)
+	rm -f libusdt.a
+	$(AR) cru libusdt.a $(objects) 
+	$(RANLIB) libusdt.a
+
+# Tracepoints build. 
+#
+# If on Darwin and building a universal library, manually assemble a
+# two-way fat object file from both the 32 and 64 bit tracepoint asm
+# files.
+#
+# Otherwise, just choose the appropriate asm file based on the build
+# architecture.
+
+ifeq ($(UNAME), Darwin)
+ifeq ($(MAC_BUILD), universal)
+
+usdt_tracepoints_i386.o: usdt_tracepoints_i386.s
+	$(CC) -arch i386 -o usdt_tracepoints_i386.o -c usdt_tracepoints_i386.s
+
+usdt_tracepoints_x86_64.o: usdt_tracepoints_x86_64.s
+	$(CC) -arch x86_64 -o usdt_tracepoints_x86_64.o -c usdt_tracepoints_x86_64.s
+
+usdt_tracepoints.o: usdt_tracepoints_i386.o usdt_tracepoints_x86_64.o
+	lipo -create -output usdt_tracepoints.o usdt_tracepoints_i386.o \
+	                                        usdt_tracepoints_x86_64.o
+
+else # Darwin, not universal
+usdt_tracepoints.o: usdt_tracepoints_$(ARCH).s
+	$(CC) -arch $(ARCH) -o usdt_tracepoints.o -c usdt_tracepoints_$(ARCH).s
+endif
+
+else # not Darwin; FreeBSD and Illumos
+
+ifeq ($(ARCH), x86_64)
+usdt_tracepoints.o: usdt_tracepoints_x86_64.s
+	$(CC) $(CFLAGS) -o usdt_tracepoints.o -c usdt_tracepoints_x86_64.s
+endif
+ifeq ($(ARCH), i386)
+usdt_tracepoints.o: usdt_tracepoints_i386.s
+	$(CC) $(CFLAGS) -o usdt_tracepoints.o -c usdt_tracepoints_i386.s
+endif
+
+endif
+
+clean:
+	rm -f *.gch
+	rm -f *.o
+	rm -f libusdt.a
+	rm -f test_usdt
+	rm -f test_usdt32
+	rm -f test_usdt64
+	rm -f test_mem_usage
+
+.PHONY: clean test
+
+# testing
+
+test_mem_usage: libusdt.a test_mem_usage.o
+	$(CC) $(CFLAGS) -o test_mem_usage test_mem_usage.o libusdt.a 
+
+ifeq ($(UNAME), Darwin)
+ifeq ($(MAC_BUILD), universal)
+test_usdt64: libusdt.a test_usdt.o
+	$(CC) -arch x86_64 -o test_usdt64 test_usdt.o libusdt.a
+test_usdt32: libusdt.a test_usdt.o
+	$(CC) -arch i386 -o test_usdt32 test_usdt.o libusdt.a
+else
+test_usdt: libusdt.a test_usdt.o
+	$(CC) $(CFLAGS) -o test_usdt test_usdt.o libusdt.a 
+endif
+else
+test_usdt: libusdt.a test_usdt.o
+	$(CC) $(CFLAGS) -o test_usdt test_usdt.o libusdt.a 
+endif
+
+ifeq ($(UNAME), Darwin)
+ifeq ($(MAC_BUILD), universal)
+test: test_usdt32 test_usdt64
+	sudo prove test.pl :: 64
+	sudo prove test.pl :: 32
+else
+test: test_usdt
+	sudo prove test.pl
+endif
+else
+test: test_usdt
+	sudo prove test.pl
+endif
+

--- a/deps/libusdt/README.md
+++ b/deps/libusdt/README.md
@@ -1,0 +1,77 @@
+libusdt
+=======
+
+This is "libusdt", a library for creating DTrace USDT providers.
+
+The idea here is to allow the specification of a DTrace provider
+dynamically in code and then create the provider at runtime. This
+allows providers to be specified in dynamic languages, given suitable
+bindings.
+
+The general approach is to create two stub functions for each probe,
+one for the is-enabled check and one for the probe itself. These
+contain the appropriate instruction sequences to appear to DTrace as
+compiled-in tracepoints. A minimal DOF document is built describing
+the provider and indicating these stub functions as the tracepoints,
+then submitted to the kernel, creating the provider. The API then
+exposes the stubs, through which the probes may be fired.
+
+Status
+------
+
+The implementation here works as shown in test_usdt.c on Mac OS X,
+i386 and x86_64, on Solaris-like systems, i386 and x86_64 and on
+FreeBSD and Oracle Linux, x86_64 only.
+
+Is-enabled probes are supported and exposed in the API.
+
+There is a "test" target which runs a number of tests of the library,
+for which perl is required.
+
+OS X builds are Universal by default, and on Solaris, the ARCH
+variable may be set to either i386 or x86_64 to force a particular
+build.
+
+FreeBSD builds suffer from broken argument handling; this is a known
+issue with the current state of DTrace generally on FreeBSD: only the
+first five arguments work reliably. See:
+
+  http://wiki.freebsd.org/DTraceTODO
+
+See Also
+--------
+
+There are various language bindings available:
+
+Lua:
+
+  https://github.com/chrisa/lua-usdt
+
+Ruby (by Kevin Chan):
+
+  https://github.com/kevinykchan/ruby-usdt
+
+Node.JS:
+
+  https://github.com/chrisa/node-dtrace-provider
+
+Perl:
+
+  https://github.com/chrisa/perl-Devel-DTrace-Provider
+
+To Do
+-----
+
+Platform support:
+
+ * add support for FreeBSD 9.0 i386
+ * add support for Mac OS X PowerPC
+ * add support for Solaris SPARC
+
+Features:
+
+ * add a "low level" API, allowing alternative provision of
+   tracepoints for closer integration with language VMs. 
+
+ * support structured types, with close integration with the host
+   DTrace system.

--- a/deps/libusdt/libusdt.gyp
+++ b/deps/libusdt/libusdt.gyp
@@ -1,0 +1,24 @@
+{
+  'targets': [
+    {
+      'target_name': 'libusdt',
+      'type': 'static_library',
+      'sources': [
+        'usdt.h',
+        'usdt.c',
+        'usdt_dof.c',
+        'usdt_dof_file.c',
+        'usdt_dof_sections.c',
+        'usdt_probe.c',
+      ],
+      'conditions': [
+        [ '"<(target_arch)"=="ia32"', {
+          'sources': [ 'usdt_tracepoints_i386.s' ],
+          }, {
+          'sources': [ 'usdt_tracepoints_x86_64.s' ],
+          },
+        ],
+      ],
+    },
+  ],
+}

--- a/deps/libusdt/test.pl
+++ b/deps/libusdt/test.pl
@@ -1,0 +1,116 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use IPC::Open3;
+use Symbol 'gensym'; 
+use IO::Handle;
+use Test::More qw/ no_plan /;
+
+my $USDT_ARG_MAX = 32;
+if ($^O eq 'freebsd') {
+    # FreeBSD currently only supports 5 arguments to USDT probes
+    $USDT_ARG_MAX = 5;
+}
+
+my $arch;
+if (scalar @ARGV == 1) {
+    $arch = $ARGV[0];
+}
+
+my $user_t = ($^O eq 'darwin') ? 'user_addr_t' : 'uintptr_t';
+
+run_tests('c', 'A');
+run_tests('i', 1);
+
+sub run_tests {
+    my ($type, $start_arg) = @_;
+    
+    for my $i (0..$USDT_ARG_MAX) {
+        my ($t_status, $d_status, $output) = run_dtrace('type'.$type, $i.'arg', split(//, $type x $i));
+        is($t_status, 0, 'test exit status is 0');
+        is($d_status, 0, 'dtrace exit status is 0');
+        like($output, qr/type[ic]:\d+arg/, 'function and name match');
+
+        my $arg = $start_arg;
+        for my $j (0..$i - 1) {
+            like($output, qr/arg$j:'\Q$arg\E'/, "type '$type' arg $j is $arg");
+            if ($type eq 'i') {
+                $arg++;
+            }
+            else {
+                $arg = chr(ord($arg) + 1);
+            }
+        }
+    }
+}
+
+# --------------------------------------------------------------------------
+
+sub gen_d {
+    my (@types) = @_;
+
+    my $d = 'testlibusdt*:::{ ';
+    my $i = 0;
+    for my $type (@types) {
+        if ($type eq 'i') {
+            $d .= "printf(\"arg$i:'%i' \", args[$i]); ";
+        }
+        if ($type eq 'c') {
+            $d .= "printf(\"arg$i:'%s' \", copyinstr(($user_t)args[$i])); ";
+        }
+        $i++;
+    }
+    $d .= '}';
+
+    return $d;
+}
+         
+sub run_dtrace {
+    my ($func, $name, @types) = @_;
+    my $d = gen_d(@types);
+
+    my @t_cmd;
+    if (defined $arch) {
+        @t_cmd = ("./test_usdt$arch", $func, $name, @types);
+    }
+    else {
+        @t_cmd = ("./test_usdt", $func, $name, @types);
+    }
+
+    my ($d_wtr, $d_rdr, $d_err);
+    my ($t_wtr, $t_rdr, $t_err);
+
+    $d_err = gensym;
+    $t_err = gensym;
+
+    #diag(join(' ', @t_cmd));
+    my $t_pid = open3($t_wtr, $t_rdr, $t_err, @t_cmd);
+    my $enabled = $t_rdr->getline;
+
+    my @d_cmd = ('/usr/sbin/dtrace', '-p', $t_pid, '-n', $d);
+
+    #diag(join(' ', @d_cmd));
+    my $d_pid = open3($d_wtr, $d_rdr, $d_err, @d_cmd);
+    my $matched = $d_err->getline; # expect "matched 1 probe"
+
+    $t_wtr->print("go\n");
+    $t_wtr->flush;
+    waitpid( $t_pid, 0 );
+    my $t_status = $? >> 8;
+
+    my ($header, $output) = ($d_rdr->getline, $d_rdr->getline);
+    chomp $header;
+    chomp $output;
+    #diag("DTrace header: $header\n");
+    #diag("DTrace output: $output\n");
+    waitpid( $d_pid, 0 );
+
+    my $d_status = $? >> 8;
+    while (!$d_err->eof) {
+        my $error = $d_err->getline;
+        chomp $error;
+        #diag "DTrace error: $error";
+    }
+
+    return ($t_status, $d_status, $output || '');
+}

--- a/deps/libusdt/test_mem_usage.c
+++ b/deps/libusdt/test_mem_usage.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void
+create_and_free_provider(int argc, char **argv)
+{
+        usdt_provider_t *provider;
+        usdt_probedef_t *probedef;
+
+        if ((provider = usdt_create_provider("testlibusdt", "modname")) == NULL) {
+                fprintf(stderr, "unable to create provider\n");
+                exit (1);
+        }
+        if ((probedef = usdt_create_probe((const char *)argv[1],
+                                          (const char *)argv[2],
+                                          (argc-3), (const char **)&argv[3])) == NULL)
+        {
+                fprintf(stderr, "unable to create probe\n");
+                exit (1);
+        }
+        usdt_provider_add_probe(provider, probedef);
+
+        if ((usdt_provider_enable(provider)) < 0) {
+                fprintf(stderr, "unable to enable provider: %s\n", usdt_errstr(provider));
+                exit (1);
+        }
+
+        if ((usdt_provider_disable(provider)) < 0) {
+                fprintf(stderr, "unable to disable provider: %s\n", usdt_errstr(provider));
+                exit (1);
+        }
+
+        usdt_probe_release(probedef);
+        usdt_provider_free(provider);
+}
+
+int
+main(int argc, char **argv)
+{
+        char char_argv[USDT_ARG_MAX];
+        int int_argv[USDT_ARG_MAX * 2];
+        int i;
+        char buf[255];
+
+        for (i = 0; i < USDT_ARG_MAX; i++)
+                int_argv[i] = i + 1;
+        for (i = 0; i < USDT_ARG_MAX; i++)
+                char_argv[i] = (char) i + 65;
+
+        if (argc < 3) {
+                fprintf(stderr, "usage: %s func name [types ...]\n", argv[0]);
+                return(1);
+        }
+
+        for (i = 0; i < USDT_ARG_MAX; i++) {
+                if (argv[i+3] != NULL && i+3 < argc) {
+                        if (strncmp("c", argv[i+3], 1) == 0) {
+                                argv[i+3] = strdup("char *");
+                        }
+                        if (strncmp("i", argv[i+3], 1) == 0) {
+                                argv[i+3] = strdup("int");
+                        }
+                }
+        }
+
+        for (i = 0; i < 100000; i++)
+                create_and_free_provider(argc, argv);
+
+        return 0;
+}

--- a/deps/libusdt/test_usdt.c
+++ b/deps/libusdt/test_usdt.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void
+fire_probe(usdt_probedef_t *probedef, int argc, void **argv)
+{
+        if (usdt_is_enabled(probedef->probe))
+                usdt_fire_probe(probedef->probe, argc, argv);
+}
+
+int main(int argc, char **argv) {
+        usdt_provider_t *provider;
+        usdt_probedef_t *probedef;
+        char char_argv[USDT_ARG_MAX];
+        int int_argv[USDT_ARG_MAX * 2];
+        void **args = NULL;
+        int i;
+        char buf[255];
+
+        for (i = 0; i < USDT_ARG_MAX; i++)
+                int_argv[i] = i + 1;
+        for (i = 0; i < USDT_ARG_MAX; i++)
+                char_argv[i] = (char) i + 65;
+
+        if (argc < 3) {
+                fprintf(stderr, "usage: %s func name [types ...]\n", argv[0]);
+                return(1);
+        }
+
+        if (argc > 3) {
+                args = malloc((argc-3) * sizeof(void *));
+        }
+
+        for (i = 0; i < USDT_ARG_MAX; i++) {
+                if (argv[i+3] != NULL && i+3 < argc) {
+                        if (strncmp("c", argv[i+3], 1) == 0) {
+                                args[i] = (void *)strndup(&char_argv[i], 1);
+                                argv[i+3] = strdup("char *");
+                        }
+                        if (strncmp("i", argv[i+3], 1) == 0) {
+                                args[i] = (void *)(long)int_argv[i];
+                                argv[i+3] = strdup("int");
+                        }
+                }
+        }
+
+        if ((provider = usdt_create_provider("testlibusdt", "modname")) == NULL) {
+                fprintf(stderr, "unable to create provider\n");
+                exit (1);
+        }
+        if ((probedef = usdt_create_probe((const char *)argv[1],
+                                          (const char *)argv[2],
+                                          (argc-3), (const char **)&argv[3])) == NULL)
+        {
+                fprintf(stderr, "unable to create probe\n");
+                exit (1);
+        }
+        usdt_provider_add_probe(provider, probedef);
+
+        if ((usdt_provider_enable(provider)) < 0) {
+                fprintf(stderr, "unable to enable provider: %s\n", usdt_errstr(provider));
+                exit (1);
+        }
+
+        fprintf(stdout, "enabled\n");
+        fflush(stdout);
+        fgets(buf, 255, stdin);
+
+        fire_probe(probedef, (argc-3), (void **)args);
+        usdt_probe_release(probedef);
+
+        if ((usdt_provider_disable(provider)) < 0) {
+                fprintf(stderr, "unable to disable provider: %s\n", usdt_errstr(provider));
+                exit (1);
+        }
+
+        usdt_provider_free(provider);
+
+        return 0;
+}

--- a/deps/libusdt/usdt.c
+++ b/deps/libusdt/usdt.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt_internal.h"
+
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+
+char *usdt_errors[] = {
+  "failed to allocate memory",
+  "failed to allocate page-aligned memory",
+  "no probes defined",
+  "failed to load DOF: %s",
+  "provider is already enabled",
+  "failed to unload DOF: %s",
+  "probe named %s:%s:%s:%s already exists",
+  "failed to remove probe %s:%s:%s:%s"
+};
+
+static void
+free_probedef(usdt_probedef_t *pd)
+{
+        int i;
+
+        switch (pd->refcnt) {
+        case 1:
+                free((char *)pd->function);
+                free((char *)pd->name);
+                if (pd->probe) {
+                        usdt_free_tracepoints(pd->probe);
+                        free(pd->probe);
+                }
+                for (i = 0; i < pd->argc; i++)
+                        free(pd->types[i]);
+                free(pd);
+                break;
+        case 2:
+                pd->refcnt = 1;
+                break;
+        default:
+                break;
+        }
+}
+
+usdt_provider_t *
+usdt_create_provider(const char *name, const char *module)
+{
+        usdt_provider_t *provider;
+
+        if ((provider = malloc(sizeof *provider)) == NULL) 
+                return NULL;
+
+        provider->name = strdup(name);
+        provider->module = strdup(module);
+        provider->probedefs = NULL;
+        provider->enabled = 0;
+
+        return provider;
+}
+
+usdt_probedef_t *
+usdt_create_probe(const char *func, const char *name, size_t argc, const char **types)
+{
+        int i;
+        usdt_probedef_t *p;
+
+        if (argc > USDT_ARG_MAX)
+                argc = USDT_ARG_MAX;
+
+        if ((p = malloc(sizeof *p)) == NULL)
+                return (NULL);
+
+        p->refcnt = 2;
+        p->function = strdup(func);
+        p->name = strdup(name);
+        p->argc = argc;
+        p->probe = NULL;
+
+        for (i = 0; i < argc; i++)
+                p->types[i] = strdup(types[i]);
+
+        return (p);
+}
+
+void
+usdt_probe_release(usdt_probedef_t *probedef)
+{
+        free_probedef(probedef);
+}
+
+int
+usdt_provider_add_probe(usdt_provider_t *provider, usdt_probedef_t *probedef)
+{
+        usdt_probedef_t *pd;
+
+        if (provider->probedefs != NULL) {
+                for (pd = provider->probedefs; (pd != NULL); pd = pd->next) {
+                if ((strcmp(pd->name, probedef->name) == 0) &&
+                    (strcmp(pd->function, probedef->function) == 0)) {
+                                usdt_error(provider, USDT_ERROR_DUP_PROBE,
+                                           provider->name, provider->module,
+                                           probedef->function, probedef->name);
+                                return (-1);
+                        }
+                }
+        }
+
+        probedef->next = NULL;
+        if (provider->probedefs == NULL)
+                provider->probedefs = probedef;
+        else {
+                for (pd = provider->probedefs; (pd->next != NULL); pd = pd->next) ;
+                pd->next = probedef;
+        }
+
+        return (0);
+}
+
+int
+usdt_provider_remove_probe(usdt_provider_t *provider, usdt_probedef_t *probedef)
+{
+        usdt_probedef_t *pd, *prev_pd = NULL;
+
+        if (provider->probedefs == NULL) {
+                usdt_error(provider, USDT_ERROR_NOPROBES);
+                return (-1);
+        }
+
+        for (pd = provider->probedefs; (pd != NULL);
+             prev_pd = pd, pd = pd->next) {
+
+                if ((strcmp(pd->name, probedef->name) == 0) &&
+                    (strcmp(pd->function, probedef->function) == 0)) {
+
+                        if (prev_pd == NULL)
+                                provider->probedefs = pd->next;
+                        else
+                                prev_pd->next = pd->next;
+
+                        return (0);
+                }
+        }
+
+        usdt_error(provider, USDT_ERROR_REMOVE_PROBE,
+                   provider->name, provider->module,
+                   probedef->function, probedef->name);
+        return (-1);
+}
+
+int
+usdt_provider_enable(usdt_provider_t *provider)
+{
+        usdt_strtab_t strtab;
+        usdt_dof_file_t *file;
+        usdt_probedef_t *pd;
+        int i;
+        size_t size;
+        usdt_dof_section_t sects[5];
+
+        if (provider->enabled == 1) {
+                usdt_error(provider, USDT_ERROR_ALREADYENABLED);
+                return (0); /* not fatal */
+        }
+
+        if (provider->probedefs == NULL) {
+                usdt_error(provider, USDT_ERROR_NOPROBES);
+                return (-1);
+        }
+
+        for (pd = provider->probedefs; pd != NULL; pd = pd->next) {
+                if ((pd->probe = malloc(sizeof(*pd->probe))) == NULL) {
+                        usdt_error(provider, USDT_ERROR_MALLOC);
+                        return (-1);
+                }
+        }
+
+        if ((usdt_strtab_init(&strtab, 0)) < 0) {
+                usdt_error(provider, USDT_ERROR_MALLOC);
+                return (-1);
+        }
+
+        if ((usdt_strtab_add(&strtab, provider->name)) == 0) {
+                usdt_error(provider, USDT_ERROR_MALLOC);
+                return (-1);
+        }
+
+        if ((usdt_dof_probes_sect(&sects[0], provider, &strtab)) < 0)
+                return (-1);
+        if ((usdt_dof_prargs_sect(&sects[1], provider)) < 0)
+                return (-1);
+
+        size = usdt_provider_dof_size(provider, &strtab);
+        if ((file = usdt_dof_file_init(provider, size)) == NULL)
+                return (-1);
+
+        if ((usdt_dof_proffs_sect(&sects[2], provider, file->dof)) < 0)
+                return (-1);
+        if ((usdt_dof_prenoffs_sect(&sects[3], provider, file->dof)) < 0)
+                return (-1);
+        if ((usdt_dof_provider_sect(&sects[4], provider)) < 0)
+                return (-1);
+
+        for (i = 0; i < 5; i++)
+                usdt_dof_file_append_section(file, &sects[i]);
+
+        usdt_dof_file_generate(file, &strtab);
+
+        usdt_dof_section_free((usdt_dof_section_t *)&strtab);
+        for (i = 0; i < 5; i++)
+                usdt_dof_section_free(&sects[i]);
+
+        if ((usdt_dof_file_load(file, provider->module)) < 0) {
+                usdt_error(provider, USDT_ERROR_LOADDOF, strerror(errno));
+                return (-1);
+        }
+
+        provider->enabled = 1;
+        provider->file = file;
+
+        return (0);
+}
+
+int
+usdt_provider_disable(usdt_provider_t *provider)
+{
+        usdt_probedef_t *pd;
+
+        if (provider->enabled == 0)
+                return (0);
+
+        if ((usdt_dof_file_unload((usdt_dof_file_t *)provider->file)) < 0) {
+                usdt_error(provider, USDT_ERROR_UNLOADDOF, strerror(errno));
+                return (-1);
+        }
+
+        usdt_dof_file_free(provider->file);
+        provider->file = NULL;
+
+        /* We would like to free the tracepoints here too, but OS X
+         * (and to a lesser extent Illumos) struggle with this:
+         *
+         * If a provider is repeatedly disabled and re-enabled, and is
+         * allowed to reuse the same memory for its tracepoints, *and*
+         * there's a DTrace consumer running with enablings for these
+         * probes, tracepoints are not always cleaned up sufficiently
+         * that the newly-created probes work.
+         *
+         * Here, then, we will leak the memory holding the
+         * tracepoints, which serves to stop us reusing the same
+         * memory address for new tracepoints, avoiding the bug.
+         */
+
+        for (pd = provider->probedefs; (pd != NULL); pd = pd->next) {
+                /* may have an as yet never-enabled probe on an
+                   otherwise enabled provider */
+                if (pd->probe) {
+                        /* usdt_free_tracepoints(pd->probe); */
+                        free(pd->probe);
+                        pd->probe = NULL;
+                }
+        }
+
+        provider->enabled = 0;
+
+        return (0);
+}
+
+void
+usdt_provider_free(usdt_provider_t *provider)
+{
+        usdt_probedef_t *pd, *next;
+
+        for (pd = provider->probedefs; pd != NULL; pd = next) {
+                next = pd->next;
+                free_probedef(pd);
+        }
+
+        free((char *)provider->name);
+        free((char *)provider->module);
+        free(provider);
+}
+
+int
+usdt_is_enabled(usdt_probe_t *probe)
+{
+        if (probe != NULL)
+                return (*probe->isenabled_addr)();
+        else
+                return 0;
+}
+
+void
+usdt_fire_probe(usdt_probe_t *probe, size_t argc, void **nargv)
+{
+        if (probe != NULL)
+                usdt_probe_args(probe->probe_addr, argc, nargv);
+}
+
+static void
+usdt_verror(usdt_provider_t *provider, usdt_error_t error, va_list argp)
+{
+        vasprintf(&provider->error, usdt_errors[error], argp);
+}
+
+void
+usdt_error(usdt_provider_t *provider, usdt_error_t error, ...)
+{
+        va_list argp;
+
+        va_start(argp, error);
+        usdt_verror(provider, error, argp);
+        va_end(argp);
+}
+
+char *
+usdt_errstr(usdt_provider_t *provider)
+{
+        return (provider->error);
+}

--- a/deps/libusdt/usdt.h
+++ b/deps/libusdt/usdt.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+
+#define USDT_ARG_MAX 32
+
+typedef enum usdt_error {
+        USDT_ERROR_MALLOC = 0,
+        USDT_ERROR_VALLOC,
+        USDT_ERROR_NOPROBES,
+        USDT_ERROR_LOADDOF,
+        USDT_ERROR_ALREADYENABLED,
+        USDT_ERROR_UNLOADDOF,
+        USDT_ERROR_DUP_PROBE,
+        USDT_ERROR_REMOVE_PROBE
+} usdt_error_t;
+
+typedef struct usdt_probe {
+        int (*isenabled_addr)(void);
+        void *probe_addr;
+} usdt_probe_t;
+
+int usdt_is_enabled(usdt_probe_t *probe);
+void usdt_fire_probe(usdt_probe_t *probe, size_t argc, void **argv);
+
+typedef struct usdt_probedef {
+        const char *name;
+        const char *function;
+        size_t argc;
+        char *types[USDT_ARG_MAX];
+        struct usdt_probe *probe;
+        struct usdt_probedef *next;
+        int refcnt;
+} usdt_probedef_t;
+
+usdt_probedef_t *usdt_create_probe(const char *func, const char *name,
+                                   size_t argc, const char **types);
+void usdt_probe_release(usdt_probedef_t *probedef);
+
+typedef struct usdt_provider {
+        const char *name;
+        const char *module;
+        usdt_probedef_t *probedefs;
+        char *error;
+        int enabled;
+        void *file;
+} usdt_provider_t;
+
+usdt_provider_t *usdt_create_provider(const char *name, const char *module);
+int usdt_provider_add_probe(usdt_provider_t *provider, usdt_probedef_t *probedef);
+int usdt_provider_remove_probe(usdt_provider_t *provider, usdt_probedef_t *probedef);
+int usdt_provider_enable(usdt_provider_t *provider);
+int usdt_provider_disable(usdt_provider_t *provider);
+void usdt_provider_free(usdt_provider_t *provider);
+
+void usdt_error(usdt_provider_t *provider, usdt_error_t error, ...);
+char *usdt_errstr(usdt_provider_t *provider);
+

--- a/deps/libusdt/usdt_dof.c
+++ b/deps/libusdt/usdt_dof.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt_internal.h"
+
+int
+usdt_dof_section_add_data(usdt_dof_section_t *section, void *data, size_t length)
+{
+        int newlen = section->size + length;
+
+        if ((section->data = realloc((char *)section->data, newlen)) == NULL)
+                return (-1);
+
+        memcpy(section->data + section->size, data, length);
+        section->size = newlen;
+        return (0);
+}
+
+size_t
+usdt_provider_dof_size(usdt_provider_t *provider, usdt_strtab_t *strtab)
+{
+        uint8_t i, j;
+        int args = 0;
+        int probes = 0;
+        size_t size = 0;
+        usdt_probedef_t *pd;
+        size_t sections[8];
+
+        for (pd = provider->probedefs; pd != NULL; pd = pd->next) {
+                args += pd->argc;
+                probes++;
+        }
+
+        sections[0] = sizeof(dof_hdr_t);
+        sections[1] = sizeof(dof_sec_t) * 6;
+        sections[2] = strtab->size;
+        sections[3] = sizeof(dof_probe_t) * probes;
+        sections[4] = sizeof(uint8_t) * args;
+        sections[5] = sizeof(uint32_t) * probes;
+        sections[6] = sizeof(uint32_t) * probes;
+        sections[7] = sizeof(dof_provider_t);
+
+        for (i = 0; i < 8; i++) {
+                size += sections[i];
+                j = size % 8;
+                if (j > 0)
+                        size += (8 - j);
+        }
+
+        return size;
+}
+
+int
+usdt_dof_section_init(usdt_dof_section_t *section, uint32_t type, dof_secidx_t index)
+{
+        section->type    = type;
+        section->index   = index;
+        section->flags   = DOF_SECF_LOAD;
+        section->offset  = 0;
+        section->size    = 0;
+        section->entsize = 0;
+        section->pad	 = 0;
+        section->next    = NULL;
+
+        if ((section->data = malloc(1)) == NULL)
+                return (-1);
+
+        switch(type) {
+        case DOF_SECT_PROBES:   section->align = 8; break;
+        case DOF_SECT_PRARGS:   section->align = 1; break;
+        case DOF_SECT_PROFFS:   section->align = 4; break;
+        case DOF_SECT_PRENOFFS: section->align = 4; break;
+        case DOF_SECT_PROVIDER: section->align = 4; break;
+        }
+
+        return (0);
+}
+
+void
+usdt_dof_section_free(usdt_dof_section_t *section)
+{
+        free(section->data);
+}
+
+int
+usdt_strtab_init(usdt_strtab_t *strtab, dof_secidx_t index)
+{
+        strtab->type    = DOF_SECT_STRTAB;;
+        strtab->index   = index;
+        strtab->flags   = DOF_SECF_LOAD;
+        strtab->offset  = 0;
+        strtab->size    = 0;
+        strtab->entsize = 0;
+        strtab->pad	  = 0;
+        strtab->data    = NULL;
+        strtab->align   = 1;
+        strtab->strindex = 1;
+
+        if ((strtab->data = (char *) malloc(1)) == NULL)
+                return (-1);
+
+        *strtab->data = '\0';
+
+        return (0);
+}
+
+dof_stridx_t
+usdt_strtab_add(usdt_strtab_t *strtab, const char *string)
+{
+        size_t length;
+        int index;
+
+        length = strlen(string);
+        index = strtab->strindex;
+        strtab->strindex += (length + 1);
+
+        if ((strtab->data = realloc(strtab->data, strtab->strindex)) == NULL)
+                return (0);
+
+        memcpy((char *) (strtab->data + index), (char *)string, length + 1);
+        strtab->size = index + length + 1;
+
+        return (index);
+}
+

--- a/deps/libusdt/usdt_dof_file.c
+++ b/deps/libusdt/usdt_dof_file.c
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt_internal.h"
+
+#include <sys/ioctl.h>
+
+static uint8_t
+dof_version(uint8_t header_version)
+{
+        uint8_t dof_version;
+        /* DOF versioning: Apple always needs version 3, but Solaris can use
+           1 or 2 depending on whether is-enabled probes are needed. */
+#ifdef __APPLE__
+        dof_version = DOF_VERSION_3;
+#else
+        switch(header_version) {
+        case 1:
+                dof_version = DOF_VERSION_1;
+                break;
+        case 2:
+                dof_version = DOF_VERSION_2;
+                break;
+        default:
+                dof_version = DOF_VERSION;
+        }
+#endif
+        return dof_version;
+}
+
+#ifdef __APPLE__
+static const char *helper = "/dev/dtracehelper";
+
+static int
+load_dof(int fd, dof_helper_t *dh)
+{
+        int ret;
+        uint8_t buffer[sizeof(dof_ioctl_data_t) + sizeof(dof_helper_t)];
+        dof_ioctl_data_t* ioctlData = (dof_ioctl_data_t*)buffer;
+        user_addr_t val;
+
+        ioctlData->dofiod_count = 1;
+        memcpy(&ioctlData->dofiod_helpers[0], dh, sizeof(dof_helper_t));
+
+        val = (user_addr_t)(unsigned long)ioctlData;
+        ret = ioctl(fd, DTRACEHIOC_ADDDOF, &val);
+
+        if (ret < 0)
+                return ret;
+
+        return (int)(ioctlData->dofiod_helpers[0].dofhp_dof);
+}
+
+#else /* Solaris and FreeBSD */
+
+/* ignore Sol10 GA ... */
+static const char *helper = "/dev/dtrace/helper";
+
+static int
+load_dof(int fd, dof_helper_t *dh)
+{
+        int ret;
+
+        ret = ioctl(fd, DTRACEHIOC_ADDDOF, dh);
+
+#ifdef __FreeBSD__
+        if (ret != -1)
+                ret = dh->gen;
+#endif
+        return ret;
+}
+
+#endif
+
+static void
+pad_section(usdt_dof_section_t *sec)
+{
+        size_t i, pad;
+
+        if (sec->align > 1) {
+                i = sec->offset % sec->align;
+                if (i > 0) {
+                        pad = sec->align - i;
+                        sec->offset = (pad + sec->offset);
+                        sec->pad = pad;
+                }
+        }
+}
+
+static void
+dof_header(dof_hdr_t *header)
+{
+        int i;
+
+        header->dofh_ident[DOF_ID_MAG0] = DOF_MAG_MAG0;
+        header->dofh_ident[DOF_ID_MAG1] = DOF_MAG_MAG1;
+        header->dofh_ident[DOF_ID_MAG2] = DOF_MAG_MAG2;
+        header->dofh_ident[DOF_ID_MAG3] = DOF_MAG_MAG3;
+
+        header->dofh_ident[DOF_ID_MODEL]    = DOF_MODEL_NATIVE;
+        header->dofh_ident[DOF_ID_ENCODING] = DOF_ENCODE_NATIVE;
+        header->dofh_ident[DOF_ID_VERSION]  = dof_version(2);
+        header->dofh_ident[DOF_ID_DIFVERS]  = DIF_VERSION;
+        header->dofh_ident[DOF_ID_DIFIREG]  = DIF_DIR_NREGS;
+        header->dofh_ident[DOF_ID_DIFTREG]  = DIF_DTR_NREGS;
+
+        for (i = DOF_ID_PAD; i < DOF_ID_SIZE; i++)
+                header->dofh_ident[i] = 0;
+
+        header->dofh_flags = 0;
+
+        header->dofh_hdrsize = sizeof(dof_hdr_t);
+        header->dofh_secsize = sizeof(dof_sec_t);
+        header->dofh_secoff = sizeof(dof_hdr_t);
+
+        header->dofh_loadsz = 0;
+        header->dofh_filesz = 0;
+        header->dofh_pad = 0;
+}
+
+static size_t
+add_header(usdt_dof_file_t *file, size_t offset, usdt_dof_section_t *section)
+{
+        dof_sec_t header;
+
+        header.dofs_flags   = section->flags;
+        header.dofs_type    = section->type;
+        header.dofs_offset  = section->offset;
+        header.dofs_size    = section->size;
+        header.dofs_entsize = section->entsize;
+        header.dofs_align   = section->align;
+
+        memcpy((file->dof + offset), &header, sizeof(dof_sec_t));
+        return (offset + sizeof(dof_sec_t));
+}
+
+static size_t
+add_section(usdt_dof_file_t *file, size_t offset, usdt_dof_section_t *section)
+{
+        if (section->pad > 0) {
+                /* maximum padding required is 7 */
+                memcpy((file->dof + offset), "\0\0\0\0\0\0\0", section->pad);
+                offset += section->pad;
+        }
+
+        memcpy((file->dof + offset), section->data, section->size);
+        return (offset + section->size);
+}
+
+int
+usdt_dof_file_unload(usdt_dof_file_t *file)
+{
+        int fd, ret;
+
+        if ((fd = open(helper, O_RDWR)) < 0)
+                return (-1);
+
+#ifdef __FreeBSD__
+        ret = ioctl(fd, DTRACEHIOC_REMOVE, &file->gen);
+#else
+        ret = ioctl(fd, DTRACEHIOC_REMOVE, file->gen);
+#endif
+
+        if (ret < 0)
+                return (-1);
+
+        if ((close(fd)) < 0)
+                return (-1);
+
+        return (0);
+}
+
+int
+usdt_dof_file_load(usdt_dof_file_t *file, const char *module)
+{
+        dof_helper_t dh;
+        dof_hdr_t *dof;
+        int fd;
+
+        dof = (dof_hdr_t *) file->dof;
+
+        dh.dofhp_dof  = (uintptr_t)dof;
+        dh.dofhp_addr = (uintptr_t)dof;
+        (void) strncpy(dh.dofhp_mod, module, sizeof (dh.dofhp_mod));
+
+        if ((fd = open(helper, O_RDWR)) < 0)
+                return (-1);
+
+        file->gen = load_dof(fd, &dh);
+
+        if ((close(fd)) < 0)
+                return (-1);
+
+        if (file->gen < 0)
+                return (-1);
+
+        return (0);
+}
+
+void
+usdt_dof_file_append_section(usdt_dof_file_t *file, usdt_dof_section_t *section)
+{
+        usdt_dof_section_t *s;
+
+        if (file->sections == NULL) {
+                file->sections = section;
+        }
+        else {
+                for (s = file->sections; (s->next != NULL); s = s->next) ;
+                s->next = section;
+        }
+}
+
+void
+usdt_dof_file_generate(usdt_dof_file_t *file, usdt_strtab_t *strtab)
+{
+        dof_hdr_t header;
+        uint64_t filesz;
+        uint64_t loadsz;
+        usdt_dof_section_t *sec;
+        size_t offset;
+
+        dof_header(&header);
+        header.dofh_secnum = 6;
+
+        filesz = sizeof(dof_hdr_t) + (sizeof(dof_sec_t) * header.dofh_secnum);
+        loadsz = filesz;
+
+        strtab->offset = filesz;
+        pad_section((usdt_dof_section_t *)strtab);
+        filesz += strtab->size + strtab->pad;
+
+        if (strtab->flags & 1)
+                loadsz += strtab->size + strtab->pad;
+
+        for (sec = file->sections; sec != NULL; sec = sec->next) {
+                sec->offset = filesz;
+                pad_section(sec);
+                filesz += sec->size + sec->pad;
+                if (sec->flags & 1)
+                        loadsz += sec->size + sec->pad;
+        }
+
+        header.dofh_loadsz = loadsz;
+        header.dofh_filesz = filesz;
+        memcpy(file->dof, &header, sizeof(dof_hdr_t));
+
+        offset = sizeof(dof_hdr_t);
+
+        offset = add_header(file, offset, (usdt_dof_section_t *)strtab);
+
+        for (sec = file->sections; sec != NULL; sec = sec->next)
+                offset = add_header(file, offset, sec);
+
+        offset = add_section(file, offset, (usdt_dof_section_t *)strtab);
+
+        for (sec = file->sections; sec != NULL; sec = sec->next)
+                offset = add_section(file, offset, sec);
+}
+
+usdt_dof_file_t *
+usdt_dof_file_init(usdt_provider_t *provider, size_t size)
+{
+        usdt_dof_file_t *file;
+
+        if ((file = malloc(sizeof(*file))) == NULL) {
+                usdt_error(provider, USDT_ERROR_MALLOC);
+                return (NULL);
+        }
+
+        if ((file->dof = valloc(size)) == NULL) {
+                usdt_error(provider, USDT_ERROR_VALLOC);
+                return (NULL);
+        }
+
+        file->sections = NULL;
+        file->size = size;
+
+        return (file);
+}
+
+void
+usdt_dof_file_free(usdt_dof_file_t *file)
+{
+        free(file->dof);
+        free(file);
+}

--- a/deps/libusdt/usdt_dof_sections.c
+++ b/deps/libusdt/usdt_dof_sections.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt_internal.h"
+
+int
+usdt_dof_probes_sect(usdt_dof_section_t *probes,
+                     usdt_provider_t *provider, usdt_strtab_t *strtab)
+{
+        usdt_probedef_t *pd;
+        dof_probe_t p;
+        dof_stridx_t type, argv;
+        uint8_t argc, i;
+        uint32_t argidx = 0;
+        uint32_t offidx = 0;
+
+        usdt_dof_section_init(probes, DOF_SECT_PROBES, 1);
+
+        for (pd = provider->probedefs; pd != NULL; pd = pd->next) {
+                argc = 0;
+                argv = 0;
+                type = 0;
+
+                for (i = 0; i < pd->argc; i++) {
+                        type = usdt_strtab_add(strtab, pd->types[i]);
+                        argc++;
+                        if (argv == 0)
+                                argv = type;
+                }
+
+                if (usdt_create_tracepoints(pd->probe) < 0) {
+                        usdt_error(provider, USDT_ERROR_VALLOC);
+                        return (-1);
+                }
+
+#ifdef __x86_64__
+                p.dofpr_addr     = (uint64_t) pd->probe->isenabled_addr;
+#elif __i386__ || __i386
+                p.dofpr_addr     = (uint32_t) pd->probe->isenabled_addr;
+#else
+#error "only x86_64 and i386 supported"
+#endif
+                p.dofpr_func     = usdt_strtab_add(strtab, pd->function);
+                p.dofpr_name     = usdt_strtab_add(strtab, pd->name);
+                p.dofpr_nargv    = argv;
+                p.dofpr_xargv    = argv;
+                p.dofpr_argidx   = argidx;
+                p.dofpr_offidx   = offidx;
+                p.dofpr_nargc    = argc;
+                p.dofpr_xargc    = argc;
+                p.dofpr_noffs    = 1;
+                p.dofpr_enoffidx = offidx;
+                p.dofpr_nenoffs  = 1;
+                p.dofpr_pad1     = 0;
+                p.dofpr_pad2     = 0;
+
+                usdt_dof_section_add_data(probes, &p, sizeof(dof_probe_t));
+                probes->entsize = sizeof(dof_probe_t);
+
+                argidx += argc;
+                offidx++;
+        }
+
+        return (0);
+}
+
+int
+usdt_dof_prargs_sect(usdt_dof_section_t *prargs, usdt_provider_t *provider)
+{
+        usdt_probedef_t *pd;
+        uint8_t i;
+
+        usdt_dof_section_init(prargs, DOF_SECT_PRARGS, 2);
+        prargs->entsize = 1;
+
+        for (pd = provider->probedefs; pd != NULL; pd = pd->next) {
+                for (i = 0; i < pd->argc; i++)
+                        usdt_dof_section_add_data(prargs, &i, 1);
+        }
+        if (prargs->size == 0) {
+                i = 0;
+                if (usdt_dof_section_add_data(prargs, &i, 1) < 0) {
+                        usdt_error(provider, USDT_ERROR_MALLOC);
+                        return (-1);
+                }
+        }
+
+        return (0);
+}
+
+int
+usdt_dof_proffs_sect(usdt_dof_section_t *proffs,
+                     usdt_provider_t *provider, char *dof)
+{
+        usdt_probedef_t *pd;
+        uint32_t off;
+
+        usdt_dof_section_init(proffs, DOF_SECT_PROFFS, 3);
+        proffs->entsize = 4;
+
+        for (pd = provider->probedefs; pd != NULL; pd = pd->next) {
+                off = usdt_probe_offset(pd->probe, dof, pd->argc);
+                if (usdt_dof_section_add_data(proffs, &off, 4) < 0) {
+                        usdt_error(provider, USDT_ERROR_MALLOC);
+                        return (-1);
+                }
+        }
+
+        return (0);
+}
+
+int
+usdt_dof_prenoffs_sect(usdt_dof_section_t *prenoffs,
+                       usdt_provider_t *provider, char *dof)
+{
+        usdt_probedef_t *pd;
+        uint32_t off;
+
+        usdt_dof_section_init(prenoffs, DOF_SECT_PRENOFFS, 4);
+        prenoffs->entsize = 4;
+
+        for (pd = provider->probedefs; pd != NULL; pd = pd->next) {
+                off = usdt_is_enabled_offset(pd->probe, dof);
+                if (usdt_dof_section_add_data(prenoffs, &off, 4) < 0) {
+                        usdt_error(provider, USDT_ERROR_MALLOC);
+                        return (-1);
+                }
+        }
+
+        return (0);
+}
+
+int
+usdt_dof_provider_sect(usdt_dof_section_t *provider_s, usdt_provider_t *provider)
+{
+        dof_provider_t p;
+
+        usdt_dof_section_init(provider_s, DOF_SECT_PROVIDER, 5);
+
+        p.dofpv_strtab   = 0;
+        p.dofpv_probes   = 1;
+        p.dofpv_prargs   = 2;
+        p.dofpv_proffs   = 3;
+        p.dofpv_prenoffs = 4;
+        p.dofpv_name     = 1; /* provider name always first strtab entry. */
+
+        /*
+         * Stability is something of a hack. Everything is marked *
+         * "stable" here to permit use of the "args" array, which is *
+         * needed to access arguments past "arg9".
+         *
+         * It should be up to the creator of the provider to decide
+         * this, though, and it should be possible to set the
+         * appropriate stability at creation time.
+         */
+
+        p.dofpv_provattr = DOF_ATTR(DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE);
+        p.dofpv_modattr  = DOF_ATTR(DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE);
+        p.dofpv_funcattr = DOF_ATTR(DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE);
+        p.dofpv_nameattr = DOF_ATTR(DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE);
+        p.dofpv_argsattr = DOF_ATTR(DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE,
+                                    DTRACE_STABILITY_STABLE);
+
+        if ((usdt_dof_section_add_data(provider_s, &p, sizeof(p))) < 0) {
+                usdt_error(provider, USDT_ERROR_MALLOC);
+                return (-1);
+        }
+
+        return (0);
+}

--- a/deps/libusdt/usdt_internal.h
+++ b/deps/libusdt/usdt_internal.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#ifdef __linux__
+#include <endian.h>
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#ifndef _LITTLE_ENDIAN
+#define _LITTLE_ENDIAN
+#endif
+#endif
+#endif
+
+#include <sys/dtrace.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <assert.h>
+
+#define FUNC_SIZE 32
+
+#include "usdt.h"
+
+extern void usdt_tracepoint_isenabled(void);
+extern void usdt_tracepoint_probe(void);
+extern void usdt_tracepoint_end(void);
+extern void usdt_probe_args(void *, int, void**);
+
+uint32_t usdt_probe_offset(usdt_probe_t *probe, char *dof, uint8_t argc);
+uint32_t usdt_is_enabled_offset(usdt_probe_t *probe, char *dof);
+int usdt_create_tracepoints(usdt_probe_t *probe);
+void usdt_free_tracepoints(usdt_probe_t *probe);
+
+typedef struct usdt_dof_section {
+        dof_secidx_t index;
+        uint32_t type;
+        uint32_t flags;
+        uint32_t align;
+        uint64_t offset;
+        uint64_t size;
+        uint32_t entsize;
+        size_t pad;
+        struct usdt_dof_section *next;
+        char *data;
+} usdt_dof_section_t;
+
+int usdt_dof_section_init(usdt_dof_section_t *section,
+                          uint32_t type, dof_secidx_t index);
+int usdt_dof_section_add_data(usdt_dof_section_t *section,
+                              void *data, size_t length);
+void usdt_dof_section_free(usdt_dof_section_t *section);
+
+typedef struct usdt_strtab {
+        dof_secidx_t index;
+        uint32_t type;
+        uint32_t flags;
+        uint32_t align;
+        uint64_t offset;
+        uint64_t size;
+        uint32_t entsize;
+        size_t pad;
+        int strindex;
+        char *data;
+} usdt_strtab_t;
+
+int usdt_strtab_init(usdt_strtab_t *strtab, dof_secidx_t index);
+dof_stridx_t usdt_strtab_add(usdt_strtab_t *strtab, const char *string);
+char *usdt_strtab_header(usdt_strtab_t *strtab);
+size_t usdt_strtab_size(usdt_strtab_t *strtab);
+
+size_t usdt_provider_dof_size(usdt_provider_t *provider, usdt_strtab_t *strtab);
+
+typedef struct usdt_dof_file {
+        char *dof;
+        int gen;
+        size_t size;
+        usdt_dof_section_t *sections;
+} usdt_dof_file_t;
+
+usdt_dof_file_t *usdt_dof_file_init(usdt_provider_t *provider, size_t size);
+void usdt_dof_file_append_section(usdt_dof_file_t *file, usdt_dof_section_t *section);
+void usdt_dof_file_generate(usdt_dof_file_t *file, usdt_strtab_t *strtab);
+int usdt_dof_file_load(usdt_dof_file_t *file, const char *module);
+int usdt_dof_file_unload(usdt_dof_file_t *file);
+void usdt_dof_file_free(usdt_dof_file_t *file);
+
+int usdt_dof_probes_sect(usdt_dof_section_t *probes,
+                         usdt_provider_t *provider, usdt_strtab_t *strtab);
+int usdt_dof_prargs_sect(usdt_dof_section_t *prargs,
+                         usdt_provider_t *provider);
+int usdt_dof_proffs_sect(usdt_dof_section_t *proffs,
+                         usdt_provider_t *provider, char *dof);
+int usdt_dof_prenoffs_sect(usdt_dof_section_t *prenoffs,
+                           usdt_provider_t *provider, char *dof);
+int usdt_dof_provider_sect(usdt_dof_section_t *provider_s,
+                           usdt_provider_t *provider);
+

--- a/deps/libusdt/usdt_probe.c
+++ b/deps/libusdt/usdt_probe.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+#include "usdt_internal.h"
+
+#ifdef __APPLE__
+
+uint32_t
+usdt_probe_offset(usdt_probe_t *probe, char *dof, uint8_t argc)
+{
+        uint32_t offset;
+#ifdef __x86_64__
+        offset = ((uint64_t) probe->probe_addr - (uint64_t) dof + 2);
+#elif __i386__
+        offset = ((uint32_t) probe->probe_addr - (uint32_t) dof + 2);
+#else
+#error "only x86_64 and i386 supported"
+#endif
+        return (offset);
+}
+
+uint32_t
+usdt_is_enabled_offset(usdt_probe_t *probe, char *dof) 
+{
+        uint32_t offset;
+#ifdef __x86_64__
+        offset = ((uint64_t) probe->isenabled_addr - (uint64_t) dof + 6);
+#elif __i386__
+        offset = ((uint32_t) probe->isenabled_addr - (uint32_t) dof + 6);
+#else
+#error "only x86_64 and i386 supported"
+#endif
+        return (offset);
+}
+
+#elif defined __linux__
+
+uint32_t
+usdt_probe_offset(usdt_probe_t *probe, char *dof, uint8_t argc)
+{
+        return (16);
+}
+
+uint32_t
+usdt_is_enabled_offset(usdt_probe_t *probe, char *dof)
+{
+        return (10);
+}
+
+#else /* solaris and freebsd */
+
+uint32_t
+usdt_probe_offset(usdt_probe_t *probe, char *dof, uint8_t argc)
+{
+        return (16);
+}
+
+uint32_t
+usdt_is_enabled_offset(usdt_probe_t *probe, char *dof)
+{
+        return (8);
+}
+
+#endif
+
+int
+usdt_create_tracepoints(usdt_probe_t *probe)
+{
+        /* Prepare the tracepoints - for each probe, a separate chunk
+         * of memory with the tracepoint code copied into it, to give
+         * us unique addresses for each tracepoint.
+         *
+         * On Oracle Linux, this must be an mmapped file because USDT
+         * probes there are implemented as uprobes, which are
+         * addressed by inode and offset. The file used is a small
+         * mkstemp'd file we immediately unlink.
+         *
+         * Elsewhere, we can use the heap directly because USDT will
+         * instrument any memory mapped by the process.
+         */
+
+        size_t size;
+#ifdef __linux__
+        int fd;
+        char tmp[20] = "/tmp/libusdtXXXXXX";
+
+        if ((fd = mkstemp(tmp)) < 0)
+                return (-1);
+        if (unlink(tmp) < 0)
+                return (-1);
+        if (write(fd, "\0", FUNC_SIZE) < FUNC_SIZE)
+                return (-1);
+
+        probe->isenabled_addr = (int (*)())mmap(NULL, FUNC_SIZE,
+                                                PROT_READ | PROT_WRITE | PROT_EXEC,
+                                                MAP_PRIVATE, fd, 0);
+#else
+        probe->isenabled_addr = (int (*)())valloc(FUNC_SIZE);
+#endif
+        if (probe->isenabled_addr == NULL)
+                return (-1);
+
+        /* ensure that the tracepoints will fit the heap we're allocating */
+        size = ((char *)usdt_tracepoint_end - (char *)usdt_tracepoint_isenabled);
+        assert(size < FUNC_SIZE);
+
+        size = ((char *)usdt_tracepoint_probe - (char *)usdt_tracepoint_isenabled);
+        probe->probe_addr = (char *)probe->isenabled_addr + size;
+
+        memcpy((void *)probe->isenabled_addr,
+               (const void *)usdt_tracepoint_isenabled, FUNC_SIZE);
+
+#ifdef __linux__
+        mprotect((void *)probe->isenabled_addr, FUNC_SIZE,
+                 PROT_READ | PROT_EXEC);
+#else
+        mprotect((void *)probe->isenabled_addr, FUNC_SIZE,
+                 PROT_READ | PROT_WRITE | PROT_EXEC);
+#endif
+
+        return (0);
+}
+
+void
+usdt_free_tracepoints(usdt_probe_t *probe)
+{
+#ifdef __linux__
+        (void) munmap(probe->isenabled_addr, FUNC_SIZE);
+#else
+        free(probe->isenabled_addr);
+#endif
+}

--- a/deps/libusdt/usdt_tracepoints_i386.s
+++ b/deps/libusdt/usdt_tracepoints_i386.s
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+/*
+ * Stub functions containing DTrace tracepoints for probes and
+ * is-enabled probes. These functions are copied for each probe
+ * dynamically created.
+ *
+ */
+        .text
+
+        .align 4, 0x90
+        .globl usdt_tracepoint_isenabled
+        .globl _usdt_tracepoint_isenabled
+        .globl usdt_tracepoint_probe
+        .globl _usdt_tracepoint_probe
+        .globl usdt_tracepoint_end
+        .globl _usdt_tracepoint_end
+        .globl usdt_probe_args
+        .globl _usdt_probe_args
+
+usdt_tracepoint_isenabled:
+_usdt_tracepoint_isenabled:
+        pushl   %ebp
+        movl    %esp, %ebp
+        subl    $8, %esp
+        xorl    %eax, %eax
+        nop
+        nop
+        leave
+        ret
+usdt_tracepoint_probe:
+_usdt_tracepoint_probe:
+        nop
+        nop
+        nop
+        nop
+        nop
+        addl    $0x20,%esp
+        leave
+usdt_tracepoint_end:
+_usdt_tracepoint_end:
+        ret
+
+/*
+ * Probe argument marshalling, i386 style
+ *
+ */
+
+usdt_probe_args:
+_usdt_probe_args:
+        pushl   %ebp
+        movl    %esp,%ebp
+        subl    $8,%esp
+        subl    $8,%esp
+        movl    8(%ebp),%ebx 
+        movl    0xc(%ebp),%ecx
+        test    %ecx,%ecx
+        je      fire
+args:   movl    %ecx,%eax
+        sal     $2,%eax
+        subl    $4,%eax
+        addl    0x10(%ebp),%eax
+        pushl   (%eax)
+        dec     %ecx
+        jne     args
+fire:   jmp     *%ebx
+

--- a/deps/libusdt/usdt_tracepoints_x86_64.s
+++ b/deps/libusdt/usdt_tracepoints_x86_64.s
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2012, Chris Andrews. All rights reserved.
+ */
+
+/*
+ * Stub functions containing DTrace tracepoints for probes and
+ * is-enabled probes. These functions are copied for each probe
+ * dynamically created.
+ *
+ */
+        .text
+
+        .align 4, 0x90
+        .globl usdt_tracepoint_isenabled
+        .globl _usdt_tracepoint_isenabled
+        .globl usdt_tracepoint_probe
+        .globl _usdt_tracepoint_probe
+        .globl usdt_tracepoint_end
+        .globl _usdt_tracepoint_end
+        .globl usdt_probe_args
+        .globl _usdt_probe_args
+
+usdt_tracepoint_isenabled:
+_usdt_tracepoint_isenabled:
+        pushq   %rbp
+        movq    %rsp, %rbp
+        addq    $1, %rax
+        xorq    %rax, %rax
+        nop
+        nop
+        leave
+        ret
+usdt_tracepoint_probe:
+_usdt_tracepoint_probe:
+        nop
+        nop
+        nop
+        nop
+        nop
+        addq	%r14,%rsp
+        popq    %rbx
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        leave
+usdt_tracepoint_end:
+_usdt_tracepoint_end:
+        ret
+
+/*
+ * Probe argument marshalling, x86_64 style
+ *
+ */
+
+usdt_probe_args:
+_usdt_probe_args:
+        pushq   %rbp
+        movq    %rsp,%rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %rbx
+
+        movq    %rdi,%r12
+        movq    %rsi,%rbx
+        movq    %rdx,%r11
+        movq    $0,%r14
+
+        test    %rbx,%rbx
+        je      fire
+        movq    (%r11),%rdi
+        dec     %rbx
+        test    %rbx,%rbx
+        je      fire
+        addq    $8,%r11
+        movq    (%r11),%rsi
+        dec     %rbx
+        test    %rbx,%rbx
+        je      fire
+        addq    $8,%r11
+        movq    (%r11),%rdx
+        dec     %rbx
+        test    %rbx,%rbx
+        je      fire
+        addq    $8,%r11
+        movq    (%r11),%rcx
+        dec     %rbx
+        test    %rbx,%rbx
+        je      fire
+        addq    $8,%r11
+        movq    (%r11),%r8
+        dec     %rbx
+        test    %rbx,%rbx
+        je      fire
+        addq    $8,%r11
+        movq    (%r11),%r9
+
+        movq    %rbx,%r13
+morestack:
+        dec     %rbx
+        test    %rbx,%rbx
+        je      args
+        subq    $16,%rsp
+        addq    $16,%r14
+        dec     %rbx
+        test    %rbx,%rbx
+        je      args
+        jmp     morestack
+
+args:
+        movq    %r13,%rbx
+        movq    $0,%r13
+moreargs:
+        dec     %rbx
+        test    %rbx,%rbx
+        je      fire
+        addq    $8,%r11
+        movq    (%r11),%rax
+        movq    %rax,(%rsp,%r13)
+        addq    $8,%r13
+        jmp     moreargs
+
+fire:   jmp     *%r12

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -168,9 +168,35 @@ util.inherits(ClientRequest, OutgoingMessage);
 
 exports.ClientRequest = ClientRequest;
 
+function fireClientRequest(args) {
+  var request = args;
+  var socket = args.connection;
+  var fd = -1;
+  var host, port, bufferSize;
+
+  if (socket) {
+    fd = socket._handle ? socket._handle.fd : -1;
+    host = socket.remoteAddress;
+    port = socket.remotePort;
+    bufferSize = socket.bufferSize;
+  }
+
+  return [
+    fd,
+    host,
+    port,
+    bufferSize,
+    request.method,
+    request.path
+  ];
+}
+
 ClientRequest.prototype._finish = function() {
-  DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);
+  var self = this;
+
+  DTRACE_HTTP_CLIENT_REQUEST(fireClientRequest(this));
   COUNTER_HTTP_CLIENT_REQUEST();
+
   OutgoingMessage.prototype._finish.call(this);
 };
 
@@ -347,6 +373,24 @@ function socketOnData(d) {
 }
 
 
+function fireClientResponse(request, socket) {
+  var fd = -1;
+  var bufferSize;
+
+  if (socket) {
+    fd = socket._handle ? socket._handle.fd : -1;
+    bufferSize = socket.bufferSize;
+  }
+
+  return [
+    fd,
+    socket.remoteAddress,
+    socket.remotePort,
+    bufferSize
+  ];
+}
+
+
 // client
 function parserOnIncomingClient(res, shouldKeepAlive) {
   var socket = this.socket;
@@ -397,9 +441,9 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
     req.shouldKeepAlive = false;
   }
 
-
-  DTRACE_HTTP_CLIENT_RESPONSE(socket, req);
+  DTRACE_HTTP_CLIENT_RESPONSE(fireClientResponse(req, socket));
   COUNTER_HTTP_CLIENT_RESPONSE();
+
   req.res = res;
   res.req = req;
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -111,8 +111,20 @@ function ServerResponse(req) {
 }
 util.inherits(ServerResponse, OutgoingMessage);
 
+
+function fireServerResponse(response) {
+  var fd = response._handle ? response._handle.fd : -1;
+
+  return [
+    fd,
+    response.remoteAddress,
+    response.remotePort,
+    response.bufferSize
+  ];
+}
+
+
 ServerResponse.prototype._finish = function() {
-  DTRACE_HTTP_SERVER_RESPONSE(this.connection);
   COUNTER_HTTP_SERVER_RESPONSE();
   OutgoingMessage.prototype._finish.call(this);
 };
@@ -283,6 +295,19 @@ Server.prototype.setTimeout = function(msecs, callback) {
 exports.Server = Server;
 
 
+function fireServerRequest(request, socket) {
+  return [
+    socket._handle ? socket._handle.fd : -1,
+    socket.remoteAddress,
+    socket.remotePort,
+    socket.bufferSize,
+    request.url,
+    request.method,
+    request.headers['x-forward-for'] || ''
+  ];
+}
+
+
 function connectionListener(socket) {
   var self = this;
   var outgoing = [];
@@ -450,7 +475,8 @@ function connectionListener(socket) {
     var res = new ServerResponse(req);
 
     res.shouldKeepAlive = shouldKeepAlive;
-    DTRACE_HTTP_SERVER_REQUEST(req, socket);
+
+    DTRACE_HTTP_SERVER_REQUEST(fireServerRequest(req, socket));
     COUNTER_HTTP_SERVER_REQUEST();
 
     if (socket._httpMessage) {
@@ -468,6 +494,7 @@ function connectionListener(socket) {
       // be that in the case abortIncoming() was called that the incoming
       // array will be empty.
       assert(incoming.length == 0 || incoming[0] === req);
+      DTRACE_HTTP_SERVER_RESPONSE(fireServerResponse(socket));
 
       incoming.shift();
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -28,7 +28,6 @@ var cares = process.binding('cares_wrap');
 var uv = process.binding('uv');
 var Pipe = process.binding('pipe_wrap').Pipe;
 
-
 var cluster;
 var errnoException = util._errnoException;
 
@@ -394,10 +393,23 @@ Socket.prototype._read = function(n) {
 };
 
 
+function fireConnection(args) {
+  var self = args;
+
+  return [
+    self._handle ? self._handle.fd : -1,
+    self.remoteAddress,
+    self.remotePort,
+    self.bufferSize
+  ];
+}
+
+
 Socket.prototype.end = function(data, encoding) {
   stream.Duplex.prototype.end.call(this, data, encoding);
   this.writable = false;
-  DTRACE_NET_STREAM_END(this);
+
+  DTRACE_NET_STREAM_END(fireConnection(this));
 
   // just in case we're waiting for an EOF.
   if (this.readable && !this._readableState.endEmitted)
@@ -478,6 +490,7 @@ Socket.prototype._destroy = function(exception, cb) {
 
   if (this.server) {
     COUNTER_NET_SERVER_CONNECTION_CLOSE(this);
+
     debug('has server');
     this.server._connections--;
     if (this.server._emitCloseIfDrained) {
@@ -1294,8 +1307,9 @@ function onconnection(err, clientHandle) {
   self._connections++;
   socket.server = self;
 
-  DTRACE_NET_SERVER_CONNECTION(socket);
+  DTRACE_NET_SERVER_CONNECTION(fireConnection(socket));
   COUNTER_NET_SERVER_CONNECTION(socket);
+
   self.emit('connection', socket);
 }
 

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -19,8 +19,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var assert = require('assert');
+var util = require('util');
 var EventEmitter = require('events');
 var v8binding, process;
+
 
 // This needs to be loaded early, and before the "process" object is made
 // global. So allow src/node.js to pass the process object in during
@@ -66,7 +69,6 @@ v8.on('removeListener', function(name) {
     v8binding.stopGarbageCollectionTracking();
   }
 });
-
 
 // AsyncListener
 

--- a/node.gyp
+++ b/node.gyp
@@ -218,6 +218,17 @@
                 '<(SHARED_INTERMEDIATE_DIR)/node_dtrace_provider.o',
                 '<(SHARED_INTERMEDIATE_DIR)/libuv_dtrace_provider.o',
               ],
+            }, {
+              'sources': [
+                'src/dtrace-provider/dtrace_argument.cc',
+                'src/dtrace-provider/dtrace_probe.cc',
+                'src/dtrace-provider/dtrace_provider.cc',
+                'src/dtrace-provider/dtrace_provider.h',
+              ],
+              'include_dirs': [ 'deps/libusdt' ],
+              'dependencies': [
+                './deps/libusdt/libusdt.gyp:libusdt',
+              ],
             }],
             [ 'OS!="mac" and OS!="linux"', {
               'sources': [

--- a/node.gyp
+++ b/node.gyp
@@ -60,6 +60,7 @@
       'lib/tls.js',
       'lib/_tls_legacy.js',
       'lib/_tls_wrap.js',
+      'lib/tracing.js',
       'lib/tty.js',
       'lib/url.js',
       'lib/util.js',
@@ -92,6 +93,7 @@
         'src/node_buffer.cc',
         'src/node_constants.cc',
         'src/node_contextify.cc',
+        'src/node_dtrace.cc',
         'src/node_file.cc',
         'src/node_http_parser.cc',
         'src/node_javascript.cc',
@@ -210,7 +212,6 @@
           # below, and the GYP-generated Makefiles will properly build them when
           # needed.
           #
-          'sources': [ 'src/node_dtrace.cc' ],
           'conditions': [
             [ 'OS=="linux"', {
               'sources': [
@@ -240,7 +241,6 @@
             'src/node_win32_etw_provider.h',
             'src/node_win32_etw_provider-inl.h',
             'src/node_win32_etw_provider.cc',
-            'src/node_dtrace.cc',
             'tools/msvs/genfiles/node_etw_provider.h',
             'tools/msvs/genfiles/node_etw_provider.rc',
           ]

--- a/src/dtrace-provider/dtrace_argument.cc
+++ b/src/dtrace-provider/dtrace_argument.cc
@@ -54,7 +54,7 @@ namespace node {
     return reinterpret_cast<void*>(strdup(*str));
   }
 
-  void DTraceStringArgument::FreeArgument(void *arg) {
+  void DTraceStringArgument::FreeArgument(void* arg) {
     free(arg);
   }
 
@@ -84,7 +84,7 @@ namespace node {
     return reinterpret_cast<void*>(strdup(*json));
   }
 
-  void DTraceJsonArgument::FreeArgument(void *arg) {
+  void DTraceJsonArgument::FreeArgument(void* arg) {
     free(arg);
   }
 

--- a/src/dtrace-provider/dtrace_argument.cc
+++ b/src/dtrace-provider/dtrace_argument.cc
@@ -46,7 +46,7 @@ namespace node {
     : DTraceArgument(env) {
   }
 
-  void * DTraceStringArgument::ArgumentValue(Handle<Value> value) {
+  void* DTraceStringArgument::ArgumentValue(Handle<Value> value) {
     if (value->IsUndefined())
       return reinterpret_cast<void*>(strdup("undefined"));
 
@@ -58,7 +58,7 @@ namespace node {
     free(arg);
   }
 
-  const char * DTraceStringArgument::Type() {
+  const char* DTraceStringArgument::Type() {
     return "char *";
   }
 
@@ -67,7 +67,7 @@ namespace node {
   }
 
 
-  void * DTraceJsonArgument::ArgumentValue(Handle<Value> value) {
+  void* DTraceJsonArgument::ArgumentValue(Handle<Value> value) {
     HandleScope scope(env()->isolate());
 
     if (value->IsUndefined())
@@ -88,7 +88,7 @@ namespace node {
     free(arg);
   }
 
-  const char * DTraceJsonArgument::Type() {
+  const char* DTraceJsonArgument::Type() {
     return "char *";
   }
 

--- a/src/dtrace-provider/dtrace_argument.cc
+++ b/src/dtrace-provider/dtrace_argument.cc
@@ -1,0 +1,95 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "dtrace_provider.h"
+
+#include "node.h"
+#include "util.h"
+
+#include "env.h"
+#include "env-inl.h"
+
+#include "base-object.h"
+#include "base-object-inl.h"
+
+namespace node {
+
+  using v8::Function;
+  using v8::Handle;
+  using v8::HandleScope;
+  using v8::Local;
+  using v8::String;
+  using v8::Value;
+
+  DTraceArgument::DTraceArgument(Environment* env) : _env(env) {
+  }
+
+  DTraceStringArgument::DTraceStringArgument(Environment* env)
+    : DTraceArgument(env) {
+  }
+
+  void * DTraceStringArgument::ArgumentValue(Handle<Value> value) {
+    if (value->IsUndefined())
+      return reinterpret_cast<void*>(strdup("undefined"));
+
+    AsciiValue str(value->ToString());
+    return reinterpret_cast<void*>(strdup(*str));
+  }
+
+  void DTraceStringArgument::FreeArgument(void *arg) {
+    free(arg);
+  }
+
+  const char * DTraceStringArgument::Type() {
+    return "char *";
+  }
+
+  DTraceJsonArgument::DTraceJsonArgument(Environment* env)
+    : DTraceArgument(env) {
+  }
+
+
+  void * DTraceJsonArgument::ArgumentValue(Handle<Value> value) {
+    HandleScope scope(env()->isolate());
+
+    if (value->IsUndefined())
+      return reinterpret_cast<void*>(strdup("undefined"));
+
+    Local<Function> stringify = env()->json_stringify_function();
+    Handle<Value> j = stringify->Call(env()->json_object(), 1, &value);
+
+    if (*j == NULL)
+      return reinterpret_cast<void*>(
+        strdup("{ \"error\": \"stringify failed\" }"));
+
+    AsciiValue json(j->ToString());
+    return reinterpret_cast<void*>(strdup(*json));
+  }
+
+  void DTraceJsonArgument::FreeArgument(void *arg) {
+    free(arg);
+  }
+
+  const char * DTraceJsonArgument::Type() {
+    return "char *";
+  }
+
+}  // namespace node

--- a/src/dtrace-provider/dtrace_probe.cc
+++ b/src/dtrace-provider/dtrace_probe.cc
@@ -1,0 +1,182 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "dtrace_provider.h"
+
+#include "node.h"
+
+#include "env.h"
+#include "env-inl.h"
+
+#include "base-object.h"
+#include "base-object-inl.h"
+
+#include "v8.h"
+
+
+namespace node {
+
+  using v8::Array;
+  using v8::Exception;
+  using v8::Function;
+  using v8::FunctionCallbackInfo;
+  using v8::FunctionTemplate;
+  using v8::Handle;
+  using v8::HandleScope;
+  using v8::Local;
+  using v8::Object;
+  using v8::String;
+  using v8::True;
+  using v8::TryCatch;
+  using v8::Undefined;
+  using v8::Value;
+
+  DTraceProbe::DTraceProbe(Environment* env, Local<Object> obj)
+    : BaseObject(env, obj),
+      probedef(NULL),
+      argc(0) {
+    MakeWeak<DTraceProbe>(this);
+  }
+
+  DTraceProbe::~DTraceProbe() {
+    for (size_t i = 0; i < argc; i++)
+      delete(this->arguments[i]);
+    usdt_probe_release(probedef);
+  }
+
+  void DTraceProbe::Initialize(Handle<Object> target, Environment* env) {
+    HandleScope scope(env->isolate());
+
+    Local<FunctionTemplate> t = FunctionTemplate::New(env->isolate(),
+        DTraceProbe::New);
+    t->InstanceTemplate()->SetInternalFieldCount(1);
+    t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "DTraceProbe"));
+
+    NODE_SET_PROTOTYPE_METHOD(t, "fire", DTraceProbe::Fire);
+
+    target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "DTraceProbe"),
+        t->GetFunction());
+  }
+
+  void DTraceProbe::New(const FunctionCallbackInfo<Value>& args) {
+    Environment *env = Environment::GetCurrent(args.GetIsolate());
+    DTraceProbe *probe = new DTraceProbe(env, args.This());
+    args.GetReturnValue().Set(args.This());
+
+    AsciiValue name(args[0]->ToString());
+    Local<Array> arr = args[1].As<Array>();
+
+    const char *types[USDT_ARG_MAX];
+
+    fprintf(stderr, "trying to look at %u args\n", arr->Length());
+    fflush(stderr);
+
+    for (uint32_t i = 0; i < USDT_ARG_MAX && i < arr->Length(); i++) {
+      int64_t type = arr->Get(i)->IntegerValue();
+
+      switch (type) {
+        case ARGUMENT_TYPE_JSON:
+          probe->arguments[i] = new DTraceJsonArgument(env);
+          break;
+        case ARGUMENT_TYPE_INT64:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_INT64, int64_t>(env);
+          break;
+        case ARGUMENT_TYPE_UINT32:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_UINT32, uint32_t>(env);
+          break;
+        case ARGUMENT_TYPE_INT32:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_INT32, int32_t>(env);
+          break;
+        case ARGUMENT_TYPE_UINT16:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_UINT16, uint16_t>(env);
+          break;
+        case ARGUMENT_TYPE_INT16:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_INT16, int16_t>(env);
+          break;
+        case ARGUMENT_TYPE_UINT8:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_UINT8, uint8_t>(env);
+          break;
+        case ARGUMENT_TYPE_INT8:
+          probe->arguments[i] =
+            new DTraceIntegerArgument<ARGUMENT_TYPE_INT8, int8_t>(env);
+          break;
+        case ARGUMENT_TYPE_STRING:
+          probe->arguments[i] = new DTraceStringArgument(env);
+          break;
+        default:
+          probe->arguments[i] = new DTraceStringArgument(env);
+          break;
+      }
+
+      types[i] = strdup(probe->arguments[i]->Type());
+      probe->argc++;
+    }
+
+    probe->probedef = usdt_create_probe(*name, *name, probe->argc, types);
+
+    for (size_t i = 0; i < probe->argc; i++) {
+      delete types[i];
+    }
+  }
+
+  void DTraceProbe::Fire(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
+    DTraceProbe *pd = Unwrap<DTraceProbe>(args.This());
+    args.GetReturnValue().Set(pd->_fire(args[0]));
+  }
+
+  Handle<Value> DTraceProbe::_fire(v8::Local<v8::Value> probe_args) {
+    if (usdt_is_enabled(this->probedef->probe) == 0)
+      return Undefined(env()->isolate());
+
+    // invoke fire callback
+    TryCatch try_catch;
+
+    // check return
+    if (!probe_args->IsArray())
+      return Undefined(env()->isolate());
+
+    Local<Array> a = probe_args.As<Array>();
+    void *argv[USDT_ARG_MAX];
+
+    // convert each argument value
+    for (size_t i = 0; i < argc; i++) {
+      argv[i] = this->arguments[i]->ArgumentValue(a->Get(i));
+    }
+
+    // finally fire the probe
+    usdt_fire_probe(this->probedef->probe, argc, argv);
+
+    // free argument values
+    for (size_t i = 0; i < argc; i++) {
+      this->arguments[i]->FreeArgument(argv[i]);
+    }
+
+    return True(env()->isolate());
+  }
+
+}  //  namespace node

--- a/src/dtrace-provider/dtrace_probe.cc
+++ b/src/dtrace-provider/dtrace_probe.cc
@@ -77,14 +77,14 @@ namespace node {
   }
 
   void DTraceProbe::New(const FunctionCallbackInfo<Value>& args) {
-    Environment *env = Environment::GetCurrent(args.GetIsolate());
-    DTraceProbe *probe = new DTraceProbe(env, args.This());
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    DTraceProbe* probe = new DTraceProbe(env, args.This());
     args.GetReturnValue().Set(args.This());
 
     AsciiValue name(args[0]->ToString());
     Local<Array> arr = args[1].As<Array>();
 
-    const char *types[USDT_ARG_MAX];
+    const char* types[USDT_ARG_MAX];
 
     fprintf(stderr, "trying to look at %u args\n", arr->Length());
     fflush(stderr);
@@ -145,7 +145,7 @@ namespace node {
 
   void DTraceProbe::Fire(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(args.GetIsolate());
-    DTraceProbe *pd = Unwrap<DTraceProbe>(args.This());
+    DTraceProbe* pd = Unwrap<DTraceProbe>(args.This());
     args.GetReturnValue().Set(pd->_fire(args[0]));
   }
 
@@ -161,7 +161,7 @@ namespace node {
       return Undefined(env()->isolate());
 
     Local<Array> a = probe_args.As<Array>();
-    void *argv[USDT_ARG_MAX];
+    void* argv[USDT_ARG_MAX];
 
     // convert each argument value
     for (size_t i = 0; i < argc; i++) {

--- a/src/dtrace-provider/dtrace_provider.cc
+++ b/src/dtrace-provider/dtrace_provider.cc
@@ -80,8 +80,8 @@ namespace node {
 
   void DTraceProvider::New(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(args.GetIsolate());
-    Environment *env = Environment::GetCurrent(args.GetIsolate());
-    DTraceProvider *p = new DTraceProvider(env, args.This());
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    DTraceProvider* p = new DTraceProvider(env, args.This());
     char module[128];
 
     if (args.Length() < 1 || !args[0]->IsString()) {
@@ -121,11 +121,11 @@ namespace node {
     HandleScope scope(isolate);
 
     Handle<Object> obj = args.This();
-    DTraceProvider *provider = Unwrap<DTraceProvider>(obj);
+    DTraceProvider* provider = Unwrap<DTraceProvider>(obj);
 
     Local<Object> dprobe = args[0].As<Object>();
 
-    DTraceProbe *probe = Unwrap<DTraceProbe>(dprobe);
+    DTraceProbe* probe = Unwrap<DTraceProbe>(dprobe);
 
     // store in provider object
     obj->Set(dprobe->ToString(), dprobe);
@@ -140,10 +140,10 @@ namespace node {
     HandleScope scope(isolate);
 
     Handle<Object> provider_obj = args.This();
-    DTraceProvider *provider = Unwrap<DTraceProvider>(provider_obj);
+    DTraceProvider* provider = Unwrap<DTraceProvider>(provider_obj);
 
     Handle<Object> probe_obj = Local<Object>::Cast(args[0]);
-    DTraceProbe *probe = Unwrap<DTraceProbe>(probe_obj);
+    DTraceProbe* probe = Unwrap<DTraceProbe>(probe_obj);
 
     Handle<String> name = String::NewFromUtf8(isolate,
         probe->probedef->name);
@@ -160,7 +160,7 @@ namespace node {
 
   void DTraceProvider::Enable(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(args.GetIsolate());
-    DTraceProvider *provider = Unwrap<DTraceProvider>(args.This());
+    DTraceProvider* provider = Unwrap<DTraceProvider>(args.This());
 
     if (usdt_provider_enable(provider->provider) != 0) {
       ThrowError(usdt_errstr(provider->provider));
@@ -170,7 +170,7 @@ namespace node {
 
   void DTraceProvider::Disable(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(args.GetIsolate());
-    DTraceProvider *provider = Unwrap<DTraceProvider>(args.Holder());
+    DTraceProvider* provider = Unwrap<DTraceProvider>(args.Holder());
 
     if (usdt_provider_disable(provider->provider) != 0) {
       ThrowError(usdt_errstr(provider->provider));
@@ -183,7 +183,7 @@ namespace node {
        Handle<Value> unused,
        Handle<Context> context,
        void* priv) {
-    Environment *env = Environment::GetCurrent(context);
+    Environment* env = Environment::GetCurrent(context);
     DTraceProvider::Initialize(target, env);
   }
 

--- a/src/dtrace-provider/dtrace_provider.cc
+++ b/src/dtrace-provider/dtrace_provider.cc
@@ -1,0 +1,191 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "dtrace_provider.h"
+
+#include "node.h"
+
+#include "base-object.h"
+#include "base-object-inl.h"
+
+#include "env.h"
+#include "env-inl.h"
+
+#include "v8.h"
+
+#include <stdio.h>
+
+namespace node {
+
+  using v8::Context;
+  using v8::Function;
+  using v8::FunctionCallbackInfo;
+  using v8::FunctionTemplate;
+  using v8::Handle;
+  using v8::HandleScope;
+  using v8::Isolate;
+  using v8::Local;
+  using v8::Object;
+  using v8::String;
+  using v8::True;
+  using v8::Value;
+
+  DTraceProvider::DTraceProvider(Environment* env, Local<Object> obj)
+    : BaseObject(env, obj) {
+    provider = NULL;
+    MakeWeak<DTraceProvider>(this);
+  }
+
+  DTraceProvider::~DTraceProvider() {
+    usdt_provider_disable(provider);
+    usdt_provider_free(provider);
+  }
+
+  void DTraceProvider::Initialize(Handle<Object> target, Environment* env) {
+    HandleScope scope(env->isolate());
+
+    Local<FunctionTemplate> t = FunctionTemplate::New(env->isolate(),
+        DTraceProvider::New);
+    t->InstanceTemplate()->SetInternalFieldCount(1);
+    t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "DTraceProvider"));
+
+    NODE_SET_PROTOTYPE_METHOD(t, "addProbe", DTraceProvider::AddProbe);
+    NODE_SET_PROTOTYPE_METHOD(t, "removeProbe", DTraceProvider::RemoveProbe);
+    NODE_SET_PROTOTYPE_METHOD(t, "enable", DTraceProvider::Enable);
+    NODE_SET_PROTOTYPE_METHOD(t, "disable", DTraceProvider::Disable);
+
+    target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "DTraceProvider"),
+        t->GetFunction());
+
+    DTraceProbe::Initialize(target, env);
+  }
+
+  void DTraceProvider::New(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
+    Environment *env = Environment::GetCurrent(args.GetIsolate());
+    DTraceProvider *p = new DTraceProvider(env, args.This());
+    char module[128];
+
+    if (args.Length() < 1 || !args[0]->IsString()) {
+      ThrowError("Must give provider name as argument");
+      return;
+    }
+
+    AsciiValue name(args[0].As<String>());
+
+    if (args.Length() == 2) {
+      if (!args[1]->IsString()) {
+        ThrowError("Must give module name as argument");
+        return;
+      }
+
+      AsciiValue mod(args[1].As<String>());
+      snprintf(module, sizeof(module), "%s", *mod);
+    } else if (args.Length() == 1) {
+      // If no module name is provided, develop a synthetic module name based
+      // on our address
+      snprintf(module, sizeof(module), "mod-%p", p);
+    } else {
+      ThrowError("Expected only provider name and module as arguments");
+      return;
+    }
+
+    if ((p->provider = usdt_create_provider(*name, module)) == NULL) {
+      ThrowError("usdt_create_provider failed");
+      return;
+    }
+
+    args.GetReturnValue().Set(args.This());
+  }
+
+  void DTraceProvider::AddProbe(const FunctionCallbackInfo<Value>& args) {
+    Isolate* isolate = args.GetIsolate();
+    HandleScope scope(isolate);
+
+    Handle<Object> obj = args.This();
+    DTraceProvider *provider = Unwrap<DTraceProvider>(obj);
+
+    Local<Object> dprobe = args[0].As<Object>();
+
+    DTraceProbe *probe = Unwrap<DTraceProbe>(dprobe);
+
+    // store in provider object
+    obj->Set(dprobe->ToString(), dprobe);
+
+    usdt_provider_add_probe(provider->provider, probe->probedef);
+
+    args.GetReturnValue().Set(dprobe);
+  }
+
+  void DTraceProvider::RemoveProbe(const FunctionCallbackInfo<Value>& args) {
+    Isolate* isolate = args.GetIsolate();
+    HandleScope scope(isolate);
+
+    Handle<Object> provider_obj = args.This();
+    DTraceProvider *provider = Unwrap<DTraceProvider>(provider_obj);
+
+    Handle<Object> probe_obj = Local<Object>::Cast(args[0]);
+    DTraceProbe *probe = Unwrap<DTraceProbe>(probe_obj);
+
+    Handle<String> name = String::NewFromUtf8(isolate,
+        probe->probedef->name);
+
+    provider_obj->Delete(name);
+
+    if (usdt_provider_remove_probe(provider->provider, probe->probedef) != 0) {
+      ThrowError(usdt_errstr(provider->provider));
+      return;
+    }
+
+    args.GetReturnValue().Set(True(isolate));
+  }
+
+  void DTraceProvider::Enable(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
+    DTraceProvider *provider = Unwrap<DTraceProvider>(args.This());
+
+    if (usdt_provider_enable(provider->provider) != 0) {
+      ThrowError(usdt_errstr(provider->provider));
+      return;
+    }
+  }
+
+  void DTraceProvider::Disable(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
+    DTraceProvider *provider = Unwrap<DTraceProvider>(args.Holder());
+
+    if (usdt_provider_disable(provider->provider) != 0) {
+      ThrowError(usdt_errstr(provider->provider));
+      return;
+    }
+  }
+
+  static void
+  init(Handle<Object> target,
+       Handle<Value> unused,
+       Handle<Context> context,
+       void* priv) {
+    Environment *env = Environment::GetCurrent(context);
+    DTraceProvider::Initialize(target, env);
+  }
+
+  NODE_MODULE_CONTEXT_AWARE_BUILTIN(dtrace_provider, init)
+}  // namespace node

--- a/src/dtrace-provider/dtrace_provider.h
+++ b/src/dtrace-provider/dtrace_provider.h
@@ -1,0 +1,156 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+#ifndef SRC_DTRACE_PROVIDER_DTRACE_PROVIDER_H_
+#define SRC_DTRACE_PROVIDER_DTRACE_PROVIDER_H_
+
+#include "node.h"
+#include "base-object.h"
+#include "node_dtrace.h"
+
+#include "v8.h"
+
+extern "C" {
+#include <usdt.h>
+}
+
+#include <sys/dtrace.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#ifndef __APPLE__
+#include <stdlib.h>
+#include <malloc.h>
+#endif
+
+namespace node {
+
+  class DTraceArgument {
+  public:
+    virtual const char *Type() = 0;
+    virtual void *ArgumentValue(v8::Handle<v8::Value>) = 0;
+    virtual void FreeArgument(void* arg) = 0;
+    virtual ~DTraceArgument() { }
+    explicit DTraceArgument(Environment* env);
+    Environment* env() { return _env; }
+  private:
+    Environment* _env;
+  };
+
+  template <TracingArgumentType T, typename P>
+  class DTraceIntegerArgument : public DTraceArgument {
+  public:
+    explicit DTraceIntegerArgument(Environment* env) :
+      DTraceArgument(env) {
+    }
+
+    const char *Type() {
+      switch (T) {
+        case ARGUMENT_TYPE_INT64:
+          return "int64_t";
+          break;
+        case ARGUMENT_TYPE_UINT32:
+          return "uint32_t";
+          break;
+        case ARGUMENT_TYPE_INT32:
+          return "int32_t";
+          break;
+        case ARGUMENT_TYPE_UINT16:
+          return "uint16_t";
+          break;
+        case ARGUMENT_TYPE_INT16:
+          return "int16_t";
+          break;
+        case ARGUMENT_TYPE_UINT8:
+          return "uint8_t";
+          break;
+        case ARGUMENT_TYPE_INT8:
+          return "int8_t";
+          break;
+      }
+    }
+
+    void *ArgumentValue(v8::Handle<v8::Value> value) {
+      int64_t ret = value->IntegerValue();
+      P r = static_cast<P>(ret);
+      return reinterpret_cast<void*>(r);
+    }
+
+    void FreeArgument(void* arg) {
+    }
+  };
+
+  class DTraceStringArgument : public DTraceArgument {
+  public:
+    const char *Type();
+    void *ArgumentValue(v8::Handle<v8::Value>);
+    void FreeArgument(void* arg);
+    explicit DTraceStringArgument(Environment* env);
+  };
+
+  class DTraceJsonArgument : public DTraceArgument {
+  public:
+    const char *Type();
+    void *ArgumentValue(v8::Handle<v8::Value>);
+    void FreeArgument(void* arg);
+    explicit DTraceJsonArgument(Environment* env);
+  };
+
+  class DTraceProbe : public BaseObject {
+  public:
+    static void Initialize(v8::Handle<v8::Object> target, Environment *env);
+    usdt_probedef_t *probedef;
+    size_t argc;
+    DTraceArgument *arguments[USDT_ARG_MAX];
+
+    static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Fire(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+    v8::Handle<v8::Value> _fire(v8::Local<v8::Value>);
+
+    DTraceProbe(Environment *env, v8::Local<v8::Object> obj);
+    ~DTraceProbe();
+  };
+
+  class DTraceProvider : public BaseObject {
+  public:
+    static void Initialize(v8::Handle<v8::Object> target, Environment *env);
+    usdt_provider_t *provider;
+
+    static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void AddProbe(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void RemoveProbe(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Enable(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Disable(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Fire(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+    DTraceProvider(Environment *env, v8::Local<v8::Object> obj);
+    ~DTraceProvider();
+  };
+
+  void InitDTraceProvider(v8::Handle<v8::Object> target);
+}
+
+#endif  // SRC_DTRACE_PROVIDER_DTRACE_PROVIDER_H_

--- a/src/dtrace-provider/dtrace_provider.h
+++ b/src/dtrace-provider/dtrace_provider.h
@@ -49,8 +49,8 @@ namespace node {
 
   class DTraceArgument {
   public:
-    virtual const char *Type() = 0;
-    virtual void *ArgumentValue(v8::Handle<v8::Value>) = 0;
+    virtual const char* Type() = 0;
+    virtual void* ArgumentValue(v8::Handle<v8::Value>) = 0;
     virtual void FreeArgument(void* arg) = 0;
     virtual ~DTraceArgument() { }
     explicit DTraceArgument(Environment* env);
@@ -66,7 +66,7 @@ namespace node {
       DTraceArgument(env) {
     }
 
-    const char *Type() {
+    const char* Type() {
       switch (T) {
         case ARGUMENT_TYPE_INT64:
           return "int64_t";
@@ -92,7 +92,7 @@ namespace node {
       }
     }
 
-    void *ArgumentValue(v8::Handle<v8::Value> value) {
+    void* ArgumentValue(v8::Handle<v8::Value> value) {
       int64_t ret = value->IntegerValue();
       P r = static_cast<P>(ret);
       return reinterpret_cast<void*>(r);
@@ -104,40 +104,40 @@ namespace node {
 
   class DTraceStringArgument : public DTraceArgument {
   public:
-    const char *Type();
-    void *ArgumentValue(v8::Handle<v8::Value>);
+    const char* Type();
+    void* ArgumentValue(v8::Handle<v8::Value>);
     void FreeArgument(void* arg);
     explicit DTraceStringArgument(Environment* env);
   };
 
   class DTraceJsonArgument : public DTraceArgument {
   public:
-    const char *Type();
-    void *ArgumentValue(v8::Handle<v8::Value>);
+    const char* Type();
+    void* ArgumentValue(v8::Handle<v8::Value>);
     void FreeArgument(void* arg);
     explicit DTraceJsonArgument(Environment* env);
   };
 
   class DTraceProbe : public BaseObject {
   public:
-    static void Initialize(v8::Handle<v8::Object> target, Environment *env);
-    usdt_probedef_t *probedef;
+    static void Initialize(v8::Handle<v8::Object> target, Environment* env);
+    usdt_probedef_t* probedef;
     size_t argc;
-    DTraceArgument *arguments[USDT_ARG_MAX];
+    DTraceArgument* arguments[USDT_ARG_MAX];
 
     static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void Fire(const v8::FunctionCallbackInfo<v8::Value>& args);
 
     v8::Handle<v8::Value> _fire(v8::Local<v8::Value>);
 
-    DTraceProbe(Environment *env, v8::Local<v8::Object> obj);
+    DTraceProbe(Environment* env, v8::Local<v8::Object> obj);
     ~DTraceProbe();
   };
 
   class DTraceProvider : public BaseObject {
   public:
-    static void Initialize(v8::Handle<v8::Object> target, Environment *env);
-    usdt_provider_t *provider;
+    static void Initialize(v8::Handle<v8::Object> target, Environment* env);
+    usdt_provider_t* provider;
 
     static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void AddProbe(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -146,7 +146,7 @@ namespace node {
     static void Disable(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void Fire(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-    DTraceProvider(Environment *env, v8::Local<v8::Object> obj);
+    DTraceProvider(Environment* env, v8::Local<v8::Object> obj);
     ~DTraceProvider();
   };
 

--- a/src/dtrace-provider/dtrace_provider.h
+++ b/src/dtrace-provider/dtrace_provider.h
@@ -128,8 +128,6 @@ namespace node {
     static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void Fire(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-    v8::Handle<v8::Value> _fire(v8::Local<v8::Value>);
-
     DTraceProbe(Environment* env, v8::Local<v8::Object> obj);
     ~DTraceProbe();
   };

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -234,6 +234,12 @@ inline Environment::Environment(v8::Local<v8::Context> context)
   set_module_load_list_array(v8::Array::New(isolate()));
   RB_INIT(&cares_task_list_);
   QUEUE_INIT(&gc_tracker_queue_);
+
+  v8::Handle<v8::Object> json = context->Global()->Get(
+      FIXED_ONE_BYTE_STRING(isolate(), "JSON")).As<v8::Object>();
+  set_json_object(json);
+  set_json_stringify_function(json->Get(
+      FIXED_ONE_BYTE_STRING(isolate(), "stringify")).As<v8::Function>());
 }
 
 inline Environment::~Environment() {

--- a/src/env.h
+++ b/src/env.h
@@ -244,6 +244,8 @@ namespace node {
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(gc_info_callback_function, v8::Function)                                  \
+  V(json_object, v8::Object)                                                  \
+  V(json_stringify_function, v8::Function)                                    \
   V(module_load_list_array, v8::Array)                                        \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \
   V(process_object, v8::Object)                                               \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2817,14 +2817,6 @@ void Load(Environment* env) {
   // Add a reference to the global object
   Local<Object> global = env->context()->Global();
 
-#if defined HAVE_DTRACE || defined HAVE_ETW
-  InitDTrace(env, global);
-#endif
-
-#if defined HAVE_PERFCTR
-  InitPerfCounters(env, global);
-#endif
-
   // Enable handling of uncaught exceptions
   // (FatalException(), break on uncaught exception in debugger)
   //

--- a/src/node.js
+++ b/src/node.js
@@ -170,6 +170,7 @@
     global.Buffer = NativeModule.require('buffer').Buffer;
     process.domain = null;
     process._exiting = false;
+    process.binding('dtrace');
   };
 
   startup.globalTimeouts = function() {

--- a/src/node_dtrace.h
+++ b/src/node_dtrace.h
@@ -75,7 +75,23 @@ typedef struct {
 
 namespace node {
 
-void InitDTrace(Environment* env, v8::Handle<v8::Object> target);
+  enum TracingArgumentType {
+    ARGUMENT_TYPE_STRING = 1,
+    ARGUMENT_TYPE_JSON,
+    ARGUMENT_TYPE_INT64,
+    ARGUMENT_TYPE_UINT32,
+    ARGUMENT_TYPE_INT32,
+    ARGUMENT_TYPE_UINT16,
+    ARGUMENT_TYPE_INT16,
+    ARGUMENT_TYPE_UINT8,
+    ARGUMENT_TYPE_INT8,
+  };
+
+
+void InitDTrace(v8::Handle<v8::Object> target,
+                v8::Handle<v8::Value> unused,
+                v8::Handle<v8::Context> context,
+                void* priv);
 
 }  // namespace node
 

--- a/src/util.h
+++ b/src/util.h
@@ -104,6 +104,36 @@ inline void Wrap(v8::Local<v8::Object> object, void* pointer);
 template <typename TypeName>
 inline TypeName* Unwrap(v8::Local<v8::Object> object);
 
+class AsciiValue {
+  public:
+    explicit AsciiValue(v8::Handle<v8::String> value)
+      : val_(value), str_(NULL) {
+    }
+
+    ~AsciiValue() {
+      if (str_ != NULL)
+        free(str_);
+    }
+
+    char* operator*() {
+      if (str_ == NULL) {
+        size_t len = val_->Length();
+        uint8_t* str = static_cast<uint8_t*>(malloc(len));
+        size_t written = val_->WriteOneByte(str);
+
+        if (written != len)
+          str = static_cast<uint8_t*>(realloc(str, written));
+
+        str_ = reinterpret_cast<char*>(str);
+      }
+      return str_;
+    };
+
+  private:
+    v8::Handle<v8::String> val_;
+    char* str_;
+};
+
 }  // namespace node
 
 #endif  // SRC_UTIL_H_


### PR DESCRIPTION
Unconditionally compile `src/node_dtrace.cc` but only export the
functions the configuration supports. Then `lib/_trace.js` replaces any
missing probe points with a nop function.

This is a companion commit to #5938
