### PR TITLE
contextify: fix ContextifyContext leak

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -66,7 +66,7 @@ class ContextifyContext {
       , sandbox_(env->isolate(), sandbox)
       , context_(env->isolate(), CreateV8Context(env))
       , proxy_global_(env->isolate(), context()->Global())
-        // Wait for both sandbox_, proxy_global_, and context_ to die
+        // Wait for sandbox_, proxy_global_, and context_ to die
       , references_(3) {
     sandbox_.MakeWeak(this, WeakCallback);
     sandbox_.MarkIndependent();

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -78,11 +78,8 @@ class ContextifyContext {
 
 
   ~ContextifyContext() {
-    context_.ClearWeak();
     context_.Dispose();
-    proxy_global_.ClearWeak();
     proxy_global_.Dispose();
-    sandbox_.ClearWeak();
     sandbox_.Dispose();
   }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -68,11 +68,11 @@ class ContextifyContext {
       , proxy_global_(env->isolate(), context()->Global())
         // Wait for both sandbox_, proxy_global_, and context_ to die
       , references_(3) {
-    sandbox_.MakeWeak(this, SandboxFreeCallback);
+    sandbox_.MakeWeak(this, WeakCallback);
     sandbox_.MarkIndependent();
-    context_.MakeWeak(this, ContextFreeCallback);
+    context_.MakeWeak(this, WeakCallback);
     context_.MarkIndependent();
-    proxy_global_.MakeWeak(this, ProxyGlobalFreeCallback);
+    proxy_global_.MakeWeak(this, WeakCallback);
     proxy_global_.MarkIndependent();
   }
 
@@ -177,32 +177,12 @@ class ContextifyContext {
   }
 
 
-  static void SandboxFreeCallback(Isolate* isolate,
-                                  Persistent<Object>* target,
-                                  ContextifyContext* context) {
-    assert(!context->sandbox_.IsEmpty());
-    context->sandbox_.ClearWeak();
+  template <class T>
+  static void WeakCallback(Isolate* isolate,
+                           Persistent<T>* target,
+                           ContextifyContext* context) {
+    target->ClearWeak();
     if (--context->references_ == 0)
-      delete context;
-  }
-
-
-  static void ContextFreeCallback(Isolate* isolate,
-                                  Persistent<Context>* target,
-                                  ContextifyContext* context) {
-    assert(!context->context_.IsEmpty());
-    context->context_.ClearWeak();
-    if (--context->references_ == 0)
-      delete context;
-  }
-
-
-  static void ProxyGlobalFreeCallback(Isolate* isolate,
-                                      Persistent<Object>* target,
-                                      ContextifyContext* context) {
-    assert(!context->proxy_global_.IsEmpty());
-    context->proxy_global_.ClearWeak();
-      if (--context->references_ == 0)
       delete context;
   }
 

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -38,8 +38,15 @@ var interval = setInterval(function() {
   if (Date.now() - start > 5 * 1000) {
     // wait 10 seconds.
     clearInterval(interval);
+
+    testContextLeak();
   }
 }, 1);
+
+function testContextLeak() {
+  for (var i = 0; i < 1000; i++)
+    require('vm').createContext({});
+}
 
 process.on('exit', function() {
   console.error('max mem: %dmb', Math.round(maxMem / (1024 * 1024)));


### PR DESCRIPTION
Apparently, context->Global() won't be destroyed if the context itself
isn't marked as weak and independent.

Also, the weakness flag should be cleared once the weak callback is
executed, otherwise we'll get crashes in Debug builds.

fix #6115 and #6201
