### PR TITLE
Proposal: move lazy initialization deeper in timers module

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -19,7 +19,16 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var Timer = process.binding('timer_wrap').Timer;
+// Mimic Timer until it is really needed
+var Timer = function() {
+  Timer = process.binding('timer_wrap').Timer;
+  return new Timer();
+};
+Timer.now = function() {
+  Timer = process.binding('timer_wrap').Timer;
+  return Timer.now();
+};
+
 var L = require('_linklist');
 var assert = require('assert').ok;
 

--- a/src/node.js
+++ b/src/node.js
@@ -168,35 +168,13 @@
   };
 
   startup.globalTimeouts = function() {
-    global.setTimeout = function() {
-      var t = NativeModule.require('timers');
-      return t.setTimeout.apply(this, arguments);
-    };
-
-    global.setInterval = function() {
-      var t = NativeModule.require('timers');
-      return t.setInterval.apply(this, arguments);
-    };
-
-    global.clearTimeout = function() {
-      var t = NativeModule.require('timers');
-      return t.clearTimeout.apply(this, arguments);
-    };
-
-    global.clearInterval = function() {
-      var t = NativeModule.require('timers');
-      return t.clearInterval.apply(this, arguments);
-    };
-
-    global.setImmediate = function() {
-      var t = NativeModule.require('timers');
-      return t.setImmediate.apply(this, arguments);
-    };
-
-    global.clearImmediate = function() {
-      var t = NativeModule.require('timers');
-      return t.clearImmediate.apply(this, arguments);
-    };
+    var t = NativeModule.require('timers');
+    global.setTimeout = t.setTimeout;
+    global.setInterval = t.setInterval;
+    global.clearTimeout = t.clearTimeout;
+    global.clearInterval = t.clearInterval;
+    global.setImmediate = t.setImmediate;
+    global.clearImmediate = t.clearImmediate;
   };
 
   startup.globalConsole = function() {


### PR DESCRIPTION
There are wraps in `global.setTimeout`, `global.setInterval` etc. So if `setTimeout` is invoked, two excessive function calls are made. The reason, as far as I can understand, is lazy load.

There's a proposal: move lazy timers initialization into timers module itself.

But there's, uh, an side effect. Currently node startup is slightly faster, the main loop may be spontaneously (again, slightly) additional blocked in order to init timers. May I ask about the "strategy", what is the priority, to make node startup faster or to run smoother?
