### PR TITLE
tls: fix assertion when ssl is destroyed at read

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -461,7 +461,12 @@ CryptoStream.prototype._read = function read(size) {
 
     // Get NPN and Server name when ready
     this.pair.maybeInitFinished();
-  } while (read > 0 && !this._buffer.isFull && bytesRead < size);
+
+    // `maybeInitFinished()` can emit the 'secure' event which
+    // in turn destroys the connection in case of authentication
+    // failure and sets `this.pair.ssl` to `null`.
+  } while (read > 0 && !this._buffer.isFull && bytesRead < size &&
+           this.pair.ssl !== null);
 
   // Create new buffer if previous was filled up
   var pool = this._buffer.pool;


### PR DESCRIPTION
`maybeInitFinished()` might invoke `secure` event which, in turn,
could lead to the destruction of connection. If such condition
appeared after non-empty read - loop will continue and `clearOut`
will be called on `null` object instead of `crypto::Connection`
instance. In the result, following assertion was thrown:

```
ERROR: Error: Hostname/IP doesn't match certificate's altnames
Assertion failed: handle->InternalFieldCount() > 0
```

fix #5756

/cc @bnoordhuis
