### PR TITLE
stream: Change default highWaterMark for objectMode to 16 instead of 16384

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -36,7 +36,8 @@ function ReadableState(options, stream) {
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : (options.objectMode ? 16 : 16 * 1024);
+  var defaultHwm = options.objectMode ? 16 : 16 * 1024;
+  this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.
   this.highWaterMark = ~~this.highWaterMark;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -36,7 +36,7 @@ function ReadableState(options, stream) {
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
+  this.highWaterMark = (hwm || hwm === 0) ? hwm : (options.objectMode ? 16 : 16 * 1024);
 
   // cast to ints.
   this.highWaterMark = ~~this.highWaterMark;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -44,7 +44,7 @@ function WritableState(options, stream) {
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : 16 * 1024;
+  this.highWaterMark = (hwm || hwm === 0) ? hwm : (options.objectMode ? 16 : 16 * 1024);
 
   // object stream flag to indicate whether or not this stream
   // contains buffers or objects.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -44,7 +44,8 @@ function WritableState(options, stream) {
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : (options.objectMode ? 16 : 16 * 1024);
+  var defaultHwm = options.objectMode ? 16 : 16 * 1024;
+  this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // object stream flag to indicate whether or not this stream
   // contains buffers or objects.


### PR DESCRIPTION
Currently streams with `objectMode:true` share the same default highWaterMark as regular streams.
This means that they will buffer up to 16384 objects which seams quite excessive.

``` js
var rs = new (require('stream').Readable)({objectMode:true});
var buffered = 0;
rs._read = function() {
  console.log('buffered:', buffered++, 'objects');
  rs.push({hello:'world'});
};
rs.read(); // buffers 16384 objects
```

This PR changes the default highWaterMark when using objectMode to 16 which seams more reasonable.
