### PR TITLE
util.is* functions: Remove context switch

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -27,6 +27,12 @@ var util = require('util'),
     inherits = util.inherits,
     spawn = require('child_process').spawn;
 
+var isArray = util.isArray,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 exports.start = function(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));
 
@@ -182,7 +188,7 @@ exports.Client = Client;
 
 
 Client.prototype._addHandle = function(desc) {
-  if (!util.isObject(desc) || !util.isNumber(desc.handle)) {
+  if (!isObject(desc) || !isNumber(desc.handle)) {
     return;
   }
 
@@ -296,7 +302,7 @@ Client.prototype.reqLookup = function(refs, cb) {
   this.req(req, function(err, res) {
     if (err) return cb(err);
     for (var ref in res) {
-      if (util.isObject(res[ref])) {
+      if (isObject(res[ref])) {
         self._addHandle(res[ref]);
       }
     }
@@ -559,7 +565,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
         }
 
 
-        if (util.isArray(mirror) && !util.isNumber(prop.name)) {
+        if (isArray(mirror) && !isNumber(prop.name)) {
           // Skip the 'length' property.
           return;
         }
@@ -592,7 +598,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
     val = function() {};
   } else if (handle.type === 'null') {
     val = null;
-  } else if (!util.isUndefined(handle.value)) {
+  } else if (!isUndefined(handle.value)) {
     val = handle.value;
   } else if (handle.type === 'undefined') {
     val = undefined;
@@ -890,7 +896,7 @@ Interface.prototype.print = function(text, oneline) {
   if (this.killed) return;
   this.clearline();
 
-  this.stdout.write(util.isString(text) ? text : util.inspect(text));
+  this.stdout.write(isString(text) ? text : util.inspect(text));
 
   if (oneline !== true) {
     this.stdout.write('\n');
@@ -1212,7 +1218,7 @@ Interface.prototype.scripts = function() {
   this.pause();
   for (var id in client.scripts) {
     var script = client.scripts[id];
-    if (util.isObject(script) && script.name) {
+    if (isObject(script) && script.name) {
       if (displayNatives ||
           script.name == client.currentScript ||
           !script.isNative) {
@@ -1349,13 +1355,13 @@ Interface.prototype.setBreakpoint = function(script, line,
       ambiguous;
 
   // setBreakpoint() should insert breakpoint on current line
-  if (util.isUndefined(script)) {
+  if (isUndefined(script)) {
     script = this.client.currentScript;
     line = this.client.currentSourceLine + 1;
   }
 
   // setBreakpoint(line-number) should insert breakpoint in current script
-  if (util.isUndefined(line) && util.isNumber(script)) {
+  if (isUndefined(line) && isNumber(script)) {
     line = script;
     script = this.client.currentScript;
   }
@@ -1450,7 +1456,7 @@ Interface.prototype.clearBreakpoint = function(script, line) {
     if (bp.scriptId === script ||
         bp.scriptReq === script ||
         (bp.script && bp.script.indexOf(script) !== -1)) {
-      if (!util.isUndefined(index)) {
+      if (!isUndefined(index)) {
         ambiguous = true;
       }
       if (bp.line === line) {
@@ -1463,7 +1469,7 @@ Interface.prototype.clearBreakpoint = function(script, line) {
 
   if (ambiguous) return this.error('Script name is ambiguous');
 
-  if (util.isUndefined(breakpoint)) {
+  if (isUndefined(breakpoint)) {
     return this.error('Script : ' + script + ' not found');
   }
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -22,6 +22,7 @@
 var net = require('net');
 var url = require('url');
 var util = require('util');
+var isString = util.isString;
 var EventEmitter = require('events').EventEmitter;
 var ClientRequest = require('_http_client').ClientRequest;
 var debug = util.debuglog('http');
@@ -260,7 +261,7 @@ Agent.prototype.destroy = function() {
 };
 
 Agent.prototype.request = function(options, cb) {
-  if (util.isString(options)) {
+  if (isString(options)) {
     options = url.parse(options);
   }
   // don't try to do dns lookups of foo.com:8080, just foo.com

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -20,6 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var util = require('util');
+
+var isArray = util.isArray,
+    isNumber = util.isNumber,
+    isUndefined = util.isUndefined;
+
 var net = require('net');
 var EventEmitter = require('events').EventEmitter;
 var HTTPParser = process.binding('http_parser').HTTPParser;
@@ -45,14 +50,14 @@ function ClientRequest(options, cb) {
 
   options = util._extend({}, options);
 
-  self.agent = util.isUndefined(options.agent) ? globalAgent : options.agent;
+  self.agent = isUndefined(options.agent) ? globalAgent : options.agent;
 
   var defaultPort = options.defaultPort || self.agent.defaultPort;
 
   var port = options.port = options.port || defaultPort;
   var host = options.host = options.hostname || options.host || 'localhost';
 
-  if (util.isUndefined(options.setHost)) {
+  if (isUndefined(options.setHost)) {
     var setHost = true;
   }
 
@@ -64,7 +69,7 @@ function ClientRequest(options, cb) {
     self.once('response', cb);
   }
 
-  if (!util.isArray(options.headers)) {
+  if (!isArray(options.headers)) {
     if (options.headers) {
       var keys = Object.keys(options.headers);
       for (var i = 0, l = keys.length; i < l; i++) {
@@ -93,7 +98,7 @@ function ClientRequest(options, cb) {
     self.useChunkedEncodingByDefault = true;
   }
 
-  if (util.isArray(options.headers)) {
+  if (isArray(options.headers)) {
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
                       options.headers);
   } else if (self.getHeader('expect')) {
@@ -421,7 +426,7 @@ ClientRequest.prototype.onSocket = function(socket) {
     httpSocketSetup(socket);
 
     // Propagate headers limit from request object to parser
-    if (util.isNumber(req.maxHeadersCount)) {
+    if (isNumber(req.maxHeadersCount)) {
       parser.maxHeaderPairs = req.maxHeadersCount << 1;
     } else {
       // Set default value because parser may be reused from FreeList

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var util = require('util');
+var isUndefined = util.isUndefined;
+
 var Stream = require('stream');
 
 function readStart(socket) {
@@ -146,7 +148,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
   switch (field) {
     // Array headers:
     case 'set-cookie':
-      if (!util.isUndefined(dest[field])) {
+      if (!isUndefined(dest[field])) {
         dest[field].push(value);
       } else {
         dest[field] = [value];
@@ -166,7 +168,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
     case 'proxy-authenticate':
     case 'sec-websocket-extensions':
     case 'sec-websocket-protocol':
-      if (!util.isUndefined(dest[field])) {
+      if (!isUndefined(dest[field])) {
         dest[field] += ', ' + value;
       } else {
         dest[field] = value;
@@ -177,14 +179,14 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
     default:
       if (field.slice(0, 2) == 'x-') {
         // except for x-
-        if (!util.isUndefined(dest[field])) {
+        if (!isUndefined(dest[field])) {
           dest[field] += ', ' + value;
         } else {
           dest[field] = value;
         }
       } else {
         // drop duplicates
-        if (util.isUndefined(dest[field])) dest[field] = value;
+        if (isUndefined(dest[field])) dest[field] = value;
       }
       break;
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -24,6 +24,11 @@ var Stream = require('stream');
 var timers = require('timers');
 var util = require('util');
 
+var isArray = util.isArray,
+    isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isString = util.isString;
+
 var common = require('_http_common');
 
 var CRLF = common.CRLF;
@@ -123,7 +128,7 @@ OutgoingMessage.prototype._send = function(data, encoding, callback) {
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.
   if (!this._headerSent) {
-    if (util.isString(data) &&
+    if (isString(data) &&
         encoding !== 'hex' &&
         encoding !== 'base64') {
       data = this._header + data;
@@ -139,13 +144,13 @@ OutgoingMessage.prototype._send = function(data, encoding, callback) {
 
 
 OutgoingMessage.prototype._writeRaw = function(data, encoding, callback) {
-  if (util.isFunction(encoding)) {
+  if (isFunction(encoding)) {
     callback = encoding;
     encoding = null;
   }
 
   if (data.length === 0) {
-    if (util.isFunction(callback))
+    if (isFunction(callback))
       process.nextTick(callback);
     return true;
   }
@@ -204,12 +209,12 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
 
   if (headers) {
     var keys = Object.keys(headers);
-    var isArray = util.isArray(headers);
+    var isArr = isArray(headers);
     var field, value;
 
     for (var i = 0, l = keys.length; i < l; i++) {
       var key = keys[i];
-      if (isArray) {
+      if (isArr) {
         field = headers[key][0];
         value = headers[key][1];
       } else {
@@ -217,7 +222,7 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
         value = headers[key];
       }
 
-      if (util.isArray(value)) {
+      if (isArray(value)) {
         for (var j = 0; j < value.length; j++) {
           storeHeader(this, state, field, value[j]);
         }
@@ -413,7 +418,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
     return true;
   }
 
-  if (!util.isString(chunk) && !util.isBuffer(chunk)) {
+  if (!isString(chunk) && !isBuffer(chunk)) {
     throw new TypeError('first argument must be a string or Buffer');
   }
 
@@ -424,7 +429,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
 
   var len, ret;
   if (this.chunkedEncoding) {
-    if (util.isString(chunk) &&
+    if (isString(chunk) &&
         encoding !== 'hex' &&
         encoding !== 'base64' &&
         encoding !== 'binary') {
@@ -433,7 +438,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
       ret = this._send(chunk, encoding, callback);
     } else {
       // buffer, or a non-toString-friendly encoding
-      if (util.isString(chunk))
+      if (isString(chunk))
         len = Buffer.byteLength(chunk, encoding);
       else
         len = chunk.length;
@@ -459,11 +464,11 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
 OutgoingMessage.prototype.addTrailers = function(headers) {
   this._trailer = '';
   var keys = Object.keys(headers);
-  var isArray = util.isArray(headers);
+  var isArr = isArray(headers);
   var field, value;
   for (var i = 0, l = keys.length; i < l; i++) {
     var key = keys[i];
-    if (isArray) {
+    if (isArr) {
       field = headers[key][0];
       value = headers[key][1];
     } else {
@@ -480,15 +485,15 @@ var crlf_buf = new Buffer('\r\n');
 
 
 OutgoingMessage.prototype.end = function(data, encoding, callback) {
-  if (util.isFunction(data)) {
+  if (isFunction(data)) {
     callback = data;
     data = null;
-  } else if (util.isFunction(encoding)) {
+  } else if (isFunction(encoding)) {
     callback = encoding;
     encoding = null;
   }
 
-  if (data && !util.isString(data) && !util.isBuffer(data)) {
+  if (data && !isString(data) && !isBuffer(data)) {
     throw new TypeError('first argument must be a string or Buffer');
   }
 
@@ -501,7 +506,7 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
     self.emit('finish');
   }
 
-  if (util.isFunction(callback))
+  if (isFunction(callback))
     this.once('finish', callback);
 
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -20,6 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var util = require('util');
+
+var isArray = util.isArray,
+    isNumber = util.isNumber,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var net = require('net');
 var EventEmitter = require('events').EventEmitter;
 var HTTPParser = process.binding('http_parser').HTTPParser;
@@ -173,7 +179,7 @@ ServerResponse.prototype._implicitHeader = function() {
 ServerResponse.prototype.writeHead = function(statusCode) {
   var reasonPhrase, headers, headerIndex;
 
-  if (util.isString(arguments[1])) {
+  if (isString(arguments[1])) {
     reasonPhrase = arguments[1];
     headerIndex = 2;
   } else {
@@ -188,13 +194,13 @@ ServerResponse.prototype.writeHead = function(statusCode) {
     // Slow-case: when progressive API and header fields are passed.
     headers = this._renderHeaders();
 
-    if (util.isArray(obj)) {
+    if (isArray(obj)) {
       // handle array case
       // TODO: remove when array is no longer accepted
       var field;
       for (var i = 0, len = obj.length; i < len; ++i) {
         field = obj[i][0];
-        if (!util.isUndefined(headers[field])) {
+        if (!isUndefined(headers[field])) {
           obj.push([field, headers[field]]);
         }
       }
@@ -332,7 +338,7 @@ function connectionListener(socket) {
   parser.incoming = null;
 
   // Propagate headers limit from server instance to parser
-  if (util.isNumber(this.maxHeadersCount)) {
+  if (isNumber(this.maxHeadersCount)) {
     parser.maxHeaderPairs = this.maxHeadersCount << 1;
   } else {
     // Set default value because parser may be reused from FreeList
@@ -457,7 +463,7 @@ function connectionListener(socket) {
       }
     }
 
-    if (!util.isUndefined(req.headers.expect) &&
+    if (!isUndefined(req.headers.expect) &&
         (req.httpVersionMajor == 1 && req.httpVersionMinor == 1) &&
         continueExpression.test(req.headers['expect'])) {
       res._expect_continue = true;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -25,6 +25,15 @@ Readable.ReadableState = ReadableState;
 var EE = require('events').EventEmitter;
 var Stream = require('stream');
 var util = require('util');
+
+var isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isNull = util.isNull,
+    isNullOrUndefined = util.isNullOrUndefined,
+    isNumber = util.isNumber,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var StringDecoder;
 var debug = util.debuglog('stream');
 
@@ -111,7 +120,7 @@ function Readable(options) {
 Readable.prototype.push = function(chunk, encoding) {
   var state = this._readableState;
 
-  if (util.isString(chunk) && !state.objectMode) {
+  if (isString(chunk) && !state.objectMode) {
     encoding = encoding || state.defaultEncoding;
     if (encoding !== state.encoding) {
       chunk = new Buffer(chunk, encoding);
@@ -132,7 +141,7 @@ function readableAddChunk(stream, state, chunk, encoding, addToFront) {
   var er = chunkInvalid(state, chunk);
   if (er) {
     stream.emit('error', er);
-  } else if (util.isNullOrUndefined(chunk)) {
+  } else if (isNullOrUndefined(chunk)) {
     state.reading = false;
     if (!state.ended)
       onEofChunk(stream, state);
@@ -220,7 +229,7 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return n === 0 ? 0 : 1;
 
-  if (isNaN(n) || util.isNull(n)) {
+  if (isNaN(n) || isNull(n)) {
     // only flow one buffer at a time
     if (state.flowing && state.buffer.length)
       return state.buffer[0].length;
@@ -256,7 +265,7 @@ Readable.prototype.read = function(n) {
   var state = this._readableState;
   var nOrig = n;
 
-  if (!util.isNumber(n) || n > 0)
+  if (!isNumber(n) || n > 0)
     state.emittedReadable = false;
 
   // if we're doing read(0) to trigger a readable event, but we
@@ -344,7 +353,7 @@ Readable.prototype.read = function(n) {
   else
     ret = null;
 
-  if (util.isNull(ret)) {
+  if (isNull(ret)) {
     state.needReadable = true;
     n = 0;
   }
@@ -360,7 +369,7 @@ Readable.prototype.read = function(n) {
   if (nOrig !== n && state.ended && state.length === 0)
     endReadable(this);
 
-  if (!util.isNull(ret))
+  if (!isNull(ret))
     this.emit('data', ret);
 
   return ret;
@@ -368,9 +377,9 @@ Readable.prototype.read = function(n) {
 
 function chunkInvalid(state, chunk) {
   var er = null;
-  if (!util.isBuffer(chunk) &&
-      !util.isString(chunk) &&
-      !util.isNullOrUndefined(chunk) &&
+  if (!isBuffer(chunk) &&
+      !isString(chunk) &&
+      !isNullOrUndefined(chunk) &&
       !state.objectMode &&
       !er) {
     er = new TypeError('Invalid non-string/buffer chunk');
@@ -777,7 +786,7 @@ Readable.prototype.wrap = function(stream) {
   // proxy all the other methods.
   // important when wrapping filters and duplexes.
   for (var i in stream) {
-    if (util.isFunction(stream[i]) && util.isUndefined(this[i])) {
+    if (isFunction(stream[i]) && isUndefined(this[i])) {
       this[i] = function(method) { return function() {
         return stream[method].apply(stream, arguments);
       }}(i);

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -66,6 +66,10 @@ module.exports = Transform;
 
 var Duplex = require('_stream_duplex');
 var util = require('util');
+var isFunction = util.isFunction,
+    isNull = util.isNull,
+    isNullOrUndefined = util.isNullOrUndefined;
+
 util.inherits(Transform, Duplex);
 
 
@@ -92,7 +96,7 @@ function afterTransform(stream, er, data) {
   ts.writechunk = null;
   ts.writecb = null;
 
-  if (!util.isNullOrUndefined(data))
+  if (!isNullOrUndefined(data))
     stream.push(data);
 
   if (cb)
@@ -126,7 +130,7 @@ function Transform(options) {
   this._readableState.sync = false;
 
   this.once('prefinish', function() {
-    if (util.isFunction(this._flush))
+    if (isFunction(this._flush))
       this._flush(function(er) {
         done(stream, er);
       });
@@ -174,7 +178,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 Transform.prototype._read = function(n) {
   var ts = this._transformState;
 
-  if (!util.isNull(ts.writechunk) && ts.writecb && !ts.transforming) {
+  if (!isNull(ts.writechunk) && ts.writecb && !ts.transforming) {
     ts.transforming = true;
     this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -27,6 +27,11 @@ module.exports = Writable;
 Writable.WritableState = WritableState;
 
 var util = require('util');
+var isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isNullOrUndefined = util.isNullOrUndefined,
+    isString = util.isString;
+
 var Stream = require('stream');
 
 util.inherits(Writable, Stream);
@@ -152,9 +157,9 @@ function writeAfterEnd(stream, state, cb) {
 // how many bytes or characters.
 function validChunk(stream, state, chunk, cb) {
   var valid = true;
-  if (!util.isBuffer(chunk) &&
-      !util.isString(chunk) &&
-      !util.isNullOrUndefined(chunk) &&
+  if (!isBuffer(chunk) &&
+      !isString(chunk) &&
+      !isNullOrUndefined(chunk) &&
       !state.objectMode) {
     var er = new TypeError('Invalid non-string/buffer chunk');
     stream.emit('error', er);
@@ -170,17 +175,17 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
 
-  if (util.isFunction(encoding)) {
+  if (isFunction(encoding)) {
     cb = encoding;
     encoding = null;
   }
 
-  if (util.isBuffer(chunk))
+  if (isBuffer(chunk))
     encoding = 'buffer';
   else if (!encoding)
     encoding = state.defaultEncoding;
 
-  if (!util.isFunction(cb))
+  if (!isFunction(cb))
     cb = function() {};
 
   if (state.ended)
@@ -217,7 +222,7 @@ Writable.prototype.uncork = function() {
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&
-      util.isString(chunk)) {
+      isString(chunk)) {
     chunk = new Buffer(chunk, encoding);
   }
   return chunk;
@@ -228,7 +233,7 @@ function decodeChunk(state, chunk, encoding) {
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, chunk, encoding, cb) {
   chunk = decodeChunk(state, chunk, encoding);
-  if (util.isBuffer(chunk))
+  if (isBuffer(chunk))
     encoding = 'buffer';
   var len = state.objectMode ? 1 : chunk.length;
 
@@ -389,16 +394,16 @@ Writable.prototype._writev = null;
 Writable.prototype.end = function(chunk, encoding, cb) {
   var state = this._writableState;
 
-  if (util.isFunction(chunk)) {
+  if (isFunction(chunk)) {
     cb = chunk;
     chunk = null;
     encoding = null;
-  } else if (util.isFunction(encoding)) {
+  } else if (isFunction(encoding)) {
     cb = encoding;
     encoding = null;
   }
 
-  if (!util.isNullOrUndefined(chunk))
+  if (!isNullOrUndefined(chunk))
     this.write(chunk, encoding);
 
   // .end() fully uncorks

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -1,3 +1,24 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 var assert = require('assert');
 var crypto = require('crypto');
 var events = require('events');

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -4,6 +4,7 @@ var events = require('events');
 var stream = require('stream');
 var tls = require('tls');
 var util = require('util');
+var isNull = util.isNull;
 
 var Timer = process.binding('timer_wrap').Timer;
 var Connection = null;
@@ -36,7 +37,7 @@ SlabBuffer.prototype.use = function use(context, fn, size) {
 
   var actualSize = this.remaining;
 
-  if (!util.isNull(size)) actualSize = Math.min(size, actualSize);
+  if (!isNull(size)) actualSize = Math.min(size, actualSize);
 
   var bytes = fn.call(context, this.pool, this.offset, actualSize);
   if (bytes > 0) {
@@ -72,7 +73,7 @@ function CryptoStream(pair, options) {
   this._finished = false;
   this._opposite = null;
 
-  if (util.isNull(slabBuffer)) slabBuffer = new SlabBuffer();
+  if (isNull(slabBuffer)) slabBuffer = new SlabBuffer();
   this._buffer = slabBuffer;
 
   this.once('finish', onCryptoStreamFinish);
@@ -142,7 +143,7 @@ CryptoStream.prototype.init = function init() {
 
 
 CryptoStream.prototype._write = function write(data, encoding, cb) {
-  assert(util.isNull(this._pending));
+  assert(isNull(this._pending));
 
   // Black-hole data
   if (!this.pair.ssl) return cb(null);
@@ -189,7 +190,7 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
 
       // Invoke callback only when all data read from opposite stream
       if (this._opposite._halfRead) {
-        assert(util.isNull(this._sslOutCb));
+        assert(isNull(this._sslOutCb));
         this._sslOutCb = cb;
       } else {
         cb(null);
@@ -290,8 +291,8 @@ CryptoStream.prototype._read = function read(size) {
   }
 
   // Try writing pending data
-  if (!util.isNull(this._pending)) this._writePending();
-  if (!util.isNull(this._opposite._pending)) this._opposite._writePending();
+  if (!isNull(this._pending)) this._writePending();
+  if (!isNull(this._opposite._pending)) this._opposite._writePending();
 
   if (bytesRead === 0) {
     // EOF when cleartext has finished and we have nothing to read
@@ -400,7 +401,7 @@ CryptoStream.prototype.end = function(chunk, encoding) {
   }
 
   // Write pending data first
-  if (!util.isNull(this._pending)) this._writePending();
+  if (!isNull(this._pending)) this._writePending();
 
   this.writable = false;
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1,3 +1,24 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 var assert = require('assert');
 var constants = require('constants');
 var crypto = require('crypto');

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -5,6 +5,13 @@ var net = require('net');
 var tls = require('tls');
 var util = require('util');
 
+var isBoolean = util.isBoolean,
+    isFunction = util.isFunction,
+    isNull = util.isNull,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString;
+
 var Timer = process.binding('timer_wrap').Timer;
 var tls_wrap = process.binding('tls_wrap');
 
@@ -263,7 +270,7 @@ TLSSocket.prototype.setServername = function(name) {
 };
 
 TLSSocket.prototype.setSession = function(session) {
-  if (util.isString(session))
+  if (isString(session))
     session = new Buffer(session, 'binary');
   this.ssl.setSession(session);
 };
@@ -375,10 +382,10 @@ TLSSocket.prototype.getCipher = function(err) {
 //
 function Server(/* [options], listener */) {
   var options, listener;
-  if (util.isObject(arguments[0])) {
+  if (isObject(arguments[0])) {
     options = arguments[0];
     listener = arguments[1];
-  } else if (util.isFunction(arguments[0])) {
+  } else if (isFunction(arguments[0])) {
     options = {};
     listener = arguments[0];
   }
@@ -412,7 +419,7 @@ function Server(/* [options], listener */) {
 
   var timeout = options.handshakeTimeout || (120 * 1000);
 
-  if (!util.isNumber(timeout)) {
+  if (!isNumber(timeout)) {
     throw new TypeError('handshakeTimeout must be a number');
   }
 
@@ -496,13 +503,13 @@ Server.prototype._setServerData = function(data) {
 
 
 Server.prototype.setOptions = function(options) {
-  if (util.isBoolean(options.requestCert)) {
+  if (isBoolean(options.requestCert)) {
     this.requestCert = options.requestCert;
   } else {
     this.requestCert = false;
   }
 
-  if (util.isBoolean(options.rejectUnauthorized)) {
+  if (isBoolean(options.rejectUnauthorized)) {
     this.rejectUnauthorized = options.rejectUnauthorized;
   } else {
     this.rejectUnauthorized = false;
@@ -549,7 +556,7 @@ function SNICallback(servername, callback) {
   var ctx;
 
   this.server._contexts.some(function(elem) {
-    if (!util.isNull(servername.match(elem[0]))) {
+    if (!isNull(servername.match(elem[0]))) {
       ctx = elem[1];
       return true;
     }
@@ -578,9 +585,9 @@ function normalizeConnectArgs(listArgs) {
   var options = args[0];
   var cb = args[1];
 
-  if (util.isObject(listArgs[1])) {
+  if (isObject(listArgs[1])) {
     options = util._extend(options, listArgs[1]);
-  } else if (util.isObject(listArgs[2])) {
+  } else if (isObject(listArgs[2])) {
     options = util._extend(options, listArgs[2]);
   }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -24,6 +24,17 @@
 
 // UTILITY
 var util = require('util');
+
+var isBuffer = util.isBuffer,
+    isDate = util.isDate,
+    isFunction = util.isFunction,
+    isNullOrUndefined = util.isNullOrUndefined,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isRegExp = util.isRegExp,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var pSlice = Array.prototype.slice;
 
 // 1. The assert module provides functions that throw
@@ -51,20 +62,20 @@ assert.AssertionError = function AssertionError(options) {
 util.inherits(assert.AssertionError, Error);
 
 function replacer(key, value) {
-  if (util.isUndefined(value)) {
+  if (isUndefined(value)) {
     return '' + value;
   }
-  if (util.isNumber(value) && (isNaN(value) || !isFinite(value))) {
+  if (isNumber(value) && (isNaN(value) || !isFinite(value))) {
     return value.toString();
   }
-  if (util.isFunction(value) || util.isRegExp(value)) {
+  if (isFunction(value) || isRegExp(value)) {
     return value.toString();
   }
   return value;
 }
 
 function truncate(s, n) {
-  if (util.isString(s)) {
+  if (isString(s)) {
     return s.length < n ? s : s.slice(0, n);
   } else {
     return s;
@@ -144,7 +155,7 @@ function _deepEqual(actual, expected) {
   if (actual === expected) {
     return true;
 
-  } else if (util.isBuffer(actual) && util.isBuffer(expected)) {
+  } else if (isBuffer(actual) && isBuffer(expected)) {
     if (actual.length != expected.length) return false;
 
     for (var i = 0; i < actual.length; i++) {
@@ -155,13 +166,13 @@ function _deepEqual(actual, expected) {
 
   // 7.2. If the expected value is a Date object, the actual value is
   // equivalent if it is also a Date object that refers to the same time.
-  } else if (util.isDate(actual) && util.isDate(expected)) {
+  } else if (isDate(actual) && isDate(expected)) {
     return actual.getTime() === expected.getTime();
 
   // 7.3 If the expected value is a RegExp object, the actual value is
   // equivalent if it is also a RegExp object with the same source and
   // properties (`global`, `multiline`, `lastIndex`, `ignoreCase`).
-  } else if (util.isRegExp(actual) && util.isRegExp(expected)) {
+  } else if (isRegExp(actual) && isRegExp(expected)) {
     return actual.source === expected.source &&
            actual.global === expected.global &&
            actual.multiline === expected.multiline &&
@@ -170,7 +181,7 @@ function _deepEqual(actual, expected) {
 
   // 7.4. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
-  } else if (!util.isObject(actual) && !util.isObject(expected)) {
+  } else if (!isObject(actual) && !isObject(expected)) {
     return actual == expected;
 
   // 7.5 For all other Object pairs, including Array objects, equivalence is
@@ -189,7 +200,7 @@ function isArguments(object) {
 }
 
 function objEquiv(a, b) {
-  if (util.isNullOrUndefined(a) || util.isNullOrUndefined(b))
+  if (isNullOrUndefined(a) || isNullOrUndefined(b))
     return false;
   // an identical 'prototype' property.
   if (a.prototype !== b.prototype) return false;
@@ -277,7 +288,7 @@ function expectedException(actual, expected) {
 function _throws(shouldThrow, block, expected, message) {
   var actual;
 
-  if (util.isString(expected)) {
+  if (isString(expected)) {
     message = expected;
     expected = null;
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -22,6 +22,14 @@
 var buffer = process.binding('buffer');
 var smalloc = process.binding('smalloc');
 var util = require('util');
+
+var isArray = util.isArray,
+    isBuf = util.isBuffer,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var alloc = smalloc.alloc;
 var sliceOnto = smalloc.sliceOnto;
 var kMaxLength = smalloc.kMaxLength;
@@ -46,14 +54,14 @@ function createPool() {
 
 
 function Buffer(subject, encoding) {
-  if (!util.isBuffer(this))
+  if (!isBuf(this))
     return new Buffer(subject, encoding);
 
-  if (util.isNumber(subject))
+  if (isNumber(subject))
     this.length = subject > 0 ? Math.floor(subject) : 0;
-  else if (util.isString(subject))
+  else if (isString(subject))
     this.length = Buffer.byteLength(subject, encoding = encoding || 'utf8');
-  else if (util.isObject(subject))
+  else if (isObject(subject))
     this.length = +subject.length > 0 ? Math.floor(+subject.length) : 0;
   else
     throw new TypeError('must start with number, buffer, array or string');
@@ -73,14 +81,14 @@ function Buffer(subject, encoding) {
     alloc(this, this.length);
   }
 
-  if (!util.isNumber(subject)) {
-    if (util.isString(subject)) {
+  if (!isNumber(subject)) {
+    if (isString(subject)) {
       // FIXME: the number of bytes hasn't changed, so why change the length?
       this.length = this.write(subject, 0, encoding);
     } else {
-      if (util.isBuffer(subject))
+      if (isBuf(subject))
         subject.copy(this, 0, 0, this.length);
-      else if (util.isNumber(subject.length) || util.isArray(subject))
+      else if (isNumber(subject.length) || isArray(subject))
         for (var i = 0; i < this.length; i++)
           this[i] = subject[i];
     }
@@ -114,7 +122,7 @@ buffer.setupBufferJS(NativeBuffer, internal);
 // Static methods
 
 Buffer.isBuffer = function isBuffer(b) {
-  return util.isBuffer(b);
+  return isBuf(b);
 };
 
 
@@ -140,10 +148,10 @@ Buffer.isEncoding = function(encoding) {
 
 
 Buffer.concat = function(list, length) {
-  if (!util.isArray(list))
+  if (!isArray(list))
     throw new TypeError('Usage: Buffer.concat(list[, length])');
 
-  if (util.isUndefined(length)) {
+  if (isUndefined(length)) {
     length = 0;
     for (var i = 0; i < list.length; i++)
       length += list[i].length;
@@ -205,7 +213,7 @@ Buffer.prototype.toString = function(encoding, start, end) {
   encoding = !!encoding ? (encoding + '').toLowerCase() : 'utf8';
 
   start = ~~start;
-  end = util.isUndefined(end) ? this.length : ~~end;
+  end = isUndefined(end) ? this.length : ~~end;
 
   if (start < 0) start = 0;
   if (end > this.length) end = this.length;
@@ -278,7 +286,7 @@ var writeMsg = '.write(string, encoding, offset, length) is deprecated.' +
                ' Use write(string, offset, length, encoding) instead.';
 Buffer.prototype.write = function(string, offset, length, encoding) {
   // allow write(string, encoding)
-  if (util.isString(offset) && util.isUndefined(length)) {
+  if (isString(offset) && isUndefined(length)) {
     encoding = offset;
     offset = 0;
 
@@ -311,7 +319,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
   }
 
   var remaining = this.length - offset;
-  if (util.isUndefined(length) || length > remaining)
+  if (isUndefined(length) || length > remaining)
     length = remaining;
 
   encoding = !!encoding ? (encoding + '').toLowerCase() : 'utf8';
@@ -371,7 +379,7 @@ Buffer.prototype.toJSON = function() {
 Buffer.prototype.slice = function(start, end) {
   var len = this.length;
   start = ~~start;
-  end = util.isUndefined(end) ? len : ~~end;
+  end = isUndefined(end) ? len : ~~end;
 
   if (start < 0) {
     start += len;
@@ -396,7 +404,7 @@ Buffer.prototype.slice = function(start, end) {
   sliceOnto(this, buf, start, end);
   buf.length = end - start;
   if (buf.length > 0)
-    buf.parent = util.isUndefined(this.parent) ? this : this.parent;
+    buf.parent = isUndefined(this.parent) ? this : this.parent;
 
   return buf;
 };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -26,6 +26,15 @@ var dgram = require('dgram');
 var assert = require('assert');
 var util = require('util');
 
+var isArray = util.isArray,
+    isFunction = util.isFunction,
+    isNull = util.isNull,
+    isNullOrUndefined = util.isNullOrUndefined,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var Process = process.binding('process_wrap').Process;
 var uv = process.binding('uv');
 
@@ -39,7 +48,7 @@ function handleWrapGetter(name, callback) {
 
   Object.defineProperty(handleWraps, name, {
     get: function() {
-      if (!util.isUndefined(cons)) return cons;
+      if (!isUndefined(cons)) return cons;
       return cons = callback();
     }
   });
@@ -308,9 +317,9 @@ function getSocketList(type, slave, key) {
 var INTERNAL_PREFIX = 'NODE_';
 function handleMessage(target, message, handle) {
   var eventName = 'message';
-  if (!util.isNull(message) &&
-      util.isObject(message) &&
-      util.isString(message.cmd) &&
+  if (!isNull(message) &&
+      isObject(message) &&
+      isString(message.cmd) &&
       message.cmd.length > INTERNAL_PREFIX.length &&
       message.cmd.slice(0, INTERNAL_PREFIX.length) === INTERNAL_PREFIX) {
     eventName = 'internalMessage';
@@ -366,7 +375,7 @@ function setupChannel(target, channel) {
   target.on('internalMessage', function(message, handle) {
     // Once acknowledged - continue sending handles.
     if (message.cmd === 'NODE_HANDLE_ACK') {
-      assert(util.isArray(target._handleQueue));
+      assert(isArray(target._handleQueue));
       var queue = target._handleQueue;
       target._handleQueue = null;
       queue.forEach(function(args) {
@@ -395,7 +404,7 @@ function setupChannel(target, channel) {
   });
 
   target.send = function(message, handle) {
-    if (util.isUndefined(message)) {
+    if (isUndefined(message)) {
       throw new TypeError('message cannot be undefined');
     }
 
@@ -508,7 +517,7 @@ exports.fork = function(modulePath /*, args, options*/) {
 
   // Get options and args arguments.
   var options, args, execArgv;
-  if (util.isArray(arguments[1])) {
+  if (isArray(arguments[1])) {
     args = arguments[1];
     options = util._extend({}, arguments[2]);
   } else {
@@ -553,7 +562,7 @@ exports._forkChild = function(fd) {
 exports.exec = function(command /*, options, callback */) {
   var file, args, options, callback;
 
-  if (util.isFunction(arguments[1])) {
+  if (isFunction(arguments[1])) {
     options = undefined;
     callback = arguments[1];
   } else {
@@ -593,11 +602,11 @@ exports.execFile = function(file /* args, options, callback */) {
 
   // Parse the parameters.
 
-  if (util.isFunction(arguments[arguments.length - 1])) {
+  if (isFunction(arguments[arguments.length - 1])) {
     callback = arguments[arguments.length - 1];
   }
 
-  if (util.isArray(arguments[1])) {
+  if (isArray(arguments[1])) {
     args = arguments[1];
     options = util._extend(options, arguments[2]);
   } else {
@@ -835,14 +844,14 @@ ChildProcess.prototype.spawn = function(options) {
       stdio = options.stdio || 'pipe';
 
   // Replace shortcut with an array
-  if (util.isString(stdio)) {
+  if (isString(stdio)) {
     switch (stdio) {
       case 'ignore': stdio = ['ignore', 'ignore', 'ignore']; break;
       case 'pipe': stdio = ['pipe', 'pipe', 'pipe']; break;
       case 'inherit': stdio = [0, 1, 2]; break;
       default: throw new TypeError('Incorrect value of stdio option: ' + stdio);
     }
-  } else if (!util.isArray(stdio)) {
+  } else if (!isArray(stdio)) {
     throw new TypeError('Incorrect value of stdio option: ' + stdio);
   }
 
@@ -864,16 +873,16 @@ ChildProcess.prototype.spawn = function(options) {
     }
 
     // Defaults
-    if (util.isNullOrUndefined(stdio)) {
+    if (isNullOrUndefined(stdio)) {
       stdio = i < 3 ? 'pipe' : 'ignore';
     }
 
     if (stdio === 'ignore') {
       acc.push({type: 'ignore'});
-    } else if (stdio === 'pipe' || util.isNumber(stdio) && stdio < 0) {
+    } else if (stdio === 'pipe' || isNumber(stdio) && stdio < 0) {
       acc.push({type: 'pipe', handle: createPipe()});
     } else if (stdio === 'ipc') {
-      if (!util.isUndefined(ipc)) {
+      if (!isUndefined(ipc)) {
         // Cleanup previously created pipes
         cleanup();
         throw Error('Child process can have only one IPC pipe');
@@ -883,7 +892,7 @@ ChildProcess.prototype.spawn = function(options) {
       ipcFd = i;
 
       acc.push({ type: 'pipe', handle: ipc, ipc: true });
-    } else if (util.isNumber(stdio) || util.isNumber(stdio.fd)) {
+    } else if (isNumber(stdio) || isNumber(stdio.fd)) {
       acc.push({ type: 'fd', fd: stdio.fd || stdio });
     } else if (getHandleWrapType(stdio) || getHandleWrapType(stdio.handle) ||
                getHandleWrapType(stdio._handle)) {
@@ -907,7 +916,7 @@ ChildProcess.prototype.spawn = function(options) {
 
   options.stdio = stdio;
 
-  if (!util.isUndefined(ipc)) {
+  if (!isUndefined(ipc)) {
     // Let child process know about opened IPC channel
     options.envPairs = options.envPairs || [];
     options.envPairs.push('NODE_CHANNEL_FD=' + ipcFd);
@@ -952,19 +961,19 @@ ChildProcess.prototype.spawn = function(options) {
     }
   });
 
-  this.stdin = stdio.length >= 1 && !util.isUndefined(stdio[0].socket) ?
+  this.stdin = stdio.length >= 1 && !isUndefined(stdio[0].socket) ?
       stdio[0].socket : null;
-  this.stdout = stdio.length >= 2 && !util.isUndefined(stdio[1].socket) ?
+  this.stdout = stdio.length >= 2 && !isUndefined(stdio[1].socket) ?
       stdio[1].socket : null;
-  this.stderr = stdio.length >= 3 && !util.isUndefined(stdio[2].socket) ?
+  this.stderr = stdio.length >= 3 && !isUndefined(stdio[2].socket) ?
       stdio[2].socket : null;
 
   this.stdio = stdio.map(function(stdio) {
-    return util.isUndefined(stdio.socket) ? null : stdio.socket;
+    return isUndefined(stdio.socket) ? null : stdio.socket;
   });
 
   // Add .send() method and start listening for IPC data
-  if (!util.isUndefined(ipc)) setupChannel(this, ipc);
+  if (!isUndefined(ipc)) setupChannel(this, ipc);
 
   return err;
 };
@@ -985,7 +994,7 @@ ChildProcess.prototype.kill = function(sig) {
     signal = constants[sig];
   }
 
-  if (util.isUndefined(signal)) {
+  if (isUndefined(signal)) {
     throw new Error('Unknown signal: ' + sig);
   }
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -25,6 +25,11 @@ var dgram = require('dgram');
 var fork = require('child_process').fork;
 var net = require('net');
 var util = require('util');
+
+var isNull = util.isNull,
+    isNumber = util.isNumber,
+    isUndefined = util.isUndefined;
+
 var SCHED_NONE = 1;
 var SCHED_RR = 2;
 
@@ -67,7 +72,7 @@ function SharedHandle(key, address, port, addressType, backlog, fd) {
   else
     rval = net._createServerHandle(address, port, addressType, fd);
 
-  if (util.isNumber(rval))
+  if (isNumber(rval))
     this.errno = rval;
   else
     this.handle = rval;
@@ -134,7 +139,7 @@ RoundRobinHandle.prototype.add = function(worker, send) {
     self.handoff(worker);  // In case there are connections pending.
   }
 
-  if (util.isNull(this.server)) return done();
+  if (isNull(this.server)) return done();
   // Still busy binding.
   this.server.once('listening', done);
   this.server.once('error', function(err) {
@@ -169,7 +174,7 @@ RoundRobinHandle.prototype.handoff = function(worker) {
     return;  // Worker is closing (or has closed) the server.
   }
   var handle = this.handles.shift();
-  if (util.isUndefined(handle)) {
+  if (isUndefined(handle)) {
     this.free.push(worker);  // Add to ready queue again.
     return;
   }
@@ -228,7 +233,7 @@ function masterInit() {
     'rr': SCHED_RR
   }[process.env.NODE_CLUSTER_SCHED_POLICY];
 
-  if (util.isUndefined(schedulingPolicy)) {
+  if (isUndefined(schedulingPolicy)) {
     // FIXME Round-robin doesn't perform well on Windows right now due to the
     // way IOCP is wired up. Bert is going to fix that, eventually.
     schedulingPolicy = (process.platform === 'win32') ? SCHED_NONE : SCHED_RR;
@@ -371,7 +376,7 @@ function masterInit() {
                 message.fd];
     var key = args.join(':');
     var handle = handles[key];
-    if (util.isUndefined(handle)) {
+    if (isUndefined(handle)) {
       var constructor = RoundRobinHandle;
       // UDP is exempt from round-robin connection balancing for what should
       // be obvious reasons: it's connectionless. There is nothing to send to
@@ -488,7 +493,7 @@ function workerInit() {
       delete handles[key];
       return close.apply(this, arguments);
     };
-    assert(util.isUndefined(handles[key]));
+    assert(isUndefined(handles[key]));
     handles[key] = handle;
     cb(message.errno, handle);
   }
@@ -512,7 +517,7 @@ function workerInit() {
       // the ack by the master process in which we can still receive handles.
       // onconnection() below handles that by sending those handles back to
       // the master.
-      if (util.isUndefined(key)) return;
+      if (isUndefined(key)) return;
       send({ act: 'close', key: key });
       delete handles[key];
       key = undefined;
@@ -533,7 +538,7 @@ function workerInit() {
     if (message.sockname) {
       handle.getsockname = getsockname;  // TCP handles only.
     }
-    assert(util.isUndefined(handles[key]));
+    assert(isUndefined(handles[key]));
     handles[key] = handle;
     cb(0, handle);
   }
@@ -542,7 +547,7 @@ function workerInit() {
   function onconnection(message, handle) {
     var key = message.key;
     var server = handles[key];
-    var accepted = !util.isUndefined(server);
+    var accepted = !isUndefined(server);
     send({ ack: message.seq, accepted: accepted });
     if (accepted) server.onconnection(0, handle);
   }
@@ -588,7 +593,7 @@ function internal(worker, cb) {
   return function(message, handle) {
     if (message.cmd !== 'NODE_CLUSTER') return;
     var fn = cb;
-    if (!util.isUndefined(message.ack)) {
+    if (!isUndefined(message.ack)) {
       fn = callbacks[message.ack];
       delete callbacks[message.ack];
     }

--- a/lib/console.js
+++ b/lib/console.js
@@ -20,12 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var util = require('util');
+var isFunction = util.isFunction;
 
 function Console(stdout, stderr) {
   if (!(this instanceof Console)) {
     return new Console(stdout, stderr);
   }
-  if (!stdout || !util.isFunction(stdout.write)) {
+  if (!stdout || !isFunction(stdout.write)) {
     throw new TypeError('Console expects a writable stream instance');
   }
   if (!stderr) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -38,12 +38,16 @@ try {
 var stream = require('stream');
 var util = require('util');
 
+var isArray = util.isArray,
+    isFunction = util.isFunction,
+    isString = util.isString;
+
 // This is here because many functions accepted binary strings without
 // any explicit encoding in older versions of node, and we don't want
 // to break them unnecessarily.
 function toBuf(str, encoding) {
   encoding = encoding || 'binary';
-  if (util.isString(str)) {
+  if (isString(str)) {
     if (encoding === 'buffer')
       encoding = 'binary';
     str = new Buffer(str, encoding);
@@ -100,7 +104,7 @@ exports.createCredentials = function(options, context) {
   if (options.ciphers) c.context.setCiphers(options.ciphers);
 
   if (options.ca) {
-    if (util.isArray(options.ca)) {
+    if (isArray(options.ca)) {
       for (var i = 0, len = options.ca.length; i < len; i++) {
         c.context.addCACert(options.ca[i]);
       }
@@ -112,7 +116,7 @@ exports.createCredentials = function(options, context) {
   }
 
   if (options.crl) {
-    if (util.isArray(options.crl)) {
+    if (isArray(options.crl)) {
       for (var i = 0, len = options.crl.length; i < len; i++) {
         c.context.addCRL(options.crl[i]);
       }
@@ -198,7 +202,7 @@ Hash.prototype._flush = function(callback) {
 
 Hash.prototype.update = function(data, encoding) {
   encoding = encoding || exports.DEFAULT_ENCODING;
-  if (encoding === 'buffer' && util.isString(data))
+  if (encoding === 'buffer' && isString(data))
     encoding = 'binary';
   this._binding.update(data, encoding);
   return this;
@@ -539,7 +543,7 @@ DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
 
 
 exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
-  if (!util.isFunction(callback))
+  if (!isFunction(callback))
     throw new Error('No callback provided to pbkdf2');
 
   return pbkdf2(password, salt, iterations, keylen, callback);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -21,6 +21,12 @@
 
 var assert = require('assert');
 var util = require('util');
+
+var isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isNumber = util.isNumber,
+    isString = util.isString;
+
 var events = require('events');
 
 var UDP = process.binding('udp_wrap').UDP;
@@ -77,7 +83,7 @@ function newHandle(type) {
 
 exports._createSocketHandle = function(address, port, addressType, fd) {
   // Opening an existing fd is not supported for UDP handles.
-  assert(!util.isNumber(fd) || fd < 0);
+  assert(!isNumber(fd) || fd < 0);
 
   var handle = newHandle(addressType);
 
@@ -105,7 +111,7 @@ function Socket(type, listener) {
   this.type = type;
   this.fd = null; // compatibility hack
 
-  if (util.isFunction(listener))
+  if (isFunction(listener))
     this.on('message', listener);
 }
 util.inherits(Socket, events.EventEmitter);
@@ -151,7 +157,7 @@ Socket.prototype.bind = function(/*port, address, callback*/) {
 
   this._bindState = BIND_STATE_BINDING;
 
-  if (util.isFunction(arguments[arguments.length - 1]))
+  if (isFunction(arguments[arguments.length - 1]))
     self.once('listening', arguments[arguments.length - 1]);
 
   var UDP = process.binding('udp_wrap').UDP;
@@ -163,7 +169,7 @@ Socket.prototype.bind = function(/*port, address, callback*/) {
 
   var port = arguments[0];
   var address = arguments[1];
-  if (util.isFunction(address)) address = '';  // a.k.a. "any address"
+  if (isFunction(address)) address = '';  // a.k.a. "any address"
 
   // resolve address first
   self._handle.lookup(address, function(err, ip) {
@@ -217,10 +223,10 @@ Socket.prototype.sendto = function(buffer,
                                    port,
                                    address,
                                    callback) {
-  if (!util.isNumber(offset) || !util.isNumber(length))
+  if (!isNumber(offset) || !isNumber(length))
     throw new Error('send takes offset and length as args 2 and 3');
 
-  if (!util.isString(address))
+  if (!isString(address))
     throw new Error(this.type + ' sockets must send to port, address');
 
   this.send(buffer, offset, length, port, address, callback);
@@ -235,7 +241,7 @@ Socket.prototype.send = function(buffer,
                                  callback) {
   var self = this;
 
-  if (!util.isBuffer(buffer))
+  if (!isBuffer(buffer))
     throw new TypeError('First argument must be a buffer object.');
 
   offset = offset | 0;
@@ -260,7 +266,7 @@ Socket.prototype.send = function(buffer,
 
   // Normalize callback so it's either a function or undefined but not anything
   // else.
-  if (!util.isFunction(callback))
+  if (!isFunction(callback))
     callback = undefined;
 
   self._healthCheck();
@@ -351,7 +357,7 @@ Socket.prototype.setBroadcast = function(arg) {
 
 
 Socket.prototype.setTTL = function(arg) {
-  if (!util.isNumber(arg)) {
+  if (!isNumber(arg)) {
     throw new TypeError('Argument must be a number');
   }
 
@@ -365,7 +371,7 @@ Socket.prototype.setTTL = function(arg) {
 
 
 Socket.prototype.setMulticastTTL = function(arg) {
-  if (!util.isNumber(arg)) {
+  if (!isNumber(arg)) {
     throw new TypeError('Argument must be a number');
   }
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -22,6 +22,9 @@
 var net = require('net');
 var util = require('util');
 
+var isFunction = util.isFunction,
+    isString = util.isString;
+
 var cares = process.binding('cares_wrap');
 var uv = process.binding('uv');
 
@@ -61,7 +64,7 @@ function errnoException(err, syscall) {
 //   callback.immediately = true;
 // }
 function makeAsync(callback) {
-  if (!util.isFunction(callback)) {
+  if (!isFunction(callback)) {
     return callback;
   }
   return function asyncCallback() {
@@ -180,7 +183,7 @@ exports.reverse = resolveMap.PTR = resolver('getHostByAddr');
 
 exports.resolve = function(domain, type_, callback_) {
   var resolver, callback;
-  if (util.isString(type_)) {
+  if (isString(type_)) {
     resolver = resolveMap[type_];
     callback = callback_;
   } else {
@@ -188,7 +191,7 @@ exports.resolve = function(domain, type_, callback_) {
     callback = type_;
   }
 
-  if (util.isFunction(resolver)) {
+  if (isFunction(resolver)) {
     return resolver(domain, callback);
   } else {
     throw new Error('Unknown type "' + type_ + '"');

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var util = require('util');
+var isFunction = util.isFunction;
 var events = require('events');
 var EventEmitter = events.EventEmitter;
 var inherits = util.inherits;
@@ -290,7 +291,7 @@ Domain.prototype.dispose = function() {
     // so it's quite possible that calling some of these methods
     // might cause additional exceptions to be thrown.
     endMethods.forEach(function(method) {
-      if (util.isFunction(m[method])) {
+      if (isFunction(m[method])) {
         try {
           m[method]();
         } catch (er) {}

--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,11 @@
 var domain;
 var util = require('util');
 
+var isFunction = util.isFunction,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isUndefined = util.isUndefined;
+
 function EventEmitter() {
   this.domain = null;
   if (EventEmitter.usingDomains) {
@@ -53,7 +58,7 @@ EventEmitter.defaultMaxListeners = 10;
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.
 EventEmitter.prototype.setMaxListeners = function(n) {
-  if (!util.isNumber(n) || n < 0)
+  if (!isNumber(n) || n < 0)
     throw TypeError('n must be a positive number');
   this._maxListeners = n;
   return this;
@@ -68,7 +73,7 @@ EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error') {
     if (!this._events.error ||
-        (util.isObject(this._events.error) && !this._events.error.length)) {
+        (isObject(this._events.error) && !this._events.error.length)) {
       er = arguments[1];
       if (this.domain) {
         if (!er) er = new TypeError('Uncaught, unspecified "error" event.');
@@ -87,13 +92,13 @@ EventEmitter.prototype.emit = function(type) {
 
   handler = this._events[type];
 
-  if (util.isUndefined(handler))
+  if (isUndefined(handler))
     return false;
 
   if (this.domain && this !== process)
     this.domain.enter();
 
-  if (util.isFunction(handler)) {
+  if (isFunction(handler)) {
     switch (arguments.length) {
       // fast cases
       case 1:
@@ -113,7 +118,7 @@ EventEmitter.prototype.emit = function(type) {
           args[i - 1] = arguments[i];
         handler.apply(this, args);
     }
-  } else if (util.isObject(handler)) {
+  } else if (isObject(handler)) {
     len = arguments.length;
     args = new Array(len - 1);
     for (i = 1; i < len; i++)
@@ -134,7 +139,7 @@ EventEmitter.prototype.emit = function(type) {
 EventEmitter.prototype.addListener = function(type, listener) {
   var m;
 
-  if (!util.isFunction(listener))
+  if (!isFunction(listener))
     throw TypeError('listener must be a function');
 
   if (!this._events)
@@ -144,13 +149,13 @@ EventEmitter.prototype.addListener = function(type, listener) {
   // adding it to the listeners, first emit "newListener".
   if (this._events.newListener)
     this.emit('newListener', type,
-              util.isFunction(listener.listener) ?
+              isFunction(listener.listener) ?
               listener.listener : listener);
 
   if (!this._events[type])
     // Optimize the case of one listener. Don't need the extra array object.
     this._events[type] = listener;
-  else if (util.isObject(this._events[type]))
+  else if (isObject(this._events[type]))
     // If we've already got an array, just append.
     this._events[type].push(listener);
   else
@@ -158,9 +163,9 @@ EventEmitter.prototype.addListener = function(type, listener) {
     this._events[type] = [this._events[type], listener];
 
   // Check for listener leak
-  if (util.isObject(this._events[type]) && !this._events[type].warned) {
+  if (isObject(this._events[type]) && !this._events[type].warned) {
     var m;
-    if (!util.isUndefined(this._maxListeners)) {
+    if (!isUndefined(this._maxListeners)) {
       m = this._maxListeners;
     } else {
       m = EventEmitter.defaultMaxListeners;
@@ -182,7 +187,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 EventEmitter.prototype.once = function(type, listener) {
-  if (!util.isFunction(listener))
+  if (!isFunction(listener))
     throw TypeError('listener must be a function');
 
   function g() {
@@ -200,7 +205,7 @@ EventEmitter.prototype.once = function(type, listener) {
 EventEmitter.prototype.removeListener = function(type, listener) {
   var list, position, length, i;
 
-  if (!util.isFunction(listener))
+  if (!isFunction(listener))
     throw TypeError('listener must be a function');
 
   if (!this._events || !this._events[type])
@@ -211,12 +216,12 @@ EventEmitter.prototype.removeListener = function(type, listener) {
   position = -1;
 
   if (list === listener ||
-      (util.isFunction(list.listener) && list.listener === listener)) {
+      (isFunction(list.listener) && list.listener === listener)) {
     delete this._events[type];
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
 
-  } else if (util.isObject(list)) {
+  } else if (isObject(list)) {
     for (i = length; i-- > 0;) {
       if (list[i] === listener ||
           (list[i].listener && list[i].listener === listener)) {
@@ -270,7 +275,7 @@ EventEmitter.prototype.removeAllListeners = function(type) {
 
   listeners = this._events[type];
 
-  if (util.isFunction(listeners)) {
+  if (isFunction(listeners)) {
     this.removeListener(type, listeners);
   } else {
     // LIFO order
@@ -286,7 +291,7 @@ EventEmitter.prototype.listeners = function(type) {
   var ret;
   if (!this._events || !this._events[type])
     ret = [];
-  else if (util.isFunction(this._events[type]))
+  else if (isFunction(this._events[type]))
     ret = [this._events[type]];
   else
     ret = this._events[type].slice();
@@ -297,7 +302,7 @@ EventEmitter.listenerCount = function(emitter, type) {
   var ret;
   if (!emitter._events || !emitter._events[type])
     ret = 0;
-  else if (util.isFunction(emitter._events[type]))
+  else if (isFunction(emitter._events[type]))
     ret = 1;
   else
     ret = emitter._events[type].length;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -26,6 +26,15 @@
 //   var mode = 438; /* mode=0666 */
 
 var util = require('util');
+var isBuffer = util.isBuffer,
+    isDate = util.isDate,
+    isFunction = util.isFunction,
+    isNull = util.isNull,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var pathModule = require('path');
 
 var binding = process.binding('fs');
@@ -81,14 +90,14 @@ function rethrow() {
 }
 
 function maybeCallback(cb) {
-  return util.isFunction(cb) ? cb : rethrow();
+  return isFunction(cb) ? cb : rethrow();
 }
 
 // Ensure that callbacks run in the global context. Only use this function
 // for callbacks that are passed to the binding layer, callbacks that are
 // invoked from JS already run in the proper scope.
 function makeCallback(cb) {
-  if (!util.isFunction(cb)) {
+  if (!isFunction(cb)) {
     return rethrow();
   }
 
@@ -171,13 +180,13 @@ fs.existsSync = function(path) {
 fs.readFile = function(path, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
-  if (util.isFunction(options) || !options) {
+  if (isFunction(options) || !options) {
     options = { encoding: null, flag: 'r' };
-  } else if (util.isString(options)) {
+  } else if (isString(options)) {
     options = { encoding: options, flag: 'r' };
   } else if (!options) {
     options = { encoding: null, flag: 'r' };
-  } else if (!util.isObject(options)) {
+  } else if (!isObject(options)) {
     throw new TypeError('Bad arguments');
   }
 
@@ -260,9 +269,9 @@ fs.readFile = function(path, options, callback_) {
 fs.readFileSync = function(path, options) {
   if (!options) {
     options = { encoding: null, flag: 'r' };
-  } else if (util.isString(options)) {
+  } else if (isString(options)) {
     options = { encoding: options, flag: 'r' };
-  } else if (!util.isObject(options)) {
+  } else if (!isObject(options)) {
     throw new TypeError('Bad arguments');
   }
 
@@ -332,7 +341,7 @@ fs.readFileSync = function(path, options) {
 // Used by binding.open and friends
 function stringToFlags(flag) {
   // Only mess with strings
-  if (!util.isString(flag)) {
+  if (!isString(flag)) {
     return flag;
   }
 
@@ -381,9 +390,9 @@ fs.closeSync = function(fd) {
 };
 
 function modeNum(m, def) {
-  if (util.isNumber(m))
+  if (isNumber(m))
     return m;
-  if (util.isString(m))
+  if (isString(m))
     return parseInt(m, 8);
   if (def)
     return modeNum(def);
@@ -408,7 +417,7 @@ fs.openSync = function(path, flags, mode) {
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
-  if (!util.isBuffer(buffer)) {
+  if (!isBuffer(buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
     var cb = arguments[4],
         encoding = arguments[3];
@@ -439,7 +448,7 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
 
 fs.readSync = function(fd, buffer, offset, length, position) {
   var legacy = false;
-  if (!util.isBuffer(buffer)) {
+  if (!isBuffer(buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
     legacy = true;
     var encoding = arguments[3];
@@ -467,9 +476,9 @@ fs.readSync = function(fd, buffer, offset, length, position) {
 // OR
 //  fs.write(fd, string[, position[, encoding]], callback);
 fs.write = function(fd, buffer, offset, length, position, callback) {
-  if (util.isBuffer(buffer)) {
+  if (isBuffer(buffer)) {
     // if no position is passed then assume null
-    if (util.isFunction(position)) {
+    if (isFunction(position)) {
       callback = position;
       position = null;
     }
@@ -481,10 +490,10 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     return binding.writeBuffer(fd, buffer, offset, length, position, wrapper);
   }
 
-  if (util.isString(buffer))
+  if (isString(buffer))
     buffer += '';
-  if (!util.isFunction(position)) {
-    if (util.isFunction(offset)) {
+  if (!isFunction(position)) {
+    if (isFunction(offset)) {
       position = offset;
       offset = null;
     } else {
@@ -505,14 +514,14 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
 // OR
 //  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
-  if (util.isBuffer(buffer)) {
-    if (util.isUndefined(position))
+  if (isBuffer(buffer)) {
+    if (isUndefined(position))
       position = null;
     return binding.writeBuffer(fd, buffer, offset, length, position);
   }
-  if (!util.isString(buffer))
+  if (!isString(buffer))
     buffer += '';
-  if (util.isUndefined(offset))
+  if (isUndefined(offset))
     offset = null;
   return binding.writeString(fd, buffer, offset, length, position);
 };
@@ -534,14 +543,14 @@ fs.renameSync = function(oldPath, newPath) {
 };
 
 fs.truncate = function(path, len, callback) {
-  if (util.isNumber(path)) {
+  if (isNumber(path)) {
     // legacy
     return fs.ftruncate(path, len, callback);
   }
-  if (util.isFunction(len)) {
+  if (isFunction(len)) {
     callback = len;
     len = 0;
-  } else if (util.isUndefined(len)) {
+  } else if (isUndefined(len)) {
     len = 0;
   }
   callback = maybeCallback(callback);
@@ -556,11 +565,11 @@ fs.truncate = function(path, len, callback) {
 };
 
 fs.truncateSync = function(path, len) {
-  if (util.isNumber(path)) {
+  if (isNumber(path)) {
     // legacy
     return fs.ftruncateSync(path, len);
   }
-  if (util.isUndefined(len)) {
+  if (isUndefined(len)) {
     len = 0;
   }
   // allow error to be thrown, but still close fd.
@@ -574,17 +583,17 @@ fs.truncateSync = function(path, len) {
 };
 
 fs.ftruncate = function(fd, len, callback) {
-  if (util.isFunction(len)) {
+  if (isFunction(len)) {
     callback = len;
     len = 0;
-  } else if (util.isUndefined(len)) {
+  } else if (isUndefined(len)) {
     len = 0;
   }
   binding.ftruncate(fd, len, makeCallback(callback));
 };
 
 fs.ftruncateSync = function(fd, len) {
-  if (util.isUndefined(len)) {
+  if (isUndefined(len)) {
     len = 0;
   }
   return binding.ftruncate(fd, len);
@@ -618,7 +627,7 @@ fs.fsyncSync = function(fd) {
 };
 
 fs.mkdir = function(path, mode, callback) {
-  if (util.isFunction(mode)) callback = mode;
+  if (isFunction(mode)) callback = mode;
   callback = makeCallback(callback);
   if (!nullCheck(path, callback)) return;
   binding.mkdir(pathModule._makeLong(path),
@@ -698,7 +707,7 @@ function preprocessSymlinkDestination(path, type) {
 }
 
 fs.symlink = function(destination, path, type_, callback) {
-  var type = (util.isString(type_) ? type_ : null);
+  var type = (isString(type_) ? type_ : null);
   var callback = makeCallback(arguments[arguments.length - 1]);
 
   if (!nullCheck(destination, callback)) return;
@@ -711,7 +720,7 @@ fs.symlink = function(destination, path, type_, callback) {
 };
 
 fs.symlinkSync = function(destination, path, type) {
-  type = (util.isString(type) ? type : null);
+  type = (isString(type) ? type : null);
 
   nullCheck(destination);
   nullCheck(path);
@@ -849,10 +858,10 @@ fs.chownSync = function(path, uid, gid) {
 
 // converts Date or number to a fractional UNIX timestamp
 function toUnixTimestamp(time) {
-  if (util.isNumber(time)) {
+  if (isNumber(time)) {
     return time;
   }
-  if (util.isDate(time)) {
+  if (isDate(time)) {
     // convert to 123.456 UNIX timestamp
     return time.getTime() / 1000;
   }
@@ -915,13 +924,13 @@ function writeAll(fd, buffer, offset, length, position, callback) {
 fs.writeFile = function(path, data, options, callback) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
-  if (util.isFunction(options) || !options) {
+  if (isFunction(options) || !options) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
-  } else if (util.isString(options)) {
+  } else if (isString(options)) {
     options = { encoding: options, mode: 438, flag: 'w' };
   } else if (!options) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
-  } else if (!util.isObject(options)) {
+  } else if (!isObject(options)) {
     throw new TypeError('Bad arguments');
   }
 
@@ -932,7 +941,7 @@ fs.writeFile = function(path, data, options, callback) {
     if (openErr) {
       if (callback) callback(openErr);
     } else {
-      var buffer = util.isBuffer(data) ? data : new Buffer('' + data,
+      var buffer = isBuffer(data) ? data : new Buffer('' + data,
           options.encoding || 'utf8');
       var position = /a/.test(flag) ? null : 0;
       writeAll(fd, buffer, 0, buffer.length, position, callback);
@@ -943,9 +952,9 @@ fs.writeFile = function(path, data, options, callback) {
 fs.writeFileSync = function(path, data, options) {
   if (!options) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
-  } else if (util.isString(options)) {
+  } else if (isString(options)) {
     options = { encoding: options, mode: 438, flag: 'w' };
-  } else if (!util.isObject(options)) {
+  } else if (!isObject(options)) {
     throw new TypeError('Bad arguments');
   }
 
@@ -953,7 +962,7 @@ fs.writeFileSync = function(path, data, options) {
 
   var flag = options.flag || 'w';
   var fd = fs.openSync(path, flag, options.mode);
-  if (!util.isBuffer(data)) {
+  if (!isBuffer(data)) {
     data = new Buffer('' + data, options.encoding || 'utf8');
   }
   var written = 0;
@@ -972,13 +981,13 @@ fs.writeFileSync = function(path, data, options) {
 fs.appendFile = function(path, data, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
-  if (util.isFunction(options) || !options) {
+  if (isFunction(options) || !options) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
-  } else if (util.isString(options)) {
+  } else if (isString(options)) {
     options = { encoding: options, mode: 438, flag: 'a' };
   } else if (!options) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
-  } else if (!util.isObject(options)) {
+  } else if (!isObject(options)) {
     throw new TypeError('Bad arguments');
   }
 
@@ -990,9 +999,9 @@ fs.appendFile = function(path, data, options, callback_) {
 fs.appendFileSync = function(path, data, options) {
   if (!options) {
     options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
-  } else if (util.isString(options)) {
+  } else if (isString(options)) {
     options = { encoding: options, mode: 438, flag: 'a' };
-  } else if (!util.isObject(options)) {
+  } else if (!isObject(options)) {
     throw new TypeError('Bad arguments');
   }
   if (!options.flag)
@@ -1039,7 +1048,7 @@ fs.watch = function(filename) {
   var options;
   var listener;
 
-  if (util.isObject(arguments[1])) {
+  if (isObject(arguments[1])) {
     options = arguments[1];
     listener = arguments[2];
   } else {
@@ -1047,7 +1056,7 @@ fs.watch = function(filename) {
     listener = arguments[1];
   }
 
-  if (util.isUndefined(options.persistent)) options.persistent = true;
+  if (isUndefined(options.persistent)) options.persistent = true;
 
   watcher = new FSWatcher();
   watcher.start(filename, options.persistent);
@@ -1119,7 +1128,7 @@ fs.watchFile = function(filename) {
     persistent: true
   };
 
-  if (util.isObject(arguments[1])) {
+  if (isObject(arguments[1])) {
     options = util._extend(options, arguments[1]);
     listener = arguments[2];
   } else {
@@ -1146,7 +1155,7 @@ fs.unwatchFile = function(filename, listener) {
 
   var stat = statWatchers[filename];
 
-  if (util.isFunction(listener)) {
+  if (isFunction(listener)) {
     stat.removeListener('change', listener);
   } else {
     stat.removeAllListeners('change');
@@ -1249,7 +1258,7 @@ fs.realpathSync = function realpathSync(p, cache) {
           linkTarget = seenLinks[id];
         }
       }
-      if (util.isNull(linkTarget)) {
+      if (isNull(linkTarget)) {
         fs.statSync(base);
         linkTarget = fs.readlinkSync(base);
       }
@@ -1271,7 +1280,7 @@ fs.realpathSync = function realpathSync(p, cache) {
 
 
 fs.realpath = function realpath(p, cache, cb) {
-  if (!util.isFunction(cb)) {
+  if (!isFunction(cb)) {
     cb = maybeCallback(cache);
     cache = null;
   }
@@ -1432,13 +1441,13 @@ function ReadStream(path, options) {
       options.autoClose : true;
   this.pos = undefined;
 
-  if (!util.isUndefined(this.start)) {
-    if (!util.isNumber(this.start)) {
+  if (!isUndefined(this.start)) {
+    if (!isNumber(this.start)) {
       throw TypeError('start must be a Number');
     }
-    if (util.isUndefined(this.end)) {
+    if (isUndefined(this.end)) {
       this.end = Infinity;
-    } else if (!util.isNumber(this.end)) {
+    } else if (!isNumber(this.end)) {
       throw TypeError('end must be a Number');
     }
 
@@ -1449,7 +1458,7 @@ function ReadStream(path, options) {
     this.pos = this.start;
   }
 
-  if (!util.isNumber(this.fd))
+  if (!isNumber(this.fd))
     this.open();
 
   this.on('end', function() {
@@ -1480,7 +1489,7 @@ ReadStream.prototype.open = function() {
 };
 
 ReadStream.prototype._read = function(n) {
-  if (!util.isNumber(this.fd))
+  if (!isNumber(this.fd))
     return this.once('open', function() {
       this._read(n);
     });
@@ -1501,7 +1510,7 @@ ReadStream.prototype._read = function(n) {
   var toRead = Math.min(pool.length - pool.used, n);
   var start = pool.used;
 
-  if (!util.isUndefined(this.pos))
+  if (!isUndefined(this.pos))
     toRead = Math.min(this.end - this.pos + 1, toRead);
 
   // already read everything we were supposed to read!
@@ -1514,7 +1523,7 @@ ReadStream.prototype._read = function(n) {
   fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
 
   // move the pool positions, and internal position for reading.
-  if (!util.isUndefined(this.pos))
+  if (!isUndefined(this.pos))
     this.pos += toRead;
   pool.used += toRead;
 
@@ -1540,7 +1549,7 @@ ReadStream.prototype.destroy = function() {
     return;
   this.destroyed = true;
 
-  if (util.isNumber(this.fd))
+  if (isNumber(this.fd))
     this.close();
 };
 
@@ -1549,8 +1558,8 @@ ReadStream.prototype.close = function(cb) {
   var self = this;
   if (cb)
     this.once('close', cb);
-  if (this.closed || !util.isNumber(this.fd)) {
-    if (!util.isNumber(this.fd)) {
+  if (this.closed || !isNumber(this.fd)) {
+    if (!isNumber(this.fd)) {
       this.once('open', close);
       return;
     }
@@ -1598,8 +1607,8 @@ function WriteStream(path, options) {
   this.pos = undefined;
   this.bytesWritten = 0;
 
-  if (!util.isUndefined(this.start)) {
-    if (!util.isNumber(this.start)) {
+  if (!isUndefined(this.start)) {
+    if (!isNumber(this.start)) {
       throw TypeError('start must be a Number');
     }
     if (this.start < 0) {
@@ -1609,7 +1618,7 @@ function WriteStream(path, options) {
     this.pos = this.start;
   }
 
-  if (!util.isNumber(this.fd))
+  if (!isNumber(this.fd))
     this.open();
 
   // dispose on finish.
@@ -1634,10 +1643,10 @@ WriteStream.prototype.open = function() {
 
 
 WriteStream.prototype._write = function(data, encoding, cb) {
-  if (!util.isBuffer(data))
+  if (!isBuffer(data))
     return this.emit('error', new Error('Invalid data'));
 
-  if (!util.isNumber(this.fd))
+  if (!isNumber(this.fd))
     return this.once('open', function() {
       this._write(data, encoding, cb);
     });
@@ -1652,7 +1661,7 @@ WriteStream.prototype._write = function(data, encoding, cb) {
     cb();
   });
 
-  if (!util.isUndefined(this.pos))
+  if (!isUndefined(this.pos))
     this.pos += data.length;
 };
 
@@ -1686,10 +1695,10 @@ SyncWriteStream.prototype.write = function(data, arg1, arg2) {
 
   // parse arguments
   if (arg1) {
-    if (util.isString(arg1)) {
+    if (isString(arg1)) {
       encoding = arg1;
       cb = arg2;
-    } else if (util.isFunction(arg1)) {
+    } else if (isFunction(arg1)) {
       cb = arg1;
     } else {
       throw new Error('bad arg');
@@ -1698,7 +1707,7 @@ SyncWriteStream.prototype.write = function(data, arg1, arg2) {
   assertEncoding(encoding);
 
   // Change strings to buffers. SLOW
-  if (util.isString(data)) {
+  if (isString(data)) {
     data = new Buffer(data, encoding);
   }
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -22,6 +22,12 @@
 var tls = require('tls');
 var http = require('http');
 var util = require('util');
+
+var isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var inherits = require('util').inherits;
 var debug = util.debuglog('https');
 
@@ -59,21 +65,21 @@ exports.createServer = function(opts, requestListener) {
 // HTTPS agents.
 
 function createConnection(port, host, options) {
-  if (util.isObject(port)) {
+  if (isObject(port)) {
     options = port;
-  } else if (util.isObject(host)) {
+  } else if (isObject(host)) {
     options = host;
-  } else if (util.isObject(options)) {
+  } else if (isObject(options)) {
     options = options;
   } else {
     options = {};
   }
 
-  if (util.isNumber(port)) {
+  if (isNumber(port)) {
     options.port = port;
   }
 
-  if (util.isString(host)) {
+  if (isString(host)) {
     options.host = host;
   }
 
@@ -114,7 +120,7 @@ Agent.prototype.getName = function(options) {
     name += options.pfx;
 
   name += ':';
-  if (!util.isUndefined(options.rejectUnauthorized))
+  if (!isUndefined(options.rejectUnauthorized))
     name += options.rejectUnauthorized;
 
   return name;

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,6 +21,7 @@
 
 var NativeModule = require('native_module');
 var util = NativeModule.require('util');
+var isString = util.isString;
 var runInThisContext = require('vm').runInThisContext;
 var runInNewContext = require('vm').runInNewContext;
 var assert = require('assert').ok;
@@ -352,7 +353,7 @@ Module.prototype.load = function(filename) {
 
 
 Module.prototype.require = function(path) {
-  assert(util.isString(path), 'path must be a string');
+  assert(isString(path), 'path must be a string');
   assert(path, 'missing path');
   return Module._load(path, this);
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -23,6 +23,14 @@ var events = require('events');
 var stream = require('stream');
 var timers = require('timers');
 var util = require('util');
+
+var isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var assert = require('assert');
 var cares = process.binding('cares_wrap');
 var uv = process.binding('uv');
@@ -57,7 +65,7 @@ function createHandle(fd) {
 var debug = util.debuglog('net');
 
 function isPipeName(s) {
-  return util.isString(s) && toNumber(s) === false;
+  return isString(s) && toNumber(s) === false;
 }
 
 
@@ -90,7 +98,7 @@ exports.connect = exports.createConnection = function() {
 function normalizeConnectArgs(args) {
   var options = {};
 
-  if (util.isObject(args[0])) {
+  if (isObject(args[0])) {
     // connect(options, [cb])
     options = args[0];
   } else if (isPipeName(args[0])) {
@@ -99,13 +107,13 @@ function normalizeConnectArgs(args) {
   } else {
     // connect(port, [host], [cb])
     options.port = args[0];
-    if (util.isString(args[1])) {
+    if (isString(args[1])) {
       options.host = args[1];
     }
   }
 
   var cb = args[args.length - 1];
-  return util.isFunction(cb) ? [options, cb] : [options];
+  return isFunction(cb) ? [options, cb] : [options];
 }
 exports._normalizeConnectArgs = normalizeConnectArgs;
 
@@ -135,16 +143,16 @@ function Socket(options) {
   this._hadError = false;
   this._handle = null;
 
-  if (util.isNumber(options))
+  if (isNumber(options))
     options = { fd: options }; // Legacy interface.
-  else if (util.isUndefined(options))
+  else if (isUndefined(options))
     options = {};
 
   stream.Duplex.call(this, options);
 
   if (options.handle) {
     this._handle = options.handle; // private
-  } else if (!util.isUndefined(options.fd)) {
+  } else if (!isUndefined(options.fd)) {
     this._handle = createHandle(options.fd);
     this._handle.open(options.fd);
     this.readable = options.readable !== false;
@@ -257,7 +265,7 @@ function onSocketEnd() {
 // of the other side sending a FIN.  The standard 'write after end'
 // is overly vague, and makes it seem like the user's code is to blame.
 function writeAfterFIN(chunk, encoding, cb) {
-  if (util.isFunction(encoding)) {
+  if (isFunction(encoding)) {
     cb = encoding;
     encoding = null;
   }
@@ -267,7 +275,7 @@ function writeAfterFIN(chunk, encoding, cb) {
   var self = this;
   // TODO: defer error events consistently everywhere, not just the cb
   self.emit('error', er);
-  if (util.isFunction(cb)) {
+  if (isFunction(cb)) {
     process.nextTick(function() {
       cb(er);
     });
@@ -320,7 +328,7 @@ Socket.prototype._onTimeout = function() {
 Socket.prototype.setNoDelay = function(enable) {
   // backwards compatibility: assume true when `enable` is omitted
   if (this._handle && this._handle.setNoDelay)
-    this._handle.setNoDelay(util.isUndefined(enable) ? true : !!enable);
+    this._handle.setNoDelay(isUndefined(enable) ? true : !!enable);
 };
 
 
@@ -595,7 +603,7 @@ Socket.prototype.__defineGetter__('localPort', function() {
 
 
 Socket.prototype.write = function(chunk, encoding, cb) {
-  if (!util.isString(chunk) && !util.isBuffer(chunk))
+  if (!isString(chunk) && !isBuffer(chunk))
     throw new TypeError('invalid data');
   return stream.Duplex.prototype.write.apply(this, arguments);
 };
@@ -641,7 +649,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     if (err === 0) req._chunks = chunks;
   } else {
     var enc;
-    if (util.isBuffer(data)) {
+    if (isBuffer(data)) {
       req.buffer = data;  // Keep reference alive.
       enc = 'buffer';
     } else {
@@ -728,14 +736,14 @@ Socket.prototype.__defineGetter__('bytesWritten', function() {
       encoding = this._pendingEncoding;
 
   state.buffer.forEach(function(el) {
-    if (util.isBuffer(el.chunk))
+    if (isBuffer(el.chunk))
       bytes += el.chunk.length;
     else
       bytes += Buffer.byteLength(el.chunk, el.encoding);
   });
 
   if (data) {
-    if (util.isBuffer(data))
+    if (isBuffer(data))
       bytes += data.length;
     else
       bytes += Buffer.byteLength(data, encoding);
@@ -812,7 +820,7 @@ Socket.prototype.connect = function(options, cb) {
   if (this.write !== Socket.prototype.write)
     this.write = Socket.prototype.write;
 
-  if (!util.isObject(options)) {
+  if (!isObject(options)) {
     // Old API:
     // connect(port, [host], [cb])
     // connect(path, [cb]);
@@ -839,7 +847,7 @@ Socket.prototype.connect = function(options, cb) {
     initSocketHandle(this);
   }
 
-  if (util.isFunction(cb)) {
+  if (isFunction(cb)) {
     self.once('connect', cb);
   }
 
@@ -948,13 +956,13 @@ function Server(/* [ options, ] listener */) {
 
   var options;
 
-  if (util.isFunction(arguments[0])) {
+  if (isFunction(arguments[0])) {
     options = {};
     self.on('connection', arguments[0]);
   } else {
     options = arguments[0] || {};
 
-    if (util.isFunction(arguments[1])) {
+    if (isFunction(arguments[1])) {
       self.on('connection', arguments[1]);
     }
   }
@@ -994,7 +1002,7 @@ var createServerHandle = exports._createServerHandle =
   // assign handle in listen, and clean up if bind or listen fails
   var handle;
 
-  if (util.isNumber(fd) && fd >= 0) {
+  if (isNumber(fd) && fd >= 0) {
     try {
       handle = createHandle(fd);
     }
@@ -1047,7 +1055,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   if (!self._handle) {
     debug('_listen2: create a handle');
     var rval = createServerHandle(address, port, addressType, fd);
-    if (util.isNumber(rval)) {
+    if (isNumber(rval)) {
       var error = errnoException(rval, 'listen');
       process.nextTick(function() {
         self.emit('error', error);
@@ -1125,7 +1133,7 @@ Server.prototype.listen = function() {
   var self = this;
 
   var lastArg = arguments[arguments.length - 1];
-  if (util.isFunction(lastArg)) {
+  if (isFunction(lastArg)) {
     self.once('listening', lastArg);
   }
 
@@ -1137,11 +1145,11 @@ Server.prototype.listen = function() {
 
   var TCP = process.binding('tcp_wrap').TCP;
 
-  if (arguments.length == 0 || util.isFunction(arguments[0])) {
+  if (arguments.length == 0 || isFunction(arguments[0])) {
     // Bind to a random port.
     listen(self, '0.0.0.0', 0, null, backlog);
 
-  } else if (arguments[0] && util.isObject(arguments[0])) {
+  } else if (arguments[0] && isObject(arguments[0])) {
     var h = arguments[0];
     if (h._handle) {
       h = h._handle;
@@ -1151,7 +1159,7 @@ Server.prototype.listen = function() {
     if (h instanceof TCP) {
       self._handle = h;
       listen(self, null, -1, -1, backlog);
-    } else if (util.isNumber(h.fd) && h.fd >= 0) {
+    } else if (isNumber(h.fd) && h.fd >= 0) {
       listen(self, null, null, null, backlog, h.fd);
     } else {
       throw new Error('Invalid listen argument: ' + h);
@@ -1161,9 +1169,9 @@ Server.prototype.listen = function() {
     var pipeName = self._pipeName = arguments[0];
     listen(self, pipeName, -1, -1, backlog);
 
-  } else if (util.isUndefined(arguments[1]) ||
-             util.isFunction(arguments[1]) ||
-             util.isNumber(arguments[1])) {
+  } else if (isUndefined(arguments[1]) ||
+             isFunction(arguments[1]) ||
+             isNumber(arguments[1])) {
     // The first argument is the port, no IP given.
     listen(self, '0.0.0.0', port, 4, backlog);
 
@@ -1350,11 +1358,11 @@ if (process.platform === 'win32') {
   var simultaneousAccepts;
 
   exports._setSimultaneousAccepts = function(handle) {
-    if (util.isUndefined(handle)) {
+    if (isUndefined(handle)) {
       return;
     }
 
-    if (util.isUndefined(simultaneousAccepts)) {
+    if (isUndefined(simultaneousAccepts)) {
       simultaneousAccepts = (process.env.NODE_MANY_ACCEPTS &&
                              process.env.NODE_MANY_ACCEPTS !== '0');
     }

--- a/lib/path.js
+++ b/lib/path.js
@@ -23,6 +23,7 @@
 var isWindows = process.platform === 'win32';
 var util = require('util');
 
+var isString = util.isString;
 
 // resolves . and .. elements in a path array with directory names there
 // must be no slashes, empty elements, or device names (c:\) in the array
@@ -112,7 +113,7 @@ if (isWindows) {
       }
 
       // Skip empty and invalid entries
-      if (!util.isString(path)) {
+      if (!isString(path)) {
         throw new TypeError('Arguments to path.resolve must be strings');
       } else if (!path) {
         continue;
@@ -214,7 +215,7 @@ if (isWindows) {
   // windows version
   exports.join = function() {
     function f(p) {
-      if (!util.isString(p)) {
+      if (!isString(p)) {
         throw new TypeError('Arguments to path.join must be strings');
       }
       return p;
@@ -323,7 +324,7 @@ if (isWindows) {
       var path = (i >= 0) ? arguments[i] : process.cwd();
 
       // Skip empty and invalid entries
-      if (!util.isString(path)) {
+      if (!isString(path)) {
         throw new TypeError('Arguments to path.resolve must be strings');
       } else if (!path) {
         continue;
@@ -374,7 +375,7 @@ if (isWindows) {
   exports.join = function() {
     var paths = Array.prototype.slice.call(arguments, 0);
     return exports.normalize(paths.filter(function(p, index) {
-      if (!util.isString(p)) {
+      if (!isString(p)) {
         throw new TypeError('Arguments to path.join must be strings');
       }
       return p;
@@ -476,7 +477,7 @@ exports.existsSync = util.deprecate(function(path) {
 if (isWindows) {
   exports._makeLong = function(path) {
     // Note: this will *probably* throw somewhere.
-    if (!util.isString(path))
+    if (!isString(path))
       return path;
 
     if (!path) {

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -24,6 +24,12 @@
 var QueryString = exports;
 var util = require('util');
 
+var isArray = util.isArray,
+    isBoolean = util.isBoolean,
+    isNull = util.isNull,
+    isNumber = util.isNumber,
+    isObject = util.isObject,
+    isString = util.isString;
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -115,11 +121,11 @@ QueryString.escape = function(str) {
 };
 
 var stringifyPrimitive = function(v) {
-  if (util.isString(v))
+  if (isString(v))
     return v;
-  if (util.isBoolean(v))
+  if (isBoolean(v))
     return v ? 'true' : 'false';
-  if (util.isNumber(v))
+  if (isNumber(v))
     return isFinite(v) ? v : '';
   return '';
 };
@@ -128,14 +134,14 @@ var stringifyPrimitive = function(v) {
 QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
   sep = sep || '&';
   eq = eq || '=';
-  if (util.isNull(obj)) {
+  if (isNull(obj)) {
     obj = undefined;
   }
 
-  if (util.isObject(obj)) {
+  if (isObject(obj)) {
     return Object.keys(obj).map(function(k) {
       var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
-      if (util.isArray(obj[k])) {
+      if (isArray(obj[k])) {
         return obj[k].map(function(v) {
           return ks + QueryString.escape(stringifyPrimitive(v));
         }).join(sep);
@@ -157,7 +163,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   eq = eq || '=';
   var obj = {};
 
-  if (!util.isString(qs) || qs.length === 0) {
+  if (!isString(qs) || qs.length === 0) {
     return obj;
   }
 
@@ -165,7 +171,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   qs = qs.split(sep);
 
   var maxKeys = 1000;
-  if (options && util.isNumber(options.maxKeys)) {
+  if (options && isNumber(options.maxKeys)) {
     maxKeys = options.maxKeys;
   }
 
@@ -198,7 +204,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;
-    } else if (util.isArray(obj[k])) {
+    } else if (isArray(obj[k])) {
       obj[k].push(v);
     } else {
       obj[k] = [obj[k], v];

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -28,6 +28,12 @@
 var kHistorySize = 30;
 
 var util = require('util');
+
+var isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isNumber = util.isNumber,
+    isUndefined = util.isUndefined;
+
 var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 
@@ -62,13 +68,13 @@ function Interface(input, output, completer, terminal) {
 
   completer = completer || function() { return []; };
 
-  if (!util.isFunction(completer)) {
+  if (!isFunction(completer)) {
     throw new TypeError('Argument \'completer\' must be a function');
   }
 
   // backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
-  if (util.isUndefined(terminal)) {
+  if (isUndefined(terminal)) {
     terminal = !!output.isTTY;
   }
 
@@ -153,7 +159,7 @@ Interface.prototype.setPrompt = function(prompt) {
 
 
 Interface.prototype._setRawMode = function(mode) {
-  if (util.isFunction(this.input.setRawMode)) {
+  if (isFunction(this.input.setRawMode)) {
     return this.input.setRawMode(mode);
   }
 };
@@ -171,7 +177,7 @@ Interface.prototype.prompt = function(preserveCursor) {
 
 
 Interface.prototype.question = function(query, cb) {
-  if (util.isFunction(cb)) {
+  if (isFunction(cb)) {
     if (this._questionCallback) {
       this.prompt();
     } else {
@@ -287,7 +293,7 @@ Interface.prototype.write = function(d, key) {
 // \r\n, \n, or \r followed by something other than \n
 var lineEnding = /\r?\n|\r(?!\n)/;
 Interface.prototype._normalWrite = function(b) {
-  if (util.isUndefined(b)) {
+  if (isUndefined(b)) {
     return;
   }
   var string = this._decoder.write(b);
@@ -840,7 +846,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       default:
-        if (util.isBuffer(s))
+        if (isBuffer(s))
           s = s.toString('utf-8');
 
         if (s) {
@@ -941,8 +947,8 @@ function emitKey(stream, s) {
       },
       parts;
 
-  if (util.isBuffer(s)) {
-    if (s[0] > 127 && util.isUndefined(s[1])) {
+  if (isBuffer(s)) {
+    if (s[0] > 127 && isUndefined(s[1])) {
       s[0] -= 128;
       s = '\x1b' + s.toString(stream.encoding || 'utf-8');
     } else {
@@ -1121,7 +1127,7 @@ function emitKey(stream, s) {
   }
 
   // Don't emit a key if no name was found
-  if (util.isUndefined(key.name)) {
+  if (isUndefined(key.name)) {
     key = undefined;
   }
 
@@ -1140,13 +1146,13 @@ function emitKey(stream, s) {
  */
 
 function cursorTo(stream, x, y) {
-  if (!util.isNumber(x) && !util.isNumber(y))
+  if (!isNumber(x) && !isNumber(y))
     return;
 
-  if (!util.isNumber(x))
+  if (!isNumber(x))
     throw new Error("Can't set cursor row without also setting it's column");
 
-  if (!util.isNumber(y)) {
+  if (!isNumber(y)) {
     stream.write('\x1b[' + (x + 1) + 'G');
   } else {
     stream.write('\x1b[' + (y + 1) + ';' + (x + 1) + 'H');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -41,6 +41,14 @@
  */
 
 var util = require('util');
+
+var isArray = util.isArray,
+    isFunction = util.isFunction,
+    isNull = util.isNull,
+    isObject = util.isObject,
+    isString = util.isString,
+    isUndefined = util.isUndefined;
+
 var inherits = require('util').inherits;
 var Stream = require('stream');
 var vm = require('vm');
@@ -83,7 +91,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   EventEmitter.call(this);
 
   var options, input, output, dom;
-  if (util.isObject(prompt)) {
+  if (isObject(prompt)) {
     // an options object was given
     options = prompt;
     stream = options.stream || options.socket;
@@ -94,7 +102,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     ignoreUndefined = options.ignoreUndefined;
     prompt = options.prompt;
     dom = options.domain;
-  } else if (!util.isString(prompt)) {
+  } else if (!isString(prompt)) {
     throw new Error('An options Object, or a prompt String are required');
   } else {
     options = {};
@@ -160,7 +168,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.resetContext();
   self.bufferedCommand = '';
 
-  self.prompt = !util.isUndefined(prompt) ? prompt : '> ';
+  self.prompt = !isUndefined(prompt) ? prompt : '> ';
 
   function complete(text, callback) {
     self.complete(text, callback);
@@ -180,7 +188,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   // figure out which "writer" function to use
   self.writer = options.writer || exports.writer;
 
-  if (util.isUndefined(options.useColors)) {
+  if (isUndefined(options.useColors)) {
     options.useColors = rli.terminal;
   }
   self.useColors = !!options.useColors;
@@ -256,7 +264,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
                 function(e, ret) {
             if (e && !isSyntaxError(e)) return finish(e);
 
-            if (util.isFunction(ret) &&
+            if (isFunction(ret) &&
                 /^[\r\n\s]*function/.test(evalCmd) || e) {
               // Now as statement without parens.
               self.eval(evalCmd, self.context, 'repl', finish);
@@ -299,7 +307,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       self.bufferedCommand = '';
 
       // If we got any output - print it (if no error)
-      if (!e && (!self.ignoreUndefined || !util.isUndefined(ret))) {
+      if (!e && (!self.ignoreUndefined || !isUndefined(ret))) {
         self.context._ = ret;
         self.outputStream.write(self.writer(ret) + '\n');
       }
@@ -421,7 +429,7 @@ var simpleExpressionRE =
 // getter code.
 REPLServer.prototype.complete = function(line, callback) {
   // There may be local variables to evaluate, try a nested REPL
-  if (!util.isUndefined(this.bufferedCommand) && this.bufferedCommand.length) {
+  if (!isUndefined(this.bufferedCommand) && this.bufferedCommand.length) {
     // Get a new array of inputed lines
     var tmp = this.lines.slice();
     // Kill off all function declarations to push all local variables into
@@ -563,7 +571,7 @@ REPLServer.prototype.complete = function(line, callback) {
           this.eval('.scope', this.context, 'repl', function(err, globals) {
             if (err || !globals) {
               addStandardGlobals(completionGroups, filter);
-            } else if (util.isArray(globals[0])) {
+            } else if (isArray(globals[0])) {
               // Add grouped globals
               globals.forEach(function(group) {
                 completionGroups.push(group);
@@ -580,19 +588,19 @@ REPLServer.prototype.complete = function(line, callback) {
           // if (e) console.log(e);
 
           if (obj != null) {
-            if (util.isObject(obj) || util.isFunction(obj)) {
+            if (isObject(obj) || isFunction(obj)) {
               memberGroups.push(Object.getOwnPropertyNames(obj));
             }
             // works for non-objects
             try {
               var sentinel = 5;
               var p;
-              if (util.isObject(obj) || util.isFunction(obj)) {
+              if (isObject(obj) || isFunction(obj)) {
                 p = Object.getPrototypeOf(obj);
               } else {
                 p = obj.constructor ? obj.constructor.prototype : null;
               }
-              while (!util.isNull(p)) {
+              while (!isNull(p)) {
                 memberGroups.push(Object.getOwnPropertyNames(p));
                 p = Object.getPrototypeOf(p);
                 // Circular refs possible? Let's guard against that.
@@ -691,9 +699,9 @@ REPLServer.prototype.parseREPLKeyword = function(keyword, rest) {
 
 
 REPLServer.prototype.defineCommand = function(keyword, cmd) {
-  if (util.isFunction(cmd)) {
+  if (isFunction(cmd)) {
     cmd = {action: cmd};
-  } else if (!util.isFunction(cmd.action)) {
+  } else if (!isFunction(cmd.action)) {
     throw new Error('bad argument, action must be a function');
   }
   this.commands['.' + keyword] = cmd;

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -23,6 +23,12 @@ var smalloc = process.binding('smalloc');
 var kMaxLength = smalloc.kMaxLength;
 var util = require('util');
 
+var isArray = util.isArray,
+    isBuffer = util.isBuffer,
+    isNumber = util.isNumber,
+    isPrimitive = util.isPrimitive,
+    isUndefined = util.isUndefined;
+
 exports.alloc = alloc;
 exports.copyOnto = smalloc.copyOnto;
 exports.dispose = dispose;
@@ -57,20 +63,20 @@ Object.defineProperty(exports, 'Types', {
 function alloc(n, obj, type) {
   n = n >>> 0;
 
-  if (util.isUndefined(obj))
+  if (isUndefined(obj))
     obj = {};
 
-  if (util.isNumber(obj)) {
+  if (isNumber(obj)) {
     type = obj >>> 0;
     obj = {};
-  } else if (util.isPrimitive(obj)) {
+  } else if (isPrimitive(obj)) {
     throw new TypeError('obj must be an Object');
   }
 
   // 1 == v8::kExternalByteArray, 9 == v8::kExternalPixelArray
   if (type < 1 || type > 9)
     throw new TypeError('unknown external array type: ' + type);
-  if (util.isArray(obj))
+  if (isArray(obj))
     throw new TypeError('Arrays are not supported');
   if (n > kMaxLength)
     throw new RangeError('n > kMaxLength');
@@ -80,9 +86,9 @@ function alloc(n, obj, type) {
 
 
 function dispose(obj) {
-  if (util.isPrimitive(obj))
+  if (isPrimitive(obj))
     throw new TypeError('obj must be an Object');
-  if (util.isBuffer(obj))
+  if (isBuffer(obj))
     throw new TypeError('obj cannot be a Buffer');
 
   smalloc.dispose(obj);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -23,6 +23,7 @@ module.exports = Stream;
 
 var EE = require('events').EventEmitter;
 var util = require('util');
+var isFunction = util.isFunction;
 
 util.inherits(Stream, EE);
 Stream.Readable = require('_stream_readable');
@@ -84,7 +85,7 @@ Stream.prototype.pipe = function(dest, options) {
     if (didOnEnd) return;
     didOnEnd = true;
 
-    if (util.isFunction(dest.destroy)) dest.destroy();
+    if (isFunction(dest.destroy)) dest.destroy();
   }
 
   // don't leave dangling pipes when there are errors.

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -23,6 +23,9 @@ var net = require('net');
 var url = require('url');
 var util = require('util');
 
+var isArray = util.isArray,
+    isBuffer = util.isBuffer;
+
 exports.DEFAULT_CIPHERS =
     'ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:' + // TLS 1.2
     'RC4:HIGH:!MD5:!aNULL:!EDH';                   // TLS 1.0
@@ -51,7 +54,7 @@ exports.getCiphers = function() {
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")
 exports.convertNPNProtocols = function convertNPNProtocols(NPNProtocols, out) {
   // If NPNProtocols is Array - translate it into buffer
-  if (util.isArray(NPNProtocols)) {
+  if (isArray(NPNProtocols)) {
     var buff = new Buffer(NPNProtocols.reduce(function(p, c) {
       return p + 1 + Buffer.byteLength(c);
     }, 0));
@@ -68,7 +71,7 @@ exports.convertNPNProtocols = function convertNPNProtocols(NPNProtocols, out) {
   }
 
   // If it's already a Buffer - store it
-  if (util.isBuffer(NPNProtocols)) {
+  if (isBuffer(NPNProtocols)) {
     out.NPNProtocols = NPNProtocols;
   }
 };
@@ -166,7 +169,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
     // RFC6125
     if (matchCN) {
       var commonNames = cert.subject.CN;
-      if (util.isArray(commonNames)) {
+      if (isArray(commonNames)) {
         for (var i = 0, k = commonNames.length; i < k; ++i) {
           dnsNames.push(regexpify(commonNames[i], true));
         }
@@ -194,7 +197,7 @@ exports.parseCertString = function parseCertString(s) {
       var key = parts[i].slice(0, sepIndex);
       var value = parts[i].slice(sepIndex + 1);
       if (key in out) {
-        if (!util.isArray(out[key])) {
+        if (!isArray(out[key])) {
           out[key] = [out[key]];
         }
         out[key].push(value);

--- a/lib/url.js
+++ b/lib/url.js
@@ -22,6 +22,11 @@
 var punycode = require('punycode');
 var util = require('util');
 
+var isNull = util.isNull,
+    isNullOrUndefined = util.isNullOrUndefined,
+    isObject = util.isObject,
+    isString = util.isString;
+
 exports.parse = urlParse;
 exports.resolve = urlResolve;
 exports.resolveObject = urlResolveObject;
@@ -95,7 +100,7 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     querystring = require('querystring');
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (url && util.isObject(url) && url instanceof Url) return url;
+  if (url && isObject(url) && url instanceof Url) return url;
 
   var u = new Url;
   u.parse(url, parseQueryString, slashesDenoteHost);
@@ -103,7 +108,7 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
 }
 
 Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
-  if (!util.isString(url)) {
+  if (!isString(url)) {
     throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
   }
 
@@ -341,7 +346,7 @@ function urlFormat(obj) {
   // If it's an obj, this is a no-op.
   // this way, you can call url_format() on strings
   // to clean up potentially wonky urls.
-  if (util.isString(obj)) obj = urlParse(obj);
+  if (isString(obj)) obj = urlParse(obj);
   if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
   return obj.format();
 }
@@ -372,7 +377,7 @@ Url.prototype.format = function() {
   }
 
   if (this.query &&
-      util.isObject(this.query) &&
+      isObject(this.query) &&
       Object.keys(this.query).length) {
     query = querystring.stringify(this.query);
   }
@@ -416,7 +421,7 @@ function urlResolveObject(source, relative) {
 }
 
 Url.prototype.resolveObject = function(relative) {
-  if (util.isString(relative)) {
+  if (isString(relative)) {
     var rel = new Url();
     rel.parse(relative, false, true);
     relative = rel;
@@ -556,7 +561,7 @@ Url.prototype.resolveObject = function(relative) {
     srcPath = srcPath.concat(relPath);
     result.search = relative.search;
     result.query = relative.query;
-  } else if (!util.isNullOrUndefined(relative.search)) {
+  } else if (!isNullOrUndefined(relative.search)) {
     // just pull out the search.
     // like href='?foo'.
     // Put this after the other two cases because it simplifies the booleans
@@ -575,7 +580,7 @@ Url.prototype.resolveObject = function(relative) {
     result.search = relative.search;
     result.query = relative.query;
     //to support http.request
-    if (!util.isNull(result.pathname) || !util.isNull(result.search)) {
+    if (!isNull(result.pathname) || !isNull(result.search)) {
       result.path = (result.pathname ? result.pathname : '') +
                     (result.search ? result.search : '');
     }
@@ -669,7 +674,7 @@ Url.prototype.resolveObject = function(relative) {
   }
 
   //to support request.http
-  if (!util.isNull(result.pathname) || !util.isNull(result.search)) {
+  if (!isNull(result.pathname) || !isNull(result.search)) {
     result.path = (result.pathname ? result.pathname : '') +
                   (result.search ? result.search : '');
   }

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -22,6 +22,7 @@
 var binding = process.binding('contextify');
 var Script = binding.ContextifyScript;
 var util = require('util');
+var isUndefined = util.isUndefined;
 
 // The binding provides a few useful primitives:
 // - ContextifyScript(code, [filename]), with methods:
@@ -42,7 +43,7 @@ exports.createScript = function(code, filename, disp) {
 };
 
 exports.createContext = function(initSandbox) {
-  if (util.isUndefined(initSandbox)) {
+  if (isUndefined(initSandbox)) {
     initSandbox = {};
   }
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -23,6 +23,13 @@ var Transform = require('_stream_transform');
 
 var binding = process.binding('zlib');
 var util = require('util');
+
+var isBuffer = util.isBuffer,
+    isFunction = util.isFunction,
+    isNull = util.isNull,
+    isNumber = util.isNumber,
+    isUndefined = util.isUndefined;
+
 var assert = require('assert').ok;
 
 // zlib doesn't provide these, so kludge them in following the same
@@ -108,7 +115,7 @@ exports.createUnzip = function(o) {
 // Convenience methods.
 // compress/decompress a string or buffer in one step.
 exports.deflate = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -116,7 +123,7 @@ exports.deflate = function(buffer, opts, callback) {
 };
 
 exports.gzip = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -124,7 +131,7 @@ exports.gzip = function(buffer, opts, callback) {
 };
 
 exports.deflateRaw = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -132,7 +139,7 @@ exports.deflateRaw = function(buffer, opts, callback) {
 };
 
 exports.unzip = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -140,7 +147,7 @@ exports.unzip = function(buffer, opts, callback) {
 };
 
 exports.inflate = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -148,7 +155,7 @@ exports.inflate = function(buffer, opts, callback) {
 };
 
 exports.gunzip = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -156,7 +163,7 @@ exports.gunzip = function(buffer, opts, callback) {
 };
 
 exports.inflateRaw = function(buffer, opts, callback) {
-  if (util.isFunction(opts)) {
+  if (isFunction(opts)) {
     callback = opts;
     opts = {};
   }
@@ -305,7 +312,7 @@ function Zlib(opts, mode) {
   }
 
   if (opts.dictionary) {
-    if (!util.isBuffer(opts.dictionary)) {
+    if (!isBuffer(opts.dictionary)) {
       throw new Error('Invalid dictionary: it should be a Buffer instance');
     }
   }
@@ -327,10 +334,10 @@ function Zlib(opts, mode) {
   };
 
   var level = exports.Z_DEFAULT_COMPRESSION;
-  if (util.isNumber(opts.level)) level = opts.level;
+  if (isNumber(opts.level)) level = opts.level;
 
   var strategy = exports.Z_DEFAULT_STRATEGY;
-  if (util.isNumber(opts.strategy)) strategy = opts.strategy;
+  if (isNumber(opts.strategy)) strategy = opts.strategy;
 
   this._binding.init(opts.windowBits || exports.Z_DEFAULT_WINDOWBITS,
                      level,
@@ -390,7 +397,7 @@ Zlib.prototype._flush = function(callback) {
 Zlib.prototype.flush = function(kind, callback) {
   var ws = this._writableState;
 
-  if (util.isFunction(kind) || (util.isUndefined(kind) && !callback)) {
+  if (isFunction(kind) || (isUndefined(kind) && !callback)) {
     callback = kind;
     kind = binding.Z_FULL_FLUSH;
   }
@@ -435,7 +442,7 @@ Zlib.prototype._transform = function(chunk, encoding, cb) {
   var ending = ws.ending || ws.ended;
   var last = ending && (!chunk || ws.length === chunk.length);
 
-  if (!util.isNull(chunk) && !util.isBuffer(chunk))
+  if (!isNull(chunk) && !isBuffer(chunk))
     return cb(new Error('invalid input'));
 
   // If it's the last chunk, or a final flush, we use the Z_FINISH flush flag.


### PR DESCRIPTION
Create local refs to `util.is*` functions so that they don't require a context-switch.

Review, please: @trevnorris and/or @bnoordhuis

Thanks.
