### PR TITLE
test: Check that stream events are not emitted too soon

### DIFF
--- a/test/simple/test-stream2-basic.js
+++ b/test/simple/test-stream2-basic.js
@@ -466,6 +466,7 @@ test('adding readable triggers data flow', function(t) {
     onReadable = true;
     r.read();
   });
+  t.ok(!onReadable);
 
   r.on('end', function() {
     t.equal(readCalled, 3);

--- a/test/simple/test-stream2-compatibility.js
+++ b/test/simple/test-stream2-compatibility.js
@@ -47,6 +47,7 @@ TestReader.prototype._read = function(n) {
 };
 
 var reader = new TestReader();
+assert.equal(ondataCalled, 0);
 setImmediate(function() {
   assert.equal(ondataCalled, 1);
   console.log('ok');


### PR DESCRIPTION
Add some test that explicitly validates that listeners are not called before nextTick.

These are highly relevant to test since `Readable` streams override the `on()` method, and currently [_fails the updated compatibility test_](https://github.com/joyent/node/issues/6105) when applied to the stable 0.10 branch.
