### PR TITLE
src: use v8::String::NewFrom*() functions

### DIFF
--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -75,16 +75,16 @@ void FSEventWrap::Initialize(Handle<Object> target) {
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(String::NewSymbol("FSEvent"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "FSEvent"));
 
   NODE_SET_PROTOTYPE_METHOD(t, "start", Start);
   NODE_SET_PROTOTYPE_METHOD(t, "close", Close);
 
-  target->Set(String::New("FSEvent"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "FSEvent"), t->GetFunction());
 
-  change_sym = String::New("change");
-  onchange_sym = String::New("onchange");
-  rename_sym = String::New("rename");
+  change_sym = FIXED_ONE_BYTE_STRING(node_isolate, "change");
+  onchange_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onchange");
+  rename_sym = FIXED_ONE_BYTE_STRING(node_isolate, "rename");
 }
 
 
@@ -161,7 +161,7 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
   };
 
   if (filename != NULL) {
-    argv[2] = String::New(filename);
+    argv[2] = OneByteString(node_isolate, filename);
   }
 
   MakeCallback(wrap->object(), onchange_sym, ARRAY_SIZE(argv), argv);

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -76,7 +76,9 @@ void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
   wrap->handle__ = NULL;
 
   if (args[0]->IsFunction()) {
-    if (close_sym.IsEmpty() == true) close_sym = String::New("close");
+    if (close_sym.IsEmpty() == true) {
+      close_sym = FIXED_ONE_BYTE_STRING(node_isolate, "close");
+    }
     wrap->object()->Set(close_sym, args[0]);
     wrap->flags_ |= kCloseCallback;
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -242,7 +242,8 @@ static void CheckImmediate(uv_check_t* handle, int status) {
   HandleScope scope(node_isolate);
 
   if (immediate_callback_sym.IsEmpty()) {
-    immediate_callback_sym = String::New("_immediateCallback");
+    immediate_callback_sym =
+        FIXED_ONE_BYTE_STRING(node_isolate, "_immediateCallback");
   }
 
   MakeCallback(process_p, immediate_callback_sym, 0, NULL);
@@ -738,26 +739,30 @@ Local<Value> ErrnoException(int errorno,
                             const char *msg,
                             const char *path) {
   Local<Value> e;
-  Local<String> estring = String::NewSymbol(errno_string(errorno));
+  Local<String> estring = OneByteString(node_isolate, errno_string(errorno));
   if (msg == NULL || msg[0] == '\0') {
     msg = strerror(errorno);
   }
-  Local<String> message = String::NewSymbol(msg);
+  Local<String> message = OneByteString(node_isolate, msg);
 
-  Local<String> cons1 = String::Concat(estring, String::NewSymbol(", "));
+  Local<String> cons1 =
+      String::Concat(estring, FIXED_ONE_BYTE_STRING(node_isolate, ", "));
   Local<String> cons2 = String::Concat(cons1, message);
 
   if (syscall_symbol.IsEmpty()) {
-    syscall_symbol = String::New("syscall");
-    errno_symbol = String::New("errno");
-    errpath_symbol = String::New("path");
-    code_symbol = String::New("code");
+    syscall_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "syscall");
+    errno_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "errno");
+    errpath_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "path");
+    code_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "code");
   }
 
   if (path) {
-    Local<String> cons3 = String::Concat(cons2, String::NewSymbol(" '"));
-    Local<String> cons4 = String::Concat(cons3, String::New(path));
-    Local<String> cons5 = String::Concat(cons4, String::NewSymbol("'"));
+    Local<String> cons3 =
+        String::Concat(cons2, FIXED_ONE_BYTE_STRING(node_isolate, " '"));
+    Local<String> cons4 =
+        String::Concat(cons3, String::NewFromUtf8(node_isolate, path));
+    Local<String> cons5 =
+        String::Concat(cons4, FIXED_ONE_BYTE_STRING(node_isolate, "'"));
     e = Exception::Error(cons5);
   } else {
     e = Exception::Error(cons2);
@@ -767,8 +772,8 @@ Local<Value> ErrnoException(int errorno,
 
   obj->Set(errno_symbol, Integer::New(errorno, node_isolate));
   obj->Set(code_symbol, estring);
-  if (path) obj->Set(errpath_symbol, String::New(path));
-  if (syscall) obj->Set(syscall_symbol, String::NewSymbol(syscall));
+  if (path) obj->Set(errpath_symbol, String::NewFromUtf8(node_isolate, path));
+  if (syscall) obj->Set(syscall_symbol, OneByteString(node_isolate, syscall));
   return e;
 }
 
@@ -779,18 +784,19 @@ Local<Value> UVException(int errorno,
                          const char *msg,
                          const char *path) {
   if (syscall_symbol.IsEmpty()) {
-    syscall_symbol = String::New("syscall");
-    errno_symbol = String::New("errno");
-    errpath_symbol = String::New("path");
-    code_symbol = String::New("code");
+    syscall_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "syscall");
+    errno_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "errno");
+    errpath_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "path");
+    code_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "code");
   }
 
   if (!msg || !msg[0])
     msg = uv_strerror(errorno);
 
-  Local<String> estring = String::NewSymbol(uv_err_name(errorno));
-  Local<String> message = String::NewSymbol(msg);
-  Local<String> cons1 = String::Concat(estring, String::NewSymbol(", "));
+  Local<String> estring = OneByteString(node_isolate, uv_err_name(errorno));
+  Local<String> message = OneByteString(node_isolate, msg);
+  Local<String> cons1 =
+      String::Concat(estring, FIXED_ONE_BYTE_STRING(node_isolate, ", "));
   Local<String> cons2 = String::Concat(cons1, message);
 
   Local<Value> e;
@@ -800,19 +806,23 @@ Local<Value> UVException(int errorno,
   if (path) {
 #ifdef _WIN32
     if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
-      path_str = String::Concat(String::New("\\\\"), String::New(path + 8));
+      path_str = String::Concat(FIXED_ONE_BYTE_STRING(node_isolate, "\\\\"),
+                                String::NewFromUtf8(node_isolate, path + 8));
     } else if (strncmp(path, "\\\\?\\", 4) == 0) {
-      path_str = String::New(path + 4);
+      path_str = String::NewFromUtf8(node_isolate, path + 4);
     } else {
-      path_str = String::New(path);
+      path_str = String::NewFromUtf8(node_isolate, path);
     }
 #else
-    path_str = String::New(path);
+    path_str = String::NewFromUtf8(node_isolate, path);
 #endif
 
-    Local<String> cons3 = String::Concat(cons2, String::NewSymbol(" '"));
-    Local<String> cons4 = String::Concat(cons3, path_str);
-    Local<String> cons5 = String::Concat(cons4, String::NewSymbol("'"));
+    Local<String> cons3 =
+        String::Concat(cons2, FIXED_ONE_BYTE_STRING(node_isolate, " '"));
+    Local<String> cons4 =
+        String::Concat(cons3, path_str);
+    Local<String> cons5 =
+        String::Concat(cons4, FIXED_ONE_BYTE_STRING(node_isolate, "'"));
     e = Exception::Error(cons5);
   } else {
     e = Exception::Error(cons2);
@@ -824,7 +834,7 @@ Local<Value> UVException(int errorno,
   obj->Set(errno_symbol, Integer::New(errorno, node_isolate));
   obj->Set(code_symbol, estring);
   if (path) obj->Set(errpath_symbol, path_str);
-  if (syscall) obj->Set(syscall_symbol, String::NewSymbol(syscall));
+  if (syscall) obj->Set(syscall_symbol, OneByteString(node_isolate, syscall));
   return e;
 }
 
@@ -862,19 +872,22 @@ Local<Value> WinapiErrnoException(int errorno,
   if (!msg || !msg[0]) {
     msg = winapi_strerror(errorno);
   }
-  Local<String> message = String::NewSymbol(msg);
+  Local<String> message = OneByteString(node_isolate, msg);
 
   if (syscall_symbol.IsEmpty()) {
-    syscall_symbol = String::New("syscall");
-    errno_symbol = String::New("errno");
-    errpath_symbol = String::New("path");
-    code_symbol = String::New("code");
+    syscall_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "syscall");
+    errno_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "errno");
+    errpath_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "path");
+    code_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "code");
   }
 
   if (path) {
-    Local<String> cons1 = String::Concat(message, String::NewSymbol(" '"));
-    Local<String> cons2 = String::Concat(cons1, String::New(path));
-    Local<String> cons3 = String::Concat(cons2, String::NewSymbol("'"));
+    Local<String> cons1 =
+        String::Concat(message, FIXED_ONE_BYTE_STRING(node_isolate, " '"));
+    Local<String> cons2 =
+        String::Concat(cons1, String::NewFromUtf8(node_isolate, path));
+    Local<String> cons3 =
+        String::Concat(cons2, FIXED_ONE_BYTE_STRING(node_isolate, "'"));
     e = Exception::Error(cons3);
   } else {
     e = Exception::Error(message);
@@ -883,8 +896,8 @@ Local<Value> WinapiErrnoException(int errorno,
   Local<Object> obj = e->ToObject();
 
   obj->Set(errno_symbol, Integer::New(errorno, node_isolate));
-  if (path) obj->Set(errpath_symbol, String::New(path));
-  if (syscall) obj->Set(syscall_symbol, String::NewSymbol(syscall));
+  if (path) obj->Set(errpath_symbol, String::NewFromUtf8(node_isolate, path));
+  if (syscall) obj->Set(syscall_symbol, OneByteString(node_isolate, syscall));
   return e;
 }
 #endif
@@ -895,8 +908,10 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
   using_domains = true;
   Local<Object> process = PersistentToLocal(node_isolate, process_p);
-  Local<Value> tdc_v = process->Get(String::New("_tickDomainCallback"));
-  Local<Value> ndt_v = process->Get(String::New("_nextDomainTick"));
+  Local<Value> tdc_v =
+      process->Get(FIXED_ONE_BYTE_STRING(node_isolate, "_tickDomainCallback"));
+  Local<Value> ndt_v =
+      process->Get(FIXED_ONE_BYTE_STRING(node_isolate, "_nextDomainTick"));
   if (!tdc_v->IsFunction()) {
     fprintf(stderr, "process._tickDomainCallback assigned to non-function\n");
     abort();
@@ -907,8 +922,8 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
   }
   Local<Function> tdc = tdc_v.As<Function>();
   Local<Function> ndt = ndt_v.As<Function>();
-  process->Set(String::New("_tickCallback"), tdc);
-  process->Set(String::New("nextTick"), ndt);
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "_tickCallback"), tdc);
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "nextTick"), ndt);
   process_tickCallback.Reset(node_isolate, tdc);
 }
 
@@ -922,9 +937,9 @@ MakeDomainCallback(const Handle<Object> object,
 
   // lazy load domain specific symbols
   if (enter_symbol.IsEmpty()) {
-    enter_symbol = String::New("enter");
-    exit_symbol = String::New("exit");
-    disposed_symbol = String::New("_disposed");
+    enter_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "enter");
+    exit_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "exit");
+    disposed_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "_disposed");
   }
 
   Local<Value> domain_v = object->Get(domain_symbol);
@@ -1008,7 +1023,8 @@ MakeCallback(const Handle<Object> object,
 
   // lazy load no domain next tick callbacks
   if (process_tickCallback.IsEmpty()) {
-    Local<Value> cb_v = process->Get(String::New("_tickCallback"));
+    Local<Value> cb_v =
+        process->Get(FIXED_ONE_BYTE_STRING(node_isolate, "_tickCallback"));
     if (!cb_v->IsFunction()) {
       fprintf(stderr, "process._tickCallback assigned to non-function\n");
       abort();
@@ -1069,8 +1085,8 @@ MakeCallback(const Handle<Object> object,
              Handle<Value> argv[]) {
   HandleScope scope(node_isolate);
 
-  Handle<Value> ret =
-    MakeCallback(object, String::NewSymbol(method), argc, argv);
+  Local<String> method_string = OneByteString(node_isolate, method);
+  Handle<Value> ret = MakeCallback(object, method_string, argc, argv);
 
   return scope.Close(ret);
 }
@@ -1219,7 +1235,8 @@ static void ReportException(Handle<Value> er, Handle<Message> message) {
 
   DisplayExceptionLine(message);
 
-  Local<Value> trace_value(er->ToObject()->Get(String::New("stack")));
+  Local<Value> trace_value(
+      er->ToObject()->Get(FIXED_ONE_BYTE_STRING(node_isolate, "stack")));
   String::Utf8Value trace(trace_value);
 
   // range errors have a trace member set to undefined
@@ -1229,18 +1246,27 @@ static void ReportException(Handle<Value> er, Handle<Message> message) {
     // this really only happens for RangeErrors, since they're the only
     // kind that won't have all this info in the trace, or when non-Error
     // objects are thrown manually.
-    bool isErrorObject = er->IsObject() &&
-      !(er->ToObject()->Get(String::New("message"))->IsUndefined()) &&
-      !(er->ToObject()->Get(String::New("name"))->IsUndefined());
+    Local<Value> message;
+    Local<Value> name;
 
-    if (isErrorObject) {
-      String::Utf8Value name(er->ToObject()->Get(String::New("name")));
-      fprintf(stderr, "%s: ", *name);
+    if (er->IsObject()) {
+      Local<Object> err_obj = er.As<Object>();
+      message = err_obj->Get(FIXED_ONE_BYTE_STRING(node_isolate, "message"));
+      name = err_obj->Get(FIXED_ONE_BYTE_STRING(node_isolate, "name"));
     }
 
-    String::Utf8Value msg(!isErrorObject ? er
-                         : er->ToObject()->Get(String::New("message")));
-    fprintf(stderr, "%s\n", *msg);
+    if (message.IsEmpty() ||
+        message->IsUndefined() ||
+        name.IsEmpty() ||
+        name->IsUndefined()) {
+      // Not an error object. Just print as-is.
+      String::Utf8Value message(er);
+      fprintf(stderr, "%s\n", *message);
+    } else {
+      String::Utf8Value name_string(name);
+      String::Utf8Value message_string(message);
+      fprintf(stderr, "%s: %s\n", *name_string, *message_string);
+    }
   }
 
   fflush(stderr);
@@ -1303,7 +1329,7 @@ void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
   QUEUE* q = NULL;
   int i = 0;
 
-  Local<String> owner_sym = String::New("owner");
+  Local<String> owner_sym = FIXED_ONE_BYTE_STRING(node_isolate, "owner");
 
   QUEUE_FOREACH(q, &handle_wrap_queue) {
     HandleWrap* w = container_of(q, HandleWrap, handle_wrap_queue_);
@@ -1353,7 +1379,7 @@ static void Cwd(const FunctionCallbackInfo<Value>& args) {
   }
 
   buf[ARRAY_SIZE(buf) - 1] = '\0';
-  Local<String> cwd = String::New(buf);
+  Local<String> cwd = String::NewFromUtf8(node_isolate, buf);
 
   args.GetReturnValue().Set(cwd);
 }
@@ -1687,9 +1713,9 @@ void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
   Local<Object> info = Object::New();
 
   if (rss_symbol.IsEmpty()) {
-    rss_symbol = String::New("rss");
-    heap_total_symbol = String::New("heapTotal");
-    heap_used_symbol = String::New("heapUsed");
+    rss_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "rss");
+    heap_total_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "heapTotal");
+    heap_used_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "heapUsed");
   }
 
   info->Set(rss_symbol, Number::New(rss));
@@ -1770,12 +1796,12 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
   String::Utf8Value filename(args[1]);  // Cast
 
   if (exports_symbol.IsEmpty()) {
-    exports_symbol = String::New("exports");
+    exports_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "exports");
   }
   Local<Object> exports = module->Get(exports_symbol)->ToObject();
 
   if (uv_dlopen(*filename, &lib)) {
-    Local<String> errmsg = String::New(uv_dlerror(&lib));
+    Local<String> errmsg = OneByteString(node_isolate, uv_dlerror(&lib));
 #ifdef _WIN32
     // Windows needs to add the filename into the error message
     errmsg = String::Concat(errmsg, args[1]->ToString());
@@ -1870,8 +1896,10 @@ NO_RETURN void FatalError(const char* location, const char* message) {
 void FatalException(Handle<Value> error, Handle<Message> message) {
   HandleScope scope(node_isolate);
 
-  if (fatal_exception_symbol.IsEmpty())
-    fatal_exception_symbol = String::New("_fatalException");
+  if (fatal_exception_symbol.IsEmpty()) {
+    fatal_exception_symbol =
+        FIXED_ONE_BYTE_STRING(node_isolate, "_fatalException");
+  }
 
   Local<Object> process = PersistentToLocal(node_isolate, process_p);
   Local<Value> fatal_v = process->Get(fatal_exception_symbol);
@@ -1943,7 +1971,7 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
 
   Local<Array> modules = PersistentToLocal(node_isolate, module_load_list);
   uint32_t l = modules->Length();
-  modules->Set(l, String::New(buf));
+  modules->Set(l, String::NewFromUtf8(node_isolate, buf));
 
   if ((modp = get_builtin_module(*module_v)) != NULL) {
     exports = Object::New();
@@ -1972,7 +2000,7 @@ static void ProcessTitleGetter(Local<String> property,
   HandleScope scope(node_isolate);
   char buffer[512];
   uv_get_process_title(buffer, sizeof(buffer));
-  info.GetReturnValue().Set(String::New(buffer));
+  info.GetReturnValue().Set(String::NewFromUtf8(node_isolate, buffer));
 }
 
 
@@ -1993,7 +2021,7 @@ static void EnvGetter(Local<String> property,
   String::Utf8Value key(property);
   const char* val = getenv(*key);
   if (val) {
-    return info.GetReturnValue().Set(String::New(val));
+    return info.GetReturnValue().Set(String::NewFromUtf8(node_isolate, val));
   }
 #else  // _WIN32
   String::Value key(property);
@@ -2006,8 +2034,9 @@ static void EnvGetter(Local<String> property,
   // not found.
   if ((result > 0 || GetLastError() == ERROR_SUCCESS) &&
       result < ARRAY_SIZE(buffer)) {
-    return info.GetReturnValue().Set(
-        String::New(reinterpret_cast<uint16_t*>(buffer), result));
+    const uint16_t* two_byte_buffer = reinterpret_cast<const uint16_t*>(buffer);
+    Local<String> rc = String::NewFromTwoByte(node_isolate, two_byte_buffer);
+    return info.GetReturnValue().Set(rc);
   }
 #endif
   // Not found.  Fetch from prototype.
@@ -2097,7 +2126,11 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
     const char* var = environ[i];
     const char* s = strchr(var, '=');
     const int length = s ? s - var : strlen(var);
-    env->Set(i, String::New(var, length));
+    Local<String> name = String::NewFromUtf8(node_isolate,
+                                             var,
+                                             String::kNormalString,
+                                             length);
+    env->Set(i, name);
   }
 #else  // _WIN32
   WCHAR* environment = GetEnvironmentStringsW();
@@ -2117,7 +2150,8 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
     if (!s) {
       s = p + wcslen(p);
     }
-    env->Set(i++, String::New(reinterpret_cast<uint16_t*>(p), s - p));
+    const uint16_t* two_byte_buffer = reinterpret_cast<const uint16_t*>(p);
+    env->Set(i++, TWO_BYTE_STRING(node_isolate, two_byte_buffer, s - p));
     p = s + wcslen(s) + 1;
   }
   FreeEnvironmentStringsW(environment);
@@ -2137,15 +2171,18 @@ static Handle<Object> GetFeatures() {
   Local<Value> debug = False(node_isolate);
 #endif  // defined(DEBUG) && DEBUG
 
-  obj->Set(String::NewSymbol("debug"), debug);
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "debug"), debug);
 
-  obj->Set(String::NewSymbol("uv"), True(node_isolate));
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "uv"), True(node_isolate));
   // TODO(bnoordhuis) ping libuv
-  obj->Set(String::NewSymbol("ipv6"), True(node_isolate));
-  obj->Set(String::NewSymbol("tls_npn"), Boolean::New(use_npn));
-  obj->Set(String::NewSymbol("tls_sni"), Boolean::New(use_sni));
-  obj->Set(String::NewSymbol("tls"),
-      Boolean::New(get_builtin_module("crypto") != NULL));
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "ipv6"), True(node_isolate));
+
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "tls_npn"),
+           Boolean::New(use_npn));
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "tls_sni"),
+           Boolean::New(use_sni));
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "tls"),
+           Boolean::New(get_builtin_module("crypto") != NULL));
 
   return scope.Close(obj);
 }
@@ -2201,7 +2238,7 @@ static void NeedImmediateCallbackSetter(Local<String> property,
 
 #define READONLY_PROPERTY(obj, str, var)                                      \
   do {                                                                        \
-    obj->Set(String::New(str), var, v8::ReadOnly);                            \
+    obj->Set(OneByteString(node_isolate, str), var, v8::ReadOnly);            \
   } while (0)
 
 
@@ -2211,7 +2248,8 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   int i, j;
 
   Local<FunctionTemplate> process_template = FunctionTemplate::New();
-  process_template->SetClassName(String::New("process"));
+  process_template->SetClassName(
+      FIXED_ONE_BYTE_STRING(node_isolate, "process"));
 
   Local<Object> process = process_template->GetFunction()->NewInstance();
   assert(process.IsEmpty() == false);
@@ -2219,12 +2257,14 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
 
   process_p.Reset(node_isolate, process);
 
-  process->SetAccessor(String::New("title"),
+  process->SetAccessor(FIXED_ONE_BYTE_STRING(node_isolate, "title"),
                        ProcessTitleGetter,
                        ProcessTitleSetter);
 
   // process.version
-  READONLY_PROPERTY(process, "version", String::New(NODE_VERSION));
+  READONLY_PROPERTY(process,
+                    "version",
+                    FIXED_ONE_BYTE_STRING(node_isolate, NODE_VERSION));
 
   // process.moduleLoadList
   Local<Array> modules = Array::New();
@@ -2234,17 +2274,33 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   // process.versions
   Local<Object> versions = Object::New();
   READONLY_PROPERTY(process, "versions", versions);
-  READONLY_PROPERTY(versions, "http_parser", String::New(
-                    NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR) "."
-                    NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR)));
+
+  const char http_parser_version[] = NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR)
+                                     "."
+                                     NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR);
+  READONLY_PROPERTY(versions,
+                    "http_parser",
+                    FIXED_ONE_BYTE_STRING(node_isolate, http_parser_version));
+
   // +1 to get rid of the leading 'v'
-  READONLY_PROPERTY(versions, "node", String::New(NODE_VERSION+1));
-  READONLY_PROPERTY(versions, "v8", String::New(V8::GetVersion()));
-  READONLY_PROPERTY(versions, "uv", String::New(uv_version_string()));
-  READONLY_PROPERTY(versions, "zlib", String::New(ZLIB_VERSION));
+  READONLY_PROPERTY(versions,
+                    "node",
+                    OneByteString(node_isolate, NODE_VERSION + 1));
+  READONLY_PROPERTY(versions,
+                    "v8",
+                    OneByteString(node_isolate, V8::GetVersion()));
+  READONLY_PROPERTY(versions,
+                    "uv",
+                    OneByteString(node_isolate, uv_version_string()));
+  READONLY_PROPERTY(versions,
+                    "zlib",
+                    FIXED_ONE_BYTE_STRING(node_isolate, ZLIB_VERSION));
+
+  const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);
   READONLY_PROPERTY(versions,
                     "modules",
-                    String::New(NODE_STRINGIFY(NODE_MODULE_VERSION)));
+                    FIXED_ONE_BYTE_STRING(node_isolate, node_modules_version));
+
 #if HAVE_OPENSSL
   // Stupid code to slice out the version string.
   int c, l = strlen(OPENSSL_VERSION_TEXT);
@@ -2258,36 +2314,41 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
       break;
     }
   }
-  READONLY_PROPERTY(versions,
-                    "openssl",
-                    String::New(&OPENSSL_VERSION_TEXT[i], j - i));
+  READONLY_PROPERTY(
+      versions,
+      "openssl",
+      OneByteString(node_isolate, &OPENSSL_VERSION_TEXT[i], j - i));
 #endif
 
 
 
   // process.arch
-  READONLY_PROPERTY(process, "arch", String::New(ARCH));
+  READONLY_PROPERTY(process, "arch", OneByteString(node_isolate, ARCH));
 
   // process.platform
-  READONLY_PROPERTY(process, "platform", String::New(PLATFORM));
+  READONLY_PROPERTY(process,
+                    "platform",
+                    OneByteString(node_isolate, PLATFORM));
 
   // process.argv
   Local<Array> arguments = Array::New(argc - option_end_index + 1);
-  arguments->Set(Integer::New(0, node_isolate), String::New(argv[0]));
+  arguments->Set(Integer::New(0, node_isolate),
+                 String::NewFromUtf8(node_isolate, argv[0]));
   for (j = 1, i = option_end_index; i < argc; j++, i++) {
-    Local<String> arg = String::New(argv[i]);
+    Local<String> arg = String::NewFromUtf8(node_isolate, argv[i]);
     arguments->Set(Integer::New(j, node_isolate), arg);
   }
   // assign it
-  process->Set(String::NewSymbol("argv"), arguments);
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "argv"), arguments);
 
   // process.execArgv
   Local<Array> execArgv = Array::New(option_end_index - 1);
   for (j = 1, i = 0; j < option_end_index; j++, i++) {
-    execArgv->Set(Integer::New(i, node_isolate), String::New(argv[j]));
+    execArgv->Set(Integer::New(i, node_isolate),
+                  String::NewFromUtf8(node_isolate, argv[j]));
   }
   // assign it
-  process->Set(String::NewSymbol("execArgv"), execArgv);
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "execArgv"), execArgv);
 
 
   // create process.env
@@ -2299,17 +2360,20 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
                                        EnvEnumerator,
                                        Object::New());
   Local<Object> env = envTemplate->NewInstance();
-  process->Set(String::NewSymbol("env"), env);
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "env"), env);
 
   READONLY_PROPERTY(process, "pid", Integer::New(getpid(), node_isolate));
   READONLY_PROPERTY(process, "features", GetFeatures());
-  process->SetAccessor(String::New("_needImmediateCallback"),
-                       NeedImmediateCallbackGetter,
-                       NeedImmediateCallbackSetter);
+  process->SetAccessor(
+      FIXED_ONE_BYTE_STRING(node_isolate, "_needImmediateCallback"),
+      NeedImmediateCallbackGetter,
+      NeedImmediateCallbackSetter);
 
   // -e, --eval
   if (eval_string) {
-    READONLY_PROPERTY(process, "_eval", String::New(eval_string));
+    READONLY_PROPERTY(process,
+                      "_eval",
+                      String::NewFromUtf8(node_isolate, eval_string));
   }
 
   // -p, --print
@@ -2337,17 +2401,23 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
     READONLY_PROPERTY(process, "traceDeprecation", True(node_isolate));
   }
 
-  size_t size = 2*PATH_MAX;
-  char* execPath = new char[size];
-  if (uv_exepath(execPath, &size) != 0) {
-    // as a last ditch effort, fallback on argv[0] ?
-    process->Set(String::NewSymbol("execPath"), String::New(argv[0]));
+  size_t exec_path_len = 2 * PATH_MAX;
+  char* exec_path = new char[exec_path_len];
+  Local<String> exec_path_value;
+  if (uv_exepath(exec_path, &exec_path_len) == 0) {
+    exec_path_value = String::NewFromUtf8(node_isolate,
+                                          exec_path,
+                                          String::kNormalString,
+                                          exec_path_len);
   } else {
-    process->Set(String::NewSymbol("execPath"), String::New(execPath, size));
+    // as a last ditch effort, fallback on argv[0] ?
+    exec_path_value = String::NewFromUtf8(node_isolate, argv[0]);
   }
-  delete [] execPath;
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "execPath"),
+               exec_path_value);
+  delete[] exec_path;
 
-  process->SetAccessor(String::New("debugPort"),
+  process->SetAccessor(FIXED_ONE_BYTE_STRING(node_isolate, "debugPort"),
                        DebugPortGetter,
                        DebugPortSetter);
 
@@ -2396,10 +2466,10 @@ Handle<Object> SetupProcessObject(int argc, char *argv[]) {
   info_box->SetIndexedPropertiesToExternalArrayData(&tick_infobox,
                                                     kExternalUnsignedIntArray,
                                                     4);
-  process->Set(String::NewSymbol("_tickInfoBox"), info_box);
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "_tickInfoBox"), info_box);
 
   // pre-set _events object for faster emit checks
-  process->Set(String::NewSymbol("_events"), Object::New());
+  process->Set(FIXED_ONE_BYTE_STRING(node_isolate, "_events"), Object::New());
 
   return scope.Close(process);
 }
@@ -2422,8 +2492,8 @@ static void SignalExit(int signal) {
 void Load(Handle<Object> process_l) {
   HandleScope handle_scope(node_isolate);
 
-  process_symbol = String::New("process");
-  domain_symbol = String::New("domain");
+  process_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "process");
+  domain_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "domain");
 
   // Compile, execute the src/node.js file. (Which was included as static C
   // string in node_natives.h. 'natve_node' is the string containing that
@@ -2439,7 +2509,8 @@ void Load(Handle<Object> process_l) {
   // are not safe to ignore.
   try_catch.SetVerbose(false);
 
-  Local<Value> f_value = ExecuteString(MainSource(), String::New("node.js"));
+  Local<String> script_name = FIXED_ONE_BYTE_STRING(node_isolate, "node.js");
+  Local<Value> f_value = ExecuteString(MainSource(), script_name);
   if (try_catch.HasCaught())  {
     ReportException(try_catch);
     exit(10);
@@ -2632,8 +2703,12 @@ static void DispatchMessagesDebugAgentCallback() {
 static void EmitDebugEnabledAsyncCallback(uv_async_t* handle, int status) {
   HandleScope handle_scope(node_isolate);
   Local<Object> obj = Object::New();
-  obj->Set(String::New("cmd"), String::New("NODE_DEBUG_ENABLED"));
-  Local<Value> args[] = { String::New("internalMessage"), obj };
+  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "cmd"),
+           FIXED_ONE_BYTE_STRING(node_isolate, "NODE_DEBUG_ENABLED"));
+  Local<Value> args[] = {
+    FIXED_ONE_BYTE_STRING(node_isolate, "internalMessage"),
+    obj
+  };
   MakeCallback(process_p, "emit", ARRAY_SIZE(args), args);
 }
 
@@ -3001,8 +3076,12 @@ void AtExit(void (*cb)(void* arg), void* arg) {
 
 void EmitExit(v8::Handle<v8::Object> process_l) {
   // process.emit('exit')
-  process_l->Set(String::NewSymbol("_exiting"), True(node_isolate));
-  Local<Value> args[] = { String::New("exit"), Integer::New(0, node_isolate) };
+  process_l->Set(FIXED_ONE_BYTE_STRING(node_isolate, "_exiting"),
+                 True(node_isolate));
+  Local<Value> args[] = {
+    FIXED_ONE_BYTE_STRING(node_isolate, "exit"),
+    Integer::New(0, node_isolate)
+  };
   MakeCallback(process_l, "emit", ARRAY_SIZE(args), args);
 }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -559,13 +559,14 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 
   Local<Function> bv = args[0].As<Function>();
   p_buffer_fn.Reset(node_isolate, bv);
-  Local<Value> proto_v = bv->Get(String::New("prototype"));
+  Local<Value> proto_v =
+      bv->Get(FIXED_ONE_BYTE_STRING(node_isolate, "prototype"));
 
   assert(proto_v->IsObject());
 
   Local<Object> proto = proto_v.As<Object>();
 
-  bv->Set(String::New("byteLength"),
+  bv->Set(FIXED_ONE_BYTE_STRING(node_isolate, "byteLength"),
           FunctionTemplate::New(ByteLength)->GetFunction());
 
   NODE_SET_METHOD(proto, "asciiSlice", AsciiSlice);
@@ -596,14 +597,16 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
   NODE_SET_METHOD(proto, "fill", Fill);
 
   // for backwards compatibility
-  proto->Set(String::New("offset"), Uint32::New(0, node_isolate), v8::ReadOnly);
+  proto->Set(FIXED_ONE_BYTE_STRING(node_isolate, "offset"),
+             Uint32::New(0, node_isolate),
+             v8::ReadOnly);
 }
 
 
 void Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
-  target->Set(String::New("setupBufferJS"),
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "setupBufferJS"),
               FunctionTemplate::New(SetupBufferJS)->GetFunction());
 }
 

--- a/src/node_counters.cc
+++ b/src/node_counters.cc
@@ -114,7 +114,7 @@ void InitPerfCounters(Handle<Object> target) {
   };
 
   for (int i = 0; i < ARRAY_SIZE(tab); i++) {
-    Local<String> key = String::New(tab[i].name);
+    Local<String> key = OneByteString(node_isolate, tab[i].name);
     Local<Value> val = FunctionTemplate::New(tab[i].func)->GetFunction();
     target->Set(key, val);
   }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -169,7 +169,8 @@ static void After(uv_fs_t *req) {
         break;
 
       case UV_FS_READLINK:
-        argv[1] = String::New(static_cast<char*>(req->ptr));
+        argv[1] = String::NewFromUtf8(node_isolate,
+                                      static_cast<const char*>(req->ptr));
         break;
 
       case UV_FS_READ:
@@ -185,7 +186,7 @@ static void After(uv_fs_t *req) {
           Local<Array> names = Array::New(nnames);
 
           for (int i = 0; i < nnames; i++) {
-            Local<String> name = String::New(namebuf);
+            Local<String> name = String::NewFromUtf8(node_isolate, namebuf);
             names->Set(Integer::New(i, node_isolate), name);
 #ifndef NDEBUG
             namebuf += strlen(namebuf);
@@ -206,7 +207,7 @@ static void After(uv_fs_t *req) {
   }
 
   if (oncomplete_sym.IsEmpty()) {
-    oncomplete_sym = String::New("oncomplete");
+    oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
   }
   MakeCallback(req_wrap->object(), oncomplete_sym, argc, argv);
 
@@ -290,19 +291,19 @@ Local<Object> BuildStatsObject(const uv_stat_t* s) {
   HandleScope scope(node_isolate);
 
   if (dev_symbol.IsEmpty()) {
-    dev_symbol = String::New("dev");
-    ino_symbol = String::New("ino");
-    mode_symbol = String::New("mode");
-    nlink_symbol = String::New("nlink");
-    uid_symbol = String::New("uid");
-    gid_symbol = String::New("gid");
-    rdev_symbol = String::New("rdev");
-    size_symbol = String::New("size");
-    blksize_symbol = String::New("blksize");
-    blocks_symbol = String::New("blocks");
-    atime_symbol = String::New("atime");
-    mtime_symbol = String::New("mtime");
-    ctime_symbol = String::New("ctime");
+    dev_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "dev");
+    ino_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "ino");
+    mode_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "mode");
+    nlink_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "nlink");
+    uid_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "uid");
+    gid_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "gid");
+    rdev_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "rdev");
+    size_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "size");
+    blksize_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "blksize");
+    blocks_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "blocks");
+    atime_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "atime");
+    mtime_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "mtime");
+    ctime_symbol = FIXED_ONE_BYTE_STRING(node_isolate, "ctime");
   }
 
   Local<Function> constructor =
@@ -481,8 +482,9 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
     ASYNC_CALL(readlink, args[1], *path)
   } else {
     SYNC_CALL(readlink, *path, *path)
-    args.GetReturnValue().Set(
-        String::New(static_cast<const char*>(SYNC_REQ.ptr)));
+    const char* link_path = static_cast<const char*>(SYNC_REQ.ptr);
+    Local<String> rc = String::NewFromUtf8(node_isolate, link_path);
+    args.GetReturnValue().Set(rc);
   }
 }
 
@@ -621,7 +623,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
     Local<Array> names = Array::New(nnames);
 
     for (int i = 0; i < nnames; i++) {
-      Local<String> name = String::New(namebuf);
+      Local<String> name = String::NewFromUtf8(node_isolate, namebuf);
       names->Set(Integer::New(i, node_isolate), name);
 #ifndef NDEBUG
       namebuf += strlen(namebuf);
@@ -1005,12 +1007,12 @@ void InitFs(Handle<Object> target) {
 
   // Initialize the stats object
   Local<Function> constructor = FunctionTemplate::New()->GetFunction();
-  target->Set(String::NewSymbol("Stats"), constructor);
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Stats"), constructor);
   stats_constructor.Reset(node_isolate, constructor);
 
   File::Initialize(target);
 
-  oncomplete_sym = String::New("oncomplete");
+  oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
 
   StatWatcher::Initialize(target);
 }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -179,7 +179,7 @@ struct StringPtr {
 
   Local<String> ToString() const {
     if (str_)
-      return String::New(str_, size_);
+      return OneByteString(node_isolate, str_, size_);
     else
       return String::Empty(node_isolate);
   }
@@ -433,10 +433,12 @@ class Parser : public ObjectWrap {
     if (!parser->parser_.upgrade && nparsed != buffer_len) {
       enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
 
-      Local<Value> e = Exception::Error(String::NewSymbol("Parse Error"));
+      Local<Value> e = Exception::Error(
+          FIXED_ONE_BYTE_STRING(node_isolate, "Parse Error"));
       Local<Object> obj = e->ToObject();
-      obj->Set(String::NewSymbol("bytesParsed"), nparsed_obj);
-      obj->Set(String::NewSymbol("code"), String::New(http_errno_name(err)));
+      obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "bytesParsed"), nparsed_obj);
+      obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "code"),
+               OneByteString(node_isolate, http_errno_name(err)));
       args.GetReturnValue().Set(e);
     } else {
       args.GetReturnValue().Set(nparsed_obj);
@@ -459,10 +461,13 @@ class Parser : public ObjectWrap {
     if (rv != 0) {
       enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
 
-      Local<Value> e = Exception::Error(String::NewSymbol("Parse Error"));
+      Local<Value> e = Exception::Error(
+          FIXED_ONE_BYTE_STRING(node_isolate, "Parse Error"));
       Local<Object> obj = e->ToObject();
-      obj->Set(String::NewSymbol("bytesParsed"), Integer::New(0, node_isolate));
-      obj->Set(String::NewSymbol("code"), String::New(http_errno_name(err)));
+      obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "bytesParsed"),
+               Integer::New(0, node_isolate));
+      obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "code"),
+               OneByteString(node_isolate, http_errno_name(err)));
       args.GetReturnValue().Set(e);
     }
   }
@@ -547,38 +552,45 @@ void InitHttpParser(Handle<Object> target) {
 
   Local<FunctionTemplate> t = FunctionTemplate::New(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(String::NewSymbol("HTTPParser"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "HTTPParser"));
 
-  t->Set(String::NewSymbol("REQUEST"),
+  t->Set(FIXED_ONE_BYTE_STRING(node_isolate, "REQUEST"),
          Integer::New(HTTP_REQUEST, node_isolate));
-  t->Set(String::NewSymbol("RESPONSE"),
+  t->Set(FIXED_ONE_BYTE_STRING(node_isolate, "RESPONSE"),
          Integer::New(HTTP_RESPONSE, node_isolate));
 
   NODE_SET_PROTOTYPE_METHOD(t, "execute", Parser::Execute);
   NODE_SET_PROTOTYPE_METHOD(t, "finish", Parser::Finish);
   NODE_SET_PROTOTYPE_METHOD(t, "reinitialize", Parser::Reinitialize);
 
-  target->Set(String::NewSymbol("HTTPParser"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "HTTPParser"),
+              t->GetFunction());
 
-  on_headers_sym          = String::New("onHeaders");
-  on_headers_complete_sym = String::New("onHeadersComplete");
-  on_body_sym             = String::New("onBody");
-  on_message_complete_sym = String::New("onMessageComplete");
+  on_headers_sym =
+      FIXED_ONE_BYTE_STRING(node_isolate, "onHeaders");
+  on_headers_complete_sym =
+      FIXED_ONE_BYTE_STRING(node_isolate, "onHeadersComplete");
+  on_body_sym =
+      FIXED_ONE_BYTE_STRING(node_isolate, "onBody");
+  on_message_complete_sym =
+      FIXED_ONE_BYTE_STRING(node_isolate, "onMessageComplete");
 
-#define X(num, name, string) name##_sym = String::New(#string);
+#define X(num, name, string)                                                  \
+  name ## _sym = OneByteString(node_isolate, #string);
   HTTP_METHOD_MAP(X)
 #undef X
-  unknown_method_sym = String::New("UNKNOWN_METHOD");
+  unknown_method_sym = FIXED_ONE_BYTE_STRING(node_isolate, "UNKNOWN_METHOD");
 
-  method_sym = String::New("method");
-  status_code_sym = String::New("statusCode");
-  http_version_sym = String::New("httpVersion");
-  version_major_sym = String::New("versionMajor");
-  version_minor_sym = String::New("versionMinor");
-  should_keep_alive_sym = String::New("shouldKeepAlive");
-  upgrade_sym = String::New("upgrade");
-  headers_sym = String::New("headers");
-  url_sym = String::New("url");
+  method_sym = FIXED_ONE_BYTE_STRING(node_isolate, "method");
+  status_code_sym = FIXED_ONE_BYTE_STRING(node_isolate, "statusCode");
+  http_version_sym = FIXED_ONE_BYTE_STRING(node_isolate, "httpVersion");
+  version_major_sym = FIXED_ONE_BYTE_STRING(node_isolate, "versionMajor");
+  version_minor_sym = FIXED_ONE_BYTE_STRING(node_isolate, "versionMinor");
+  should_keep_alive_sym =
+      FIXED_ONE_BYTE_STRING(node_isolate, "shouldKeepAlive");
+  upgrade_sym = FIXED_ONE_BYTE_STRING(node_isolate, "upgrade");
+  headers_sym = FIXED_ONE_BYTE_STRING(node_isolate, "headers");
+  url_sym = FIXED_ONE_BYTE_STRING(node_isolate, "url");
 
   settings.on_message_begin    = Parser::on_message_begin;
   settings.on_url              = Parser::on_url;

--- a/src/node_javascript.cc
+++ b/src/node_javascript.cc
@@ -37,7 +37,7 @@ using v8::Object;
 using v8::String;
 
 Handle<String> MainSource() {
-  return String::New(node_native, sizeof(node_native) - 1);
+  return OneByteString(node_isolate, node_native, sizeof(node_native) - 1);
 }
 
 void DefineJavaScript(Handle<Object> target) {
@@ -45,9 +45,11 @@ void DefineJavaScript(Handle<Object> target) {
 
   for (int i = 0; natives[i].name; i++) {
     if (natives[i].source != node_native) {
-      Local<String> name = String::New(natives[i].name);
-      Handle<String> source = String::New(natives[i].source,
-                                                      natives[i].source_len);
+      Local<String> name = String::NewFromUtf8(node_isolate, natives[i].name);
+      Handle<String> source = String::NewFromUtf8(node_isolate,
+                                                  natives[i].source,
+                                                  String::kNormalString,
+                                                  natives[i].source_len);
       target->Set(name, source);
     }
   }

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -59,7 +59,7 @@ using v8::Value;
 static void GetEndianness(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
   const char* rval = IsBigEndian() ? "BE" : "LE";
-  args.GetReturnValue().Set(String::New(rval));
+  args.GetReturnValue().Set(OneByteString(node_isolate, rval));
 }
 
 
@@ -77,7 +77,7 @@ static void GetHostname(const FunctionCallbackInfo<Value>& args) {
   }
   buf[sizeof(buf) - 1] = '\0';
 
-  args.GetReturnValue().Set(String::New(buf));
+  args.GetReturnValue().Set(OneByteString(node_isolate, buf));
 }
 
 
@@ -95,7 +95,7 @@ static void GetOSType(const FunctionCallbackInfo<Value>& args) {
   rval ="Windows_NT";
 #endif  // __POSIX__
 
-  args.GetReturnValue().Set(String::New(rval));
+  args.GetReturnValue().Set(OneByteString(node_isolate, rval));
 }
 
 
@@ -125,7 +125,7 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
   rval = release;
 #endif  // __POSIX__
 
-  args.GetReturnValue().Set(String::New(rval));
+  args.GetReturnValue().Set(OneByteString(node_isolate, rval));
 }
 
 
@@ -142,21 +142,23 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
     uv_cpu_info_t* ci = cpu_infos + i;
 
     Local<Object> times_info = Object::New();
-    times_info->Set(String::New("user"),
+    times_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "user"),
                     Number::New(node_isolate, ci->cpu_times.user));
-    times_info->Set(String::New("nice"),
+    times_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "nice"),
                     Number::New(node_isolate, ci->cpu_times.nice));
-    times_info->Set(String::New("sys"),
+    times_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "sys"),
                     Number::New(node_isolate, ci->cpu_times.sys));
-    times_info->Set(String::New("idle"),
+    times_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "idle"),
                     Number::New(node_isolate, ci->cpu_times.idle));
-    times_info->Set(String::New("irq"),
+    times_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "irq"),
                     Number::New(node_isolate, ci->cpu_times.irq));
 
     Local<Object> cpu_info = Object::New();
-    cpu_info->Set(String::New("model"), String::New(ci->model));
-    cpu_info->Set(String::New("speed"), Number::New(node_isolate, ci->speed));
-    cpu_info->Set(String::New("times"), times_info);
+    cpu_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "model"),
+                  OneByteString(node_isolate, ci->model));
+    cpu_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "speed"),
+                  Number::New(node_isolate, ci->speed));
+    cpu_info->Set(FIXED_ONE_BYTE_STRING(node_isolate, "times"), times_info);
 
     (*cpus)->Set(i, cpu_info);
   }
@@ -221,7 +223,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   ret = Object::New();
 
   for (i = 0; i < count; i++) {
-    name = String::New(interfaces[i].name);
+    name = OneByteString(node_isolate, interfaces[i].name);
     if (ret->Has(name)) {
       ifarr = Local<Array>::Cast(ret->Get(name));
     } else {
@@ -242,24 +244,27 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
     if (interfaces[i].address.address4.sin_family == AF_INET) {
       uv_ip4_name(&interfaces[i].address.address4, ip, sizeof(ip));
       uv_ip4_name(&interfaces[i].netmask.netmask4, netmask, sizeof(netmask));
-      family = String::New("IPv4");
+      family = FIXED_ONE_BYTE_STRING(node_isolate, "IPv4");
     } else if (interfaces[i].address.address4.sin_family == AF_INET6) {
       uv_ip6_name(&interfaces[i].address.address6, ip, sizeof(ip));
       uv_ip6_name(&interfaces[i].netmask.netmask6, netmask, sizeof(netmask));
-      family = String::New("IPv6");
+      family = FIXED_ONE_BYTE_STRING(node_isolate, "IPv6");
     } else {
       strncpy(ip, "<unknown sa family>", INET6_ADDRSTRLEN);
-      family = String::New("<unknown>");
+      family = FIXED_ONE_BYTE_STRING(node_isolate, "<unknown>");
     }
 
     o = Object::New();
-    o->Set(String::New("address"), String::New(ip));
-    o->Set(String::New("netmask"), String::New(netmask));
-    o->Set(String::New("family"), family);
-    o->Set(String::New("mac"), String::New(mac));
+    o->Set(FIXED_ONE_BYTE_STRING(node_isolate, "address"),
+           OneByteString(node_isolate, ip));
+    o->Set(FIXED_ONE_BYTE_STRING(node_isolate, "netmask"),
+           OneByteString(node_isolate, netmask));
+    o->Set(FIXED_ONE_BYTE_STRING(node_isolate, "family"), family);
+    o->Set(FIXED_ONE_BYTE_STRING(node_isolate, "mac"),
+           FIXED_ONE_BYTE_STRING(node_isolate, mac));
 
     const bool internal = interfaces[i].is_internal;
-    o->Set(String::New("internal"),
+    o->Set(FIXED_ONE_BYTE_STRING(node_isolate, "internal"),
            internal ? True(node_isolate) : False(node_isolate));
 
     ifarr->Set(ifarr->Length(), o);

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -46,12 +46,13 @@ void StatWatcher::Initialize(Handle<Object> target) {
 
   Local<FunctionTemplate> t = FunctionTemplate::New(StatWatcher::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(String::NewSymbol("StatWatcher"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "StatWatcher"));
 
   NODE_SET_PROTOTYPE_METHOD(t, "start", StatWatcher::Start);
   NODE_SET_PROTOTYPE_METHOD(t, "stop", StatWatcher::Stop);
 
-  target->Set(String::NewSymbol("StatWatcher"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "StatWatcher"),
+              t->GetFunction());
 }
 
 
@@ -85,7 +86,7 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
   argv[1] = BuildStatsObject(prev);
   argv[2] = Integer::New(status, node_isolate);
   if (onchange_sym.IsEmpty()) {
-    onchange_sym = String::New("onchange");
+    onchange_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onchange");
   }
   MakeCallback(wrap->handle(node_isolate),
                onchange_sym,
@@ -121,7 +122,7 @@ void StatWatcher::Stop(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(node_isolate);
   StatWatcher* wrap = ObjectWrap::Unwrap<StatWatcher>(args.This());
   if (onstop_sym.IsEmpty()) {
-    onstop_sym = String::New("onstop");
+    onstop_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onstop");
   }
   MakeCallback(wrap->handle(node_isolate), onstop_sym, 0, NULL);
   wrap->Stop();

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -294,7 +294,7 @@ class ZCtx : public ObjectWrap {
     assert(handle->Get(onerror_sym)->IsFunction() && "Invalid error handler");
     HandleScope scope(node_isolate);
     Local<Value> args[2] = {
-      String::New(msg),
+      OneByteString(node_isolate, msg),
       Number::New(ctx->err_)
     };
     MakeCallback(handle, onerror_sym, ARRAY_SIZE(args), args);
@@ -543,11 +543,11 @@ void InitZlib(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(z, "params", ZCtx::Params);
   NODE_SET_PROTOTYPE_METHOD(z, "reset", ZCtx::Reset);
 
-  z->SetClassName(String::NewSymbol("Zlib"));
-  target->Set(String::NewSymbol("Zlib"), z->GetFunction());
+  z->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Zlib"));
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Zlib"), z->GetFunction());
 
-  callback_sym = String::New("callback");
-  onerror_sym = String::New("onerror");
+  callback_sym = FIXED_ONE_BYTE_STRING(node_isolate, "callback");
+  onerror_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onerror");
 
   // valid flush values.
   NODE_DEFINE_CONSTANT(target, Z_NO_FLUSH);
@@ -587,7 +587,8 @@ void InitZlib(Handle<Object> target) {
   NODE_DEFINE_CONSTANT(target, INFLATERAW);
   NODE_DEFINE_CONSTANT(target, UNZIP);
 
-  target->Set(String::NewSymbol("ZLIB_VERSION"), String::New(ZLIB_VERSION));
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "ZLIB_VERSION"),
+              FIXED_ONE_BYTE_STRING(node_isolate, ZLIB_VERSION));
 }
 
 }  // namespace node

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -78,13 +78,13 @@ void PipeWrap::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
-  t->SetClassName(String::NewSymbol("Pipe"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Pipe"));
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(String::New("fd"),
+  t->InstanceTemplate()->SetAccessor(FIXED_ONE_BYTE_STRING(node_isolate, "fd"),
                                      StreamWrap::GetFD,
                                      NULL,
                                      Handle<Value>(),
@@ -117,7 +117,7 @@ void PipeWrap::Initialize(Handle<Object> target) {
 
   pipeConstructorTmpl.Reset(node_isolate, t);
   pipeConstructor.Reset(node_isolate, t->GetFunction());
-  target->Set(String::NewSymbol("Pipe"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Pipe"), t->GetFunction());
 }
 
 
@@ -214,7 +214,7 @@ void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
   // Successful accept. Call the onconnection callback in JavaScript land.
   argv[1] = client_obj;
   if (onconnection_sym.IsEmpty()) {
-    onconnection_sym = String::New("onconnection");
+    onconnection_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onconnection");
   }
   MakeCallback(wrap->object(), onconnection_sym, ARRAY_SIZE(argv), argv);
 }
@@ -249,7 +249,7 @@ void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
   };
 
   if (oncomplete_sym.IsEmpty()) {
-    oncomplete_sym = String::New("oncomplete");
+    oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
   }
   MakeCallback(req_wrap_obj, oncomplete_sym, ARRAY_SIZE(argv), argv);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -50,7 +50,7 @@ class ProcessWrap : public HandleWrap {
 
     Local<FunctionTemplate> constructor = FunctionTemplate::New(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(String::NewSymbol("Process"));
+    constructor->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Process"));
 
     NODE_SET_PROTOTYPE_METHOD(constructor, "close", HandleWrap::Close);
 
@@ -60,7 +60,8 @@ class ProcessWrap : public HandleWrap {
     NODE_SET_PROTOTYPE_METHOD(constructor, "ref", HandleWrap::Ref);
     NODE_SET_PROTOTYPE_METHOD(constructor, "unref", HandleWrap::Unref);
 
-    target->Set(String::NewSymbol("Process"), constructor->GetFunction());
+    target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Process"),
+                constructor->GetFunction());
   }
 
  private:
@@ -82,34 +83,41 @@ class ProcessWrap : public HandleWrap {
 
   static void ParseStdioOptions(Local<Object> js_options,
                                 uv_process_options_t* options) {
-    Local<Array> stdios = js_options
-        ->Get(String::NewSymbol("stdio")).As<Array>();
+    Local<String> stdio_key =
+        FIXED_ONE_BYTE_STRING(node_isolate, "stdio");
+    Local<Array> stdios = js_options->Get(stdio_key).As<Array>();
     uint32_t len = stdios->Length();
     options->stdio = new uv_stdio_container_t[len];
     options->stdio_count = len;
 
     for (uint32_t i = 0; i < len; i++) {
       Local<Object> stdio = stdios->Get(i).As<Object>();
-      Local<Value> type = stdio->Get(String::NewSymbol("type"));
+      Local<Value> type =
+          stdio->Get(FIXED_ONE_BYTE_STRING(node_isolate, "type"));
 
-      if (type->Equals(String::NewSymbol("ignore"))) {
+      if (type->Equals(FIXED_ONE_BYTE_STRING(node_isolate, "ignore"))) {
         options->stdio[i].flags = UV_IGNORE;
-      } else if (type->Equals(String::NewSymbol("pipe"))) {
+      } else if (type->Equals(FIXED_ONE_BYTE_STRING(node_isolate, "pipe"))) {
         options->stdio[i].flags = static_cast<uv_stdio_flags>(
             UV_CREATE_PIPE | UV_READABLE_PIPE | UV_WRITABLE_PIPE);
-        options->stdio[i].data.stream = reinterpret_cast<uv_stream_t*>(
-            PipeWrap::Unwrap(stdio
-                ->Get(String::NewSymbol("handle")).As<Object>())->UVHandle());
-      } else if (type->Equals(String::NewSymbol("wrap"))) {
-        uv_stream_t* stream = HandleToStream(
-            stdio->Get(String::NewSymbol("handle")).As<Object>());
+        Local<String> handle_key =
+            FIXED_ONE_BYTE_STRING(node_isolate, "handle");
+        Local<Object> handle = stdio->Get(handle_key).As<Object>();
+        options->stdio[i].data.stream =
+            reinterpret_cast<uv_stream_t*>(
+                PipeWrap::Unwrap(handle)->UVHandle());
+      } else if (type->Equals(FIXED_ONE_BYTE_STRING(node_isolate, "wrap"))) {
+        Local<String> handle_key =
+            FIXED_ONE_BYTE_STRING(node_isolate, "handle");
+        Local<Object> handle = stdio->Get(handle_key).As<Object>();
+        uv_stream_t* stream = HandleToStream(handle);
         assert(stream != NULL);
 
         options->stdio[i].flags = UV_INHERIT_STREAM;
         options->stdio[i].data.stream = stream;
       } else {
-        int fd = static_cast<int>(
-            stdio->Get(String::NewSymbol("fd"))->IntegerValue());
+        Local<String> fd_key = FIXED_ONE_BYTE_STRING(node_isolate, "fd");
+        int fd = static_cast<int>(stdio->Get(fd_key)->IntegerValue());
 
         options->stdio[i].flags = UV_INHERIT_FD;
         options->stdio[i].data.fd = fd;
@@ -130,7 +138,8 @@ class ProcessWrap : public HandleWrap {
     options.exit_cb = OnExit;
 
     // options.uid
-    Local<Value> uid_v = js_options->Get(String::NewSymbol("uid"));
+    Local<Value> uid_v =
+        js_options->Get(FIXED_ONE_BYTE_STRING(node_isolate, "uid"));
     if (uid_v->IsInt32()) {
       int32_t uid = uid_v->Int32Value();
       if (uid & ~((uv_uid_t) ~0)) {
@@ -143,7 +152,8 @@ class ProcessWrap : public HandleWrap {
     }
 
     // options.gid
-    Local<Value> gid_v = js_options->Get(String::NewSymbol("gid"));
+    Local<Value> gid_v =
+        js_options->Get(FIXED_ONE_BYTE_STRING(node_isolate, "gid"));
     if (gid_v->IsInt32()) {
       int32_t gid = gid_v->Int32Value();
       if (gid & ~((uv_gid_t) ~0)) {
@@ -158,7 +168,8 @@ class ProcessWrap : public HandleWrap {
     // TODO(bnoordhuis) is this possible to do without mallocing ?
 
     // options.file
-    Local<Value> file_v = js_options->Get(String::NewSymbol("file"));
+    Local<Value> file_v =
+        js_options->Get(FIXED_ONE_BYTE_STRING(node_isolate, "file"));
     String::Utf8Value file(file_v->IsString() ? file_v : Local<Value>());
     if (file.length() > 0) {
       options.file = *file;
@@ -167,7 +178,8 @@ class ProcessWrap : public HandleWrap {
     }
 
     // options.args
-    Local<Value> argv_v = js_options->Get(String::NewSymbol("args"));
+    Local<Value> argv_v =
+        js_options->Get(FIXED_ONE_BYTE_STRING(node_isolate, "args"));
     if (!argv_v.IsEmpty() && argv_v->IsArray()) {
       Local<Array> js_argv = Local<Array>::Cast(argv_v);
       int argc = js_argv->Length();
@@ -181,14 +193,16 @@ class ProcessWrap : public HandleWrap {
     }
 
     // options.cwd
-    Local<Value> cwd_v = js_options->Get(String::NewSymbol("cwd"));
+    Local<Value> cwd_v =
+        js_options->Get(FIXED_ONE_BYTE_STRING(node_isolate, "cwd"));
     String::Utf8Value cwd(cwd_v->IsString() ? cwd_v : Local<Value>());
     if (cwd.length() > 0) {
       options.cwd = *cwd;
     }
 
     // options.env
-    Local<Value> env_v = js_options->Get(String::NewSymbol("envPairs"));
+    Local<Value> env_v =
+        js_options->Get(FIXED_ONE_BYTE_STRING(node_isolate, "envPairs"));
     if (!env_v.IsEmpty() && env_v->IsArray()) {
       Local<Array> env = Local<Array>::Cast(env_v);
       int envc = env->Length();
@@ -204,13 +218,16 @@ class ProcessWrap : public HandleWrap {
     ParseStdioOptions(js_options, &options);
 
     // options.windows_verbatim_arguments
-    if (js_options->Get(String::NewSymbol("windowsVerbatimArguments"))->
-          IsTrue()) {
+    Local<String> windows_verbatim_arguments_key =
+        FIXED_ONE_BYTE_STRING(node_isolate, "windowsVerbatimArguments");
+    if (js_options->Get(windows_verbatim_arguments_key)->IsTrue()) {
       options.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
     }
 
     // options.detached
-    if (js_options->Get(String::NewSymbol("detached"))->IsTrue()) {
+    Local<String> detached_key =
+        FIXED_ONE_BYTE_STRING(node_isolate, "detached");
+    if (js_options->Get(detached_key)->IsTrue()) {
       options.flags |= UV_PROCESS_DETACHED;
     }
 
@@ -218,7 +235,7 @@ class ProcessWrap : public HandleWrap {
 
     if (err == 0) {
       assert(wrap->process_.data == wrap);
-      wrap->object()->Set(String::New("pid"),
+      wrap->object()->Set(FIXED_ONE_BYTE_STRING(node_isolate, "pid"),
                           Integer::New(wrap->process_.pid, node_isolate));
     }
 
@@ -255,11 +272,11 @@ class ProcessWrap : public HandleWrap {
 
     Local<Value> argv[] = {
       Integer::New(exit_status, node_isolate),
-      String::New(signo_string(term_signal))
+      OneByteString(node_isolate, signo_string(term_signal))
     };
 
     if (onexit_sym.IsEmpty()) {
-      onexit_sym = String::New("onexit");
+      onexit_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onexit");
     }
 
     MakeCallback(wrap->object(), onexit_sym, ARRAY_SIZE(argv), argv);

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -46,7 +46,7 @@ class SignalWrap : public HandleWrap {
 
     Local<FunctionTemplate> constructor = FunctionTemplate::New(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(String::NewSymbol("Signal"));
+    constructor->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Signal"));
 
     NODE_SET_PROTOTYPE_METHOD(constructor, "close", HandleWrap::Close);
     NODE_SET_PROTOTYPE_METHOD(constructor, "ref", HandleWrap::Ref);
@@ -54,9 +54,10 @@ class SignalWrap : public HandleWrap {
     NODE_SET_PROTOTYPE_METHOD(constructor, "start", Start);
     NODE_SET_PROTOTYPE_METHOD(constructor, "stop", Stop);
 
-    onsignal_sym = String::New("onsignal");
+    onsignal_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onsignal");
 
-    target->Set(String::NewSymbol("Signal"), constructor->GetFunction());
+    target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Signal"),
+                constructor->GetFunction());
   }
 
  private:

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -359,7 +359,7 @@ void Alloc(Handle<Object> obj,
   assert(!obj->HasIndexedPropertiesInExternalArrayData());
 
   if (smalloc_sym.IsEmpty()) {
-    smalloc_sym = String::New("_smalloc_p");
+    smalloc_sym = FIXED_ONE_BYTE_STRING(node_isolate, "_smalloc_p");
     using_alloc_cb = true;
   }
 
@@ -466,7 +466,7 @@ void Initialize(Handle<Object> exports) {
   NODE_SET_METHOD(exports, "alloc", Alloc);
   NODE_SET_METHOD(exports, "dispose", AllocDispose);
 
-  exports->Set(String::New("kMaxLength"),
+  exports->Set(FIXED_ONE_BYTE_STRING(node_isolate, "kMaxLength"),
                Uint32::NewFromUnsigned(kMaxLength, node_isolate));
 
   // for performance, begin checking if allocation object may contain

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -63,11 +63,11 @@ void StreamWrap::Initialize(Handle<Object> target) {
   initialized = true;
 
   HandleScope scope(node_isolate);
-  buffer_sym = String::New("buffer");
-  bytes_sym = String::New("bytes");
-  write_queue_size_sym = String::New("writeQueueSize");
-  onread_sym = String::New("onread");
-  oncomplete_sym = String::New("oncomplete");
+  buffer_sym = FIXED_ONE_BYTE_STRING(node_isolate, "buffer");
+  bytes_sym = FIXED_ONE_BYTE_STRING(node_isolate, "bytes");
+  write_queue_size_sym = FIXED_ONE_BYTE_STRING(node_isolate, "writeQueueSize");
+  onread_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onread");
+  oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
 }
 
 
@@ -299,7 +299,7 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
       // Reference StreamWrap instance to prevent it from being garbage
       // collected before `AfterWrite` is called.
       if (handle_sym.IsEmpty()) {
-        handle_sym = String::New("handle");
+        handle_sym = FIXED_ONE_BYTE_STRING(node_isolate, "handle");
       }
       assert(!req_wrap->persistent().IsEmpty());
       req_wrap->object()->Set(handle_sym, send_handle_obj);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -645,20 +645,14 @@ Local<Value> StringBytes::Encode(const char* buf,
         char* out = new char[buflen];
         force_ascii(buf, out, buflen);
         if (buflen < EXTERN_APEX) {
-          val = String::NewFromOneByte(node_isolate,
-                                       reinterpret_cast<const uint8_t*>(out),
-                                       String::kNormalString,
-                                       buflen);
+          val = OneByteString(node_isolate, out, buflen);
           delete[] out;
         } else {
           val = ExternOneByteString::New(out, buflen);
         }
       } else {
         if (buflen < EXTERN_APEX)
-          val = String::NewFromOneByte(node_isolate,
-                                       reinterpret_cast<const uint8_t*>(buf),
-                                       String::kNormalString,
-                                       buflen);
+          val = OneByteString(node_isolate, buf, buflen);
         else
           val = ExternOneByteString::NewFromCopy(buf, buflen);
       }
@@ -673,10 +667,7 @@ Local<Value> StringBytes::Encode(const char* buf,
 
     case BINARY:
       if (buflen < EXTERN_APEX)
-        val = String::NewFromOneByte(node_isolate,
-                                     reinterpret_cast<const uint8_t*>(buf),
-                                     String::kNormalString,
-                                     buflen);
+        val = OneByteString(node_isolate, buf, buflen);
       else
         val = ExternOneByteString::NewFromCopy(buf, buflen);
       break;
@@ -689,10 +680,7 @@ Local<Value> StringBytes::Encode(const char* buf,
       assert(written == dlen);
 
       if (dlen < EXTERN_APEX) {
-        val = String::NewFromOneByte(node_isolate,
-                                     reinterpret_cast<const uint8_t*>(dst),
-                                     String::kNormalString,
-                                     dlen);
+        val = OneByteString(node_isolate, dst, dlen);
         delete[] dst;
       } else {
         val = ExternOneByteString::New(dst, dlen);
@@ -719,10 +707,7 @@ Local<Value> StringBytes::Encode(const char* buf,
       assert(written == dlen);
 
       if (dlen < EXTERN_APEX) {
-        val = String::NewFromOneByte(node_isolate,
-                                     reinterpret_cast<const uint8_t*>(dst),
-                                     String::kNormalString,
-                                     dlen);
+        val = OneByteString(node_isolate, dst, dlen);
         delete[] dst;
       } else {
         val = ExternOneByteString::New(dst, dlen);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -72,13 +72,13 @@ void TCPWrap::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
-  t->SetClassName(String::NewSymbol("TCP"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "TCP"));
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(String::New("fd"),
+  t->InstanceTemplate()->SetAccessor(FIXED_ONE_BYTE_STRING(node_isolate, "fd"),
                                      StreamWrap::GetFD,
                                      NULL,
                                      Handle<Value>(),
@@ -119,12 +119,12 @@ void TCPWrap::Initialize(Handle<Object> target) {
                             SetSimultaneousAccepts);
 #endif
 
-  onconnection_sym = String::New("onconnection");
-  oncomplete_sym = String::New("oncomplete");
+  onconnection_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onconnection");
+  oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
 
   tcpConstructorTmpl.Reset(node_isolate, t);
   tcpConstructor.Reset(node_isolate, t->GetFunction());
-  target->Set(String::NewSymbol("TCP"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "TCP"), t->GetFunction());
 }
 
 
@@ -431,11 +431,11 @@ Local<Object> AddressToJS(const sockaddr* addr, Handle<Object> info) {
   int port;
 
   if (address_sym.IsEmpty()) {
-    address_sym = String::New("address");
-    family_sym = String::New("family");
-    port_sym = String::New("port");
-    ipv4_sym = String::New("IPv4");
-    ipv6_sym = String::New("IPv6");
+    address_sym = FIXED_ONE_BYTE_STRING(node_isolate, "address");
+    family_sym = FIXED_ONE_BYTE_STRING(node_isolate, "family");
+    port_sym = FIXED_ONE_BYTE_STRING(node_isolate, "port");
+    ipv4_sym = FIXED_ONE_BYTE_STRING(node_isolate, "IPv4");
+    ipv6_sym = FIXED_ONE_BYTE_STRING(node_isolate, "IPv6");
   }
 
   if (info.IsEmpty()) info = Object::New();
@@ -445,7 +445,7 @@ Local<Object> AddressToJS(const sockaddr* addr, Handle<Object> info) {
     a6 = reinterpret_cast<const sockaddr_in6*>(addr);
     uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
     port = ntohs(a6->sin6_port);
-    info->Set(address_sym, String::New(ip));
+    info->Set(address_sym, OneByteString(node_isolate, ip));
     info->Set(family_sym, ipv6_sym);
     info->Set(port_sym, Integer::New(port, node_isolate));
     break;
@@ -454,7 +454,7 @@ Local<Object> AddressToJS(const sockaddr* addr, Handle<Object> info) {
     a4 = reinterpret_cast<const sockaddr_in*>(addr);
     uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
     port = ntohs(a4->sin_port);
-    info->Set(address_sym, String::New(ip));
+    info->Set(address_sym, OneByteString(node_isolate, ip));
     info->Set(family_sym, ipv4_sym);
     info->Set(port_sym, Integer::New(port, node_isolate));
     break;

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -44,7 +44,7 @@ class TimerWrap : public HandleWrap {
 
     Local<FunctionTemplate> constructor = FunctionTemplate::New(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(String::NewSymbol("Timer"));
+    constructor->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Timer"));
 
     NODE_SET_METHOD(constructor, "now", Now);
 
@@ -58,9 +58,10 @@ class TimerWrap : public HandleWrap {
     NODE_SET_PROTOTYPE_METHOD(constructor, "getRepeat", GetRepeat);
     NODE_SET_PROTOTYPE_METHOD(constructor, "again", Again);
 
-    ontimeout_sym = String::New("ontimeout");
+    ontimeout_sym = FIXED_ONE_BYTE_STRING(node_isolate, "ontimeout");
 
-    target->Set(String::NewSymbol("Timer"), constructor->GetFunction());
+    target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Timer"),
+                constructor->GetFunction());
   }
 
  private:

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -49,13 +49,13 @@ void TTYWrap::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
-  t->SetClassName(String::NewSymbol("TTY"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "TTY"));
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(String::New("fd"),
+  t->InstanceTemplate()->SetAccessor(FIXED_ONE_BYTE_STRING(node_isolate, "fd"),
                                      StreamWrap::GetFD,
                                      NULL,
                                      Handle<Value>(),
@@ -82,7 +82,7 @@ void TTYWrap::Initialize(Handle<Object> target) {
   NODE_SET_METHOD(target, "guessHandleType", GuessHandleType);
 
   ttyConstructorTmpl.Reset(node_isolate, t);
-  target->Set(String::NewSymbol("TTY"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "TTY"), t->GetFunction());
 }
 
 
@@ -117,7 +117,7 @@ void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
     abort();
   }
 
-  args.GetReturnValue().Set(String::New(type));
+  args.GetReturnValue().Set(OneByteString(node_isolate, type));
 }
 
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -68,17 +68,17 @@ UDPWrap::~UDPWrap() {
 void UDPWrap::Initialize(Handle<Object> target) {
   HandleScope scope(node_isolate);
 
-  buffer_sym = String::New("buffer");
-  oncomplete_sym = String::New("oncomplete");
-  onmessage_sym = String::New("onmessage");
+  buffer_sym = FIXED_ONE_BYTE_STRING(node_isolate, "buffer");
+  oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
+  onmessage_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onmessage");
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(String::NewSymbol("UDP"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "UDP"));
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(String::New("fd"),
+  t->InstanceTemplate()->SetAccessor(FIXED_ONE_BYTE_STRING(node_isolate, "fd"),
                                      UDPWrap::GetFD,
                                      NULL,
                                      Handle<Value>(),
@@ -104,7 +104,7 @@ void UDPWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "unref", HandleWrap::Unref);
 
   constructor.Reset(node_isolate, t->GetFunction());
-  target->Set(String::NewSymbol("UDP"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "UDP"), t->GetFunction());
 }
 
 

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -40,16 +40,17 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
   int err = args[0]->Int32Value();
   if (err >= 0) return ThrowError("err >= 0");
   const char* name = uv_err_name(err);
-  args.GetReturnValue().Set(String::New(name));
+  args.GetReturnValue().Set(OneByteString(node_isolate, name));
 }
 
 
 void Initialize(Handle<Object> target) {
   v8::HandleScope handle_scope(node_isolate);
-  target->Set(String::New("errname"),
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "errname"),
               FunctionTemplate::New(ErrName)->GetFunction());
-#define V(name, _) target->Set(String::New("UV_" # name),                     \
-                               Integer::New(UV_ ## name, node_isolate));
+#define V(name, _)                                                            \
+  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "UV_" # name),              \
+              Integer::New(UV_ ## name, node_isolate));
   UV_ERRNO_MAP(V)
 #undef V
 }


### PR DESCRIPTION
- Change calls to String::New() and String::NewSymbol() to their
  respective one-byte, two-byte or UTF-8 counterparts.
- Add a FIXED_ONE_BYTE_STRING macro that takes a string literal and
  turns it into a `v8::Local<v8::String>`.
- Add helper functions that make v8::String::NewFromOneByte() easier to
  work with. Said function expects a `const uint8_t*` but almost every
  call site deals with `const char*` or `const unsigned char*`.
  The helpers help us avoid doing reinterpret_casts all over the place.
- Code that handles file paths uses UTF-8 for backwards compatibility.

CI test.
