### PR TITLE
Make available methods for TLSv1.1 and TLSv1.2

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -256,6 +256,18 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
       method = TLSv1_server_method();
     } else if (strcmp(*sslmethod, "TLSv1_client_method") == 0) {
       method = TLSv1_client_method();
+    } else if (strcmp(*sslmethod, "TLSv1_1_method") == 0) {
+      method = TLSv1_1_method();
+    } else if (strcmp(*sslmethod, "TLSv1_1_server_method") == 0) {
+      method = TLSv1_1_server_method();
+    } else if (strcmp(*sslmethod, "TLSv1_1_client_method") == 0) {
+      method = TLSv1_1_client_method();
+    } else if (strcmp(*sslmethod, "TLSv1_2_method") == 0) {
+      method = TLSv1_2_method();
+    } else if (strcmp(*sslmethod, "TLSv1_2_server_method") == 0) {
+      method = TLSv1_2_server_method();
+    } else if (strcmp(*sslmethod, "TLSv1_2_client_method") == 0) {
+      method = TLSv1_2_client_method();
     } else {
       return ThrowError("Unknown method");
     }


### PR DESCRIPTION
OpenSSL also provides methods for TLSv1.1 and TLSv1.2 (even though they're not in the documentation). This change makes them available in node
