### PR TITLE
self.agent can and will be a non-object so this needs to be checked

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -289,6 +289,8 @@ Agent.prototype.request = function(options, cb) {
   if (options.agent === false)
     options.agent = new this.constructor(options);
 
+  options.agent = options.agent || this;
+
   debug('agent.request', options);
   return new ClientRequest(options, cb);
 };

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -47,7 +47,7 @@ function ClientRequest(options, cb) {
 
   self.agent = util.isUndefined(options.agent) ? globalAgent : options.agent;
 
-  var defaultPort = options.defaultPort || self.agent.defaultPort;
+  var defaultPort = options.defaultPort || (self.agent ? self.agent.defaultPort : 80);
 
   var port = options.port = options.port || defaultPort;
   var host = options.host = options.hostname || options.host || 'localhost';

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -47,7 +47,8 @@ function ClientRequest(options, cb) {
 
   self.agent = util.isUndefined(options.agent) ? globalAgent : options.agent;
 
-  var defaultPort = options.defaultPort || (self.agent ? self.agent.defaultPort : 80);
+  var defaultPort = (self.agent ? self.agent.defaultPort : 80);
+  defaultPort = options.defaultPort || defaultPort;
 
   var port = options.port = options.port || defaultPort;
   var host = options.host = options.hostname || options.host || 'localhost';

--- a/test/simple/test-http-noagent.js
+++ b/test/simple/test-http-noagent.js
@@ -1,0 +1,108 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var url = require('url');
+
+function p(x) {
+  common.error(common.inspect(x));
+}
+
+var responses_sent = 0;
+var responses_recvd = 0;
+var body0 = '';
+var body1 = '';
+
+var server = http.Server(function(req, res) {
+  if (responses_sent == 0) {
+    assert.equal('GET', req.method);
+    assert.equal('/hello', url.parse(req.url).pathname);
+
+    console.dir(req.headers);
+    assert.equal(true, 'accept' in req.headers);
+    assert.equal('*/*', req.headers['accept']);
+
+    assert.equal(true, 'foo' in req.headers);
+    assert.equal('bar', req.headers['foo']);
+  }
+
+  if (responses_sent == 1) {
+    assert.equal('POST', req.method);
+    assert.equal('/world', url.parse(req.url).pathname);
+    this.close();
+  }
+
+  req.on('end', function() {
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.write('The path was ' + url.parse(req.url).pathname);
+    res.end();
+    responses_sent += 1;
+  });
+  req.resume();
+
+  //assert.equal('127.0.0.1', res.connection.remoteAddress);
+});
+server.listen(common.PORT);
+
+server.on('listening', function() {
+  http.get({
+    port: common.PORT,
+    path: '/hello',
+    headers: {'Accept': '*/*', 'Foo': 'bar'},
+    agent: undefined
+  }, function(res) {
+    assert.equal(200, res.statusCode);
+    responses_recvd += 1;
+    res.setEncoding('utf8');
+    res.on('data', function(chunk) { body0 += chunk; });
+    common.debug('Got /hello response');
+  });
+
+  setTimeout(function() {
+    var req = http.request({
+      port: common.PORT,
+      method: 'POST',
+      path: '/world',
+      agent: undefined
+    }, function(res) {
+      assert.equal(200, res.statusCode);
+      responses_recvd += 1;
+      res.setEncoding('utf8');
+      res.on('data', function(chunk) { body1 += chunk; });
+      common.debug('Got /world response');
+    });
+    req.end();
+  }, 1);
+});
+
+process.on('exit', function() {
+  common.debug('responses_recvd: ' + responses_recvd);
+  assert.equal(2, responses_recvd);
+
+  common.debug('responses_sent: ' + responses_sent);
+  assert.equal(2, responses_sent);
+
+  assert.equal('The path was /hello', body0);
+  assert.equal('The path was /world', body1);
+});
+


### PR DESCRIPTION
The current version throws an exception when used with options { agent:false } because globalAgent is undefined.

This is really just a kludge. The real issue is that the whole agent:false thing is documented and has been broken, fixed and rebroken too many times.

Because if I choose not to use an agent, the default port should come from the protocol and not from the globalAgent. There is an assumption in there somewhere that there will be an agent and that it will be the HTTP or HTTPS agent, which is just not true by design.
