### PR TITLE
debugger: show current line, fix for #6150

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1152,8 +1152,15 @@ Interface.prototype.list = function(delta) {
       } else {
         line = lines[i];
       }
+      
+      var prefixChar = ' ';
+      if (current) {
+        prefixChar = '>';
+      } else if (breakpoint) {
+        prefixChar = '*';
+      }
 
-      self.print(leftPad(lineno, breakpoint && '*') + ' ' + line);
+      self.print(leftPad(lineno, prefixChar) + ' ' + line);
     }
     self.resume();
   });


### PR DESCRIPTION
This patch always shows '>' before current line, see #6150 for reasoning.

If there's a breakpoint, it replaces '*' with '>', so breakpoint on the current line will not be shown anymore. I am in doubt about this.

PS: I'd replace '>' with '→' character because first one makes it harder to read line number. Is there a good way to conditionally insert unicode if it is supported?
