### PR TITLE
domain: move error handling directly into instance

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -54,8 +54,8 @@ process._setupDomainUse(_domain, _domain_flag);
 
 exports.Domain = Domain;
 
-exports.create = exports.createDomain = function(cb) {
-  return new Domain(cb);
+exports.create = exports.createDomain = function() {
+  return new Domain();
 };
 
 // it's possible to enter one domain while already inside
@@ -73,6 +73,58 @@ function Domain() {
 
   this.members = [];
 }
+
+Domain.prototype.members = undefined;
+Domain.prototype._disposed = undefined;
+
+// Called by process._fatalException in case an error was thrown.
+Domain.prototype._errorHandler = function errorHandler(er) {
+  var caught = false;
+  // ignore errors on disposed domains.
+  //
+  // XXX This is a bit stupid.  We should probably get rid of
+  // domain.dispose() altogether.  It's almost always a terrible
+  // idea.  --isaacs
+  if (this._disposed)
+    return true;
+
+  er.domain = this;
+  er.domainThrown = true;
+  // wrap this in a try/catch so we don't get infinite throwing
+  try {
+    // One of three things will happen here.
+    //
+    // 1. There is a handler, caught = true
+    // 2. There is no handler, caught = false
+    // 3. It throws, caught = false
+    //
+    // If caught is false after this, then there's no need to exit()
+    // the domain, because we're going to crash the process anyway.
+    caught = this.emit('error', er);
+
+    // Exit all domains on the stack.  Uncaught exceptions end the
+    // current tick and no domains should be left on the stack
+    // between ticks.
+    stack.length = 0;
+    exports.active = process.domain = null;
+  } catch (er2) {
+    // The domain error handler threw!  oh no!
+    // See if another domain can catch THIS error,
+    // or else crash on the original one.
+    // If the user already exited it, then don't double-exit.
+    if (this === exports.active) {
+      stack.pop();
+    }
+    if (stack.length) {
+      exports.active = process.domain = stack[stack.length - 1];
+      caught = process._fatalException(er2);
+    } else {
+      caught = false;
+    }
+    return caught;
+  }
+  return caught;
+};
 
 Domain.prototype.enter = function() {
   if (this._disposed) return;


### PR DESCRIPTION
Instead of doing all the domain handling in core, allow the domain to
set an error handler that'll take care of it all. This way the domain
error handling can be abstracted enough for any user to use it.
