### PR TITLE
apply Array.prototype.slice on arguments

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -107,22 +107,13 @@ EventEmitter.prototype.emit = function(type) {
         break;
       // slower
       default:
-        len = arguments.length;
-        args = new Array(len - 1);
-        for (i = 1; i < len; i++)
-          args[i - 1] = arguments[i];
-        handler.apply(this, args);
+        handler.apply(this, [].prototype.slice(arguments, 1));
     }
   } else if (util.isObject(handler)) {
-    len = arguments.length;
-    args = new Array(len - 1);
-    for (i = 1; i < len; i++)
-      args[i - 1] = arguments[i];
-
     listeners = handler.slice();
     len = listeners.length;
     for (i = 0; i < len; i++)
-      listeners[i].apply(this, args);
+      listeners[i].apply(this, [].prototype.slice(arguments, 1));
   }
 
   if (this.domain && this !== process)


### PR DESCRIPTION
Isn't it quicker to and easier to read if we apply Array.prototype.slice on the arguments object rather than new up an empty Array?
