### PR TITLE
tls: fix sporadic hang and partial reads

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -447,10 +447,9 @@ CryptoStream.prototype._read = function read(size) {
   var bytesRead = 0,
       start = this._buffer.offset;
   do {
-    var read = this._buffer.use(this.pair.ssl, out, size);
+    var read = this._buffer.use(this.pair.ssl, out, size - bytesRead);
     if (read > 0) {
       bytesRead += read;
-      size -= read;
     }
 
     // Handle and report errors


### PR DESCRIPTION
Do not decrement size in read loop, its used later, when comparing to
`bytesRead`.

fix #6270

NOTE: Original patch contributed by @roadrunner2

/cc @bnoordhuis
