### PR TITLE
cluster: overridable options

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -245,9 +245,10 @@ function masterInit() {
 
   var initialized = false;
   cluster.setupMaster = function(options) {
+    // allow defaults to be overridden any number of times despite first-time initializers
+    settings = util._extend(settings, options || {});
     if (initialized === true) return;
     initialized = true;
-    settings = util._extend(settings, options || {});
     // Tell V8 to write profile data for each process to a separate file.
     // Without --logfile=v8-%p.log, everything ends up in a single, unusable
     // file. (Unusable because what V8 logs are memory addresses and each
@@ -275,15 +276,17 @@ function masterInit() {
   var ids = 0;
   cluster.fork = function(env) {
     cluster.setupMaster();
+    // leverage per-call options if available
+    var lsettings = options ? util._extend(settings, options || {}) : settings;
     var worker = new Worker;
     worker.id = ++ids;
     var workerEnv = util._extend({}, process.env);
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + worker.id;
-    worker.process = fork(settings.exec, settings.args, {
+    worker.process = fork(lsettings.exec, lsettings.args, {
       env: workerEnv,
-      silent: settings.silent,
-      execArgv: createWorkerExecArgv(settings.execArgv, worker)
+      silent: lsettings.silent,
+      execArgv: createWorkerExecArgv(lsettings.execArgv, worker)
     });
     worker.process.once('exit', function(exitCode, signalCode) {
       worker.suicide = !!worker.suicide;


### PR DESCRIPTION
Allow setup to be invoked any number of times to override options without screwing up first-time initializers, as well as adding the ability to invoke fork with custom options. This will separate out "defaults" from "local" overrides, making the module more flexible.
#6264
