### PR TITLE
buffer: adhere to INSPECT_MAX_BYTES

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -237,8 +237,12 @@ Buffer.prototype.toString = function(encoding, start, end) {
 // Inspect
 Buffer.prototype.inspect = function inspect() {
   var str = '';
-  if (this.length > 0)
-    str = this.hexSlice(0, this.length).match(/.{2}/g).join(' ');
+  var max = exports.INSPECT_MAX_BYTES;
+  if (this.length > 0) {
+    str = this.hexSlice(0, max).match(/.{2}/g).join(' ');
+    if (this.length > max)
+      str += ' ... ';
+  }
   return '<' + this.constructor.name + ' ' + str + '>';
 };
 

--- a/test/simple/test-buffer-inspect.js
+++ b/test/simple/test-buffer-inspect.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var util = require('util');
+
+var buffer = require('buffer');
+
+buffer.INSPECT_MAX_BYTES = 2;
+
+var b = new Buffer(4);
+b.fill('1234');
+
+var s = new buffer.SlowBuffer(4);
+s.fill('1234');
+
+var expected = '<Buffer 31 32 ... >';
+
+assert.strictEqual(util.inspect(b), expected);
+assert.strictEqual(util.inspect(s), expected);
+
+b = new Buffer(2);
+b.fill('12');
+
+s = new buffer.SlowBuffer(2);
+s.fill('12');
+
+expected = '<Buffer 31 32>';
+
+assert.strictEqual(util.inspect(b), expected);
+assert.strictEqual(util.inspect(s), expected);


### PR DESCRIPTION
During the buffer revamping `Buffer.prototype.inspect` stopped limiting how many bytes were inspected for `util.inspect`

Re-add this functionality.

/cc @trevnorris
