### PR TITLE
src: clean up CLI argument parser

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -120,11 +120,6 @@ NODE_EXTERN extern bool no_deprecation;
 
 NODE_EXTERN int Start(int argc, char *argv[]);
 
-char** Init(int argc, char *argv[]);
-v8::Handle<v8::Object> SetupProcessObject(int argc, char *argv[]);
-void Load(v8::Handle<v8::Object> process);
-void EmitExit(v8::Handle<v8::Object> process);
-
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(1000*static_cast<double>(t))
 #define NODE_V8_UNIXTIME(v) (static_cast<double>((v)->NumberValue())/1000.0);

--- a/test/simple/test-child-process-fork-exec-argv.js
+++ b/test/simple/test-child-process-fork-exec-argv.js
@@ -31,7 +31,7 @@ if (process.argv[2] === 'fork') {
 } else if (process.argv[2] === 'child') {
   fork(__filename, ['fork']);
 } else {
-  var execArgv = ['--harmony_proxies', '--max-stack-size=0'];
+  var execArgv = ['--harmony_proxies', '--stack-size=64'];
   var args = [__filename, 'child', 'arg0'];
 
   var child = spawn(process.execPath, execArgv.concat(args));

--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -90,3 +90,8 @@ child.exec(nodejs + ' -p "\\-42"',
       assert.equal(stdout, '-42\n');
       assert.equal(stderr, '');
     });
+
+child.exec(nodejs + ' --use-strict -p process.execArgv',
+    function(status, stdout, stderr) {
+      assert.equal(stdout, "[ '--use-strict', '-p', 'process.execArgv' ]\n");
+    });

--- a/test/simple/test-process-exec-argv.js
+++ b/test/simple/test-process-exec-argv.js
@@ -25,7 +25,7 @@ var spawn = require('child_process').spawn;
 if (process.argv[2] === 'child') {
   process.stdout.write(JSON.stringify(process.execArgv));
 } else {
-  var execArgv = ['--harmony_proxies', '--max-stack-size=0'];
+  var execArgv = ['--harmony_proxies', '--stack-size=64'];
   var args = [__filename, 'child', 'arg0'];
   var child = spawn(process.execPath, execArgv.concat(args));
   var out = '';


### PR DESCRIPTION
- Exit with an error message when the option is not a node or V8 option.
- Remove the option_end_index global.  Needs to happen anyway for
  the multi-context work, might as well land it in master now.
- Add a smidgen of const-correctness.
- Pay off a few years of accrued technical debt.

Hit it, Jenkins.
