### PR TITLE
Added Visual Studio 2013 support to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ non-standard name, run the following instead:
 Prerequisites (Windows only):
 
     * Python 2.6 or 2.7
-    * Visual Studio 2010 or 2012
+    * Visual Studio 2010, 2012 or 2013
 
 Windows:
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -99,6 +99,15 @@ ENDLOCAL
 @rem Skip project generation if requested.
 if defined nobuild goto sign
 
+@rem Look for Visual Studio 2013
+if not defined VS120COMNTOOLS goto vc-set-2012
+if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2012
+call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if not defined VCINSTALLDIR goto msbuild-not-found
+set GYP_MSVS_VERSION=2013
+goto msbuild-found
+
+:vc-set-2012
 @rem Look for Visual Studio 2012
 if not defined VS110COMNTOOLS goto vc-set-2010
 if not exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2010


### PR DESCRIPTION
vcbuild: Added support for building with Microsoft Visual Studio 2013 in Node.

**Note**: In order for this to be implemented, gyp needs to be updated to [r1676](https://code.google.com/p/gyp/source/detail?r=1676) or higher (I used r1743 to test)

This is a three step addition:
1. Bump gyp to r1676 or higher to get VS2013 support (Not complete, needs to be done by someone with commit access)
2. Edit vcbuild.bat to look for VS2013
3. Add a reference to VS2013 support in README.md

Results:
I ran _vcbuild test_ and it passed with no errors. The resulting node.exe was functional.

Discussion:
The current behavior of vcbuild is to select the greatest version of visual studio possible. Is this desirable? Also, should there be an optional command argument for visual studio version? It would be a bit easier to find and work with than setting the gyp environmental variable.

Other:
As this is my first time committing, I should probably mention that I signed the CLA.
