### PR TITLE
child_process: spawn optional process arguments

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -696,7 +696,17 @@ exports.execFile = function(file /* args, options, callback */) {
 };
 
 
-var spawn = exports.spawn = function(file, args, options) {
+var spawn = exports.spawn = function(file /*, args, options*/) {
+  var args, options;
+
+  if (util.isObject(arguments[1]) && !util.isArray(arguments[1])) {
+    args = undefined;
+    options = arguments[1];
+  } else {
+    args = arguments[1];
+    options = arguments[2];
+  }
+
   args = args ? args.slice(0) : [];
   args.unshift(file);
 

--- a/test/common.js
+++ b/test/common.js
@@ -67,9 +67,9 @@ exports.spawnCat = function(options) {
   var spawn = require('child_process').spawn;
 
   if (process.platform === 'win32') {
-    return spawn('more', [], options);
+    return spawn('more', options);
   } else {
-    return spawn('cat', [], options);
+    return spawn('cat', options);
   }
 };
 
@@ -80,7 +80,7 @@ exports.spawnPwd = function(options) {
   if (process.platform === 'win32') {
     return spawn('cmd.exe', ['/c', 'cd'], options);
   } else {
-    return spawn('pwd', [], options);
+    return spawn('pwd', options);
   }
 };
 

--- a/test/disabled/test-child-process-uid-gid.js
+++ b/test/disabled/test-child-process-uid-gid.js
@@ -57,8 +57,8 @@ if (!otherUid && !otherGid) throw new Error('failed getting passwd info.');
 
 console.error('name, id, gid = %j', [otherName, otherUid, otherGid]);
 
-var whoNumber = spawn('id', [], { uid: otherUid, gid: otherGid });
-var whoName = spawn('id', [], { uid: otherName, gid: otherGid });
+var whoNumber = spawn('id', { uid: otherUid, gid: otherGid });
+var whoName = spawn('id', { uid: otherName, gid: otherGid });
 
 whoNumber.stdout.buf = 'byNumber:';
 whoName.stdout.buf = 'byName:';

--- a/test/simple/test-child-process-env.js
+++ b/test/simple/test-child-process-env.js
@@ -36,7 +36,7 @@ env.__proto__ = {
 if (isWindows) {
   var child = spawn('cmd.exe', ['/c', 'set'], {env: env});
 } else {
-  var child = spawn('/usr/bin/env', [], {env: env});
+  var child = spawn('/usr/bin/env', {env: env});
 }
 
 

--- a/test/simple/test-stdin-script-child.js
+++ b/test/simple/test-stdin-script-child.js
@@ -23,7 +23,7 @@ var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;
-var child = spawn(process.execPath, [], {
+var child = spawn(process.execPath, {
   env: {
     NODE_DEBUG: process.argv[2]
   }


### PR DESCRIPTION
`child_process.spawn` required an empty arguments array if also using options. This removes that requirement.

`spawn(command, [], options)` -> `spawn(command, options)`

Fixes #6068.  The documentation already implies that `args` is optional so no update needed.  The patch was done against `master` but will apply cleanly against `0.10.x` if required.
