### PR TITLE
WIP: add new continuation-local-storage module

### DIFF
--- a/doc/api/_toc.markdown
+++ b/doc/api/_toc.markdown
@@ -6,6 +6,7 @@
 * [Child Processes](child_process.html)
 * [Cluster](cluster.html)
 * [Console](console.html)
+* [Continuation Local Storage](continuation_local_storage.html)
 * [Crypto](crypto.html)
 * [Debugger](debugger.html)
 * [DNS](dns.html)

--- a/doc/api/continuation_local_storage.md
+++ b/doc/api/continuation_local_storage.md
@@ -1,0 +1,117 @@
+# Continuation Local Storage
+
+    Stability: 1 - Experimental
+
+Continuation-local storage provides a mechanism similar to thread-local storage
+in threaded programming, with closures wrapped around portions of a
+continuation chain taking the place of mutable cells bound to thread data
+structures. Contexts are created on namespaces and can be be nested.
+
+Every namespace is created with a default context. The currently active
+context on a namespace is available via `namespace.active`.
+
+A simple rule of thumb is anywhere where you might have set a property on the
+`request` or `response` objects in an HTTP handler, you can (and should) now
+use continuation-local storage.
+
+A simple, annotated example:
+
+```javascript
+var cls = require('contination_local_storage');
+
+var writer = cls.createNamespace('writer');
+writer.set('value', 0);
+
+function requestHandler() {
+  writer.run(function(outer) {
+    // writer.get('value') returns 0
+    // outer.value is 0
+    writer.set('value', 1);
+    // writer.get('value') returns 1
+    // outer.value is 1
+    process.nextTick(function() {
+      // writer.get('value') returns 1
+      // outer.value is 1
+      writer.run(function(inner) {
+        // writer.get('value') returns 1
+        // outer.value is 1
+        // inner.value is 1
+        writer.set('value', 2);
+        // writer.get('value') returns 2
+        // outer.value is 1
+        // inner.value is 2
+      });
+    });
+  });
+
+  setTimeout(function() {
+    // runs with the default context, because nested contexts have ended
+    console.log(writer.get('value')); // prints 0
+  }, 1000);
+}
+```
+
+## cls.createNamespace(name)
+
+* return: {Namespace}
+
+Each application wanting to use continuation-local values should create its own
+namespace. Reading from (or, more significantly, writing to) namespaces that
+don't belong to you is a faux pas.
+
+## cls.getNamespace(name)
+
+* return: {Namespace}
+
+Look up an existing namespace.
+
+## process.namespaces
+
+* return: dictionary of {Namespace} objects
+
+The set of available namespaces.
+
+## Class: Namespace
+
+Application-specific namespaces provide access to continuation-local
+properties. Once the execution of a continuation chain begins, creating new
+contexts and changing local values is analogous to mutating the value of a
+given attribute scoped to that particular continuation chain.
+
+### namespace.active
+
+* return: the currently active context on a namespace
+
+### namespace.set(key, value)
+
+* return: `value`
+
+Set a value on the current continuation context.
+
+### namespace.get(key)
+
+* return: the requested value, or `undefined`
+
+Look up a value on the current continuation context. Recursively searches from
+the innermost to outermost nested continuation context for a value associated
+with a given key.
+
+### namespace.run(continuation)
+
+* return: the context associated with that continuation
+
+Create a new context on which values can be set or mutated. Run the
+continuation in this new scope (passing the new context into the
+continuation).
+
+### namespace.bind(callback, [context])
+
+* return: a continuation wrapped up in a context closure
+
+Bind a function to the specified continuation context. Works analagously to
+`Function.bind()` or `domain.bind()`. If context is omitted, it will default to
+the currently active context in the namespace.
+
+## context
+
+A context is a plain object created using the enclosing context as its prototype.

--- a/lib/continuation_local_storage.js
+++ b/lib/continuation_local_storage.js
@@ -24,7 +24,12 @@ var assert = require('assert');
 var namespaces = Object.create(null);
 Object.defineProperty(process,
                       'namespaces',
-                      {enumerable: true, value: namespaces});
+                      {
+                        enumerable: true,
+                        writable: false,
+                        configurable: false,
+                        value: namespaces
+                      });
 
 function each(obj, action) {
   var keys = Object.keys(obj);
@@ -57,7 +62,12 @@ function wrapContinuations(callback) {
 }
 Object.defineProperty(process,
                       '_wrapContinuations',
-                      {enumerable: true, value: wrapContinuations});
+                      {
+                        enumerable: true,
+                        writable: false,
+                        configurable: false,
+                        value: wrapContinuations
+                      });
 
 function Namespace(name) {
   namespaces[name] = this;

--- a/lib/continuation_local_storage.js
+++ b/lib/continuation_local_storage.js
@@ -1,0 +1,138 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+
+var namespaces = Object.create(null);
+Object.defineProperty(process,
+                      'namespaces',
+                      {enumerable: true, value: namespaces});
+
+function each(obj, action) {
+  var keys = Object.keys(obj);
+  for (var i = 0, l = keys.length; i < l; ++i) {
+    var key = keys[i];
+    action(key, obj[key]);
+  }
+}
+
+function wrapContinuations(callback) {
+  // get the currently active contexts in all the namespaces.
+  var contexts = {};
+  each(namespaces, function(name, namespace) {
+    contexts[name] = namespace.active;
+  });
+
+  // return a callback that enters all the saved namespaces when called.
+  return function() {
+    each(contexts, function(name, context) {
+      namespaces[name].enter(context);
+    });
+    try {
+      return callback.apply(this, arguments);
+    } finally {
+      each(contexts, function(name, context) {
+        namespaces[name].exit(context);
+      });
+    }
+  };
+}
+Object.defineProperty(process,
+                      '_wrapContinuations',
+                      {enumerable: true, value: wrapContinuations});
+
+function Namespace(name) {
+  namespaces[name] = this;
+
+  this.name = name;
+
+  // TODO: by default, contexts nest -- but domains won't
+  this._stack = [];
+
+  // every namespace has a default / "global" context
+  // FIXME: domains require different behavior to preserve distinction between
+  // _makeCallback and _makeDomainCallback, for performance reasons.
+  this.active = Object.create(null);
+}
+
+Namespace.prototype.set = function(key, value) {
+  this.active[key] = value;
+  return value;
+};
+
+Namespace.prototype.get = function(key) {
+  return this.active[key];
+};
+
+Namespace.prototype.createContext = function() {
+  return Object.create(this.active);
+};
+
+Namespace.prototype.run = function(fn) {
+  var context = this.createContext();
+  this.enter(context);
+  fn(context);
+  this.exit(context);
+  return context;
+};
+
+Namespace.prototype.bind = function(fn, context) {
+  if (!context)
+    context = this.active;
+
+  var self = this;
+  return function() {
+    self.enter(context);
+    var result = fn.apply(this, arguments);
+    self.exit(context);
+    return result;
+  };
+};
+
+Namespace.prototype.enter = function(context) {
+  assert(context, 'context must be provided for entering');
+  this._stack.push(this.active);
+  this.active = context;
+};
+
+// TODO: generalize nesting via configuration to handle domains
+Namespace.prototype.exit = function(context) {
+  assert(context, 'context must be provided for exiting');
+
+  // Fast path for most exits that are at the top of the stack
+  if (this.active === context) {
+    assert(this._stack.length, 'can\'t remove top context');
+    this.active = this._stack.pop();
+    return;
+  }
+
+  // Fast search in the stack using lastIndexOf
+  var index = this._stack.lastIndexOf(context);
+  assert(index >= 0, 'context not currently entered; can\'t exit');
+  assert(index, 'can\'t remove top context');
+  this.active = this._stack[index - 1];
+  this._stack.length = index - 1;
+};
+
+module.exports = {
+  createNamespace: function(name) { return new Namespace(name); },
+  getNamespace: function(name) { return namespaces[name]; }
+};

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -188,6 +188,9 @@ exports.setTimeout = function(callback, after) {
 
   timer = new Timeout(after);
 
+  if (process._wrapContinuations)
+    callback = process._wrapContinuations(callback);
+
   if (arguments.length <= 2) {
     timer._onTimeout = callback;
   } else {
@@ -232,6 +235,9 @@ exports.setInterval = function(callback, repeat) {
   if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour
   }
+
+  if (process._wrapContinuations)
+    callback = process._wrapContinuations(callback);
 
   var timer = new Timeout(repeat);
   var args = Array.prototype.slice.call(arguments, 2);
@@ -339,6 +345,9 @@ exports.setImmediate = function(callback) {
   var immediate = {}, args;
 
   L.init(immediate);
+
+  if (process._wrapContinuations)
+    callback = process._wrapContinuations(callback);
 
   immediate._onImmediate = callback;
 

--- a/node.gyp
+++ b/node.gyp
@@ -26,6 +26,7 @@
       'lib/child_process.js',
       'lib/console.js',
       'lib/constants.js',
+      'lib/continuation_local_storage.js',
       'lib/crypto.js',
       'lib/cluster.js',
       'lib/dgram.js',

--- a/src/node.js
+++ b/src/node.js
@@ -415,6 +415,9 @@
       if (process._exiting)
         return;
 
+      if (process._wrapContinuations)
+        callback = process._wrapContinuations(callback);
+
       nextTickQueue.push({ callback: callback, domain: null });
       infoBox[length]++;
     }
@@ -423,6 +426,9 @@
       // on the way out, don't bother. it won't get fired anyway.
       if (process._exiting)
         return;
+
+      if (process._wrapContinuations)
+        callback = process._wrapContinuations(callback);
 
       nextTickQueue.push({ callback: callback, domain: process.domain });
       infoBox[length]++;

--- a/src/node.js
+++ b/src/node.js
@@ -165,6 +165,8 @@
     global.Buffer = NativeModule.require('buffer').Buffer;
     process.domain = null;
     process._exiting = false;
+    process.namespaces = null;
+    process._wrapContinuations = null;
   };
 
   startup.globalTimeouts = function() {

--- a/test/simple/test-continuation_local_storage.js
+++ b/test/simple/test-continuation_local_storage.js
@@ -29,8 +29,8 @@ var run = 0;
 var expectRun = 0;
 
 // don't expose namespaces until module is loaded.
-assert(process.namespaces === undefined);
-assert(process._wrapContinuations === undefined);
+assert(!process.namespaces);
+assert(!process._wrapContinuations);
 
 var cls = require('continuation_local_storage');
 

--- a/test/simple/test-continuation_local_storage.js
+++ b/test/simple/test-continuation_local_storage.js
@@ -1,0 +1,184 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// basic tests of continuation-local storage
+
+require('../common');
+var assert = require('assert');
+
+var run = 0;
+var expectRun = 0;
+
+// don't expose namespaces until module is loaded.
+assert(process.namespaces === undefined);
+assert(process._wrapContinuations === undefined);
+
+var cls = require('continuation_local_storage');
+
+// now they should be exposed
+assert(process.namespaces);
+assert(process._wrapContinuations);
+
+// namespaces can't be removed from process
+assert(!(delete process.namespaces));
+assert(process.namespaces);
+
+// nor can its helper function
+assert(!(delete process._wrapContinuations));
+assert(process._wrapContinuations);
+
+// namespaces aren't writable
+var original = process.namespaces;
+process.namespaces = 'ham';
+assert.equal(process.namespaces, original);
+
+// ...nor is the helper function
+original = process._wrapContinuations;
+process._wrapContinuations = 'ham';
+assert.equal(process._wrapContinuations, original);
+
+process.on('exit', function() {
+  console.error('exit', run, expectRun);
+  assert.equal(run, expectRun, 'ran the expected number of continuations');
+  console.log('ok');
+});
+
+var namespace = cls.createNamespace('test');
+assert(cls.getNamespace('test'));
+
+namespace.set('value', 1);
+
+// run synchronously
+expectRun++;
+namespace.run(function() {
+  assert(cls.getNamespace('test'));
+  assert.equal(namespace.get('value'), 1);
+
+  namespace.set('value', 2);
+  namespace.set('synchronous', true);
+
+  assert.equal(namespace.get('value'), 2);
+
+  assert(namespace.get('synchronous'));
+  assert(!namespace.get('process.nextTick'));
+  assert(!namespace.get('setImmediate'));
+  assert(!namespace.get('setTimeout'));
+  assert(!namespace.get('setInterval'));
+
+  run++;
+});
+
+assert.equal(namespace.get('value'), 1);
+
+// process.nextTick
+expectRun++;
+namespace.run(function() {
+  assert(cls.getNamespace('test'));
+  assert.equal(namespace.get('value'), 1);
+
+  namespace.set('value', 3);
+  namespace.set('process.nextTick', true);
+  process.nextTick(function() {
+    assert.equal(namespace.get('value'), 3);
+
+    assert(!namespace.get('synchronous'));
+    assert(namespace.get('process.nextTick'));
+    assert(!namespace.get('setImmediate'));
+    assert(!namespace.get('setTimeout'));
+    assert(!namespace.get('setInterval'));
+
+    run++;
+  });
+});
+
+assert.equal(namespace.get('value'), 1);
+
+// setImmediate
+expectRun++;
+namespace.run(function() {
+  assert(cls.getNamespace('test'));
+  assert.equal(namespace.get('value'), 1);
+
+  namespace.set('value', 4);
+  namespace.set('setImmediate', true);
+  setImmediate(function() {
+    assert.equal(namespace.get('value'), 4);
+
+    assert(!namespace.get('synchronous'));
+    assert(!namespace.get('process.nextTick'));
+    assert(namespace.get('setImmediate'));
+    assert(!namespace.get('setTimeout'));
+    assert(!namespace.get('setInterval'));
+
+    run++;
+  });
+});
+
+assert.equal(namespace.get('value'), 1);
+
+// setTimeout
+expectRun++;
+namespace.run(function() {
+  assert(cls.getNamespace('test'));
+  assert.equal(namespace.get('value'), 1);
+
+  namespace.set('value', 5);
+  namespace.set('setTimeout', true);
+  setTimeout(function() {
+    assert.equal(namespace.get('value'), 5);
+
+    assert(!namespace.get('synchronous'));
+    assert(!namespace.get('process.nextTick'));
+    assert(!namespace.get('setImmediate'));
+    assert(namespace.get('setTimeout'));
+    assert(!namespace.get('setInterval'));
+
+    run++;
+  }, 0);
+});
+
+assert.equal(namespace.get('value'), 1);
+
+// setInterval
+expectRun++;
+namespace.run(function() {
+  assert(cls.getNamespace('test'));
+  assert.equal(namespace.get('value'), 1);
+
+  namespace.set('value', 6);
+  namespace.set('setInterval', true);
+  var ref = setInterval(function() {
+    clearInterval(ref);
+
+    assert.equal(namespace.get('value'), 6);
+
+    assert(!namespace.get('synchronous'));
+    assert(!namespace.get('process.nextTick'));
+    assert(!namespace.get('setImmediate'));
+    assert(!namespace.get('setTimeout'));
+    assert(namespace.get('setInterval'));
+
+    run++;
+  }, 0);
+});
+
+assert.equal(namespace.get('value'), 1);


### PR DESCRIPTION
This module adds continuation-local storage that works analogously to the thread-local variables used in multithreaded programming. It allows you to set variables specific to a particular request or handler execution, and can be used to create things like pure-JS execution tracers and long stacktrace generators, and to replace the grotesque hack of stashing per-request state on `req` and `res`. It is also a more generalized version of `domains`, and is intended, eventually, to be used as the mechanism by which domains are implemented.

This is the first part of an implementation of the API described on #5243 & #3733. There is also a [userland implementation](https://github.com/othiym23/node-continuation-local-storage) of the API and [another module that monkeypatches the API](https://github.com/othiym23/node-continuation-local-storage-glue) onto 0.10. @creationix and I have been hacking on this for a few months now and feel pretty good about the core API.

So far, this PR includes the core API (with its documentation) as well as a sort of hacky implementation that applies over `process.nextTick` and the timer functions (`setImmediate`, `setTimeout`, and `setInterval`). The next piece of work @creationix and I intend to tackle is dealing with Make(Domain)Callback and net.Socket. The final step is to rework domains to run on top of this and to take advantage, as much as possible, of the optimization work that @trevnorris has already put into domains.

All of the tests pass and there is a first pass of the documentations, but I haven't done any benchmarking yet. Style and performance review on what's there so far would be great. I know this thing is wacky and may be coming out of nowhere for some of you, but @isaacs and I have been talking about this for a while and I think we're agreed that it's useful (and low-level) enough to belong in core.
