### PR TITLE
crypto: make randomBytes/pbkdf2 cbs domain aware

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3370,6 +3370,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   if (args[4]->IsFunction()) {
     Local<Object> obj = Object::New();
     obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "ondone"), args[4]);
+    obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "domain"), GetDomain());
     req->obj.Reset(node_isolate, obj);
     uv_queue_work(uv_default_loop(),
                   &req->work_req,
@@ -3493,6 +3494,7 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   if (args[1]->IsFunction()) {
     Local<Object> obj = Object::New();
     obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "ondone"), args[1]);
+    obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "domain"), GetDomain());
     req->obj_.Reset(node_isolate, obj);
 
     uv_queue_work(uv_default_loop(),

--- a/test/simple/test-crypto-domain.js
+++ b/test/simple/test-crypto-domain.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+
+try {
+  var crypto = require('crypto');
+} catch (e) {
+  console.log('Skipping test, compiled without crypto support.');
+  return;
+}
+
+function test(fn) {
+  var ex = new Error('BAM');
+  var d = domain.create();
+  d.on('error', common.mustCall(function(err) {
+    assert.equal(err, ex);
+  }));
+  var cb = common.mustCall(function() {
+    throw ex;
+  });
+  d.run(cb);
+}
+
+test(function(cb) {
+  crypto.pbkdf2('password', 'salt', 1, 8, cb);
+});
+
+test(function(cb) {
+  crypto.randomBytes(32, cb);
+});


### PR DESCRIPTION
Make the crypto.randomBytes() and crypto.pbkdf2() callback functions
run inside the current domain (if any.)

Fixes #3965.

Suggested reviewer: @isaacs - mostly to check if the test actually tests proper domain usage.
