### PR TITLE
domain: add advanced state sharing

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -32,8 +32,25 @@ var endMethods = ['end', 'abort', 'destroy', 'destroySoon'];
 // a few side effects.
 events.usingDomains = true;
 
+// overwrite process.domain with a getter/setter that will allow for more
+// effective optimizations
+var _domain = [null];
+Object.defineProperty(process, 'domain', {
+  enumerable: true,
+  get: function() {
+    return _domain[0];
+  },
+  set: function(arg) {
+    return _domain[0] = arg;
+  }
+});
+
+// objects with external array data are excellent ways to communicate state
+// between js and c++ w/o much overhead
+var _domain_flag = {};
+
 // let the process know we're using domains
-process._setupDomainUse();
+process._setupDomainUse(_domain, _domain_flag);
 
 exports.Domain = Domain;
 
@@ -64,6 +81,7 @@ Domain.prototype.enter = function() {
   // to push it onto the stack so that we can pop it later.
   exports.active = process.domain = this;
   stack.push(this);
+  _domain_flag[0] = stack.length;
 };
 
 Domain.prototype.exit = function() {
@@ -74,6 +92,7 @@ Domain.prototype.exit = function() {
   do {
     d = stack.pop();
   } while (d && d !== this);
+  _domain_flag[0] = stack.length;
 
   exports.active = stack[stack.length - 1];
   process.domain = exports.active;

--- a/src/node.cc
+++ b/src/node.cc
@@ -910,20 +910,12 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
   Local<Object> process = PersistentToLocal(node_isolate, process_p);
   Local<Value> tdc_v =
       process->Get(FIXED_ONE_BYTE_STRING(node_isolate, "_tickDomainCallback"));
-  Local<Value> ndt_v =
-      process->Get(FIXED_ONE_BYTE_STRING(node_isolate, "_nextDomainTick"));
   if (!tdc_v->IsFunction()) {
     fprintf(stderr, "process._tickDomainCallback assigned to non-function\n");
     abort();
   }
-  if (!ndt_v->IsFunction()) {
-    fprintf(stderr, "process._nextDomainTick assigned to non-function\n");
-    abort();
-  }
   Local<Function> tdc = tdc_v.As<Function>();
-  Local<Function> ndt = ndt_v.As<Function>();
   process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "_tickCallback"), tdc);
-  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "nextTick"), ndt);
   process_tickCallback.Reset(node_isolate, tdc);
 }
 

--- a/src/node.js
+++ b/src/node.js
@@ -330,7 +330,6 @@
 
     process.nextTick = nextTick;
     // needs to be accessible from cc land
-    process._nextDomainTick = _nextDomainTick;
     process._tickCallback = _tickCallback;
     process._tickDomainCallback = _tickDomainCallback;
 
@@ -415,16 +414,10 @@
       if (process._exiting)
         return;
 
-      nextTickQueue.push({ callback: callback, domain: null });
-      infoBox[length]++;
-    }
-
-    function _nextDomainTick(callback) {
-      // on the way out, don't bother. it won't get fired anyway.
-      if (process._exiting)
-        return;
-
-      nextTickQueue.push({ callback: callback, domain: process.domain });
+      nextTickQueue.push({
+        callback: callback,
+        domain: process.domain || null
+      });
       infoBox[length]++;
     }
   };

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -218,9 +218,6 @@ NO_RETURN void FatalError(const char* location, const char* message);
     abort();                                                                \
   }
 
-// allow for quick domain check
-extern bool using_domains;
-
 enum Endianness {
   kLittleEndian,  // _Not_ LITTLE_ENDIAN, clashes with endian.h.
   kBigEndian
@@ -377,6 +374,10 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                     v8::String::kNormalString,
                                     length);
 }
+
+bool InDomain();
+
+v8::Handle<v8::Value> GetDomain();
 
 }  // namespace node
 

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -23,6 +23,7 @@
 #define SRC_REQ_WRAP_H_
 
 #include "node.h"
+#include "node_internals.h"
 #include "queue.h"
 
 namespace node {
@@ -40,16 +41,10 @@ class ReqWrap {
     if (object.IsEmpty()) object = v8::Object::New();
     persistent().Reset(node_isolate, object);
 
-    if (using_domains) {
-      v8::Local<v8::Value> domain = v8::Context::GetCurrent()
-                                    ->Global()
-                                    ->Get(process_symbol)
-                                    ->ToObject()
-                                    ->Get(domain_symbol);
-
-      if (domain->IsObject()) {
+    if (InDomain()) {
+      v8::Local<v8::Value> domain = GetDomain();
+      if (domain->IsObject())
         object->Set(domain_symbol, domain);
-      }
     }
 
     QUEUE_INSERT_TAIL(&req_wrap_queue, &req_wrap_queue_);


### PR DESCRIPTION
Using some more advanced state sharing to speed up domains.

This will now only check the domain object if actively in a domain. Also added a quicker way to get the domain object.

I feel like there should be a way to generic-ify the way this state sharing is going on.
