### PR TITLE
Http outgoing part1

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -23,14 +23,14 @@ var util = require('util');
 var Stream = require('stream');
 
 function readStart(socket) {
-  if (!socket || !socket._handle || !socket._handle.readStart) return;
-  socket._handle.readStart();
+  if (socket)
+    socket.resume();
 }
 exports.readStart = readStart;
 
 function readStop(socket) {
-  if (!socket || !socket._handle || !socket._handle.readStop) return;
-  socket._handle.readStop();
+  if (socket)
+    socket.pause();
 }
 exports.readStop = readStop;
 
@@ -196,9 +196,6 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
 IncomingMessage.prototype._dump = function() {
   if (!this._dumped) {
     this._dumped = true;
-    if (this.socket.parser) this.socket.parser.incoming = null;
-    this.push(null);
-    readStart(this.socket);
-    this.read();
+    this.resume();
   }
 };

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -122,7 +122,7 @@ OutgoingMessage.prototype._send = function(data, encoding, callback) {
       data = this._header + data;
     } else {
       this.output.unshift(this._header);
-      this.outputEncodings.unshift('ascii');
+      this.outputEncodings.unshift('binary');
       this.outputCallbacks.unshift(null);
     }
     this._headerSent = true;
@@ -421,7 +421,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
 
       if (this.connection)
         this.connection.cork();
-      this._send(len.toString(16), 'ascii', null);
+      this._send(len.toString(16), 'binary', null);
       this._send(crlf_buf, null, null);
       this._send(chunk, encoding, null);
       ret = this._send(crlf_buf, null, callback);
@@ -507,10 +507,10 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   }
 
   if (this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii', finish);
+    ret = this._send('0\r\n' + this._trailer + '\r\n', 'binary', finish);
   } else {
     // Force a flush, HACK.
-    ret = this._send('', 'ascii', finish);
+    ret = this._send('', 'binary', finish);
   }
 
   if (this.connection && data)

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -60,6 +60,7 @@ function OutgoingMessage() {
 
   this.output = [];
   this.outputEncodings = [];
+  this.outputCallbacks = [];
 
   this.writable = true;
 
@@ -110,7 +111,7 @@ OutgoingMessage.prototype.destroy = function(error) {
 
 
 // This abstract either writing directly to the socket or buffering it.
-OutgoingMessage.prototype._send = function(data, encoding) {
+OutgoingMessage.prototype._send = function(data, encoding, callback) {
   // This is a shameful hack to get the headers and first body chunk onto
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.
@@ -122,15 +123,23 @@ OutgoingMessage.prototype._send = function(data, encoding) {
     } else {
       this.output.unshift(this._header);
       this.outputEncodings.unshift('ascii');
+      this.outputCallbacks.unshift(null);
     }
     this._headerSent = true;
   }
-  return this._writeRaw(data, encoding);
+  return this._writeRaw(data, encoding, callback);
 };
 
 
-OutgoingMessage.prototype._writeRaw = function(data, encoding) {
+OutgoingMessage.prototype._writeRaw = function(data, encoding, callback) {
+  if (util.isFunction(encoding)) {
+    callback = encoding;
+    encoding = null;
+  }
+
   if (data.length === 0) {
+    if (util.isFunction(callback))
+      process.nextTick(callback);
     return true;
   }
 
@@ -141,32 +150,33 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
     // There might be pending data in the this.output buffer.
     while (this.output.length) {
       if (!this.connection.writable) {
-        this._buffer(data, encoding);
+        this._buffer(data, encoding, callback);
         return false;
       }
       var c = this.output.shift();
       var e = this.outputEncodings.shift();
-      this.connection.write(c, e);
+      var cb = this.outputCallbacks.shift();
+      this.connection.write(c, e, cb);
     }
 
     // Directly write to socket.
-    return this.connection.write(data, encoding);
+    return this.connection.write(data, encoding, callback);
   } else if (this.connection && this.connection.destroyed) {
     // The socket was destroyed.  If we're still trying to write to it,
     // then we haven't gotten the 'close' event yet.
     return false;
   } else {
     // buffer, as long as we're not destroyed.
-    this._buffer(data, encoding);
+    this._buffer(data, encoding, callback);
     return false;
   }
 };
 
 
-OutgoingMessage.prototype._buffer = function(data, encoding) {
+OutgoingMessage.prototype._buffer = function(data, encoding, callback) {
   this.output.push(data);
   this.outputEncodings.push(encoding);
-
+  this.outputCallbacks.push(callback);
   return false;
 };
 
@@ -373,7 +383,7 @@ Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
 });
 
 
-OutgoingMessage.prototype.write = function(chunk, encoding) {
+OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
   if (!this._header) {
     this._implicitHeader();
   }
@@ -401,7 +411,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
         encoding !== 'binary') {
       len = Buffer.byteLength(chunk, encoding);
       chunk = len.toString(16) + CRLF + chunk + CRLF;
-      ret = this._send(chunk, encoding);
+      ret = this._send(chunk, encoding, callback);
     } else {
       // buffer, or a non-toString-friendly encoding
       if (util.isString(chunk))
@@ -411,15 +421,15 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
 
       if (this.connection)
         this.connection.cork();
-      this._send(len.toString(16), 'ascii');
-      this._send(crlf_buf);
-      this._send(chunk, encoding);
-      ret = this._send(crlf_buf);
+      this._send(len.toString(16), 'ascii', null);
+      this._send(crlf_buf, null, null);
+      this._send(chunk, encoding, null);
+      ret = this._send(crlf_buf, null, callback);
       if (this.connection)
         this.connection.uncork();
     }
   } else {
-    ret = this._send(chunk, encoding);
+    ret = this._send(chunk, encoding, callback);
   }
 
   debug('write ret = ' + ret);
@@ -451,7 +461,15 @@ var zero_chunk_buf = new Buffer('\r\n0\r\n');
 var crlf_buf = new Buffer('\r\n');
 
 
-OutgoingMessage.prototype.end = function(data, encoding) {
+OutgoingMessage.prototype.end = function(data, encoding, callback) {
+  if (util.isFunction(data)) {
+    callback = data;
+    data = null;
+  } else if (util.isFunction(encoding)) {
+    callback = encoding;
+    encoding = null;
+  }
+
   if (data && !util.isString(data) && !util.isBuffer(data)) {
     throw new TypeError('first argument must be a string or Buffer');
   }
@@ -466,7 +484,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   if (data && !this._hasBody) {
     debug('This type of response MUST NOT have a body. ' +
           'Ignoring data passed to end().');
-    data = false;
+    data = null;
   }
 
   if (this.connection && data)
@@ -479,10 +497,10 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   }
 
   if (this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii');
+    ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii', callback);
   } else {
     // Force a flush, HACK.
-    ret = this._send('');
+    ret = this._send('', 'ascii', callback);
   }
 
   if (this.connection && data)
@@ -537,8 +555,9 @@ OutgoingMessage.prototype._flush = function() {
 
     var data = this.output.shift();
     var encoding = this.outputEncodings.shift();
+    var cb = this.outputCallbacks.shift();
 
-    ret = this.socket.write(data, encoding);
+    ret = this.socket.write(data, encoding, cb);
   }
 
   if (this.finished) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -477,6 +477,16 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   if (this.finished) {
     return false;
   }
+
+  var self = this;
+  function finish() {
+    self.emit('finish');
+  }
+
+  if (util.isFunction(callback))
+    this.once('finish', callback);
+
+
   if (!this._header) {
     this._implicitHeader();
   }
@@ -497,10 +507,10 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   }
 
   if (this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii', callback);
+    ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii', finish);
   } else {
     // Force a flush, HACK.
-    ret = this._send('', 'ascii', callback);
+    ret = this._send('', 'ascii', finish);
   }
 
   if (this.connection && data)
@@ -521,7 +531,7 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
 
 OutgoingMessage.prototype._finish = function() {
   assert(this.connection);
-  this.emit('finish');
+  this.emit('prefinish');
 };
 
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -115,7 +115,9 @@ OutgoingMessage.prototype._send = function(data, encoding) {
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.
   if (!this._headerSent) {
-    if (util.isString(data)) {
+    if (util.isString(data) &&
+        encoding !== 'hex' &&
+        encoding !== 'base64') {
       data = this._header + data;
     } else {
       this.output.unshift(this._header);
@@ -162,25 +164,6 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
 
 
 OutgoingMessage.prototype._buffer = function(data, encoding) {
-  if (data.length === 0) return;
-
-  var length = this.output.length;
-
-  if (length === 0 || !util.isString(data)) {
-    this.output.push(data);
-    this.outputEncodings.push(encoding);
-    return false;
-  }
-
-  var lastEncoding = this.outputEncodings[length - 1];
-  var lastData = this.output[length - 1];
-
-  if ((encoding && lastEncoding === encoding) ||
-      (!encoding && data.constructor === lastData.constructor)) {
-    this.output[length - 1] = lastData + data;
-    return false;
-  }
-
   this.output.push(data);
   this.outputEncodings.push(encoding);
 
@@ -421,13 +404,16 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
       ret = this._send(chunk, encoding);
     } else {
       // buffer, or a non-toString-friendly encoding
-      len = chunk.length;
+      if (util.isString(chunk))
+        len = Buffer.byteLength(chunk, encoding);
+      else
+        len = chunk.length;
 
       if (this.connection)
         this.connection.cork();
-      this._send(len.toString(16));
+      this._send(len.toString(16), 'ascii');
       this._send(crlf_buf);
-      this._send(chunk);
+      this._send(chunk, encoding);
       ret = this._send(crlf_buf);
       if (this.connection)
         this.connection.uncork();
@@ -493,7 +479,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   }
 
   if (this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n'); // Last chunk.
+    ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii');
   } else {
     // Force a flush, HACK.
     ret = this._send('');

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -525,46 +525,41 @@ OutgoingMessage.prototype._finish = function() {
 };
 
 
+// This logic is probably a bit confusing. Let me explain a bit:
+//
+// In both HTTP servers and clients it is possible to queue up several
+// outgoing messages. This is easiest to imagine in the case of a client.
+// Take the following situation:
+//
+//    req1 = client.request('GET', '/');
+//    req2 = client.request('POST', '/');
+//
+// When the user does
+//
+//   req2.write('hello world\n');
+//
+// it's possible that the first request has not been completely flushed to
+// the socket yet. Thus the outgoing messages need to be prepared to queue
+// up data internally before sending it on further to the socket's queue.
+//
+// This function, outgoingFlush(), is called by both the Server and Client
+// to attempt to flush any pending messages out to the socket.
 OutgoingMessage.prototype._flush = function() {
-  // This logic is probably a bit confusing. Let me explain a bit:
-  //
-  // In both HTTP servers and clients it is possible to queue up several
-  // outgoing messages. This is easiest to imagine in the case of a client.
-  // Take the following situation:
-  //
-  //    req1 = client.request('GET', '/');
-  //    req2 = client.request('POST', '/');
-  //
-  // When the user does
-  //
-  //   req2.write('hello world\n');
-  //
-  // it's possible that the first request has not been completely flushed to
-  // the socket yet. Thus the outgoing messages need to be prepared to queue
-  // up data internally before sending it on further to the socket's queue.
-  //
-  // This function, outgoingFlush(), is called by both the Server and Client
-  // to attempt to flush any pending messages out to the socket.
+  if (this.socket && this.socket.writable) {
+    var ret;
+    while (this.output.length) {
+      var data = this.output.shift();
+      var encoding = this.outputEncodings.shift();
+      var cb = this.outputCallbacks.shift();
+      ret = this.socket.write(data, encoding, cb);
+    }
 
-  if (!this.socket) return;
-
-  var ret;
-  while (this.output.length) {
-
-    if (!this.socket.writable) return; // XXX Necessary?
-
-    var data = this.output.shift();
-    var encoding = this.outputEncodings.shift();
-    var cb = this.outputCallbacks.shift();
-
-    ret = this.socket.write(data, encoding, cb);
-  }
-
-  if (this.finished) {
-    // This is a queue to the server or client to bring in the next this.
-    this._finish();
-  } else if (ret) {
-    // This is necessary to prevent https from breaking
-    this.emit('drain');
+    if (this.finished) {
+      // This is a queue to the server or client to bring in the next this.
+      this._finish();
+    } else if (ret) {
+      // This is necessary to prevent https from breaking
+      this.emit('drain');
+    }
   }
 };

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -429,7 +429,7 @@ function connectionListener(socket) {
 
     // When we're finished writing the response, check if this is the last
     // respose, if so destroy the socket.
-    res.on('finish', resOnFinish);
+    res.on('prefinish', resOnFinish);
     function resOnFinish() {
       // Usually the first incoming element should be our request.  it may
       // be that in the case abortIncoming() was called that the incoming

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -161,8 +161,8 @@ ServerResponse.prototype.detachSocket = function(socket) {
   this.socket = this.connection = null;
 };
 
-ServerResponse.prototype.writeContinue = function() {
-  this._writeRaw('HTTP/1.1 100 Continue' + CRLF + CRLF, 'ascii');
+ServerResponse.prototype.writeContinue = function(cb) {
+  this._writeRaw('HTTP/1.1 100 Continue' + CRLF + CRLF, 'ascii', cb);
   this._sent100 = true;
 };
 

--- a/test/simple/test-http-byteswritten.js
+++ b/test/simple/test-http-byteswritten.js
@@ -26,12 +26,19 @@ var http = require('http');
 
 var body = 'hello world\n';
 
+var sawFinish = false;
+process.on('exit', function() {
+  assert(sawFinish);
+  console.log('ok');
+});
+
 var httpServer = http.createServer(function(req, res) {
+  httpServer.close();
+
   res.on('finish', function() {
+    sawFinish = true;
     assert(typeof(req.connection.bytesWritten) === 'number');
     assert(req.connection.bytesWritten > 0);
-    httpServer.close();
-    console.log('ok');
   });
   res.writeHead(200, { 'Content-Type': 'text/plain' });
 
@@ -51,6 +58,9 @@ var httpServer = http.createServer(function(req, res) {
 });
 
 httpServer.listen(common.PORT, function() {
-  http.get({ port: common.PORT });
+  // XXX(isaacs): This should not be necessary.
+  http.get({ port: common.PORT }, function(res) {
+    res.resume();
+  });
 });
 

--- a/test/simple/test-http-byteswritten.js
+++ b/test/simple/test-http-byteswritten.js
@@ -58,9 +58,6 @@ var httpServer = http.createServer(function(req, res) {
 });
 
 httpServer.listen(common.PORT, function() {
-  // XXX(isaacs): This should not be necessary.
-  http.get({ port: common.PORT }, function(res) {
-    res.resume();
-  });
+  http.get({ port: common.PORT });
 });
 

--- a/test/simple/test-http-hex-write.js
+++ b/test/simple/test-http-hex-write.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+var expect = 'hex\nutf8\n';
+var data = '';
+var ended = false;
+
+process.on('exit', function() {
+  assert(ended);
+  assert.equal(data, expect);
+  console.log('ok');
+});
+
+http.createServer(function(q, s) {
+  s.setHeader('content-length', expect.length);
+  s.write('6865780a', 'hex');
+  s.write('utf8\n');
+  s.end();
+  this.close();
+}).listen(common.PORT, function() {
+  http.request({ port: common.PORT }).on('response', function(res) {
+    res.setEncoding('ascii');
+    res.on('data', function(c) {
+      data += c;
+    });
+    res.on('end', function() {
+      ended = true;
+    });
+  }).end();
+});

--- a/test/simple/test-http-outgoing-finish.js
+++ b/test/simple/test-http-outgoing-finish.js
@@ -1,0 +1,74 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+http.createServer(function(req, res) {
+  write(res);
+  req.resume();
+  this.close();
+}).listen(common.PORT, function() {
+  var req = http.request({
+    port: common.PORT,
+    method: 'PUT'
+  });
+  write(req);
+  req.on('response', function(res) {
+    res.resume();
+  });
+});
+
+var buf = new Buffer(1024 * 16);
+buf.fill('x');
+function write(out) {
+  var name = out.constructor.name;
+  var finishEvent = false;
+  var endCb = false;
+
+  // first, write until it gets some backpressure
+  while (out.write(buf)) {}
+
+  // now end, and make sure that we don't get the 'finish' event
+  // before the tick where the cb gets called.  We give it until
+  // nextTick because this is added as a listener before the endcb
+  // is registered.  The order is not what we're testing here, just
+  // that 'finish' isn't emitted until the stream is fully flushed.
+  out.on('finish', function() {
+    finishEvent = true;
+    console.error('%s finish event', name);
+    process.nextTick(function() {
+      assert(endCb, name + ' got finish event before endcb!');
+      console.log('ok - %s finishEvent', name);
+    });
+  });
+
+  out.end(buf, function() {
+    endCb = true;
+    console.error('%s endCb', name);
+    process.nextTick(function() {
+      assert(endCb, name + ' got endCb event before finishEvent!');
+      console.log('ok - %s endCb', name);
+    });
+  });
+}

--- a/test/simple/test-http-write-callbacks.js
+++ b/test/simple/test-http-write-callbacks.js
@@ -1,0 +1,100 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+var serverEndCb = false;
+var serverIncoming = '';
+var serverIncomingExpect = 'bazquuxblerg';
+
+var clientEndCb = false;
+var clientIncoming = '';
+var clientIncomingExpect = 'asdffoobar';
+
+process.on('exit', function() {
+  assert(serverEndCb);
+  assert.equal(serverIncoming, serverIncomingExpect);
+  assert(clientEndCb);
+  assert.equal(clientIncoming, clientIncomingExpect);
+  console.log('ok');
+});
+
+// Verify that we get a callback when we do res.write(..., cb)
+var server = http.createServer(function(req, res) {
+  res.statusCode = 400;
+  res.end('Bad Request.\nMust send Expect:100-continue\n');
+});
+
+server.on('checkContinue', function(req, res) {
+  server.close();
+  assert.equal(req.method, 'PUT');
+  res.writeContinue(function() {
+    // continue has been written
+    req.on('end', function() {
+      res.write('asdf', function(er) {
+        assert.ifError(er);
+        res.write('foo', 'ascii', function(er) {
+          assert.ifError(er);
+          res.end(new Buffer('bar'), 'buffer', function(er) {
+            serverEndCb = true;
+          });
+        });
+      });
+    });
+  });
+
+  req.setEncoding('ascii');
+  req.on('data', function(c) {
+    serverIncoming += c;
+  });
+});
+
+server.listen(common.PORT, function() {
+  var req = http.request({
+    port: common.PORT,
+    method: 'PUT',
+    headers: { 'expect': '100-continue' }
+  });
+  req.on('continue', function() {
+    // ok, good to go.
+    req.write('YmF6', 'base64', function(er) {
+      assert.ifError(er);
+      req.write(new Buffer('quux'), function(er) {
+        assert.ifError(er);
+        req.end('626c657267', 'hex', function(er) {
+          assert.ifError(er);
+          clientEndCb = true;
+        });
+      });
+    });
+  });
+  req.on('response', function(res) {
+    // this should not come until after the end is flushed out
+    assert(clientEndCb);
+    res.setEncoding('ascii');
+    res.on('data', function(c) {
+      clientIncoming += c;
+    });
+  });
+});


### PR DESCRIPTION
This is the first part of the HTTP OutgoingMessage refactoring that I'd like to get done.

First, make hex and base64 writes behave properly.  (This also needs to be backported to v0.10.)

Next, make http.OutgoingMessage objects consistent with other Writable streams in terms of when they emit `finish` and take callbacks for write/end.

The next step is to bring some rationality to our set/getHeaders mechanisms, but that is less pressing.

Performance impact is nil, according to my tests.  Just noise, and split evenly in both directions.
