### PR TITLE
doc: remove travis status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Evented I/O for V8 javascript. [![Build Status](https://secure.travis-ci.org/joyent/node.png)](http://travis-ci.org/joyent/node)
+Evented I/O for V8 javascript.
 ===
 
 ### To build:


### PR DESCRIPTION
If project is not to use travis and move to jenkins, then the status image is not required and shows a failed build perpetually.
