### PR TITLE
smalloc: make C++ API consistent

### DIFF
--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -224,10 +224,14 @@ void Alloc(const FunctionCallbackInfo<Value>& args) {
   enum ExternalArrayType array_type;
 
   // it's faster to not pass the default argument then use Uint32Value
-  if (args[2]->IsUndefined())
+  if (args[2]->IsUndefined()) {
     array_type = kExternalUnsignedByteArray;
-  else
+  } else {
     array_type = static_cast<ExternalArrayType>(args[2]->Uint32Value());
+    size_t type_length = ExternalArraySize(array_type);
+    assert(type_length * length >= length);
+    length *= type_length;
+  }
 
   Alloc(obj, length, array_type);
   args.GetReturnValue().Set(obj);
@@ -235,14 +239,10 @@ void Alloc(const FunctionCallbackInfo<Value>& args) {
 
 
 void Alloc(Handle<Object> obj, size_t length, enum ExternalArrayType type) {
-  assert(length <= kMaxLength);
-
   size_t type_size = ExternalArraySize(type);
 
+  assert(length <= kMaxLength);
   assert(type_size > 0);
-  assert(length * type_size >= length);
-
-  length *= type_size;
 
   if (length == 0)
     return Alloc(obj, NULL, length, type);

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -69,7 +69,7 @@ static bool using_alloc_cb;
 
 
 // return size of external array type, or 0 if unrecognized
-static inline size_t ExternalArraySize(enum ExternalArrayType type) {
+size_t ExternalArraySize(enum ExternalArrayType type) {
   switch (type) {
     case v8::kExternalUnsignedByteArray:
       return sizeof(uint8_t);

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -96,7 +96,7 @@ size_t ExternalArraySize(enum ExternalArrayType type) {
 
 // copyOnto(source, source_start, dest, dest_start, copy_length)
 void CopyOnto(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope handle_scope(node_isolate);
 
   if (!args[0]->IsObject())
     return ThrowTypeError("source must be an object");
@@ -172,7 +172,7 @@ void CopyOnto(const FunctionCallbackInfo<Value>& args) {
 // for internal use:
 //    dest._data = sliceOnto(source, dest, start, end);
 void SliceOnto(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope handle_scope(node_isolate);
 
   Local<Object> source = args[0].As<Object>();
   Local<Object> dest = args[1].As<Object>();
@@ -212,7 +212,7 @@ void SliceOnto(const FunctionCallbackInfo<Value>& args) {
 // for internal use:
 //    alloc(obj, n[, type]);
 void Alloc(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope handle_scope(node_isolate);
 
   Local<Object> obj = args[0].As<Object>();
 
@@ -250,7 +250,7 @@ void Alloc(Handle<Object> obj, size_t length, enum ExternalArrayType type) {
   char* data = static_cast<char*>(malloc(length));
   if (data == NULL) {
     FatalError("node::smalloc::Alloc(v8::Handle<v8::Object>, size_t,"
-        " ExternalArrayType)", "Out Of Memory");
+               " v8::ExternalArrayType)", "Out Of Memory");
   }
 
   Alloc(obj, data, length, type);
@@ -299,7 +299,7 @@ void AllocDispose(const FunctionCallbackInfo<Value>& args) {
 
 
 void AllocDispose(Handle<Object> obj) {
-  HandleScope scope(node_isolate);
+  HandleScope handle_scope(node_isolate);
 
   if (using_alloc_cb) {
     Local<Value> ext_v = obj->GetHiddenValue(smalloc_sym);

--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -47,11 +47,30 @@ NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
 NODE_EXTERN size_t ExternalArraySize(enum v8::ExternalArrayType type);
 
 /**
- * Allocate external memory and set to passed object. If data is passed then
- * will use that instead of allocating new.
+ * Allocate external array data onto obj.
  *
- * When you pass an ExternalArrayType and data, Alloc assumes data length is
- * the same as data length * ExternalArrayType length.
+ * Passed data transfers ownership, and if no callback is passed then memory
+ * will automatically be free'd using free() (not delete[]).
+ *
+ * length is always the byte size of the data. Not the length of the external
+ * array. This intentionally differs from the JS API so users always know
+ * exactly how much memory is being allocated, regardless of the external array
+ * type. For this reason the helper function ExternalArraySize is provided to
+ * help determine the appropriate byte size to be allocated.
+ *
+ * In the following example we're allocating a Float array and setting the
+ * "length" property on the Object:
+ *
+ * \code
+ *    size_t array_length = 8;
+ *    size_t byte_length = node::smalloc::ExternalArraySize(
+ *        v8::kExternalFloatArray);
+ *    v8::Local<v8::Object> obj = v8::Object::New();
+ *    char* data = static_cast<char*>(malloc(byte_length * array_length));
+ *    node::smalloc::Alloc(obj, data, byte_length, v8::kExternalFloatArray);
+ *    obj->Set(v8::String::NewFromUtf8("length"),
+ *             v8::Integer::NewFromUnsigned(array_length));
+ * \code
  */
 NODE_EXTERN void Alloc(v8::Handle<v8::Object> obj,
                        size_t length,

--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -42,6 +42,11 @@ static const unsigned int kMaxLength = 0x3fffffff;
 NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
 
 /**
+ * Return byte size of external array type.
+ */
+NODE_EXTERN size_t ExternalArraySize(enum v8::ExternalArrayType type);
+
+/**
  * Allocate external memory and set to passed object. If data is passed then
  * will use that instead of allocating new.
  *


### PR DESCRIPTION
`smalloc::Alloc()` expected the array length, despite array type, if no `char*` was passed, but the byte length of the data if it was. Fix so it always expects the byte length of the data.
