### PR TITLE
src: seed V8's random number generator at startup

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3224,6 +3224,12 @@ int Start(int argc, char** argv) {
   Init(&argc, const_cast<const char**>(argv), &exec_argc, &exec_argv);
 
   V8::Initialize();
+#if HAVE_OPENSSL
+  // V8 on Windows doesn't have a good source of entropy. Seed it from
+  // OpenSSL's pool.
+  V8::SetEntropySource(crypto::EntropySource);
+#endif
+
   {
     Locker locker(node_isolate);
     Environment* env =

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -185,6 +185,14 @@ void ThrowCryptoTypeError(unsigned long err) {
 }
 
 
+bool EntropySource(unsigned char* buffer, size_t length) {
+  // RAND_bytes() can return 0 to indicate that the entropy data is not truly
+  // random. That's okay, it's still better than V8's stock source of entropy,
+  // which is /dev/urandom on UNIX platforms and the current time on Windows.
+  return RAND_bytes(buffer, length) != -1;
+}
+
+
 void SecureContext::Initialize(Environment* env, Handle<Object> target) {
   Local<FunctionTemplate> t = FunctionTemplate::New(SecureContext::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -509,6 +509,7 @@ class DiffieHellman : public ObjectWrap {
   DH* dh;
 };
 
+bool EntropySource(unsigned char* buffer, size_t length);
 void InitCrypto(v8::Handle<v8::Object> target);
 
 }  // namespace crypto


### PR DESCRIPTION
The default entropy source is /dev/urandom on UNIX platforms, which is
okay but we can do better by seeding it from OpenSSL's entropy pool.

On Windows we can certainly do better; on that platform, V8 seeds the
random number generator using only the current system time.

Fixes #6250.

Suggested reviewers: @indutny, @piscisaureus
