### PR TITLE
contextify: dealloc only after global and sandbox

### DIFF
--- a/test/simple/test-vm-run-in-new-context.js
+++ b/test/simple/test-vm-run-in-new-context.js
@@ -19,9 +19,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --expose-gc
+
 var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
+
+assert.equal(typeof gc, 'function', 'Run this test with --expose-gc');
 
 common.globalCheck = false;
 
@@ -60,3 +64,8 @@ var f = { a: 1 };
 vm.runInNewContext('f.a = 2', { f: f });
 assert.equal(f.a, 2);
 
+console.error('use function in context without referencing context');
+var fn = vm.runInNewContext('(function() { obj.p = {}; })', { obj: {} })
+gc();
+fn();
+// Should not crash


### PR DESCRIPTION
Functions created using: `vm.runInNewContext('(function() { })')` will
reference only `proxy_global_` object and not `sandbox_`. Thus in case,
where there're no references to sandbox (such as in example above),
`ContextifyContext` will be destroyed and use-after-free might happen.

/cc @bnoordhuis @domenic
