### PR TITLE
Added a new njs.cmd script.  This script will assist windows users since...

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -45,6 +45,7 @@
              Absent="disallow">
       <ComponentRef Id="NodeExecutable"/>
       <ComponentRef Id="NodeVarsScript"/>
+      <ComponentRef Id="NodeCmdScript"/>
       <ComponentRef Id="NodeStartMenuAndRegistryEntries"/>
       <ComponentGroupRef Id="Product.Generated"/>
 
@@ -117,6 +118,10 @@
 
       <Component Id="NodeVarsScript">
         <File Id="nodevars.bat" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\nodevars.bat"/>
+      </Component>
+
+      <Component Id="NodeCmdScript">
+        <File Id="njs.cmd" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\njs.cmd"/>
       </Component>
 
       <?if $(var.NoPerfCtr) != 1 ?>

--- a/tools/msvs/njs.cmd
+++ b/tools/msvs/njs.cmd
@@ -1,0 +1,6 @@
+@echo off
+setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+set script=%1
+for %%p in (%1) do set prefix=%%~dp$PATH:p
+node !prefix!\%*
+endlocal


### PR DESCRIPTION
Added a new njs.cmd script.  This script will assist windows users since 
shebangs are not honored.  The script will take arg[1] and prepend it with 
the objects location in the path, then prepend that with node.exe

Usage: njs SomeNodeJSbin.js
  This will find SomeNodeJSbin.js in your path and run it under node.

Errata: Don't think it works in "." or in quoted paths, but a good starting point.
