### PR TITLE
net: add a port validation to `connect`

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -794,10 +794,16 @@ function connect(self, address, port, addressType, localAddress) {
   }
 
   var req = { oncomplete: afterConnect };
-  if (addressType == 6) {
-    err = self._handle.connect6(req, address, port);
-  } else if (addressType == 4) {
-    err = self._handle.connect(req, address, port);
+  if (addressType === 6 || addressType === 4) {
+    port = port | 0;
+    if (port <= 0 || port > 65535)
+      throw new RangeError('Port should be > 0 and < 65536');
+
+    if (addressType === 6) {
+      err = self._handle.connect6(req, address, port);
+    } else if (addressType === 4) {
+      err = self._handle.connect(req, address, port);
+    }
   } else {
     err = self._handle.connect(req, address, afterConnect);
   }

--- a/test/simple/test-net-create-connection.js
+++ b/test/simple/test-net-create-connection.js
@@ -42,6 +42,12 @@ server.listen(tcpPort, 'localhost', function() {
   net.createConnection(tcpPort, 'localhost').on('connect', cb);
   net.createConnection(tcpPort, cb);
   net.createConnection(tcpPort, 'localhost', cb);
+
+  assert.throws(function () {
+    net.createConnection({
+      port: 'invalid!'
+    }, cb);
+  });
 });
 
 process.on('exit', function() {


### PR DESCRIPTION
Fix "Assertion failed" when trying to connect to non-int ports:

```
Assertion failed: (args[2]->Uint32Value()), function Connect, file ../src/tcp_wrap.cc, line 379.
Abort trap: 6
```
