### PR TITLE
tls: fix lazy initialization of clienthello parser

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -427,7 +427,7 @@ function Server(/* [options], listener */) {
       requestCert: self.requestCert,
       rejectUnauthorized: self.rejectUnauthorized,
       NPNProtocols: self.NPNProtocols,
-      SNICallback: self.SNICallback
+      SNICallback: options.SNICallback || SNICallback
     });
 
     function listener() {
@@ -517,11 +517,6 @@ Server.prototype.setOptions = function(options) {
   }
   if (secureOptions) this.secureOptions = secureOptions;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
-  if (options.SNICallback) {
-    this.SNICallback = options.SNICallback;
-  } else {
-    this.SNICallback = this.SNICallback.bind(this);
-  }
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else if (this.requestCert) {
@@ -547,7 +542,7 @@ Server.prototype.addContext = function(servername, credentials) {
 function SNICallback(servername, callback) {
   var ctx;
 
-  this._contexts.some(function(elem) {
+  this.server._contexts.some(function(elem) {
     if (!util.isNull(servername.match(elem[0]))) {
       ctx = elem[1];
       return true;
@@ -556,8 +551,6 @@ function SNICallback(servername, callback) {
 
   callback(null, ctx);
 }
-
-Server.prototype.SNICallback = SNICallback;
 
 
 // Target API:


### PR DESCRIPTION
`server.SNICallback` was initialized with `SNICallback.bind(this)`, and
therefore check `this.SNICallback === SNICallback` was always false, and
`_tls_wrap.js` always thought that it was a custom callback instead of
default one. Which in turn was causing clienthello parser to be enabled
regardless of presence of SNI contexts.

/cc @bnoordhuis
