### PR TITLE
doc: fs.open, fix flag/mode confusion, etc.

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -296,7 +296,7 @@ An exception occurs if the file does not exist.
 
   This is primarily useful for opening files on NFS mounts as it allows you to
   skip the potentially stale local cache. It has a very real impact on I/O
-  performance so don't use this mode unless you need it.
+  performance so don't use this flag unless you need it.
 
   Note that this doesn't turn `fs.open()` into a synchronous blocking call.
   If that's what you want then you should be using `fs.openSync()`
@@ -307,28 +307,32 @@ An exception occurs if the file does not exist.
 * `'w'` - Open file for writing.
 The file is created (if it does not exist) or truncated (if it exists).
 
-* `'wx'` - Like `'w'` but opens the file in exclusive mode.
+* `'wx'` - Like `'w'` but fails if `path` exists.
 
 * `'w+'` - Open file for reading and writing.
 The file is created (if it does not exist) or truncated (if it exists).
 
-* `'wx+'` - Like `'w+'` but opens the file in exclusive mode.
+* `'wx+'` - Like `'w+'` but fails if `path` exists.
 
 * `'a'` - Open file for appending.
 The file is created if it does not exist.
 
-* `'ax'` - Like `'a'` but opens the file in exclusive mode.
+* `'ax'` - Like `'a'` but fails if `path` exists.
 
 * `'a+'` - Open file for reading and appending.
 The file is created if it does not exist.
 
-* `'ax+'` - Like `'a+'` but opens the file in exclusive mode.
+* `'ax+'` - Like `'a+'` but fails if `path` exists.
 
-`mode` defaults to `0666`. The callback gets two arguments `(err, fd)`.
+`mode` sets the file mode (permission and sticky bits), but only if the file was
+created. It defaults to `0666`, readable and writeable.
 
-Exclusive mode (`O_EXCL`) ensures that `path` is newly created. `fs.open()`
-fails if a file by that name already exists. On POSIX systems, symlinks are
-not followed. Exclusive mode may or may not work with network file systems.
+The callback gets two arguments `(err, fd)`.
+
+The exclusive flag `'x'` (`O_EXCL` flag in open(2)) ensures that `path` is newly
+created. On POSIX systems, `path` is considered to exist even if it is a symlink
+to a non-existent file. The exclusive flag may or may not work with network file
+systems.
 
 On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
@@ -336,7 +340,7 @@ the end of the file.
 
 ## fs.openSync(path, flags, [mode])
 
-Synchronous open(2).
+Synchronous version of `fs.open()`.
 
 ## fs.utimes(path, atime, mtime, callback)
 ## fs.utimesSync(path, atime, mtime)


### PR DESCRIPTION
Flags and modes aren't the same, symlinks are followed in all of the
path but the last component, docs should say something about what the
mode argument is for and when its used, fs.openSync should point to the
function that contains the docs for its args, as fs.writeSync does.
