### PR TITLE
http: no longer doing a buffer.toString in write

### DIFF
--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -12,7 +12,7 @@ var PORT = common.PORT;
 
 var bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
-  kb: [64, 128, 256, 1024],
+  kb: [64, 128, 256, 1024, 10240],
   c: [100],
   method: ['write', 'end  '] // two spaces added to line up each row
 });

--- a/lib/http.js
+++ b/lib/http.js
@@ -787,23 +787,6 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
   // signal the user to keep writing.
   if (chunk.length === 0) return true;
 
-  // TODO(bnoordhuis) Temporary optimization hack, remove in v0.11. We only
-  // want to convert the buffer when we're sending:
-  //
-  //   a) Transfer-Encoding chunks, because it lets us pack the chunk header
-  //      and the chunk into a single write(), or
-  //
-  //   b) the first chunk of a fixed-length request, because it lets us pack
-  //      the request headers and the chunk into a single write().
-  //
-  // Converting to strings is expensive, CPU-wise, but reducing the number
-  // of write() calls more than makes up for that because we're dramatically
-  // reducing the number of TCP roundtrips.
-  if (chunk instanceof Buffer && (this.chunkedEncoding || !this._headerSent)) {
-    chunk = chunk.toString('binary');
-    encoding = 'binary';
-  }
-
   var len, ret;
   if (this.chunkedEncoding) {
     if (typeof(chunk) === 'string' &&
@@ -812,8 +795,11 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
       len = Buffer.byteLength(chunk, encoding);
       chunk = len.toString(16) + CRLF + chunk + CRLF;
       ret = this._send(chunk, encoding);
+    } else if (Buffer.isBuffer(chunk)) {
+      len = new Buffer(chunk.length.toString('16') + CRLF);
+      ret = this._send(Buffer.concat([len, chunk, crlf_buf]), encoding);
     } else {
-      // buffer, or a non-toString-friendly encoding
+      // non-toString-friendly encoding
       len = chunk.length;
       this._send(len.toString(16) + CRLF);
       this._send(chunk, encoding);

--- a/lib/http.js
+++ b/lib/http.js
@@ -796,8 +796,25 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
       chunk = len.toString(16) + CRLF + chunk + CRLF;
       ret = this._send(chunk, encoding);
     } else if (Buffer.isBuffer(chunk)) {
-      len = new Buffer(chunk.length.toString('16') + CRLF);
-      ret = this._send(Buffer.concat([len, chunk, crlf_buf]), encoding);
+      var chunk_size = chunk.length.toString(16);
+      var chunk_size_len = chunk_size.length;
+      var chunk_len = chunk.length;
+      len = chunk_size_len +
+            2 + // '\r\n'.length
+            chunk_len +
+            2;  // '\r\n'.length
+      var buf = new Buffer(len);
+      var off = 0;
+
+      buf.write(chunk_size, off, chunk_size_len, 'ascii');
+      off += chunk_size_len;
+      crlf_buf.copy(buf, off);
+      off += 2;
+      chunk.copy(buf, off);
+      off += chunk_len;
+      crlf_buf.copy(buf, off);
+
+      ret = this._send(buf, encoding);
     } else {
       // non-toString-friendly encoding
       len = chunk.length;


### PR DESCRIPTION
Closes #5941

Instead of doing the .toString on the buffer chunk now write will concat buffers.

Please note that this takes a similar approach to the `OutgoingMessage.end` hot code path for buffer. 
