### PR TITLE
src: centralize class wrap/unwrap

### DIFF
--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -98,7 +98,8 @@ void FSEventWrap::New(const FunctionCallbackInfo<Value>& args) {
 void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(FSEventWrap)
+  FSEventWrap* wrap;
+  UNWRAP(args.This(), FSEventWrap, wrap);
 
   if (args.Length() < 1 || !args[0]->IsString()) {
     return ThrowTypeError("Bad arguments");
@@ -171,13 +172,8 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
 void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  // Unwrap manually here. The UNWRAP() macro asserts that wrap != NULL.
-  // That usually indicates an error but not here: double closes are possible
-  // and legal, HandleWrap::Close() deals with them the same way.
-  assert(!args.This().IsEmpty());
-  assert(args.This()->InternalFieldCount() > 0);
-  void* ptr = args.This()->GetAlignedPointerFromInternalField(0);
-  FSEventWrap* wrap = static_cast<FSEventWrap*>(ptr);
+  FSEventWrap* wrap;
+  UNWRAP_NO_ABORT(args.This(), FSEventWrap, wrap);
 
   if (wrap == NULL || wrap->initialized_ == false) return;
   wrap->initialized_ = false;

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -41,7 +41,8 @@ static Cached<String> close_sym;
 void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP_NO_ABORT(HandleWrap)
+  HandleWrap* wrap;
+  UNWRAP_NO_ABORT(args.This(), HandleWrap, wrap);
 
   if (wrap != NULL && wrap->handle__ != NULL) {
     uv_ref(wrap->handle__);
@@ -53,7 +54,8 @@ void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
 void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP_NO_ABORT(HandleWrap)
+  HandleWrap* wrap;
+  UNWRAP_NO_ABORT(args.This(), HandleWrap, wrap);
 
   if (wrap != NULL && wrap->handle__ != NULL) {
     uv_unref(wrap->handle__);
@@ -65,8 +67,8 @@ void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
 void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  HandleWrap *wrap = static_cast<HandleWrap*>(
-      args.This()->GetAlignedPointerFromInternalField(0));
+  HandleWrap* wrap;
+  UNWRAP(args.This(), HandleWrap, wrap);
 
   // guard against uninitialized handle or double close
   if (wrap == NULL || wrap->handle__ == NULL) return;
@@ -92,9 +94,8 @@ HandleWrap::HandleWrap(Handle<Object> object, uv_handle_t* h) {
 
   HandleScope scope(node_isolate);
   assert(persistent().IsEmpty());
-  assert(object->InternalFieldCount() > 0);
   persistent().Reset(node_isolate, object);
-  object->SetAlignedPointerInInternalField(0, this);
+  WRAP(object, this);
   QUEUE_INSERT_TAIL(&handle_wrap_queue, &handle_wrap_queue_);
 }
 

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -49,12 +49,6 @@ namespace node {
 //   js/c++ boundary crossing. At the javascript layer that should all be
 //   taken care of.
 
-#define UNWRAP_NO_ABORT(type)                                               \
-  assert(!args.This().IsEmpty());                                           \
-  assert(args.This()->InternalFieldCount() > 0);                            \
-  type* wrap = static_cast<type*>(                                          \
-      args.This()->GetAlignedPointerFromInternalField(0));
-
 class HandleWrap {
  public:
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -759,7 +759,8 @@ void SecureContext::GetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 #if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_get_tlsext_ticket_keys)
   HandleScope scope(node_isolate);
 
-  UNWRAP(SecureContext);
+  SecureContext* wrap;
+  UNWRAP(args.This(), SecureContext, wrap);
 
   Local<Object> buff = Buffer::New(48);
   if (SSL_CTX_get_tlsext_ticket_keys(wrap->ctx_,
@@ -783,7 +784,8 @@ void SecureContext::SetTicketKeys(const FunctionCallbackInfo<Value>& args) {
     return ThrowTypeError("Bad argument");
   }
 
-  UNWRAP(SecureContext);
+  SecureContext* wrap;
+  UNWRAP(args.This(), SecureContext, wrap);
 
   if (SSL_CTX_set_tlsext_ticket_keys(wrap->ctx_,
                                      Buffer::Data(args[0]),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -207,16 +207,36 @@ inline static void ThrowUVException(int errorno,
 
 NO_RETURN void FatalError(const char* location, const char* message);
 
-#define UNWRAP(type)                                                        \
-  assert(!args.This().IsEmpty());                                           \
-  assert(args.This()->InternalFieldCount() > 0);                            \
-  type* wrap = static_cast<type*>(                                          \
-      args.This()->GetAlignedPointerFromInternalField(0));                  \
-  if (!wrap) {                                                              \
-    fprintf(stderr, #type ": Aborting due to unwrap failure at %s:%d\n",    \
-            __FILE__, __LINE__);                                            \
-    abort();                                                                \
-  }
+#define WRAP(Object, Pointer)                                                  \
+  do {                                                                         \
+    assert(!Object.IsEmpty());                                                 \
+    assert(Object->InternalFieldCount() > 0);                                  \
+    Object->SetAlignedPointerInInternalField(0, Pointer);                      \
+  }                                                                            \
+  while (0)
+
+#define UNWRAP(Object, TypeName, Var)                                          \
+  do {                                                                         \
+    assert(!Object.IsEmpty());                                                 \
+    assert(Object->InternalFieldCount() > 0);                                  \
+    Var = static_cast<TypeName*>(                                              \
+        Object->GetAlignedPointerFromInternalField(0));                        \
+    if (!Var) {                                                                \
+      fprintf(stderr, #TypeName ": Aborting due to unwrap failure at %s:%d\n", \
+              __FILE__, __LINE__);                                             \
+      abort();                                                                 \
+    }                                                                          \
+  }                                                                            \
+  while (0)
+
+#define UNWRAP_NO_ABORT(Object, TypeName, Var)                                 \
+  do {                                                                         \
+    assert(!Object.IsEmpty());                                                 \
+    assert(Object->InternalFieldCount() > 0);                                  \
+    Var = static_cast<TypeName*>(                                              \
+        Object->GetAlignedPointerFromInternalField(0));                        \
+  }                                                                            \
+  while (0)
 
 enum Endianness {
   kLittleEndian,  // _Not_ LITTLE_ENDIAN, clashes with endian.h.

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -66,9 +66,9 @@ Local<Object> PipeWrap::Instantiate() {
 
 
 PipeWrap* PipeWrap::Unwrap(Local<Object> obj) {
-  assert(!obj.IsEmpty());
-  assert(obj->InternalFieldCount() > 0);
-  return static_cast<PipeWrap*>(obj->GetAlignedPointerFromInternalField(0));
+  PipeWrap* wrap;
+  UNWRAP(obj, PipeWrap, wrap);
+  return wrap;
 }
 
 
@@ -145,7 +145,8 @@ PipeWrap::PipeWrap(Handle<Object> object, bool ipc)
 void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(PipeWrap)
+  PipeWrap* wrap;
+  UNWRAP(args.This(), PipeWrap, wrap);
 
   String::AsciiValue name(args[0]);
   int err = uv_pipe_bind(&wrap->handle_, *name);
@@ -157,7 +158,8 @@ void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
 void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(PipeWrap)
+  PipeWrap* wrap;
+  UNWRAP(args.This(), PipeWrap, wrap);
 
   int instances = args[0]->Int32Value();
 
@@ -169,7 +171,8 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(PipeWrap)
+  PipeWrap* wrap;
+  UNWRAP(args.This(), PipeWrap, wrap);
 
   int backlog = args[0]->Int32Value();
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
@@ -183,12 +186,12 @@ void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
 void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
   HandleScope scope(node_isolate);
 
-  PipeWrap* wrap = static_cast<PipeWrap*>(handle->data);
-  assert(&wrap->handle_ == reinterpret_cast<uv_pipe_t*>(handle));
+  PipeWrap* pipe_wrap = static_cast<PipeWrap*>(handle->data);
+  assert(&pipe_wrap->handle_ == reinterpret_cast<uv_pipe_t*>(handle));
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.
-  assert(wrap->persistent().IsEmpty() == false);
+  assert(pipe_wrap->persistent().IsEmpty() == false);
 
   Local<Value> argv[] = {
     Integer::New(status, node_isolate),
@@ -196,7 +199,7 @@ void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
   };
 
   if (status != 0) {
-    MakeCallback(wrap->object(), "onconnection", ARRAY_SIZE(argv), argv);
+    MakeCallback(pipe_wrap->object(), "onconnection", ARRAY_SIZE(argv), argv);
     return;
   }
 
@@ -204,19 +207,18 @@ void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
   Local<Object> client_obj = NewInstance(pipeConstructor);
 
   // Unwrap the client javascript object.
-  assert(client_obj->InternalFieldCount() > 0);
-  PipeWrap* client_wrap =
-      static_cast<PipeWrap*>(client_obj->GetAlignedPointerFromInternalField(0));
-  uv_stream_t* client_handle =
-      reinterpret_cast<uv_stream_t*>(&client_wrap->handle_);
-  if (uv_accept(handle, client_handle)) return;
+  PipeWrap* wrap;
+  UNWRAP(client_obj, PipeWrap, wrap);
+  uv_stream_t* client_handle = reinterpret_cast<uv_stream_t*>(&wrap->handle_);
+  if (uv_accept(handle, client_handle))
+    return;
 
   // Successful accept. Call the onconnection callback in JavaScript land.
   argv[1] = client_obj;
   if (onconnection_sym.IsEmpty()) {
     onconnection_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onconnection");
   }
-  MakeCallback(wrap->object(), onconnection_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(pipe_wrap->object(), onconnection_sym, ARRAY_SIZE(argv), argv);
 }
 
 // TODO(bnoordhuis) Maybe share this with TCPWrap?
@@ -260,7 +262,8 @@ void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
 void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(PipeWrap)
+  PipeWrap* wrap;
+  UNWRAP(args.This(), PipeWrap, wrap);
 
   int fd = args[0]->IntegerValue();
 
@@ -271,7 +274,8 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
 void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(PipeWrap)
+  PipeWrap* wrap;
+  UNWRAP(args.This(), PipeWrap, wrap);
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -128,7 +128,8 @@ class ProcessWrap : public HandleWrap {
   static void Spawn(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
 
-    UNWRAP(ProcessWrap)
+    ProcessWrap* wrap;
+    UNWRAP(args.This(), ProcessWrap, wrap);
 
     Local<Object> js_options = args[0]->ToObject();
 
@@ -256,7 +257,8 @@ class ProcessWrap : public HandleWrap {
 
   static void Kill(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(ProcessWrap)
+    ProcessWrap* wrap;
+    UNWRAP(args.This(), ProcessWrap, wrap);
 
     int signal = args[0]->Int32Value();
     int err = uv_process_kill(&wrap->process_, signal);

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -82,7 +82,8 @@ class SignalWrap : public HandleWrap {
 
   static void Start(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(SignalWrap)
+    SignalWrap* wrap;
+    UNWRAP(args.This(), SignalWrap, wrap);
 
     int signum = args[0]->Int32Value();
     int err = uv_signal_start(&wrap->handle_, OnSignal, signum);
@@ -91,7 +92,8 @@ class SignalWrap : public HandleWrap {
 
   static void Stop(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(SignalWrap)
+    SignalWrap* wrap;
+    UNWRAP(args.This(), SignalWrap, wrap);
 
     int err = uv_signal_stop(&wrap->handle_);
     args.GetReturnValue().Set(err);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -80,7 +80,8 @@ StreamWrap::StreamWrap(Handle<Object> object, uv_stream_t* stream)
 void StreamWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 #if !defined(_WIN32)
   HandleScope scope(node_isolate);
-  UNWRAP_NO_ABORT(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP_NO_ABORT(args.This(), StreamWrap, wrap);
   int fd = -1;
   if (wrap != NULL && wrap->stream() != NULL) {
     fd = wrap->stream()->io_watcher.fd;
@@ -101,7 +102,8 @@ void StreamWrap::UpdateWriteQueueSize() {
 void StreamWrap::ReadStart(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP(args.This(), StreamWrap, wrap);
 
   int err;
   if (wrap->is_named_pipe_ipc()) {
@@ -117,7 +119,8 @@ void StreamWrap::ReadStart(const FunctionCallbackInfo<Value>& args) {
 void StreamWrap::ReadStop(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP(args.This(), StreamWrap, wrap);
 
   int err = uv_read_stop(wrap->stream());
   args.GetReturnValue().Set(err);
@@ -135,15 +138,14 @@ template <class WrapType, class UVType>
 static Local<Object> AcceptHandle(uv_stream_t* pipe) {
   HandleScope scope(node_isolate);
   Local<Object> wrap_obj;
-  WrapType* wrap;
   UVType* handle;
 
   wrap_obj = WrapType::Instantiate();
   if (wrap_obj.IsEmpty())
     return Local<Object>();
 
-  wrap = static_cast<WrapType*>(
-      wrap_obj->GetAlignedPointerFromInternalField(0));
+  WrapType* wrap;
+  UNWRAP(wrap_obj, WrapType, wrap);
   handle = wrap->UVHandle();
 
   if (uv_accept(pipe, reinterpret_cast<uv_stream_t*>(handle)))
@@ -202,7 +204,8 @@ size_t StreamWrap::WriteBuffer(Handle<Value> val, uv_buf_t* buf) {
 void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP(args.This(), StreamWrap, wrap);
 
   assert(args[0]->IsObject());
   assert(Buffer::HasInstance(args[1]));
@@ -239,7 +242,8 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
   int err;
 
-  UNWRAP(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP(args.This(), StreamWrap, wrap);
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
@@ -287,11 +291,10 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
     uv_handle_t* send_handle = NULL;
 
     if (args[2]->IsObject()) {
-      Local<Object> send_handle_obj = args[2]->ToObject();
-      assert(send_handle_obj->InternalFieldCount() > 0);
-      HandleWrap* send_handle_wrap = static_cast<HandleWrap*>(
-          send_handle_obj->GetAlignedPointerFromInternalField(0));
-      send_handle = send_handle_wrap->GetHandle();
+      Local<Object> send_handle_obj = args[2].As<Object>();
+      HandleWrap* wrap;
+      UNWRAP(send_handle_obj, HandleWrap, wrap);
+      send_handle = wrap->GetHandle();
 
       // Reference StreamWrap instance to prevent it from being garbage
       // collected before `AfterWrite` is called.
@@ -325,7 +328,8 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
 void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope;
 
-  UNWRAP(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP(args.This(), StreamWrap, wrap);
 
   assert(args[0]->IsObject());
   assert(args[1]->IsArray());
@@ -469,7 +473,8 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
 void StreamWrap::Shutdown(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(StreamWrap)
+  StreamWrap* wrap;
+  UNWRAP(args.This(), StreamWrap, wrap);
 
   assert(args[0]->IsObject());
   Local<Object> req_wrap_obj = args[0].As<Object>();

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -85,7 +85,8 @@ class TimerWrap : public HandleWrap {
 
   static void Start(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(TimerWrap)
+    TimerWrap* wrap;
+    UNWRAP(args.This(), TimerWrap, wrap);
 
     int64_t timeout = args[0]->IntegerValue();
     int64_t repeat = args[1]->IntegerValue();
@@ -95,7 +96,8 @@ class TimerWrap : public HandleWrap {
 
   static void Stop(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(TimerWrap)
+    TimerWrap* wrap;
+    UNWRAP(args.This(), TimerWrap, wrap);
 
     int err = uv_timer_stop(&wrap->handle_);
     args.GetReturnValue().Set(err);
@@ -103,7 +105,8 @@ class TimerWrap : public HandleWrap {
 
   static void Again(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(TimerWrap)
+    TimerWrap* wrap;
+    UNWRAP(args.This(), TimerWrap, wrap);
 
     int err = uv_timer_again(&wrap->handle_);
     args.GetReturnValue().Set(err);
@@ -111,7 +114,8 @@ class TimerWrap : public HandleWrap {
 
   static void SetRepeat(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(TimerWrap)
+    TimerWrap* wrap;
+    UNWRAP(args.This(), TimerWrap, wrap);
 
     int64_t repeat = args[0]->IntegerValue();
     uv_timer_set_repeat(&wrap->handle_, repeat);
@@ -120,7 +124,8 @@ class TimerWrap : public HandleWrap {
 
   static void GetRepeat(const FunctionCallbackInfo<Value>& args) {
     HandleScope scope(node_isolate);
-    UNWRAP(TimerWrap)
+    TimerWrap* wrap;
+    UNWRAP(args.This(), TimerWrap, wrap);
 
     int64_t repeat = uv_timer_get_repeat(&wrap->handle_);
     args.GetReturnValue().Set(static_cast<double>(repeat));

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -27,6 +27,7 @@
 #include "node_crypto_clienthello-inl.h"
 #include "node_wrap.h"  // WithGenericStream
 #include "node_counters.h"
+#include "node_internals.h"
 
 namespace node {
 
@@ -99,7 +100,7 @@ TLSCallbacks::TLSCallbacks(Kind kind,
   sc_handle_.Reset(node_isolate, sc);
 
   Local<Object> object = NewInstance(tlsWrap);
-  object->SetAlignedPointerInInternalField(0, this);
+  WRAP(object, this);
   persistent().Reset(node_isolate, object);
 
   // Initialize queue for clearIn writes
@@ -331,7 +332,8 @@ void TLSCallbacks::Wrap(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::Start(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (wrap->started_)
     return ThrowError("Already started.");
@@ -666,7 +668,8 @@ int TLSCallbacks::DoShutdown(ShutdownWrap* req_wrap, uv_shutdown_cb cb) {
 void TLSCallbacks::VerifyError(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   // XXX Do this check in JS land?
   X509* peer_cert = SSL_get_peer_certificate(wrap->ssl_);
@@ -732,7 +735,8 @@ void TLSCallbacks::VerifyError(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (args.Length() < 2 || !args[0]->IsBoolean() || !args[1]->IsBoolean())
     return ThrowTypeError("Bad arguments, expected two booleans");
@@ -760,7 +764,8 @@ void TLSCallbacks::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
 
 void TLSCallbacks::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
   bool yes = SSL_session_reused(wrap->ssl_);
   args.GetReturnValue().Set(yes);
 }
@@ -770,18 +775,19 @@ void TLSCallbacks::EnableSessionCallbacks(
     const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   wrap->session_callbacks_ = true;
   EnableHelloParser(args);
 }
 
 
-void TLSCallbacks::EnableHelloParser(
-    const FunctionCallbackInfo<Value>& args) {
+void TLSCallbacks::EnableHelloParser(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   wrap->hello_.Start(OnClientHello, OnClientHelloParseEnd, wrap);
 }
@@ -822,7 +828,8 @@ void TLSCallbacks::OnClientHelloParseEnd(void* arg) {
 void TLSCallbacks::GetPeerCertificate(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   Local<Object> info = Object::New();
   X509* peer_cert = SSL_get_peer_certificate(wrap->ssl_);
@@ -955,7 +962,8 @@ void TLSCallbacks::GetPeerCertificate(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::GetSession(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   SSL_SESSION* sess = SSL_get_session(wrap->ssl_);
   if (!sess) return;
@@ -980,7 +988,8 @@ void TLSCallbacks::GetSession(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::SetSession(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (wrap->started_)
     return ThrowError("Already started.");
@@ -1015,7 +1024,8 @@ void TLSCallbacks::SetSession(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::LoadSession(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (args.Length() >= 1 && Buffer::HasInstance(args[0])) {
     ssize_t slen = Buffer::Length(args[0]);
@@ -1045,7 +1055,8 @@ void TLSCallbacks::LoadSession(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::EndParser(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   wrap->hello_.End();
 }
@@ -1054,7 +1065,8 @@ void TLSCallbacks::EndParser(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::GetCurrentCipher(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   const SSL_CIPHER* c;
 
@@ -1147,7 +1159,8 @@ int TLSCallbacks::SelectNextProtoCallback(SSL* s,
 void TLSCallbacks::GetNegotiatedProto(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (wrap->kind_ == kTLSClient) {
     if (wrap->selected_npn_proto_.IsEmpty() == false) {
@@ -1173,7 +1186,8 @@ void TLSCallbacks::GetNegotiatedProto(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
     return ThrowTypeError("Must give a Buffer as first argument");
@@ -1187,7 +1201,8 @@ void TLSCallbacks::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::GetServername(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   const char* servername = SSL_get_servername(wrap->ssl_,
                                               TLSEXT_NAMETYPE_host_name);
@@ -1202,7 +1217,8 @@ void TLSCallbacks::GetServername(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::SetServername(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TLSCallbacks);
+  TLSCallbacks* wrap;
+  UNWRAP(args.This(), TLSCallbacks, wrap);
 
   if (args.Length() < 1 || !args[0]->IsString())
     return ThrowTypeError("First argument should be a string");

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -87,9 +87,9 @@ void TTYWrap::Initialize(Handle<Object> target) {
 
 
 TTYWrap* TTYWrap::Unwrap(Local<Object> obj) {
-  assert(!obj.IsEmpty());
-  assert(obj->InternalFieldCount() > 0);
-  return static_cast<TTYWrap*>(obj->GetAlignedPointerFromInternalField(0));
+  TTYWrap* wrap;
+  UNWRAP(obj, TTYWrap, wrap);
+  return wrap;
 }
 
 
@@ -133,7 +133,8 @@ void TTYWrap::IsTTY(const FunctionCallbackInfo<Value>& args) {
 void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TTYWrap)
+  TTYWrap* wrap;
+  UNWRAP(args.This(), TTYWrap, wrap);
   assert(args[0]->IsArray());
 
   int width, height;
@@ -152,7 +153,8 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 void TTYWrap::SetRawMode(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
 
-  UNWRAP(TTYWrap)
+  TTYWrap* wrap;
+  UNWRAP(args.This(), TTYWrap, wrap);
 
   int err = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());
   args.GetReturnValue().Set(err);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -135,7 +135,8 @@ void UDPWrap::New(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 #if !defined(_WIN32)
   HandleScope scope(node_isolate);
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
   int fd = (wrap == NULL) ? -1 : wrap->handle_.io_watcher.fd;
   args.GetReturnValue().Set(fd);
 #endif
@@ -146,7 +147,8 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
   HandleScope scope(node_isolate);
   int err;
 
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
 
   // bind(ip, port, flags)
   assert(args.Length() == 3);
@@ -184,7 +186,8 @@ void UDPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
 #define X(name, fn)                                                           \
   void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {               \
     HandleScope scope(node_isolate);                                          \
-    UNWRAP(UDPWrap)                                                           \
+    UDPWrap* wrap;                                                            \
+    UNWRAP(args.This(), UDPWrap, wrap);                                       \
     assert(args.Length() == 1);                                               \
     int flag = args[0]->Int32Value();                                         \
     int err = fn(&wrap->handle_, flag);                                       \
@@ -202,7 +205,8 @@ X(SetMulticastLoopback, uv_udp_set_multicast_loop)
 void UDPWrap::SetMembership(const FunctionCallbackInfo<Value>& args,
                             uv_membership membership) {
   HandleScope scope(node_isolate);
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
 
   assert(args.Length() == 2);
 
@@ -236,7 +240,8 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   HandleScope scope(node_isolate);
   int err;
 
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
 
   // send(req, buffer, offset, length, port, address)
   assert(args[0]->IsObject());
@@ -304,7 +309,8 @@ void UDPWrap::Send6(const FunctionCallbackInfo<Value>& args) {
 
 void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
 
   int err = uv_udp_recv_start(&wrap->handle_, OnAlloc, OnRecv);
   // UV_EALREADY means that the socket is already bound but that's okay
@@ -315,7 +321,8 @@ void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
 
 void UDPWrap::RecvStop(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
 
   int r = uv_udp_recv_stop(&wrap->handle_);
   args.GetReturnValue().Set(r);
@@ -325,7 +332,8 @@ void UDPWrap::RecvStop(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::GetSockName(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
   struct sockaddr_storage address;
-  UNWRAP(UDPWrap)
+  UDPWrap* wrap;
+  UNWRAP(args.This(), UDPWrap, wrap);
 
   assert(args[0]->IsObject());
   Local<Object> obj = args[0].As<Object>();
@@ -405,9 +413,9 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
 
 
 UDPWrap* UDPWrap::Unwrap(Local<Object> obj) {
-  assert(!obj.IsEmpty());
-  assert(obj->InternalFieldCount() > 0);
-  return static_cast<UDPWrap*>(obj->GetAlignedPointerFromInternalField(0));
+  UDPWrap* wrap;
+  UNWRAP(obj, UDPWrap, wrap);
+  return wrap;
 }
 
 


### PR DESCRIPTION
While almost all cases were handled by simple WRAP/UNWRAP macros, this
extends those to cover all known occurrences.

This started as a patch to use external array data to store class instances, but didn't offer enough performance gains to justify the change. So instead this is just the cleanup that occurred during the creation of the previous patch.
