### PR TITLE
Transform: prevent endless pipe loop

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -133,6 +133,14 @@ function Transform(options) {
     else
       done(stream);
   });
+
+  // prevent potentially infinite loop
+  this.on('pipe', function(src) {
+    if (this === src) {
+      this.unpipe(this);
+      throw new Error('Cannot pipe Transform onto itself');
+    }
+  });
 }
 
 Transform.prototype.push = function(chunk, encoding) {


### PR DESCRIPTION
This is for the (absurd) case where a Transform(or PassThrough) stream is piped into itself.

```
var through = new stream.PassThrough();
through.pipe(through);
through.write("hello world"); // infinite loop
```

The patch will:

-prevent the process to freeze;
-prevent the pipe action;
-throw an error
