### PR TITLE
doc: add process.features to documentation

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -568,3 +568,17 @@ a diff reading, useful for benchmarks and measuring intervals:
     }, 1000);
 
 [EventEmitter]: events.html#events_class_events_eventemitter
+
+
+## process.features
+
+A property exposing feature availability for the currently running process.
+
+Example of possible output:
+
+    { debug: false,
+      uv: true,
+      ipv6: true,
+      tls_npn: true,
+      tls_sni: true,
+      tls: true }


### PR DESCRIPTION
@indutny I'm not sure what `tls_*` are for. Can you give me an explanation?

@bnoordhuis how would the field `uv` even be optional?

once those get cleared up I'll update the doc and throw this on.
