### PR TITLE
smalloc: allow different external array types

### DIFF
--- a/doc/api/smalloc.markdown
+++ b/doc/api/smalloc.markdown
@@ -2,10 +2,11 @@
 
     Stability: 1 - Experimental
 
-## smalloc.alloc(length[, receiver])
+## smalloc.alloc(length[, receiver][, type])
 
-* `length` Number `<= smalloc.kMaxLength`
-* `receiver` Object, Optional, Default: `new Object`
+* `length` {Number} `<= smalloc.kMaxLength`
+* `receiver` {Object}, Optional, Default: `new Object`
+* `type` {Enum}, Optional, Default: `Uint8`
 
 Returns `receiver` with allocated external array data. If no `receiver` is
 passed then a new Object will be created and returned.
@@ -34,6 +35,16 @@ this it is possible to allocate external array data to more than a plain Object.
 
 v8 does not support allocating external array data to an Array, and if passed
 will throw.
+
+It's possible is to specify the type of external array data you would like. All
+possible options are listed in `smalloc.Types`. Example usage:
+
+    var doubleArr = smalloc.alloc(3, smalloc.Types.Double);
+
+    for (var i = 0; i < 3; i++)
+      doubleArr = i / 10;
+
+    // { '0': 0, '1': 0.1, '2': 0.2 }
 
 ## smalloc.copyOnto(source, sourceStart, dest, destStart, copyLength);
 
@@ -99,3 +110,17 @@ careful. Cryptic errors may arise in applications that are difficult to trace.
 ## smalloc.kMaxLength
 
 Size of maximum allocation. This is also applicable to Buffer creation.
+
+## smalloc.Types
+
+Enum of possible external array types. Contains:
+
+* `Int8`
+* `Uint8`
+* `Int16`
+* `Uint16`
+* `Int32`
+* `Uint32`
+* `Float`
+* `Double`
+* `Uint8Clamped`

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -33,22 +33,49 @@ Object.defineProperty(exports, 'kMaxLength', {
   enumerable: true, value: kMaxLength, writable: false
 });
 
+// enumerated values for different external array types
+var Types = {};
 
-function alloc(n, obj) {
+Object.defineProperties(Types, {
+  'Int8': { enumerable: true, value: 1, writable: false },
+  'Uint8': { enumerable: true, value: 2, writable: false },
+  'Int16': { enumerable: true, value: 3, writable: false },
+  'Uint16': { enumerable: true, value: 4, writable: false },
+  'Int32': { enumerable: true, value: 5, writable: false },
+  'Uint32': { enumerable: true, value: 6, writable: false },
+  'Float': { enumerable: true, value: 7, writable: false },
+  'Double': { enumerable: true, value: 8, writable: false },
+  'Uint8Clamped': { enumerable: true, value: 9, writable: false }
+});
+
+Object.defineProperty(exports, 'Types', {
+  enumerable: true, value: Types, writable: false
+});
+
+
+// usage: obj = alloc(n[, obj][, type]);
+function alloc(n, obj, type) {
   n = n >>> 0;
 
   if (util.isUndefined(obj))
     obj = {};
-  else if (util.isPrimitive(obj))
+
+  if (util.isNumber(obj)) {
+    type = obj >>> 0;
+    obj = {};
+  } else if (util.isPrimitive(obj)) {
     throw new TypeError('obj must be an Object');
-  if (n > kMaxLength)
-    throw new RangeError('n > kMaxLength');
+  }
+
+  // 1 == v8::kExternalByteArray, 9 == v8::kExternalPixelArray
+  if (type < 1 || type > 9)
+    throw new TypeError('unknown external array type: ' + type);
   if (util.isArray(obj))
     throw new TypeError('Arrays are not supported');
-  if (obj && !(obj instanceof Object))
-    throw new TypeError('obj must be an Object');
+  if (n > kMaxLength)
+    throw new RangeError('n > kMaxLength');
 
-  return smalloc.alloc(obj, n);
+  return smalloc.alloc(obj, n, type);
 }
 
 

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -30,9 +30,7 @@ exports.dispose = dispose;
 // don't allow kMaxLength to accidentally be overwritten. it's a lot less
 // apparent when a primitive is accidentally changed.
 Object.defineProperty(exports, 'kMaxLength', {
-  enumerable: true,
-  value: kMaxLength,
-  writable: false
+  enumerable: true, value: kMaxLength, writable: false
 });
 
 
@@ -47,6 +45,8 @@ function alloc(n, obj) {
     throw new RangeError('n > kMaxLength');
   if (util.isArray(obj))
     throw new TypeError('Arrays are not supported');
+  if (obj && !(obj instanceof Object))
+    throw new TypeError('obj must be an Object');
 
   return smalloc.alloc(obj, n);
 }

--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -44,18 +44,32 @@ NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
 /**
  * Allocate external memory and set to passed object. If data is passed then
  * will use that instead of allocating new.
+ *
+ * When you pass an ExternalArrayType and data, Alloc assumes data length is
+ * the same as data length * ExternalArrayType length.
  */
-NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj, size_t length);
-NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj, char* data, size_t length);
+NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj,
+                       size_t length,
+                       enum v8::ExternalArrayType type =
+                       v8::kExternalUnsignedByteArray);
+NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj,
+                       char* data,
+                       size_t length,
+                       enum v8::ExternalArrayType type =
+                       v8::kExternalUnsignedByteArray);
 NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj,
                        size_t length,
                        FreeCallback fn,
-                       void* hint);
+                       void* hint,
+                       enum v8::ExternalArrayType type =
+                       v8::kExternalUnsignedByteArray);
 NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj,
                        char* data,
                        size_t length,
                        FreeCallback fn,
-                       void* hint);
+                       void* hint,
+                       enum v8::ExternalArrayType type =
+                       v8::kExternalUnsignedByteArray);
 
 /**
  * Free memory associated with an externally allocated object. If no external

--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -28,6 +28,7 @@ var alloc = smalloc.alloc;
 var dispose = smalloc.dispose;
 var copyOnto = smalloc.copyOnto;
 var kMaxLength = smalloc.kMaxLength;
+var Types = smalloc.Types;
 // sliceOnto is volatile and cannot be exposed to users.
 var sliceOnto = process.binding('smalloc').sliceOnto;
 
@@ -63,6 +64,60 @@ for (var i = 0; i < 5; i++)
   assert.equal(b[i], i);
 
 
+var b = alloc(1, Types.Uint8);
+b[0] = 256;
+assert.equal(b[0], 0);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Int8);
+b[0] = 128;
+assert.equal(b[0], -128);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Uint16);
+b[0] = 65536;
+assert.equal(b[0], 0);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Int16);
+b[0] = 32768;
+assert.equal(b[0], -32768);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Uint32);
+b[0] = 4294967296;
+assert.equal(b[0], 0);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Int32);
+b[0] = 2147483648;
+assert.equal(b[0], -2147483648);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Float);
+b[0] = 0.1111111111111111;
+assert.equal(b[0], 0.1111111119389534);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Double);
+b[0] = 0.1111111111111111;
+assert.equal(b[0], 0.1111111111111111);
+assert.equal(b[1], undefined);
+
+
+var b = alloc(1, Types.Uint8Clamped);
+b[0] = 300;
+assert.equal(b[0], 255);
+assert.equal(b[1], undefined);
+
+
 var b = alloc(6, {});
 var c0 = {};
 var c1 = {};
@@ -91,6 +146,14 @@ for (var i = 0; i < 6; i++) {
   assert.equal(c[i], i);
   assert.equal(c[i + 6], i * 2);
 }
+
+
+var b = alloc(1, Types.Double);
+var c = alloc(2, Types.Uint32);
+c[0] = 2576980378;
+c[1] = 1069128089;
+copyOnto(c, 0, b, 0, 2);
+assert.equal(b[0], 0.1);
 
 
 // verify alloc throws properly
@@ -124,9 +187,6 @@ assert.throws(function() {
   alloc(1, 'a');
 }, TypeError);
 assert.throws(function() {
-  alloc(1, 1);
-}, TypeError);
-assert.throws(function() {
   alloc(1, true);
 }, TypeError);
 assert.throws(function() {
@@ -139,6 +199,14 @@ alloc(1, function() { });
 alloc(1, /abc/);
 alloc(1, new Date());
 
+
+// range check on external array enumeration
+assert.throws(function() {
+  alloc(1, 0);
+}, TypeError);
+assert.throws(function() {
+  alloc(1, 10);
+}, TypeError);
 
 // very copyOnto throws properly
 
@@ -187,6 +255,12 @@ assert.throws(function() {
 // destStart + copyLength <= destLength
 assert.throws(function() {
   copyOnto(alloc(3), 0, alloc(3), 1, 3);
+}, RangeError);
+
+
+// copy_length * array_size <= dest_length
+assert.throws(function() {
+  copyOnto(alloc(2, Types.Double), 0, alloc(2, Types.Uint32), 0, 2);
 }, RangeError);
 
 


### PR DESCRIPTION
Users can specify what type of external array they want using
smalloc.TYPES.
