### PR TITLE
tls: handle errors on socket before releasing it

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -144,6 +144,8 @@ function TLSSocket(socket, options) {
   this.authorized = false;
   this.authorizationError = null;
 
+  this.on('error', this._tlsError);
+
   if (!this._handle)
     this.once('connect', this._init.bind(this));
   else
@@ -232,6 +234,13 @@ TLSSocket.prototype._tlsError = function(err) {
   this.emit('_tlsError', err);
   if (this._controlReleased)
     this.emit('error', err);
+};
+
+TLSSocket.prototype._releaseControl = function() {
+  if (this._controlReleased)
+    return;
+  this._controlReleased = true;
+  this.removeListener('error', this._tlsError);
 };
 
 TLSSocket.prototype._finishInit = function() {
@@ -454,7 +463,7 @@ function Server(/* [options], listener */) {
       }
 
       if (!socket.destroyed) {
-        socket._controlReleased = true;
+        socket._releaseControl();
         self.emit('secureConnection', socket);
       }
     });
@@ -604,7 +613,7 @@ exports.connect = function(/* [port, host], options, cb */) {
   });
 
   function onHandle() {
-    socket._controlReleased = true;
+    socket._releaseControl();
 
     if (options.session)
       socket.setSession(options.session);


### PR DESCRIPTION
Fix sudden uncatchable ECONNRESETs, when using https server.

/cc @bnoordhuis
