### PR TITLE
debugger: repeat last command

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -961,8 +961,8 @@ Interface.prototype.controlEval = function(code, context, filename, callback) {
   try {
     // Repeat last command if empty line are going to be evaluated
     if (this.repl.rli.history && this.repl.rli.history.length > 0) {
-      if (code === '(\n)') {
-        code = '(' + this.repl.rli.history[0] + '\n)';
+      if (code === '\n') {
+        code = this.repl.rli.history[0] + '\n';
       }
     }
 

--- a/test/simple/helper-debugger-repl.js
+++ b/test/simple/helper-debugger-repl.js
@@ -29,6 +29,7 @@ var port = common.PORT + 1337;
 var child;
 var buffer = '';
 var expected = [];
+var quit;
 
 function startDebugger(scriptToDebug) {
   scriptToDebug = process.env.NODE_DEBUGGER_TEST_SCRIPT ||
@@ -70,7 +71,7 @@ function startDebugger(scriptToDebug) {
   });
 
   var quitCalled = false;
-  function quit() {
+  quit = function() {
     if (quitCalled || childClosed) return;
     quitCalled = true;
     child.stdin.write('quit');

--- a/test/simple/test-debugger-repl-term.js
+++ b/test/simple/test-debugger-repl-term.js
@@ -1,0 +1,64 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+process.env.NODE_FORCE_READLINE = 1;
+
+var repl = require('./helper-debugger-repl.js');
+
+repl.startDebugger('breakpoints.js');
+
+var addTest = repl.addTest;
+
+// next
+addTest('n', [
+  /debug>.*n/,
+  /break in .*:11/,
+  /9/, /10/, /11/, /12/, /13/
+]);
+
+// should repeat next
+addTest('', [
+  /debug>/,
+  /break in .*:5/,
+  /3/, /4/, /5/, /6/, /7/,
+]);
+
+// continue
+addTest('c', [
+  /debug>.*c/,
+  /break in .*:12/,
+  /10/, /11/, /12/, /13/, /14/
+]);
+
+// should repeat continue
+addTest('', [
+  /debug>/,
+  /break in .*:5/,
+  /3/, /4/, /5/, /6/, /7/,
+]);
+
+// should repeat continue
+addTest('', [
+  /debug>/,
+  /break in .*:23/,
+  /21/, /22/, /23/, /24/, /25/,
+]);
+


### PR DESCRIPTION
Same thing as in the last year: #3921, broken by 9ef9a9dee54

Old regression test is gone, so adding a new one.

Also, error in [helper-debugger-repl.js](https://github.com/joyent/node/blob/master/test/simple/helper-debugger-repl.js#L92), addTest calls quit() function that is out of the scope.
