### PR TITLE
Multi-context support WIP

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -116,6 +116,8 @@
         'src/udp_wrap.cc',
         'src/uv.cc',
         # headers to make for a more pleasant IDE experience
+        'src/env.h',
+        'src/env-inl.h',
         'src/handle_wrap.h',
         'src/node.h',
         'src/node_buffer.h',
@@ -124,6 +126,7 @@
         'src/node_extensions.h',
         'src/node_file.h',
         'src/node_http_parser.h',
+        'src/node_internals.h',
         'src/node_javascript.h',
         'src/node_root_certs.h',
         'src/node_version.h',
@@ -139,6 +142,8 @@
         'src/string_bytes.h',
         'src/stream_wrap.h',
         'src/tree.h',
+        'src/util.h',
+        'src/util-inl.h',
         'deps/http_parser/http_parser.h',
         '<(SHARED_INTERMEDIATE_DIR)/node_natives.h',
         # javascript files to make for an even more pleasant IDE experience

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1,0 +1,289 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_ENV_INL_H_
+#define SRC_ENV_INL_H_
+
+#include "env.h"
+#include "util.h"
+#include "util-inl.h"
+#include "uv.h"
+#include "v8.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace node {
+
+inline Environment::IsolateData* Environment::IsolateData::GetOrCreate(
+    v8::Isolate* isolate) {
+  IsolateData* isolate_data = static_cast<IsolateData*>(isolate->GetData());
+  if (isolate_data == NULL) {
+    isolate_data = new IsolateData(isolate);
+    isolate->SetData(isolate_data);
+  }
+  isolate_data->ref_count_ += 1;
+  return isolate_data;
+}
+
+inline void Environment::IsolateData::Put() {
+  if (--ref_count_ == 0) {
+    isolate()->SetData(NULL);
+    delete this;
+  }
+}
+
+inline Environment::IsolateData::IsolateData(v8::Isolate* isolate)
+    : event_loop_(uv_default_loop())
+    , isolate_(isolate)
+#define V(PropertyName, StringValue)                                          \
+    , PropertyName ## _index_(                                                \
+        FIXED_ONE_BYTE_STRING(isolate, StringValue).Eternalize(isolate))
+    PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+    , ref_count_(0) {
+}
+
+inline uv_loop_t* Environment::IsolateData::event_loop() const {
+  return event_loop_;
+}
+
+inline v8::Isolate* Environment::IsolateData::isolate() const {
+  return isolate_;
+}
+
+inline Environment::DomainFlag::DomainFlag() {
+  for (int i = 0; i < kFieldsCount; ++i) fields_[i] = 0;
+}
+
+inline uint32_t* Environment::DomainFlag::fields() {
+  return fields_;
+}
+
+inline int Environment::DomainFlag::fields_count() const {
+  return kFieldsCount;
+}
+
+inline uint32_t Environment::DomainFlag::count() const {
+  return fields_[kCount];
+}
+
+inline Environment::TickInfo::TickInfo() {
+  for (int i = 0; i < kFieldsCount; ++i) fields_[i] = 0;
+}
+
+inline uint32_t* Environment::TickInfo::fields() {
+  return fields_;
+}
+
+inline int Environment::TickInfo::fields_count() const {
+  return kFieldsCount;
+}
+
+inline uint32_t Environment::TickInfo::in_tick() const {
+  return fields_[kInTick];
+}
+
+inline uint32_t Environment::TickInfo::index() const {
+  return fields_[kIndex];
+}
+
+inline uint32_t Environment::TickInfo::last_threw() const {
+  return fields_[kLastThrew];
+}
+
+inline uint32_t Environment::TickInfo::length() const {
+  return fields_[kLength];
+}
+
+inline void Environment::TickInfo::set_index(uint32_t value) {
+  fields_[kIndex] = value;
+}
+
+inline void Environment::TickInfo::set_last_threw(uint32_t value) {
+  fields_[kLastThrew] = value;
+}
+
+inline Environment* Environment::New(v8::Local<v8::Context> context) {
+  Environment* env = new Environment(context);
+  context->SetAlignedPointerInEmbedderData(kContextEmbedderDataIndex, env);
+  return env;
+}
+
+inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {
+  return GetCurrent(isolate->GetCurrentContext());
+}
+
+inline Environment* Environment::GetCurrent(v8::Local<v8::Context> context) {
+  return static_cast<Environment*>(
+      context->GetAlignedPointerFromEmbedderData(kContextEmbedderDataIndex));
+}
+
+inline Environment* Environment::GetCurrentChecked(v8::Isolate* isolate) {
+  if (isolate == NULL) {
+    return NULL;
+  } else {
+    return GetCurrentChecked(isolate->GetCurrentContext());
+  }
+}
+
+inline Environment* Environment::GetCurrentChecked(
+    v8::Local<v8::Context> context) {
+  if (context.IsEmpty()) {
+    return NULL;
+  } else {
+    return GetCurrent(context);
+  }
+}
+
+inline Environment::Environment(v8::Local<v8::Context> context)
+    : isolate_(context->GetIsolate())
+    , isolate_data_(IsolateData::GetOrCreate(context->GetIsolate()))
+    , using_smalloc_alloc_cb_(false)
+    , using_domains_(false)
+    , context_(context->GetIsolate(), context) {
+  // We'll be creating new objects so make sure we've entered the context.
+  v8::Context::Scope context_scope(context);
+  v8::HandleScope handle_scope(isolate());
+  set_binding_cache_object(v8::Object::New());
+  set_module_load_list_array(v8::Array::New());
+}
+
+inline Environment::~Environment() {
+  context()->SetAlignedPointerInEmbedderData(kContextEmbedderDataIndex, NULL);
+#define V(PropertyName, TypeName) PropertyName ## _.Dispose();
+  ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
+#undef V
+  isolate_data()->Put();
+}
+
+inline void Environment::Dispose() {
+  delete this;
+}
+
+inline v8::Isolate* Environment::isolate() const {
+  return isolate_;
+}
+
+inline bool Environment::in_domain() const {
+  // The const_cast is okay, it doesn't violate conceptual const-ness.
+  return using_domains() &&
+         const_cast<Environment*>(this)->domain_flag()->count() > 0;
+}
+
+inline Environment* Environment::from_immediate_check_handle(
+    uv_check_t* handle) {
+  return CONTAINER_OF(handle, Environment, immediate_check_handle_);
+}
+
+inline uv_check_t* Environment::immediate_check_handle() {
+  return &immediate_check_handle_;
+}
+
+inline uv_idle_t* Environment::immediate_idle_handle() {
+  return &immediate_idle_handle_;
+}
+
+inline uv_loop_t* Environment::event_loop() const {
+  return isolate_data()->event_loop();
+}
+
+inline Environment::DomainFlag* Environment::domain_flag() {
+  return &domain_flag_;
+}
+
+inline Environment::TickInfo* Environment::tick_info() {
+  return &tick_info_;
+}
+
+inline bool Environment::using_smalloc_alloc_cb() const {
+  return using_smalloc_alloc_cb_;
+}
+
+inline void Environment::set_using_smalloc_alloc_cb(bool value) {
+  using_smalloc_alloc_cb_ = value;
+}
+
+inline bool Environment::using_domains() const {
+  return using_domains_;
+}
+
+inline void Environment::set_using_domains(bool value) {
+  using_domains_ = value;
+}
+
+inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {
+  return CONTAINER_OF(handle, Environment, cares_timer_handle_);
+}
+
+inline uv_timer_t* Environment::cares_timer_handle() {
+  return &cares_timer_handle_;
+}
+
+inline ares_channel Environment::cares_channel() {
+  return cares_channel_;
+}
+
+// Only used in the call to ares_init_options().
+inline ares_channel* Environment::cares_channel_ptr() {
+  return &cares_channel_;
+}
+
+inline ares_task_list* Environment::cares_task_list() {
+  return &cares_task_list_;
+}
+
+inline Environment::IsolateData* Environment::isolate_data() const {
+  return isolate_data_;
+}
+
+#define V(PropertyName, StringValue)                                          \
+  inline                                                                      \
+  v8::Local<v8::String> Environment::IsolateData::PropertyName() const {      \
+    return v8::Local<v8::String>::GetEternal(isolate(),                       \
+                                             PropertyName ## _index_);        \
+  }
+  PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, StringValue)                                          \
+  inline v8::Local<v8::String> Environment::PropertyName() const {            \
+    return isolate_data()->PropertyName();                                    \
+  }
+  PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, TypeName)                                             \
+  inline v8::Local<TypeName> Environment::PropertyName() const {              \
+    return StrongPersistentToLocal(PropertyName ## _);                        \
+  }                                                                           \
+  inline void Environment::set_ ## PropertyName(v8::Local<TypeName> value) {  \
+    PropertyName ## _.Reset(isolate(), value);                                \
+  }
+  ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
+#undef V
+
+#undef ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES
+#undef PER_ISOLATE_STRING_PROPERTIES
+
+}  // namespace node
+
+#endif  // SRC_ENV_INL_H_

--- a/src/env.h
+++ b/src/env.h
@@ -1,0 +1,324 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_ENV_H_
+#define SRC_ENV_H_
+
+#include "ares.h"
+#include "tree.h"
+#include "util.h"
+#include "uv.h"
+#include "v8.h"
+
+#include <stdint.h>
+
+// Caveat emptor: we're going slightly crazy with macros here but the end
+// hopefully justifies the means. We have a lot of per-context properties
+// and adding and maintaining their getters and setters by hand would be
+// a nightmare so let's make the preprocessor generate them for us.
+//
+// Make sure that any macros defined here are undefined again at the bottom
+// of context-inl.h. The sole exception is NODE_CONTEXT_EMBEDDER_DATA_INDEX,
+// it may have been defined externally.
+namespace node {
+
+// Pick an index that's hopefully out of the way when we're embedded inside
+// another application. Performance-wise or memory-wise it doesn't matter:
+// Context::SetAlignedPointerInEmbedderData() is backed by a FixedArray,
+// worst case we pay a one-time penalty for resizing the array.
+#ifndef NODE_CONTEXT_EMBEDDER_DATA_INDEX
+#define NODE_CONTEXT_EMBEDDER_DATA_INDEX 32
+#endif
+
+// Strings are per-isolate primitives but Environment proxies them
+// for the sake of convenience.
+#define PER_ISOLATE_STRING_PROPERTIES(V)                                      \
+  V(DELETE_string, "DELETE")                                                  \
+  V(GET_string, "GET")                                                        \
+  V(HEAD_string, "HEAD")                                                      \
+  V(POST_string, "POST")                                                      \
+  V(PUT_string, "PUT")                                                        \
+  V(address_string, "address")                                                \
+  V(atime_string, "atime")                                                    \
+  V(birthtime_string, "birthtime")                                            \
+  V(blksize_string, "blksize")                                                \
+  V(blocks_string, "blocks")                                                  \
+  V(buffer_string, "buffer")                                                  \
+  V(bytes_string, "bytes")                                                    \
+  V(callback_string, "callback")                                              \
+  V(change_string, "change")                                                  \
+  V(close_string, "close")                                                    \
+  V(code_string, "code")                                                      \
+  V(ctime_string, "ctime")                                                    \
+  V(dev_string, "dev")                                                        \
+  V(disposed_string, "_disposed")                                             \
+  V(domain_string, "domain")                                                  \
+  V(enter_string, "enter")                                                    \
+  V(errno_string, "errno")                                                    \
+  V(exit_string, "exit")                                                      \
+  V(exponent_string, "exponent")                                              \
+  V(exports_string, "exports")                                                \
+  V(ext_key_usage_string, "ext_key_usage")                                    \
+  V(family_string, "family")                                                  \
+  V(fatal_exception_string, "_fatalException")                                \
+  V(fingerprint_string, "fingerprint")                                        \
+  V(gid_string, "gid")                                                        \
+  V(handle_string, "handle")                                                  \
+  V(headers_string, "headers")                                                \
+  V(heap_total_string, "heapTotal")                                           \
+  V(heap_used_string, "heapUsed")                                             \
+  V(immediate_callback_string, "_immediateCallback")                          \
+  V(ino_string, "ino")                                                        \
+  V(ipv4_string, "IPv4")                                                      \
+  V(ipv6_string, "IPv6")                                                      \
+  V(issuer_string, "issuer")                                                  \
+  V(method_string, "method")                                                  \
+  V(mode_string, "mode")                                                      \
+  V(modulus_string, "modulus")                                                \
+  V(mtime_string, "mtime")                                                    \
+  V(name_string, "name")                                                      \
+  V(nlink_string, "nlink")                                                    \
+  V(onchange_string, "onchange")                                              \
+  V(onclienthello_string, "onclienthello")                                    \
+  V(oncomplete_string, "oncomplete")                                          \
+  V(onconnection_string, "onconnection")                                      \
+  V(onerror_string, "onerror")                                                \
+  V(onexit_string, "onexit")                                                  \
+  V(onhandshakedone_string, "onhandshakedone")                                \
+  V(onhandshakestart_string, "onhandshakestart")                              \
+  V(onmessage_string, "onmessage")                                            \
+  V(onnewsession_string, "onnewsession")                                      \
+  V(onread_string, "onread")                                                  \
+  V(onsignal_string, "onsignal")                                              \
+  V(onstop_string, "onstop")                                                  \
+  V(path_string, "path")                                                      \
+  V(port_string, "port")                                                      \
+  V(rdev_string, "rdev")                                                      \
+  V(rename_string, "rename")                                                  \
+  V(rss_string, "rss")                                                        \
+  V(servername_string, "servername")                                          \
+  V(session_id_string, "sessionId")                                           \
+  V(should_keep_alive_string, "shouldKeepAlive")                              \
+  V(size_string, "size")                                                      \
+  V(smalloc_p_string, "_smalloc_p")                                           \
+  V(sni_context_string, "sni_context")                                        \
+  V(status_code_string, "statusCode")                                         \
+  V(subject_string, "subject")                                                \
+  V(subjectaltname_string, "subjectaltname")                                  \
+  V(syscall_string, "syscall")                                                \
+  V(tls_ticket_string, "tlsTicket")                                           \
+  V(uid_string, "uid")                                                        \
+  V(upgrade_string, "upgrade")                                                \
+  V(url_string, "url")                                                        \
+  V(valid_from_string, "valid_from")                                          \
+  V(valid_to_string, "valid_to")                                              \
+  V(version_major_string, "versionMajor")                                     \
+  V(version_minor_string, "versionMinor")                                     \
+  V(version_string, "version")                                                \
+  V(write_queue_size_string, "writeQueueSize")                                \
+
+#define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
+  V(binding_cache_object, v8::Object)                                         \
+  V(buffer_constructor_function, v8::Function)                                \
+  V(context, v8::Context)                                                     \
+  V(domain_array, v8::Array)                                                  \
+  V(module_load_list_array, v8::Array)                                        \
+  V(pipe_constructor_template, v8::FunctionTemplate)                          \
+  V(process_object, v8::Object)                                               \
+  V(script_context_constructor_template, v8::FunctionTemplate)                \
+  V(script_data_constructor_function, v8::Function)                           \
+  V(secure_context_constructor_template, v8::FunctionTemplate)                \
+  V(stats_constructor_function, v8::Function)                                 \
+  V(tcp_constructor_template, v8::FunctionTemplate)                           \
+  V(tick_callback_function, v8::Function)                                     \
+  V(tls_wrap_constructor_function, v8::Function)                              \
+  V(tty_constructor_template, v8::FunctionTemplate)                           \
+  V(udp_constructor_function, v8::Function)                                   \
+
+class Environment;
+
+// TODO(bnoordhuis) Rename struct, the ares_ prefix implies it's part
+// of the c-ares API while the _t suffix implies it's a typedef.
+struct ares_task_t {
+  Environment* env;
+  ares_socket_t sock;
+  uv_poll_t poll_watcher;
+  RB_ENTRY(ares_task_t) node;
+};
+
+RB_HEAD(ares_task_list, ares_task_t);
+
+class Environment {
+ public:
+  class DomainFlag {
+   public:
+    inline uint32_t* fields();
+    inline int fields_count() const;
+    inline uint32_t count() const;
+
+   private:
+    friend class Environment;  // So we can call the constructor.
+    inline DomainFlag();
+
+    enum Fields {
+      kCount,
+      kFieldsCount
+    };
+
+    uint32_t fields_[kFieldsCount];
+
+    DISALLOW_COPY_AND_ASSIGN(DomainFlag);
+  };
+
+  class TickInfo {
+   public:
+    inline uint32_t* fields();
+    inline int fields_count() const;
+    inline uint32_t in_tick() const;
+    inline uint32_t index() const;
+    inline uint32_t last_threw() const;
+    inline uint32_t length() const;
+    inline void set_index(uint32_t value);
+    inline void set_last_threw(uint32_t value);
+
+   private:
+    friend class Environment;  // So we can call the constructor.
+    inline TickInfo();
+
+    enum Fields {
+      kInTick,
+      kIndex,
+      kLastThrew,
+      kLength,
+      kFieldsCount
+    };
+
+    uint32_t fields_[kFieldsCount];
+
+    DISALLOW_COPY_AND_ASSIGN(TickInfo);
+  };
+
+  static inline Environment* GetCurrent(v8::Isolate* isolate);
+  static inline Environment* GetCurrent(v8::Local<v8::Context> context);
+  static inline Environment* GetCurrentChecked(v8::Isolate* isolate);
+  static inline Environment* GetCurrentChecked(v8::Local<v8::Context> context);
+
+  // See CreateEnvironment() in src/node.cc.
+  static inline Environment* New(v8::Local<v8::Context> context);
+  inline void Dispose();
+
+  inline v8::Isolate* isolate() const;
+  inline uv_loop_t* event_loop() const;
+  inline bool in_domain() const;
+
+  static inline Environment* from_immediate_check_handle(uv_check_t* handle);
+  inline uv_check_t* immediate_check_handle();
+  inline uv_idle_t* immediate_idle_handle();
+  inline DomainFlag* domain_flag();
+  inline TickInfo* tick_info();
+
+  static inline Environment* from_cares_timer_handle(uv_timer_t* handle);
+  inline uv_timer_t* cares_timer_handle();
+  inline ares_channel cares_channel();
+  inline ares_channel* cares_channel_ptr();
+  inline ares_task_list* cares_task_list();
+
+  inline bool using_smalloc_alloc_cb() const;
+  inline void set_using_smalloc_alloc_cb(bool value);
+
+  inline bool using_domains() const;
+  inline void set_using_domains(bool value);
+
+  // Strings are shared across shared contexts. The getters simply proxy to
+  // the per-isolate primitive.
+#define V(PropertyName, StringValue)                                          \
+  inline v8::Local<v8::String> PropertyName() const;
+  PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, TypeName)                                             \
+  inline v8::Local<TypeName> PropertyName() const;                            \
+  inline void set_ ## PropertyName(v8::Local<TypeName> value);
+  ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
+#undef V
+
+ private:
+  class IsolateData;
+  inline explicit Environment(v8::Local<v8::Context> context);
+  inline ~Environment();
+  inline IsolateData* isolate_data() const;
+
+  enum ContextEmbedderDataIndex {
+    kContextEmbedderDataIndex = NODE_CONTEXT_EMBEDDER_DATA_INDEX
+  };
+
+  v8::Isolate* const isolate_;
+  IsolateData* const isolate_data_;
+  uv_check_t immediate_check_handle_;
+  uv_idle_t immediate_idle_handle_;
+  DomainFlag domain_flag_;
+  TickInfo tick_info_;
+  uv_timer_t cares_timer_handle_;
+  ares_channel cares_channel_;
+  ares_task_list cares_task_list_;
+  bool using_smalloc_alloc_cb_;
+  bool using_domains_;
+
+#define V(PropertyName, TypeName)                                             \
+  v8::Persistent<TypeName> PropertyName ## _;
+  ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
+#undef V
+
+  // Per-thread, reference-counted singleton.
+  class IsolateData {
+   public:
+    static inline IsolateData* GetOrCreate(v8::Isolate* isolate);
+    inline void Put();
+    inline uv_loop_t* event_loop() const;
+
+#define V(PropertyName, StringValue)                                          \
+    inline v8::Local<v8::String> PropertyName() const;
+    PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+   private:
+    inline explicit IsolateData(v8::Isolate* isolate);
+    inline v8::Isolate* isolate() const;
+
+    uv_loop_t* const event_loop_;
+    v8::Isolate* const isolate_;
+
+#define V(PropertyName, StringValue)                                          \
+    const int PropertyName ## _index_;
+    PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+    unsigned int ref_count_;
+
+    DISALLOW_COPY_AND_ASSIGN(IsolateData);
+  };
+
+  DISALLOW_COPY_AND_ASSIGN(Environment);
+};
+
+}  // namespace node
+
+#endif  // SRC_ENV_H_

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -22,6 +22,7 @@
 #ifndef SRC_HANDLE_WRAP_H_
 #define SRC_HANDLE_WRAP_H_
 
+#include "env.h"
 #include "node.h"
 #include "queue.h"
 #include "uv.h"
@@ -58,11 +59,17 @@ class HandleWrap {
   inline uv_handle_t* GetHandle() { return handle__; }
 
  protected:
-  explicit HandleWrap(v8::Handle<v8::Object> object, uv_handle_t* handle);
+  HandleWrap(Environment* env,
+             v8::Handle<v8::Object> object,
+             uv_handle_t* handle);
   virtual ~HandleWrap();
 
+  inline Environment* env() const {
+    return env_;
+  }
+
   inline v8::Local<v8::Object> object() {
-    return PersistentToLocal(node_isolate, persistent());
+    return PersistentToLocal(env()->isolate(), persistent());
   }
 
   inline v8::Persistent<v8::Object>& persistent() {
@@ -74,10 +81,11 @@ class HandleWrap {
   static void OnClose(uv_handle_t* handle);
   v8::Persistent<v8::Object> object_;
   QUEUE handle_wrap_queue_;
+  Environment* const env_;
+  unsigned int flags_;
   // Using double underscore due to handle_ member in tcp_wrap. Probably
   // tcp_wrap should rename it's member to 'handle'.
   uv_handle_t* handle__;
-  unsigned int flags_;
 
   static const unsigned int kUnref = 1;
   static const unsigned int kCloseCallback = 2;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -22,11 +22,13 @@
 
 #include "node.h"
 #include "node_buffer.h"
+
+#include "env.h"
+#include "env-inl.h"
 #include "smalloc.h"
 #include "string_bytes.h"
-
-#include "v8.h"
 #include "v8-profiler.h"
+#include "v8.h"
 
 #include <assert.h>
 #include <string.h>
@@ -55,6 +57,7 @@
 namespace node {
 namespace Buffer {
 
+using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -63,12 +66,9 @@ using v8::HandleScope;
 using v8::Local;
 using v8::Number;
 using v8::Object;
-using v8::Persistent;
 using v8::String;
 using v8::Uint32;
 using v8::Value;
-
-static Persistent<Function> p_buffer_fn;
 
 
 bool HasInstance(Handle<Value> val) {
@@ -124,12 +124,20 @@ Local<Object> New(Handle<String> string, enum encoding enc) {
 
 
 Local<Object> New(size_t length) {
+  Environment* env = Environment::GetCurrent(node_isolate);
+  return Buffer::New(env, length);
+}
+
+
+// TODO(trevnorris): these have a flaw by needing to call the Buffer inst then
+// Alloc. continue to look for a better architecture.
+Local<Object> New(Environment* env, size_t length) {
   HandleScope scope(node_isolate);
 
   assert(length <= kMaxLength);
 
   Local<Value> arg = Uint32::NewFromUnsigned(length, node_isolate);
-  Local<Object> obj = NewInstance(p_buffer_fn, 1, &arg);
+  Local<Object> obj = env->buffer_constructor_function()->NewInstance(1, &arg);
 
   // TODO(trevnorris): done like this to handle HasInstance since only checks
   // if external array data has been set, but would like to use a better
@@ -148,16 +156,22 @@ Local<Object> New(size_t length) {
 }
 
 
+Local<Object> New(const char* data, size_t length) {
+  Environment* env = Environment::GetCurrent(node_isolate);
+  return Buffer::New(env, data, length);
+}
+
+
 // TODO(trevnorris): for backwards compatibility this is left to copy the data,
 // but for consistency w/ the other should use data. And a copy version renamed
 // to something else.
-Local<Object> New(const char* data, size_t length) {
+Local<Object> New(Environment* env, const char* data, size_t length) {
   HandleScope scope(node_isolate);
 
   assert(length <= kMaxLength);
 
   Local<Value> arg = Uint32::NewFromUnsigned(length, node_isolate);
-  Local<Object> obj = NewInstance(p_buffer_fn, 1, &arg);
+  Local<Object> obj = env->buffer_constructor_function()->NewInstance(1, &arg);
 
   // TODO(trevnorris): done like this to handle HasInstance since only checks
   // if external array data has been set, but would like to use a better
@@ -182,12 +196,22 @@ Local<Object> New(char* data,
                   size_t length,
                   smalloc::FreeCallback callback,
                   void* hint) {
+  Environment* env = Environment::GetCurrent(node_isolate);
+  return Buffer::New(env, data, length, callback, hint);
+}
+
+
+Local<Object> New(Environment* env,
+                  char* data,
+                  size_t length,
+                  smalloc::FreeCallback callback,
+                  void* hint) {
   HandleScope scope(node_isolate);
 
   assert(length <= kMaxLength);
 
   Local<Value> arg = Uint32::NewFromUnsigned(length, node_isolate);
-  Local<Object> obj = NewInstance(p_buffer_fn, 1, &arg);
+  Local<Object> obj = env->buffer_constructor_function()->NewInstance(1, &arg);
 
   smalloc::Alloc(obj, data, length, callback, hint);
 
@@ -196,12 +220,18 @@ Local<Object> New(char* data,
 
 
 Local<Object> Use(char* data, uint32_t length) {
+  Environment* env = Environment::GetCurrent(node_isolate);
+  return Buffer::Use(env, data, length);
+}
+
+
+Local<Object> Use(Environment* env, char* data, uint32_t length) {
   HandleScope scope(node_isolate);
 
   assert(length <= kMaxLength);
 
   Local<Value> arg = Uint32::NewFromUnsigned(length, node_isolate);
-  Local<Object> obj = NewInstance(p_buffer_fn, 1, &arg);
+  Local<Object> obj = env->buffer_constructor_function()->NewInstance(1, &arg);
 
   smalloc::Alloc(obj, data, length);
 
@@ -534,12 +564,13 @@ void ByteLength(const FunctionCallbackInfo<Value> &args) {
 
 // pass Buffer object to load prototype methods
 void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
 
   assert(args[0]->IsFunction());
 
   Local<Function> bv = args[0].As<Function>();
-  p_buffer_fn.Reset(node_isolate, bv);
+  env->set_buffer_constructor_function(bv);
   Local<Value> proto_v =
       bv->Get(FIXED_ONE_BYTE_STRING(node_isolate, "prototype"));
 
@@ -588,10 +619,12 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target) {
-  HandleScope scope(node_isolate);
-
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "setupBufferJS"),
+void Initialize(Handle<Object> target,
+                Handle<Value> unused,
+                Handle<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+  HandleScope handle_scope(env->isolate());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "setupBufferJS"),
               FunctionTemplate::New(SetupBufferJS)->GetFunction());
 }
 
@@ -599,4 +632,4 @@ void Initialize(Handle<Object> target) {
 }  // namespace Buffer
 }  // namespace node
 
-NODE_MODULE(node_buffer, node::Buffer::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_buffer, node::Buffer::Initialize)

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -26,6 +26,10 @@
 #include "smalloc.h"
 #include "v8.h"
 
+#if defined(NODE_WANT_INTERNALS)
+#include "env.h"
+#endif  // defined(NODE_WANT_INTERNALS)
+
 namespace node {
 namespace Buffer {
 
@@ -55,6 +59,20 @@ NODE_EXTERN v8::Local<v8::Object> New(char* data,
 // public constructor - data is used.
 // TODO(trevnorris): should be New() for consistency
 NODE_EXTERN v8::Local<v8::Object> Use(char* data, uint32_t len);
+
+// Internal. Not for public consumption. We can't define these in
+// src/node_internals.h due to a circular dependency issue with
+// the smalloc.h and node_internals.h headers.
+#if defined(NODE_WANT_INTERNALS)
+v8::Local<v8::Object> New(Environment* env, size_t size);
+v8::Local<v8::Object> New(Environment* env, const char* data, size_t len);
+v8::Local<v8::Object> New(Environment* env,
+                          char* data,
+                          size_t length,
+                          smalloc::FreeCallback callback,
+                          void* hint);
+v8::Local<v8::Object> Use(Environment* env, char* data, uint32_t length);
+#endif  // defined(NODE_WANT_INTERNALS)
 
 }  // namespace Buffer
 }  // namespace node

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -27,11 +27,6 @@
 
 namespace node {
 
-class File {
- public:
-  static void Initialize(v8::Handle<v8::Object> target);
-};
-
 void InitFs(v8::Handle<v8::Object> target);
 
 }  // namespace node

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -46,6 +46,7 @@ namespace node {
 namespace os {
 
 using v8::Array;
+using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::HandleScope;
@@ -275,9 +276,9 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target) {
-  HandleScope scope(node_isolate);
-
+void Initialize(Handle<Object> target,
+                Handle<Value> unused,
+                Handle<Context> context) {
   NODE_SET_METHOD(target, "getEndianness", GetEndianness);
   NODE_SET_METHOD(target, "getHostname", GetHostname);
   NODE_SET_METHOD(target, "getLoadAvg", GetLoadAvg);
@@ -293,4 +294,4 @@ void Initialize(Handle<Object> target) {
 }  // namespace os
 }  // namespace node
 
-NODE_MODULE(node_os, node::os::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_os, node::os::Initialize)

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node_stat_watcher.h"
+#include "env.h"
+#include "env-inl.h"
 
 #include <assert.h>
 #include <string.h>
@@ -27,6 +29,7 @@
 
 namespace node {
 
+using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Handle;
@@ -36,9 +39,6 @@ using v8::Local;
 using v8::Object;
 using v8::String;
 using v8::Value;
-
-static Cached<String> onchange_sym;
-static Cached<String> onstop_sym;
 
 
 void StatWatcher::Initialize(Handle<Object> target) {
@@ -61,9 +61,11 @@ static void Delete(uv_handle_t* handle) {
 }
 
 
-StatWatcher::StatWatcher() : ObjectWrap(),
-                             watcher_(new uv_fs_poll_t) {
-  uv_fs_poll_init(uv_default_loop(), watcher_);
+StatWatcher::StatWatcher(Environment* env)
+    : ObjectWrap()
+    , watcher_(new uv_fs_poll_t)
+    , env_(env) {
+  uv_fs_poll_init(env->event_loop(), watcher_);
   watcher_->data = static_cast<void*>(this);
 }
 
@@ -80,16 +82,17 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
                            const uv_stat_t* curr) {
   StatWatcher* wrap = static_cast<StatWatcher*>(handle->data);
   assert(wrap->watcher_ == handle);
-  HandleScope scope(node_isolate);
-  Local<Value> argv[3];
-  argv[0] = BuildStatsObject(curr);
-  argv[1] = BuildStatsObject(prev);
-  argv[2] = Integer::New(status, node_isolate);
-  if (onchange_sym.IsEmpty()) {
-    onchange_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onchange");
-  }
-  MakeCallback(wrap->handle(node_isolate),
-               onchange_sym,
+  Environment* env = wrap->env();
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
+  Local<Value> argv[] = {
+    BuildStatsObject(env, curr),
+    BuildStatsObject(env, prev),
+    Integer::New(status, node_isolate)
+  };
+  MakeCallback(env,
+               wrap->handle(node_isolate),
+               env->onchange_string(),
                ARRAY_SIZE(argv),
                argv);
 }
@@ -97,8 +100,9 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
 
 void StatWatcher::New(const FunctionCallbackInfo<Value>& args) {
   assert(args.IsConstructCall());
-  HandleScope scope(node_isolate);
-  StatWatcher* s = new StatWatcher();
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
+  StatWatcher* s = new StatWatcher(env);
   s->Wrap(args.This());
 }
 
@@ -119,12 +123,11 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
 
 
 void StatWatcher::Stop(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
   StatWatcher* wrap = ObjectWrap::Unwrap<StatWatcher>(args.This());
-  if (onstop_sym.IsEmpty()) {
-    onstop_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onstop");
-  }
-  MakeCallback(wrap->handle(node_isolate), onstop_sym, 0, NULL);
+  Environment* env = wrap->env();
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
+  MakeCallback(env, wrap->handle(node_isolate), env->onstop_string());
   wrap->Stop();
 }
 

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -22,17 +22,21 @@
 #ifndef SRC_NODE_STAT_WATCHER_H_
 #define SRC_NODE_STAT_WATCHER_H_
 
-#include "node.h"
+#include "node_object_wrap.h"
+
+#include "env.h"
 #include "uv.h"
+#include "v8.h"
 
 namespace node {
 
 class StatWatcher : ObjectWrap {
  public:
   static void Initialize(v8::Handle<v8::Object> target);
+  inline Environment* env() const { return env_; }
 
  protected:
-  StatWatcher();
+  explicit StatWatcher(Environment* env);
   virtual ~StatWatcher();
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -47,6 +51,7 @@ class StatWatcher : ObjectWrap {
   void Stop();
 
   uv_fs_poll_t* watcher_;
+  Environment* const env_;
 };
 
 }  // namespace node

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -64,6 +64,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 0x000C /* v0.12 */
+#define NODE_MODULE_VERSION 13 /* v0.12 */
 
 #endif  /* SRC_NODE_VERSION_H_ */

--- a/src/node_wrap.h
+++ b/src/node_wrap.h
@@ -22,38 +22,39 @@
 #ifndef SRC_NODE_WRAP_H_
 #define SRC_NODE_WRAP_H_
 
-#include "v8.h"
-#include "uv.h"
-
+#include "env.h"
+#include "env-inl.h"
 #include "pipe_wrap.h"
-#include "tty_wrap.h"
 #include "tcp_wrap.h"
+#include "tty_wrap.h"
 #include "udp_wrap.h"
+#include "uv.h"
+#include "v8.h"
 
 namespace node {
 
-extern v8::Persistent<v8::FunctionTemplate> pipeConstructorTmpl;
-extern v8::Persistent<v8::FunctionTemplate> ttyConstructorTmpl;
-extern v8::Persistent<v8::FunctionTemplate> tcpConstructorTmpl;
-
-#define WITH_GENERIC_STREAM(obj, BODY)                    \
-    do {                                                  \
-      if (HasInstance(tcpConstructorTmpl, obj)) {         \
-        TCPWrap* const wrap = TCPWrap::Unwrap(obj);       \
-        BODY                                              \
-      } else if (HasInstance(ttyConstructorTmpl, obj)) {  \
-        TTYWrap* const wrap = TTYWrap::Unwrap(obj);       \
-        BODY                                              \
-      } else if (HasInstance(pipeConstructorTmpl, obj)) { \
-        PipeWrap* const wrap = PipeWrap::Unwrap(obj);     \
-        BODY                                              \
-      }                                                   \
+#define WITH_GENERIC_STREAM(env, obj, BODY)                                   \
+    do {                                                                      \
+      if (env->tcp_constructor_template().IsEmpty() == false &&               \
+          env->tcp_constructor_template()->HasInstance(obj)) {                \
+        TCPWrap* const wrap = TCPWrap::Unwrap(obj);                           \
+        BODY                                                                  \
+      } else if (env->tty_constructor_template().IsEmpty() == false &&        \
+                 env->tty_constructor_template()->HasInstance(obj)) {         \
+        TTYWrap* const wrap = TTYWrap::Unwrap(obj);                           \
+        BODY                                                                  \
+      } else if (env->pipe_constructor_template().IsEmpty() == false &&       \
+                 env->pipe_constructor_template()->HasInstance(obj)) {        \
+        PipeWrap* const wrap = PipeWrap::Unwrap(obj);                         \
+        BODY                                                                  \
+      }                                                                       \
     } while (0)
 
-inline uv_stream_t* HandleToStream(v8::Local<v8::Object> obj) {
+inline uv_stream_t* HandleToStream(Environment* env,
+                                   v8::Local<v8::Object> obj) {
   v8::HandleScope scope(node_isolate);
 
-  WITH_GENERIC_STREAM(obj, {
+  WITH_GENERIC_STREAM(env, obj, {
     return reinterpret_cast<uv_stream_t*>(wrap->UVHandle());
   });
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -20,16 +20,22 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "pipe_wrap.h"
+
+#include "env.h"
+#include "env-inl.h"
+#include "handle_wrap.h"
 #include "node.h"
 #include "node_buffer.h"
-#include "handle_wrap.h"
 #include "node_wrap.h"
 #include "req_wrap.h"
 #include "stream_wrap.h"
+#include "util-inl.h"
+#include "util.h"
 
 namespace node {
 
 using v8::Boolean;
+using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -38,16 +44,10 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
-using v8::Persistent;
 using v8::PropertyAttribute;
 using v8::String;
 using v8::Undefined;
 using v8::Value;
-
-static Persistent<Function> pipeConstructor;
-static Cached<String> onconnection_sym;
-static Cached<String> oncomplete_sym;
-
 
 // TODO(bnoordhuis) share with TCPWrap?
 typedef class ReqWrap<uv_connect_t> ConnectWrap;
@@ -58,10 +58,14 @@ uv_pipe_t* PipeWrap::UVHandle() {
 }
 
 
-Local<Object> PipeWrap::Instantiate() {
-  HandleScope scope(node_isolate);
-  assert(!pipeConstructor.IsEmpty());
-  return scope.Close(NewInstance(pipeConstructor));
+Local<Object> PipeWrap::Instantiate(Environment* env) {
+  HandleScope handle_scope(env->isolate());
+  assert(!env->pipe_constructor_template().IsEmpty());
+  Local<Function> constructor = env->pipe_constructor_template()->GetFunction();
+  assert(!constructor.IsEmpty());
+  Local<Object> instance = constructor->NewInstance();
+  assert(!instance.IsEmpty());
+  return handle_scope.Close(instance);
 }
 
 
@@ -72,14 +76,13 @@ PipeWrap* PipeWrap::Unwrap(Local<Object> obj) {
 }
 
 
-void PipeWrap::Initialize(Handle<Object> target) {
-  StreamWrap::Initialize(target);
-
-  HandleScope scope(node_isolate);
+void PipeWrap::Initialize(Handle<Object> target,
+                          Handle<Value> unused,
+                          Handle<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
   t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Pipe"));
-
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   enum PropertyAttribute attributes =
@@ -115,9 +118,8 @@ void PipeWrap::Initialize(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "setPendingInstances", SetPendingInstances);
 #endif
 
-  pipeConstructorTmpl.Reset(node_isolate, t);
-  pipeConstructor.Reset(node_isolate, t->GetFunction());
   target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Pipe"), t->GetFunction());
+  env->set_pipe_constructor_template(t);
 }
 
 
@@ -126,16 +128,15 @@ void PipeWrap::New(const FunctionCallbackInfo<Value>& args) {
   // Therefore we assert that we are not trying to call this as a
   // normal function.
   assert(args.IsConstructCall());
-
-  HandleScope scope(node_isolate);
-  PipeWrap* wrap = new PipeWrap(args.This(), args[0]->IsTrue());
-  assert(wrap);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
+  new PipeWrap(env, args.This(), args[0]->IsTrue());
 }
 
 
-PipeWrap::PipeWrap(Handle<Object> object, bool ipc)
-    : StreamWrap(object, reinterpret_cast<uv_stream_t*>(&handle_)) {
-  int r = uv_pipe_init(uv_default_loop(), &handle_, ipc);
+PipeWrap::PipeWrap(Environment* env, Handle<Object> object, bool ipc)
+    : StreamWrap(env, object, reinterpret_cast<uv_stream_t*>(&handle_)) {
+  int r = uv_pipe_init(env->event_loop(), &handle_, ipc);
   assert(r == 0);  // How do we proxy this error up to javascript?
                    // Suggestion: uv_pipe_init() returns void.
   UpdateWriteQueueSize();
@@ -184,10 +185,12 @@ void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
 
 // TODO(bnoordhuis) maybe share with TCPWrap?
 void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
-  HandleScope scope(node_isolate);
-
   PipeWrap* pipe_wrap = static_cast<PipeWrap*>(handle->data);
   assert(&pipe_wrap->handle_ == reinterpret_cast<uv_pipe_t*>(handle));
+
+  Environment* env = pipe_wrap->env();
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.
@@ -199,12 +202,17 @@ void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
   };
 
   if (status != 0) {
-    MakeCallback(pipe_wrap->object(), "onconnection", ARRAY_SIZE(argv), argv);
+    MakeCallback(env,
+                 pipe_wrap->object(),
+                 env->onconnection_string(),
+                 ARRAY_SIZE(argv),
+                 argv);
     return;
   }
 
   // Instanciate the client javascript object and handle.
-  Local<Object> client_obj = NewInstance(pipeConstructor);
+  Local<Object> client_obj =
+      env->pipe_constructor_template()->GetFunction()->NewInstance();
 
   // Unwrap the client javascript object.
   PipeWrap* wrap;
@@ -215,18 +223,22 @@ void PipeWrap::OnConnection(uv_stream_t* handle, int status) {
 
   // Successful accept. Call the onconnection callback in JavaScript land.
   argv[1] = client_obj;
-  if (onconnection_sym.IsEmpty()) {
-    onconnection_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onconnection");
-  }
-  MakeCallback(pipe_wrap->object(), onconnection_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               pipe_wrap->object(),
+               env->onconnection_string(),
+               ARRAY_SIZE(argv),
+               argv);
 }
 
 // TODO(bnoordhuis) Maybe share this with TCPWrap?
 void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
   ConnectWrap* req_wrap = static_cast<ConnectWrap*>(req->data);
   PipeWrap* wrap = static_cast<PipeWrap*>(req->handle->data);
+  assert(req_wrap->env() == wrap->env());
+  Environment* env = wrap->env();
 
-  HandleScope scope(node_isolate);
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   // The wrap and request objects should still be there.
   assert(req_wrap->persistent().IsEmpty() == false);
@@ -250,10 +262,11 @@ void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
     Boolean::New(writable)
   };
 
-  if (oncomplete_sym.IsEmpty()) {
-    oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
-  }
-  MakeCallback(req_wrap_obj, oncomplete_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               req_wrap_obj,
+               env->oncomplete_string(),
+               ARRAY_SIZE(argv),
+               argv);
 
   delete req_wrap;
 }
@@ -272,7 +285,8 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
 
 
 void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope scope(args.GetIsolate());
 
   PipeWrap* wrap;
   NODE_UNWRAP(args.This(), PipeWrap, wrap);
@@ -283,7 +297,7 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   Local<Object> req_wrap_obj = args[0].As<Object>();
   String::AsciiValue name(args[1]);
 
-  ConnectWrap* req_wrap = new ConnectWrap(req_wrap_obj);
+  ConnectWrap* req_wrap = new ConnectWrap(env, req_wrap_obj);
   uv_pipe_connect(&req_wrap->req_,
                   &wrap->handle_,
                   *name,
@@ -296,4 +310,4 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE(node_pipe_wrap, node::PipeWrap::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_pipe_wrap, node::PipeWrap::Initialize)

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -21,6 +21,8 @@
 
 #ifndef SRC_PIPE_WRAP_H_
 #define SRC_PIPE_WRAP_H_
+
+#include "env.h"
 #include "stream_wrap.h"
 
 namespace node {
@@ -29,12 +31,14 @@ class PipeWrap : public StreamWrap {
  public:
   uv_pipe_t* UVHandle();
 
-  static v8::Local<v8::Object> Instantiate();
+  static v8::Local<v8::Object> Instantiate(Environment* env);
   static PipeWrap* Unwrap(v8::Local<v8::Object> obj);
-  static void Initialize(v8::Handle<v8::Object> target);
+  static void Initialize(v8::Handle<v8::Object> target,
+                         v8::Handle<v8::Value> unused,
+                         v8::Handle<v8::Context> context);
 
  private:
-  PipeWrap(v8::Handle<v8::Object> object, bool ipc);
+  PipeWrap(Environment* env, v8::Handle<v8::Object> object, bool ipc);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Bind(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -22,29 +22,31 @@
 #ifndef SRC_REQ_WRAP_H_
 #define SRC_REQ_WRAP_H_
 
-#include "node.h"
-#include "node_internals.h"
+#include "env.h"
+#include "env-inl.h"
 #include "queue.h"
+#include "util.h"
 
 namespace node {
 
 // defined in node.cc
-extern Cached<v8::String> process_symbol;
-extern Cached<v8::String> domain_symbol;
 extern QUEUE req_wrap_queue;
 
 template <typename T>
 class ReqWrap {
  public:
-  ReqWrap(v8::Handle<v8::Object> object = v8::Handle<v8::Object>()) {
-    v8::HandleScope scope(node_isolate);
-    if (object.IsEmpty()) object = v8::Object::New();
-    persistent().Reset(node_isolate, object);
+  ReqWrap(Environment* env,
+          v8::Handle<v8::Object> object = v8::Handle<v8::Object>())
+      : env_(env) {
+    v8::HandleScope handle_scope(env->isolate());
 
-    if (InDomain()) {
-      v8::Local<v8::Value> domain = GetDomain();
-      if (domain->IsObject())
-        object->Set(domain_symbol, domain);
+    if (object.IsEmpty()) {
+      object = v8::Object::New();
+    }
+    persistent().Reset(env->isolate(), object);
+
+    if (env->in_domain()) {
+      object->Set(env->domain_string(), env->domain_array()->Get(0));
     }
 
     QUEUE_INSERT_TAIL(&req_wrap_queue, &req_wrap_queue_);
@@ -64,17 +66,25 @@ class ReqWrap {
     req_.data = this;
   }
 
+  inline Environment* env() const {
+    return env_;
+  }
+
   inline v8::Local<v8::Object> object() {
-    return PersistentToLocal(node_isolate, persistent());
+    return PersistentToLocal(env()->isolate(), persistent());
   }
 
   inline v8::Persistent<v8::Object>& persistent() {
     return object_;
   }
 
-  v8::Persistent<v8::Object> object_;
+  // TODO(bnoordhuis) Make these private.
   QUEUE req_wrap_queue_;
   T req_;  // *must* be last, GetActiveRequests() in node.cc depends on it
+
+ private:
+  v8::Persistent<v8::Object> object_;
+  Environment* const env_;
 };
 
 

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -20,11 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "smalloc.h"
-#include "node.h"
-#include "node_internals.h"
 
-#include "v8.h"
+#include "env.h"
+#include "env-inl.h"
+#include "node_internals.h"
 #include "v8-profiler.h"
+#include "v8.h"
 
 #include <string.h>
 #include <assert.h>
@@ -34,6 +35,7 @@
 namespace node {
 namespace smalloc {
 
+using v8::Context;
 using v8::External;
 using v8::ExternalArrayType;
 using v8::FunctionCallbackInfo;
@@ -45,7 +47,6 @@ using v8::Local;
 using v8::Object;
 using v8::Persistent;
 using v8::RetainedObjectInfo;
-using v8::String;
 using v8::Uint32;
 using v8::Value;
 using v8::kExternalUnsignedByteArray;
@@ -63,9 +64,6 @@ void TargetCallback(Isolate* isolate,
 void TargetFreeCallback(Isolate* isolate,
                         Persistent<Object>* target,
                         CallbackInfo* arg);
-
-Cached<String> smalloc_sym;
-static bool using_alloc_cb;
 
 
 // return size of external array type, or 0 if unrecognized
@@ -299,10 +297,11 @@ void AllocDispose(const FunctionCallbackInfo<Value>& args) {
 
 
 void AllocDispose(Handle<Object> obj) {
-  HandleScope handle_scope(node_isolate);
+  Environment* env = Environment::GetCurrent(node_isolate);
+  HandleScope handle_scope(env->isolate());
 
-  if (using_alloc_cb) {
-    Local<Value> ext_v = obj->GetHiddenValue(smalloc_sym);
+  if (env->using_smalloc_alloc_cb()) {
+    Local<Value> ext_v = obj->GetHiddenValue(env->smalloc_p_string());
     if (ext_v->IsExternal()) {
       Local<External> ext = ext_v.As<External>();
       CallbackInfo* cb_info = static_cast<CallbackInfo*>(ext->Value());
@@ -361,16 +360,14 @@ void Alloc(Handle<Object> obj,
            enum ExternalArrayType type) {
   assert(!obj->HasIndexedPropertiesInExternalArrayData());
 
-  if (smalloc_sym.IsEmpty()) {
-    smalloc_sym = FIXED_ONE_BYTE_STRING(node_isolate, "_smalloc_p");
-    using_alloc_cb = true;
-  }
+  Environment* env = Environment::GetCurrent(node_isolate);
+  env->set_using_smalloc_alloc_cb(true);
 
   CallbackInfo* cb_info = new CallbackInfo;
   cb_info->cb = fn;
   cb_info->hint = hint;
   cb_info->p_obj.Reset(node_isolate, obj);
-  obj->SetHiddenValue(smalloc_sym, External::New(cb_info));
+  obj->SetHiddenValue(env->smalloc_p_string(), External::New(cb_info));
 
   node_isolate->AdjustAmountOfExternalAllocatedMemory(length +
                                                       sizeof(*cb_info));
@@ -462,7 +459,11 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Handle<Value> wrapper) {
 }
 
 
-void Initialize(Handle<Object> exports) {
+void Initialize(Handle<Object> exports,
+                Handle<Value> unused,
+                Handle<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+
   NODE_SET_METHOD(exports, "copyOnto", CopyOnto);
   NODE_SET_METHOD(exports, "sliceOnto", SliceOnto);
 
@@ -470,13 +471,9 @@ void Initialize(Handle<Object> exports) {
   NODE_SET_METHOD(exports, "dispose", AllocDispose);
 
   exports->Set(FIXED_ONE_BYTE_STRING(node_isolate, "kMaxLength"),
-               Uint32::NewFromUnsigned(kMaxLength, node_isolate));
+               Uint32::NewFromUnsigned(kMaxLength, env->isolate()));
 
-  // for performance, begin checking if allocation object may contain
-  // callbacks if at least one has been set.
-  using_alloc_cb = false;
-
-  HeapProfiler* heap_profiler = node_isolate->GetHeapProfiler();
+  HeapProfiler* heap_profiler = env->isolate()->GetHeapProfiler();
   heap_profiler->SetWrapperClassInfoProvider(ALLOC_ID, WrapperInfo);
 }
 
@@ -484,4 +481,4 @@ void Initialize(Handle<Object> exports) {
 }  // namespace smalloc
 }  // namespace node
 
-NODE_MODULE(node_smalloc, node::smalloc::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_smalloc, node::smalloc::Initialize)

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -20,10 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "stream_wrap.h"
-#include "node.h"
+#include "env-inl.h"
+#include "env.h"
+#include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_counters.h"
-#include "handle_wrap.h"
 #include "pipe_wrap.h"
 #include "req_wrap.h"
 #include "tcp_wrap.h"
@@ -36,6 +37,7 @@
 namespace node {
 
 using v8::Array;
+using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::HandleScope;
@@ -49,31 +51,13 @@ using v8::Undefined;
 using v8::Value;
 
 
-static Cached<String> bytes_sym;
-static Cached<String> write_queue_size_sym;
-static Cached<String> onread_sym;
-static Cached<String> oncomplete_sym;
-static Cached<String> handle_sym;
-static bool initialized;
-
-
-void StreamWrap::Initialize(Handle<Object> target) {
-  if (initialized) return;
-  initialized = true;
-
-  HandleScope scope(node_isolate);
-  bytes_sym = FIXED_ONE_BYTE_STRING(node_isolate, "bytes");
-  write_queue_size_sym = FIXED_ONE_BYTE_STRING(node_isolate, "writeQueueSize");
-  onread_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onread");
-  oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
-}
-
-
-StreamWrap::StreamWrap(Handle<Object> object, uv_stream_t* stream)
-    : HandleWrap(object, reinterpret_cast<uv_handle_t*>(stream)),
-      stream_(stream),
-      default_callbacks_(this),
-      callbacks_(&default_callbacks_) {
+StreamWrap::StreamWrap(Environment* env,
+                       Local<Object> object,
+                       uv_stream_t* stream)
+    : HandleWrap(env, object, reinterpret_cast<uv_handle_t*>(stream))
+    , stream_(stream)
+    , default_callbacks_(this)
+    , callbacks_(&default_callbacks_) {
 }
 
 
@@ -95,7 +79,7 @@ void StreamWrap::UpdateWriteQueueSize() {
   HandleScope scope(node_isolate);
   Local<Integer> write_queue_size =
       Integer::NewFromUnsigned(stream()->write_queue_size, node_isolate);
-  object()->Set(write_queue_size_sym, write_queue_size);
+  object()->Set(env()->write_queue_size_string(), write_queue_size);
 }
 
 
@@ -137,12 +121,12 @@ void StreamWrap::OnAlloc(uv_handle_t* handle,
 
 
 template <class WrapType, class UVType>
-static Local<Object> AcceptHandle(uv_stream_t* pipe) {
+static Local<Object> AcceptHandle(Environment* env, uv_stream_t* pipe) {
   HandleScope scope(node_isolate);
   Local<Object> wrap_obj;
   UVType* handle;
 
-  wrap_obj = WrapType::Instantiate();
+  wrap_obj = WrapType::Instantiate(env);
   if (wrap_obj.IsEmpty())
     return Local<Object>();
 
@@ -208,7 +192,8 @@ size_t StreamWrap::WriteBuffer(Handle<Value> val, uv_buf_t* buf) {
 
 
 void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
 
   StreamWrap* wrap;
   NODE_UNWRAP(args.This(), StreamWrap, wrap);
@@ -221,7 +206,8 @@ void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
 
   size_t length = Buffer::Length(buf_obj);
   char* storage = new char[sizeof(WriteWrap)];
-  WriteWrap* req_wrap = new(storage) WriteWrap(req_wrap_obj, wrap);
+  WriteWrap* req_wrap =
+      new(storage) WriteWrap(env, req_wrap_obj, wrap);
 
   uv_buf_t buf;
   WriteBuffer(buf_obj, &buf);
@@ -232,7 +218,8 @@ void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
                                        NULL,
                                        StreamWrap::AfterWrite);
   req_wrap->Dispatched();
-  req_wrap_obj->Set(bytes_sym, Integer::NewFromUnsigned(length, node_isolate));
+  req_wrap_obj->Set(env->bytes_string(),
+                    Integer::NewFromUnsigned(length, node_isolate));
 
   if (err) {
     req_wrap->~WriteWrap();
@@ -245,7 +232,8 @@ void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
 
 template <enum encoding encoding>
 void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
   int err;
 
   StreamWrap* wrap;
@@ -272,7 +260,8 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
   }
 
   char* storage = new char[sizeof(WriteWrap) + storage_size + 15];
-  WriteWrap* req_wrap = new(storage) WriteWrap(req_wrap_obj, wrap);
+  WriteWrap* req_wrap =
+      new(storage) WriteWrap(env, req_wrap_obj, wrap);
 
   char* data = reinterpret_cast<char*>(ROUND_UP(
       reinterpret_cast<uintptr_t>(storage) + sizeof(WriteWrap), 16));
@@ -301,14 +290,10 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
       HandleWrap* wrap;
       NODE_UNWRAP(send_handle_obj, HandleWrap, wrap);
       send_handle = wrap->GetHandle();
-
       // Reference StreamWrap instance to prevent it from being garbage
       // collected before `AfterWrite` is called.
-      if (handle_sym.IsEmpty()) {
-        handle_sym = FIXED_ONE_BYTE_STRING(node_isolate, "handle");
-      }
       assert(!req_wrap->persistent().IsEmpty());
-      req_wrap->object()->Set(handle_sym, send_handle_obj);
+      req_wrap->object()->Set(env->handle_string(), send_handle_obj);
     }
 
     err = wrap->callbacks()->DoWrite(
@@ -320,7 +305,8 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
   }
 
   req_wrap->Dispatched();
-  req_wrap->object()->Set(bytes_sym, Number::New(node_isolate, data_size));
+  req_wrap->object()->Set(env->bytes_string(),
+                          Number::New(node_isolate, data_size));
 
   if (err) {
     req_wrap->~WriteWrap();
@@ -332,7 +318,8 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
 
 
 void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope;
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
 
   StreamWrap* wrap;
   NODE_UNWRAP(args.This(), StreamWrap, wrap);
@@ -378,7 +365,8 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
 
   storage_size += sizeof(WriteWrap);
   char* storage = new char[storage_size];
-  WriteWrap* req_wrap = new(storage) WriteWrap(req_wrap_obj, wrap);
+  WriteWrap* req_wrap =
+      new(storage) WriteWrap(env, req_wrap_obj, wrap);
 
   uint32_t bytes = 0;
   size_t offset = sizeof(WriteWrap);
@@ -419,7 +407,8 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
     delete[] bufs;
 
   req_wrap->Dispatched();
-  req_wrap->object()->Set(bytes_sym, Number::New(node_isolate, bytes));
+  req_wrap->object()->Set(env->bytes_string(),
+                          Number::New(node_isolate, bytes));
 
   if (err) {
     req_wrap->~WriteWrap();
@@ -448,8 +437,10 @@ void StreamWrap::WriteUcs2String(const FunctionCallbackInfo<Value>& args) {
 void StreamWrap::AfterWrite(uv_write_t* req, int status) {
   WriteWrap* req_wrap = container_of(req, WriteWrap, req_);
   StreamWrap* wrap = req_wrap->wrap();
+  Environment* env = wrap->env();
 
-  HandleScope scope(node_isolate);
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   // The wrap and request objects should still be there.
   assert(req_wrap->persistent().IsEmpty() == false);
@@ -457,11 +448,8 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
 
   // Unref handle property
   Local<Object> req_wrap_obj = req_wrap->object();
-  if (!handle_sym.IsEmpty()) {
-    req_wrap_obj->Delete(handle_sym);
-  }
-
-  wrap->callbacks()->AfterWrite(req_wrap);
+  req_wrap_obj->Delete(env->handle_string());
+  wrap->callbacks_->AfterWrite(req_wrap);
 
   Local<Value> argv[] = {
     Integer::New(status, node_isolate),
@@ -469,7 +457,11 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
     req_wrap_obj
   };
 
-  MakeCallback(req_wrap_obj, oncomplete_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               req_wrap_obj,
+               env->oncomplete_string(),
+               ARRAY_SIZE(argv),
+               argv);
 
   req_wrap->~WriteWrap();
   delete[] reinterpret_cast<char*>(req_wrap);
@@ -477,7 +469,8 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
 
 
 void StreamWrap::Shutdown(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
 
   StreamWrap* wrap;
   NODE_UNWRAP(args.This(), StreamWrap, wrap);
@@ -485,7 +478,7 @@ void StreamWrap::Shutdown(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsObject());
   Local<Object> req_wrap_obj = args[0].As<Object>();
 
-  ShutdownWrap* req_wrap = new ShutdownWrap(req_wrap_obj);
+  ShutdownWrap* req_wrap = new ShutdownWrap(env, req_wrap_obj);
   int err = wrap->callbacks()->DoShutdown(req_wrap, AfterShutdown);
   req_wrap->Dispatched();
   if (err) delete req_wrap;
@@ -496,12 +489,14 @@ void StreamWrap::Shutdown(const FunctionCallbackInfo<Value>& args) {
 void StreamWrap::AfterShutdown(uv_shutdown_t* req, int status) {
   ShutdownWrap* req_wrap = static_cast<ShutdownWrap*>(req->data);
   StreamWrap* wrap = static_cast<StreamWrap*>(req->handle->data);
+  Environment* env = wrap->env();
 
   // The wrap and request objects should still be there.
   assert(req_wrap->persistent().IsEmpty() == false);
   assert(wrap->persistent().IsEmpty() == false);
 
-  HandleScope scope(node_isolate);
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   Local<Object> req_wrap_obj = req_wrap->object();
   Local<Value> argv[3] = {
@@ -510,7 +505,11 @@ void StreamWrap::AfterShutdown(uv_shutdown_t* req, int status) {
     req_wrap_obj
   };
 
-  MakeCallback(req_wrap_obj, oncomplete_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               req_wrap_obj,
+               env->oncomplete_string(),
+               ARRAY_SIZE(argv),
+               argv);
 
   delete req_wrap;
 }
@@ -568,7 +567,9 @@ void StreamWrapCallbacks::DoRead(uv_stream_t* handle,
                                  ssize_t nread,
                                  const uv_buf_t* buf,
                                  uv_handle_type pending) {
-  HandleScope scope(node_isolate);
+  Environment* env = wrap()->env();
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   Local<Value> argv[] = {
     Integer::New(nread, node_isolate),
@@ -579,7 +580,7 @@ void StreamWrapCallbacks::DoRead(uv_stream_t* handle,
   if (nread < 0)  {
     if (buf->base != NULL)
       free(buf->base);
-    MakeCallback(Self(), onread_sym, ARRAY_SIZE(argv), argv);
+    MakeCallback(env, Self(), env->onread_string(), ARRAY_SIZE(argv), argv);
     return;
   }
 
@@ -591,15 +592,15 @@ void StreamWrapCallbacks::DoRead(uv_stream_t* handle,
 
   char* base = static_cast<char*>(realloc(buf->base, nread));
   assert(static_cast<size_t>(nread) <= buf->len);
-  argv[1] = Buffer::Use(base, nread);
+  argv[1] = Buffer::Use(env, base, nread);
 
   Local<Object> pending_obj;
   if (pending == UV_TCP) {
-    pending_obj = AcceptHandle<TCPWrap, uv_tcp_t>(handle);
+    pending_obj = AcceptHandle<TCPWrap, uv_tcp_t>(env, handle);
   } else if (pending == UV_NAMED_PIPE) {
-    pending_obj = AcceptHandle<PipeWrap, uv_pipe_t>(handle);
+    pending_obj = AcceptHandle<PipeWrap, uv_pipe_t>(env, handle);
   } else if (pending == UV_UDP) {
-    pending_obj = AcceptHandle<UDPWrap, uv_udp_t>(handle);
+    pending_obj = AcceptHandle<UDPWrap, uv_udp_t>(env, handle);
   } else {
     assert(pending == UV_UNKNOWN_HANDLE);
   }
@@ -608,7 +609,11 @@ void StreamWrapCallbacks::DoRead(uv_stream_t* handle,
     argv[2] = pending_obj;
   }
 
-  MakeCallback(wrap()->object(), onread_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               wrap()->object(),
+               env->onread_string(),
+               ARRAY_SIZE(argv),
+               argv);
 }
 
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -22,11 +22,11 @@
 #ifndef SRC_STREAM_WRAP_H_
 #define SRC_STREAM_WRAP_H_
 
-#include "v8.h"
-#include "node.h"
+#include "env.h"
 #include "handle_wrap.h"
 #include "req_wrap.h"
 #include "string_bytes.h"
+#include "v8.h"
 
 namespace node {
 
@@ -37,8 +37,8 @@ typedef class ReqWrap<uv_shutdown_t> ShutdownWrap;
 
 class WriteWrap: public ReqWrap<uv_write_t> {
  public:
-  WriteWrap(v8::Local<v8::Object> obj, StreamWrap* wrap)
-      : ReqWrap<uv_write_t>(obj)
+  WriteWrap(Environment* env, v8::Local<v8::Object> obj, StreamWrap* wrap)
+      : ReqWrap<uv_write_t>(env, obj)
       , wrap_(wrap) {
   }
 
@@ -108,8 +108,6 @@ class StreamWrap : public HandleWrap {
       delete old;
   }
 
-  static void Initialize(v8::Handle<v8::Object> target);
-
   static void GetFD(v8::Local<v8::String>,
                     const v8::PropertyCallbackInfo<v8::Value>&);
 
@@ -148,7 +146,9 @@ class StreamWrap : public HandleWrap {
  protected:
   static size_t WriteBuffer(v8::Handle<v8::Value> val, uv_buf_t* buf);
 
-  StreamWrap(v8::Handle<v8::Object> object, uv_stream_t* stream);
+  StreamWrap(Environment* env,
+             v8::Local<v8::Object> object,
+             uv_stream_t* stream);
 
   ~StreamWrap() {
     if (callbacks_ != &default_callbacks_) {

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -20,10 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "tcp_wrap.h"
-#include "node.h"
+
+#include "env.h"
+#include "env-inl.h"
+#include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_wrap.h"
-#include "handle_wrap.h"
 #include "req_wrap.h"
 #include "stream_wrap.h"
 
@@ -32,6 +34,7 @@
 
 namespace node {
 
+using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -40,40 +43,32 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
-using v8::Persistent;
 using v8::PropertyAttribute;
 using v8::String;
 using v8::Undefined;
 using v8::Value;
 
-static Persistent<Function> tcpConstructor;
-static Cached<String> oncomplete_sym;
-static Cached<String> onconnection_sym;
-
-
 typedef class ReqWrap<uv_connect_t> ConnectWrap;
 
 
-Local<Object> TCPWrap::Instantiate() {
-  // If this assert fire then process.binding('tcp_wrap') hasn't been
-  // called yet.
-  assert(tcpConstructor.IsEmpty() == false);
-
-  HandleScope scope(node_isolate);
-  Local<Object> obj = NewInstance(tcpConstructor);
-
-  return scope.Close(obj);
+Local<Object> TCPWrap::Instantiate(Environment* env) {
+  HandleScope handle_scope(env->isolate());
+  assert(env->tcp_constructor_template().IsEmpty() == false);
+  Local<Function> constructor = env->tcp_constructor_template()->GetFunction();
+  assert(constructor.IsEmpty() == false);
+  Local<Object> instance = constructor->NewInstance();
+  assert(instance.IsEmpty() == false);
+  return handle_scope.Close(instance);
 }
 
 
-void TCPWrap::Initialize(Handle<Object> target) {
-  StreamWrap::Initialize(target);
-
-  HandleScope scope(node_isolate);
+void TCPWrap::Initialize(Handle<Object> target,
+                         Handle<Value> unused,
+                         Handle<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = FunctionTemplate::New(New);
   t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "TCP"));
-
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   enum PropertyAttribute attributes =
@@ -119,12 +114,8 @@ void TCPWrap::Initialize(Handle<Object> target) {
                             SetSimultaneousAccepts);
 #endif
 
-  onconnection_sym = FIXED_ONE_BYTE_STRING(node_isolate, "onconnection");
-  oncomplete_sym = FIXED_ONE_BYTE_STRING(node_isolate, "oncomplete");
-
-  tcpConstructorTmpl.Reset(node_isolate, t);
-  tcpConstructor.Reset(node_isolate, t->GetFunction());
   target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "TCP"), t->GetFunction());
+  env->set_tcp_constructor_template(t);
 }
 
 
@@ -145,15 +136,16 @@ void TCPWrap::New(const FunctionCallbackInfo<Value>& args) {
   // Therefore we assert that we are not trying to call this as a
   // normal function.
   assert(args.IsConstructCall());
-  HandleScope scope(node_isolate);
-  TCPWrap* wrap = new TCPWrap(args.This());
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
+  TCPWrap* wrap = new TCPWrap(env, args.This());
   assert(wrap);
 }
 
 
-TCPWrap::TCPWrap(Handle<Object> object)
-    : StreamWrap(object, reinterpret_cast<uv_stream_t*>(&handle_)) {
-  int r = uv_tcp_init(uv_default_loop(), &handle_);
+TCPWrap::TCPWrap(Environment* env, Handle<Object> object)
+    : StreamWrap(env, object, reinterpret_cast<uv_stream_t*>(&handle_)) {
+  int r = uv_tcp_init(env->event_loop(), &handle_);
   assert(r == 0);  // How do we proxy this error up to javascript?
                    // Suggestion: uv_tcp_init() returns void.
   UpdateWriteQueueSize();
@@ -166,7 +158,8 @@ TCPWrap::~TCPWrap() {
 
 
 void TCPWrap::GetSockName(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
   struct sockaddr_storage address;
 
   TCPWrap* wrap;
@@ -181,7 +174,7 @@ void TCPWrap::GetSockName(const FunctionCallbackInfo<Value>& args) {
                                &addrlen);
   if (err == 0) {
     const sockaddr* addr = reinterpret_cast<const sockaddr*>(&address);
-    AddressToJS(addr, out);
+    AddressToJS(env, addr, out);
   }
 
   args.GetReturnValue().Set(err);
@@ -189,7 +182,8 @@ void TCPWrap::GetSockName(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::GetPeerName(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
   struct sockaddr_storage address;
 
   TCPWrap* wrap;
@@ -204,7 +198,7 @@ void TCPWrap::GetPeerName(const FunctionCallbackInfo<Value>& args) {
                                &addrlen);
   if (err == 0) {
     const sockaddr* addr = reinterpret_cast<const sockaddr*>(&address);
-    AddressToJS(addr, out);
+    AddressToJS(env, addr, out);
   }
 
   args.GetReturnValue().Set(err);
@@ -311,10 +305,12 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::OnConnection(uv_stream_t* handle, int status) {
-  HandleScope scope(node_isolate);
-
   TCPWrap* tcp_wrap = static_cast<TCPWrap*>(handle->data);
   assert(&tcp_wrap->handle_ == reinterpret_cast<uv_tcp_t*>(handle));
+  Environment* env = tcp_wrap->env();
+
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.
@@ -327,7 +323,7 @@ void TCPWrap::OnConnection(uv_stream_t* handle, int status) {
 
   if (status == 0) {
     // Instantiate the client javascript object and handle.
-    Local<Object> client_obj = Instantiate();
+    Local<Object> client_obj = Instantiate(env);
 
     // Unwrap the client javascript object.
     TCPWrap* wrap;
@@ -340,15 +336,22 @@ void TCPWrap::OnConnection(uv_stream_t* handle, int status) {
     argv[1] = client_obj;
   }
 
-  MakeCallback(tcp_wrap->object(), onconnection_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               tcp_wrap->object(),
+               env->onconnection_string(),
+               ARRAY_SIZE(argv),
+               argv);
 }
 
 
 void TCPWrap::AfterConnect(uv_connect_t* req, int status) {
   ConnectWrap* req_wrap = static_cast<ConnectWrap*>(req->data);
   TCPWrap* wrap = static_cast<TCPWrap*>(req->handle->data);
+  assert(req_wrap->env() == wrap->env());
+  Environment* env = wrap->env();
 
-  HandleScope scope(node_isolate);
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
 
   // The wrap and request objects should still be there.
   assert(req_wrap->persistent().IsEmpty() == false);
@@ -362,14 +365,19 @@ void TCPWrap::AfterConnect(uv_connect_t* req, int status) {
     v8::True(node_isolate),
     v8::True(node_isolate)
   };
-  MakeCallback(req_wrap_obj, oncomplete_sym, ARRAY_SIZE(argv), argv);
+  MakeCallback(env,
+               req_wrap_obj,
+               env->oncomplete_string(),
+               ARRAY_SIZE(argv),
+               argv);
 
   delete req_wrap;
 }
 
 
 void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
 
   TCPWrap* wrap;
   NODE_UNWRAP(args.This(), TCPWrap, wrap);
@@ -386,7 +394,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   int err = uv_ip4_addr(*ip_address, port, &addr);
 
   if (err == 0) {
-    ConnectWrap* req_wrap = new ConnectWrap(req_wrap_obj);
+    ConnectWrap* req_wrap = new ConnectWrap(env, req_wrap_obj);
     err = uv_tcp_connect(&req_wrap->req_,
                          &wrap->handle_,
                          reinterpret_cast<const sockaddr*>(&addr),
@@ -400,7 +408,8 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
 
   TCPWrap* wrap;
   NODE_UNWRAP(args.This(), TCPWrap, wrap);
@@ -417,7 +426,7 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
   int err = uv_ip6_addr(*ip_address, port, &addr);
 
   if (err == 0) {
-    ConnectWrap* req_wrap = new ConnectWrap(req_wrap_obj);
+    ConnectWrap* req_wrap = new ConnectWrap(env, req_wrap_obj);
     err = uv_tcp_connect(&req_wrap->req_,
                          &wrap->handle_,
                          reinterpret_cast<const sockaddr*>(&addr),
@@ -431,26 +440,14 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
 
 
 // also used by udp_wrap.cc
-Local<Object> AddressToJS(const sockaddr* addr, Handle<Object> info) {
-  static Cached<String> address_sym;
-  static Cached<String> family_sym;
-  static Cached<String> port_sym;
-  static Cached<String> ipv4_sym;
-  static Cached<String> ipv6_sym;
-
+Local<Object> AddressToJS(Environment* env,
+                          const sockaddr* addr,
+                          Local<Object> info) {
   HandleScope scope(node_isolate);
   char ip[INET6_ADDRSTRLEN];
   const sockaddr_in *a4;
   const sockaddr_in6 *a6;
   int port;
-
-  if (address_sym.IsEmpty()) {
-    address_sym = FIXED_ONE_BYTE_STRING(node_isolate, "address");
-    family_sym = FIXED_ONE_BYTE_STRING(node_isolate, "family");
-    port_sym = FIXED_ONE_BYTE_STRING(node_isolate, "port");
-    ipv4_sym = FIXED_ONE_BYTE_STRING(node_isolate, "IPv4");
-    ipv6_sym = FIXED_ONE_BYTE_STRING(node_isolate, "IPv6");
-  }
 
   if (info.IsEmpty()) info = Object::New();
 
@@ -459,22 +456,22 @@ Local<Object> AddressToJS(const sockaddr* addr, Handle<Object> info) {
     a6 = reinterpret_cast<const sockaddr_in6*>(addr);
     uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
     port = ntohs(a6->sin6_port);
-    info->Set(address_sym, OneByteString(node_isolate, ip));
-    info->Set(family_sym, ipv6_sym);
-    info->Set(port_sym, Integer::New(port, node_isolate));
+    info->Set(env->address_string(), OneByteString(node_isolate, ip));
+    info->Set(env->family_string(), env->ipv6_string());
+    info->Set(env->port_string(), Integer::New(port, node_isolate));
     break;
 
   case AF_INET:
     a4 = reinterpret_cast<const sockaddr_in*>(addr);
     uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
     port = ntohs(a4->sin_port);
-    info->Set(address_sym, OneByteString(node_isolate, ip));
-    info->Set(family_sym, ipv4_sym);
-    info->Set(port_sym, Integer::New(port, node_isolate));
+    info->Set(env->address_string(), OneByteString(node_isolate, ip));
+    info->Set(env->family_string(), env->ipv4_string());
+    info->Set(env->port_string(), Integer::New(port, node_isolate));
     break;
 
   default:
-    info->Set(address_sym, String::Empty(node_isolate));
+    info->Set(env->address_string(), String::Empty(node_isolate));
   }
 
   return scope.Close(info);
@@ -483,4 +480,4 @@ Local<Object> AddressToJS(const sockaddr* addr, Handle<Object> info) {
 
 }  // namespace node
 
-NODE_MODULE(node_tcp_wrap, node::TCPWrap::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_tcp_wrap, node::TCPWrap::Initialize)

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -21,20 +21,24 @@
 
 #ifndef SRC_TCP_WRAP_H_
 #define SRC_TCP_WRAP_H_
+
+#include "env.h"
 #include "stream_wrap.h"
 
 namespace node {
 
 class TCPWrap : public StreamWrap {
  public:
-  static v8::Local<v8::Object> Instantiate();
+  static v8::Local<v8::Object> Instantiate(Environment* env);
   static TCPWrap* Unwrap(v8::Local<v8::Object> obj);
-  static void Initialize(v8::Handle<v8::Object> target);
+  static void Initialize(v8::Handle<v8::Object> target,
+                         v8::Handle<v8::Value> unused,
+                         v8::Handle<v8::Context> context);
 
   uv_tcp_t* UVHandle();
 
  private:
-  explicit TCPWrap(v8::Handle<v8::Object> object);
+  TCPWrap(Environment* env, v8::Handle<v8::Object> object);
   ~TCPWrap();
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -19,13 +19,15 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "node.h"
+#include "env.h"
+#include "env-inl.h"
 #include "handle_wrap.h"
 
 #include <stdint.h>
 
 namespace node {
 
+using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -40,9 +42,9 @@ const uint32_t kOnTimeout = 0;
 
 class TimerWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target) {
-    HandleScope scope(node_isolate);
-
+  static void Initialize(Handle<Object> target,
+                         Handle<Value> unused,
+                         Handle<Context> context) {
     Local<FunctionTemplate> constructor = FunctionTemplate::New(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
     constructor->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Timer"));
@@ -71,13 +73,14 @@ class TimerWrap : public HandleWrap {
     // Therefore we assert that we are not trying to call this as a
     // normal function.
     assert(args.IsConstructCall());
-    HandleScope scope(node_isolate);
-    new TimerWrap(args.This());
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    HandleScope handle_scope(args.GetIsolate());
+    new TimerWrap(env, args.This());
   }
 
-  explicit TimerWrap(Handle<Object> object)
-      : HandleWrap(object, reinterpret_cast<uv_handle_t*>(&handle_)) {
-    int r = uv_timer_init(uv_default_loop(), &handle_);
+  TimerWrap(Environment* env, Handle<Object> object)
+      : HandleWrap(env, object, reinterpret_cast<uv_handle_t*>(&handle_)) {
+    int r = uv_timer_init(env->event_loop(), &handle_);
     assert(r == 0);
   }
 
@@ -133,19 +136,19 @@ class TimerWrap : public HandleWrap {
   }
 
   static void OnTimeout(uv_timer_t* handle, int status) {
-    HandleScope scope(node_isolate);
-
     TimerWrap* wrap = static_cast<TimerWrap*>(handle->data);
-    assert(wrap);
-
+    Environment* env = wrap->env();
+    Context::Scope context_scope(env->context());
+    HandleScope handle_scope(env->isolate());
     Local<Value> argv[1] = { Integer::New(status, node_isolate) };
-    MakeCallback(wrap->object(), kOnTimeout, ARRAY_SIZE(argv), argv);
+    MakeCallback(env, wrap->object(), kOnTimeout, ARRAY_SIZE(argv), argv);
   }
 
   static void Now(const FunctionCallbackInfo<Value>& args) {
-    HandleScope scope(node_isolate);
-    uv_update_time(uv_default_loop());
-    double now = static_cast<double>(uv_now(uv_default_loop()));
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    HandleScope handle_scope(args.GetIsolate());
+    uv_update_time(env->event_loop());
+    double now = static_cast<double>(uv_now(env->event_loop()));
     args.GetReturnValue().Set(now);
   }
 
@@ -155,4 +158,4 @@ class TimerWrap : public HandleWrap {
 
 }  // namespace node
 
-NODE_MODULE(node_timer_wrap, node::TimerWrap::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_timer_wrap, node::TimerWrap::Initialize)

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -24,6 +24,8 @@
 
 #include "node.h"
 #include "node_crypto.h"  // SSLWrap
+
+#include "env.h"
 #include "queue.h"
 #include "stream_wrap.h"
 #include "v8.h"
@@ -42,7 +44,9 @@ namespace crypto {
 class TLSCallbacks : public crypto::SSLWrap<TLSCallbacks>,
                      public StreamWrapCallbacks {
  public:
-  static void Initialize(v8::Handle<v8::Object> target);
+  static void Initialize(v8::Handle<v8::Object> target,
+                         v8::Handle<v8::Value> unused,
+                         v8::Handle<v8::Context> context);
 
   int DoWrite(WriteWrap* w,
               uv_buf_t* bufs,
@@ -82,7 +86,10 @@ class TLSCallbacks : public crypto::SSLWrap<TLSCallbacks>,
     QUEUE member_;
   };
 
-  TLSCallbacks(Kind kind, v8::Handle<v8::Object> sc, StreamWrapCallbacks* old);
+  TLSCallbacks(Environment* env,
+               Kind kind,
+               v8::Handle<v8::Object> sc,
+               StreamWrapCallbacks* old);
   ~TLSCallbacks();
 
   static void SSLInfoCallback(const SSL* ssl_, int where, int ret);
@@ -99,7 +106,7 @@ class TLSCallbacks : public crypto::SSLWrap<TLSCallbacks>,
     EncOut();
   }
 
-  v8::Handle<v8::Value> GetSSLError(int status, int* err);
+  v8::Local<v8::Value> GetSSLError(int status, int* err);
   static void OnClientHelloParseEnd(void* arg);
 
   static void Wrap(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -22,6 +22,7 @@
 #ifndef SRC_TTY_WRAP_H_
 #define SRC_TTY_WRAP_H_
 
+#include "env.h"
 #include "handle_wrap.h"
 #include "stream_wrap.h"
 
@@ -29,13 +30,18 @@ namespace node {
 
 class TTYWrap : public StreamWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target);
+  static void Initialize(v8::Handle<v8::Object> target,
+                         v8::Handle<v8::Value> unused,
+                         v8::Handle<v8::Context> context);
   static TTYWrap* Unwrap(v8::Local<v8::Object> obj);
 
   uv_tty_t* UVHandle();
 
  private:
-  TTYWrap(v8::Handle<v8::Object> object, int fd, bool readable);
+  TTYWrap(Environment* env,
+          v8::Handle<v8::Object> object,
+          int fd,
+          bool readable);
 
   static void GuessHandleType(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void IsTTY(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -22,15 +22,19 @@
 #ifndef SRC_UDP_WRAP_H_
 #define SRC_UDP_WRAP_H_
 
-#include "node.h"
-#include "req_wrap.h"
+#include "env.h"
 #include "handle_wrap.h"
+#include "req_wrap.h"
+#include "uv.h"
+#include "v8.h"
 
 namespace node {
 
 class UDPWrap: public HandleWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target);
+  static void Initialize(v8::Handle<v8::Object> target,
+                         v8::Handle<v8::Value> unused,
+                         v8::Handle<v8::Context> context);
   static void GetFD(v8::Local<v8::String>,
                     const v8::PropertyCallbackInfo<v8::Value>&);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -50,11 +54,11 @@ class UDPWrap: public HandleWrap {
   static void SetTTL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static UDPWrap* Unwrap(v8::Local<v8::Object> obj);
 
-  static v8::Local<v8::Object> Instantiate();
+  static v8::Local<v8::Object> Instantiate(Environment* env);
   uv_udp_t* UVHandle();
 
  private:
-  explicit UDPWrap(v8::Handle<v8::Object> object);
+  UDPWrap(Environment* env, v8::Handle<v8::Object> object);
   virtual ~UDPWrap();
 
   static void DoBind(const v8::FunctionCallbackInfo<v8::Value>& args,

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -1,0 +1,83 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_UTIL_INL_H_
+#define SRC_UTIL_INL_H_
+
+#include "util.h"
+
+namespace node {
+
+template <class TypeName>
+inline v8::Local<TypeName> PersistentToLocal(
+    v8::Isolate* isolate,
+    const v8::Persistent<TypeName>& persistent) {
+  if (persistent.IsWeak()) {
+    return WeakPersistentToLocal(isolate, persistent);
+  } else {
+    return StrongPersistentToLocal(persistent);
+  }
+}
+
+template <class TypeName>
+inline v8::Local<TypeName> StrongPersistentToLocal(
+    const v8::Persistent<TypeName>& persistent) {
+  return *reinterpret_cast<v8::Local<TypeName>*>(
+      const_cast<v8::Persistent<TypeName>*>(&persistent));
+}
+
+template <class TypeName>
+inline v8::Local<TypeName> WeakPersistentToLocal(
+    v8::Isolate* isolate,
+    const v8::Persistent<TypeName>& persistent) {
+  return v8::Local<TypeName>::New(isolate, persistent);
+}
+
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const char* data,
+                                           int length) {
+  return v8::String::NewFromOneByte(isolate,
+                                    reinterpret_cast<const uint8_t*>(data),
+                                    v8::String::kNormalString,
+                                    length);
+}
+
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const signed char* data,
+                                           int length) {
+  return v8::String::NewFromOneByte(isolate,
+                                    reinterpret_cast<const uint8_t*>(data),
+                                    v8::String::kNormalString,
+                                    length);
+}
+
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const unsigned char* data,
+                                           int length) {
+  return v8::String::NewFromOneByte(isolate,
+                                    reinterpret_cast<const uint8_t*>(data),
+                                    v8::String::kNormalString,
+                                    length);
+}
+
+}  // namespace node
+
+#endif  // SRC_UTIL_INL_H_

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,82 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_UTIL_H_
+#define SRC_UTIL_H_
+
+#include "v8.h"
+#include <stddef.h>
+
+namespace node {
+
+#define OFFSET_OF(TypeName, Field)                                            \
+  (reinterpret_cast<uintptr_t>(&(reinterpret_cast<TypeName*>(8)->Field)) - 8)
+
+#define CONTAINER_OF(Pointer, TypeName, Field)                                \
+  reinterpret_cast<TypeName*>(                                                \
+      reinterpret_cast<uintptr_t>(Pointer) - OFFSET_OF(TypeName, Field))
+
+#define FIXED_ONE_BYTE_STRING(isolate, string)                                \
+  (node::OneByteString((isolate), (string), sizeof(string) - 1))
+
+#define DISALLOW_COPY_AND_ASSIGN(TypeName)                                    \
+  void operator=(const TypeName&);                                            \
+  TypeName(const TypeName&)
+
+// If persistent.IsWeak() == false, then do not call persistent.Dispose()
+// while the returned Local<T> is still in scope, it will destroy the
+// reference to the object.
+template <class TypeName>
+inline v8::Local<TypeName> PersistentToLocal(
+    v8::Isolate* isolate,
+    const v8::Persistent<TypeName>& persistent);
+
+// Unchecked conversion from a non-weak Persistent<T> to Local<TLocal<T>,
+// use with care!
+//
+// Do not call persistent.Dispose() while the returned Local<T> is still in
+// scope, it will destroy the reference to the object.
+template <class TypeName>
+inline v8::Local<TypeName> StrongPersistentToLocal(
+    const v8::Persistent<TypeName>& persistent);
+
+template <class TypeName>
+inline v8::Local<TypeName> WeakPersistentToLocal(
+    v8::Isolate* isolate,
+    const v8::Persistent<TypeName>& persistent);
+
+// Convenience wrapper around v8::String::NewFromOneByte().
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const char* data,
+                                           int length = -1);
+
+// For the people that compile with -funsigned-char.
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const signed char* data,
+                                           int length = -1);
+
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const unsigned char* data,
+                                           int length = -1);
+
+}  // namespace node
+
+#endif  // SRC_UTIL_H_

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -25,6 +25,7 @@
 namespace node {
 namespace uv {
 
+using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Handle;
@@ -44,8 +45,9 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target) {
-  v8::HandleScope handle_scope(node_isolate);
+void Initialize(Handle<Object> target,
+                Handle<Value> unused,
+                Handle<Context> context) {
   target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "errname"),
               FunctionTemplate::New(ErrName)->GetFunction());
 #define V(name, _)                                                            \
@@ -59,4 +61,4 @@ void Initialize(Handle<Object> target) {
 }  // namespace uv
 }  // namespace node
 
-NODE_MODULE(node_uv, node::uv::Initialize)
+NODE_MODULE_CONTEXT_AWARE(node_uv, node::uv::Initialize)


### PR DESCRIPTION
@isaacs @piscisaureus @trevnorris and anyone else who wants to look.

There is currently no JS API but you can start scripts in a separate context with `--context='path/to/script.js arg1 arg2 etc'`.  The security token defaults to off and can be set with `--security-token=<token>`, which then affects the --context arguments that follow it.  (You can't turn it off again currently.)

There is still some cleanup to do here and there but it's mostly complete.  I have half a mind to eradicate node_isolate while I'm here but there's almost 1,000 use sites...

@nathansobo  @zcbenz Feedback welcome.
