### PR TITLE
Fix sporadic hang.

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -467,7 +467,7 @@ CryptoStream.prototype._read = function read(size) {
     // failure and sets `this.pair.ssl` to `null`.
   } while (read > 0 &&
            !this._buffer.isFull &&
-           bytesRead < size &&
+           size > 0 &&
            this.pair.ssl !== null);
 
   // Create new buffer if previous was filled up


### PR DESCRIPTION
The buffer wasn't being processed completely, which under the right conditions
could leave the writer and reader both waiting for a signal to continue.
