### PR TITLE
https: fix default port

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -37,19 +37,21 @@ var OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 
 var agent = require('_http_agent');
 var Agent = agent.Agent;
-var globalAgent = agent.globalAgent;
 
 
 function ClientRequest(options, cb) {
   var self = this;
   OutgoingMessage.call(self);
 
+  options = util._extend({}, options);
+
+  var globalAgent = require('http').globalAgent // for lazy loading
   self.agent = util.isUndefined(options.agent) ? globalAgent : options.agent;
 
-  var defaultPort = options.defaultPort || 80;
+  var defaultPort = options.defaultPort || self.agent.defaultPort;
 
-  var port = options.port || defaultPort;
-  var host = options.hostname || options.host || 'localhost';
+  var port = options.port = options.port || defaultPort;
+  var host = options.host = options.hostname || options.host || 'localhost';
 
   if (util.isUndefined(options.setHost)) {
     var setHost = true;

--- a/test/disabled/test-http-default-port.js
+++ b/test/disabled/test-http-default-port.js
@@ -42,6 +42,7 @@ var http = require('http'),
 http.createServer(function(req, res) {
   console.error(req.headers);
   assert.equal(req.headers.host, hostExpect);
+  assert.equal(req.headers['x-port'], PORT);
   res.writeHead(200);
   res.end('ok');
   this.close();
@@ -50,19 +51,37 @@ http.createServer(function(req, res) {
 https.createServer(options, function(req, res) {
   console.error(req.headers);
   assert.equal(req.headers.host, hostExpect);
+  assert.equal(req.headers['x-port'], SSLPORT);
   res.writeHead(200);
   res.end('ok');
   this.close();
 }).listen(SSLPORT);
 
-http
-  .get({ host: 'localhost',
-      port: PORT,
-      headers: { 'x-port': PORT } })
-  .on('response', function(res) {});
+http.get({
+  host: 'localhost',
+  headers: {
+    'x-port': PORT
+  }
+}, function(res) {
+  res.resume();
+});
 
-https
-  .get({ host: 'localhost',
-      port: SSLPORT,
-      headers: { 'x-port': SSLPORT } })
-  .on('response', function(res) {});
+https.get({
+  host: 'localhost',
+  headers: {
+    'x-port': SSLPORT
+  },
+  agent: new https.Agent({
+    rejectUnauthorized: false
+  })
+}, function(res) {
+  res.resume();
+});
+
+http.get('http://www.google.com/', function(res) {
+  res.resume();
+});
+
+https.get('https://www.google.com', function(res) {
+  res.resume();
+});


### PR DESCRIPTION
`https.get('https://github.com/')` should use port 443, not 80.
