### PR TITLE
Restore .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+
+before_script:
+  - "./configure"
+  - "make"
+
+script:
+  - "make test"
+
+notifications:
+  email: false
+  irc:
+    - "irc.freenode.net#libuv"


### PR DESCRIPTION
The travis file was removed from the master branch 2 commits back. This causes travis to attempt to build as a ruby project.
