### PR TITLE
process: Add internal _rawDebug() method

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -248,9 +248,6 @@
 
   var assert;
   startup.processAssert = function() {
-    // Note that calls to assert() are pre-processed out by JS2C for the
-    // normal build of node. They persist only in the node_g build.
-    // Similarly for debug().
     assert = process.assert = function(x, msg) {
       if (!x) throw new Error(msg || 'assertion error');
     };

--- a/src/node.js
+++ b/src/node.js
@@ -55,6 +55,8 @@
 
     startup.processChannel();
 
+    startup.processRawDebug();
+
     startup.resolveArgv0();
 
     // There are various modes that Node can run in. The most common two
@@ -649,7 +651,17 @@
       cp._forkChild(fd);
       assert(process.send);
     }
-  }
+  };
+
+
+  startup.processRawDebug = function() {
+    var format = NativeModule.require('util').format;
+    var rawDebug = process._rawDebug;
+    process._rawDebug = function() {
+      rawDebug(format.apply(null, arguments));
+    };
+  };
+
 
   startup.resolveArgv0 = function() {
     var cwd = process.cwd();

--- a/test/simple/test-process-raw-debug.js
+++ b/test/simple/test-process-raw-debug.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+switch (process.argv[2]) {
+  case 'child':
+    return child();
+  case undefined:
+    return parent();
+  default:
+    throw new Error('wtf? ' + process.argv[2]);
+}
+
+function parent() {
+  var spawn = require('child_process').spawn;
+  var child = spawn(process.execPath, [__filename, 'child']);
+
+  var output = '';
+
+  child.stderr.on('data', function(c) {
+    output += c;
+  });
+
+  child.stderr.setEncoding('utf8');
+
+  child.stderr.on('end', function() {
+    assert.equal(output, 'I can still debug!\n');
+    console.log('ok - got expected message');
+  });
+
+  child.on('exit', function(c) {
+    assert(!c);
+    console.log('ok - child exited nicely');
+  });
+}
+
+function child() {
+  // even when all hope is lost...
+
+  process.nextTick = function() {
+    throw new Error('No ticking!');
+  };
+
+  var stderr = process.stderr;
+  stderr.write = function() {
+    throw new Error('No writing to stderr!');
+  };
+
+  process._rawDebug('I can still %s!', 'debug');
+}


### PR DESCRIPTION
This is useful when we need to push some debugging messages out to
stderr, without going through the Writable class, or triggering any kind
of nextTick or callback behavior.
