### PR TITLE
doc: fixed syntax error in stream.Transform example

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1174,7 +1174,7 @@ approach.
 
 ```javascript
 var util = require('util');
-var Transform = require('stream').Transform);
+var Transform = require('stream').Transform;
 util.inherits(SimpleProtocol, Transform);
 
 function SimpleProtocol(options) {


### PR DESCRIPTION
Found this syntax error when using a tool I made called [mdlint](https://github.com/ChrisWren/mdlint). It lints JavaScript code blocks in markdown files to find syntax errors.
