### PR TITLE
doc: fix writable.write link

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1508,7 +1508,7 @@ modify them.
 [`_read(size)`]: #stream_readable_read_size_1
 [`_read()`]: #stream_readable_read_size_1
 [_read]: #stream_readable_read_size_1
-[`writable.write(chunk)`]
+[`writable.write(chunk)`]: #stream_writable_write_chunk_encoding_callback
 [`write(chunk, encoding, callback)`]: #stream_writable_write_chunk_encoding_callback
 [`write()`]: #stream_writable_write_chunk_encoding_callback
 [`stream.write(chunk)`]: #stream_writable_write_chunk_encoding_callback


### PR DESCRIPTION
Fixing the link to `writable.write(chunk)`. Thanks!
