### PR TITLE
http: Handle hex/base64 encodings properly

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -495,7 +495,9 @@ OutgoingMessage.prototype._send = function(data, encoding) {
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.
   if (!this._headerSent) {
-    if (typeof data === 'string') {
+    if (typeof data === 'string' &&
+        encoding !== 'hex' &&
+        encoding !== 'base64') {
       data = this._header + data;
     } else {
       this.output.unshift(this._header);
@@ -542,25 +544,6 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding) {
 
 
 OutgoingMessage.prototype._buffer = function(data, encoding) {
-  if (data.length === 0) return;
-
-  var length = this.output.length;
-
-  if (length === 0 || typeof data != 'string') {
-    this.output.push(data);
-    this.outputEncodings.push(encoding);
-    return false;
-  }
-
-  var lastEncoding = this.outputEncodings[length - 1];
-  var lastData = this.output[length - 1];
-
-  if ((encoding && lastEncoding === encoding) ||
-      (!encoding && data.constructor === lastData.constructor)) {
-    this.output[length - 1] = lastData + data;
-    return false;
-  }
-
   this.output.push(data);
   this.outputEncodings.push(encoding);
 
@@ -888,8 +871,12 @@ OutgoingMessage.prototype.write = function(chunk, encoding) {
       ret = this._send(buf, encoding);
     } else {
       // Non-toString-friendly encoding.
-      len = chunk.length;
-      this._send(len.toString(16) + CRLF);
+      if (typeof chunk === 'string')
+        len = Buffer.byteLength(chunk, encoding);
+      else
+        len = chunk.length;
+
+      this._send(len.toString(16) + CRLF, 'ascii');
       this._send(chunk, encoding);
       ret = this._send(CRLF);
     }
@@ -957,6 +944,10 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   if (hot && Buffer.isBuffer(data) && data.length > 120 * 1024)
     hot = false;
 
+  // Can't concatenate safely with hex or base64 encodings.
+  if (encoding === 'hex' || encoding === 'base64')
+    hot = false;
+
   if (hot) {
     // Hot path. They're doing
     //   res.writeHead();
@@ -995,7 +986,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
 
   if (!hot) {
     if (this.chunkedEncoding) {
-      ret = this._send('0\r\n' + this._trailer + '\r\n'); // Last chunk.
+      ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii');
     } else {
       // Force a flush, HACK.
       ret = this._send('');

--- a/test/simple/test-http-hex-write.js
+++ b/test/simple/test-http-hex-write.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+var expect = 'hex\nutf8\n';
+var data = '';
+var ended = false;
+
+process.on('exit', function() {
+  assert(ended);
+  assert.equal(data, expect);
+  console.log('ok');
+});
+
+http.createServer(function(q, s) {
+  s.setHeader('content-length', expect.length);
+  s.write('6865780a', 'hex');
+  s.write('utf8\n');
+  s.end();
+  this.close();
+}).listen(common.PORT, function() {
+  http.request({ port: common.PORT }).on('response', function(res) {
+    res.setEncoding('ascii');
+    res.on('data', function(c) {
+      data += c;
+    });
+    res.on('end', function() {
+      ended = true;
+    });
+  }).end();
+});


### PR DESCRIPTION
This is a backport of 6d3d60aced39d59eaa5e705b7d822c227d0d3dae for v0.10.
