### PR TITLE
Chainable pause resume

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -244,6 +244,7 @@ emission of a [`'data'` event][].
 #### readable.setEncoding(encoding)
 
 * `encoding` {String} The encoding to use.
+* Return: `this`
 
 Call this function to cause the stream to return strings of the
 specified encoding instead of Buffer objects.  For example, if you do
@@ -268,6 +269,8 @@ readable.on('data', function(chunk) {
 
 #### readable.resume()
 
+* Return: `this`
+
 This method will cause the readable stream to resume emitting `data`
 events.
 
@@ -285,6 +288,8 @@ readable.on('end', function(chunk) {
 ```
 
 #### readable.pause()
+
+* Return: `this`
 
 This method will cause a stream in flowing mode to stop emitting
 `data` events, switching out of flowing mode.  Any data that becomes

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -855,13 +855,14 @@ function Interface(stdin, stdout, args) {
 
 
 Interface.prototype.pause = function() {
-  if (this.killed || this.paused++ > 0) return false;
+  if (this.killed || this.paused++ > 0) return this;
   this.repl.rli.pause();
   this.stdin.pause();
+  return this;
 };
 
 Interface.prototype.resume = function(silent) {
-  if (this.killed || this.paused === 0 || --this.paused !== 0) return false;
+  if (this.killed || this.paused === 0 || --this.paused !== 0) return this;
   this.repl.rli.resume();
   if (silent !== true) {
     this.repl.displayPrompt();
@@ -872,6 +873,7 @@ Interface.prototype.resume = function(silent) {
     this.waiting();
     this.waiting = null;
   }
+  return this;
 };
 
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -198,6 +198,7 @@ Readable.prototype.setEncoding = function(enc) {
     StringDecoder = require('string_decoder').StringDecoder;
   this._readableState.decoder = new StringDecoder(enc);
   this._readableState.encoding = enc;
+  return this;
 };
 
 // Don't raise the hwm > 128MB

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -705,6 +705,7 @@ Readable.prototype.resume = function() {
     }
     resume(this, state);
   }
+  return this;
 };
 
 function resume(stream, state) {
@@ -731,6 +732,7 @@ Readable.prototype.pause = function() {
     this._readableState.flowing = false;
     this.emit('pause');
   }
+  return this;
 };
 
 function flow(stream) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -268,6 +268,7 @@ Interface.prototype.pause = function() {
   this.input.pause();
   this.paused = true;
   this.emit('pause');
+  return this;
 };
 
 
@@ -276,6 +277,7 @@ Interface.prototype.resume = function() {
   this.input.resume();
   this.paused = false;
   this.emit('resume');
+  return this;
 };
 
 

--- a/test/simple/test-stream2-basic.js
+++ b/test/simple/test-stream2-basic.js
@@ -473,3 +473,11 @@ test('adding readable triggers data flow', function(t) {
     t.end();
   });
 });
+
+test('chainable', function(t) {
+  var r = new R();
+  r._read = function() {};
+  var r2 = r.setEncoding('utf8').pause().resume().pause();
+  t.equal(r, r2);
+  t.end();
+});

--- a/test/simple/test-stream2-set-encoding.js
+++ b/test/simple/test-stream2-set-encoding.js
@@ -359,3 +359,9 @@ test('encoding: base64', function(t) {
     t.end();
   });
 });
+
+test('chainable', function(t) {
+  var tr = new TestReader(100);
+  t.equal(tr.setEncoding('utf8'), tr);
+  t.end();
+});


### PR DESCRIPTION
I was reviewing #6076, and I think it's not a terrible idea, but we may as well do the same thing for pause() and resume(), since userland streams are overriding to add this behavior anyway.

(This PR includes @juliangruber's patch from #6076.)
