### PR TITLE
src: notify V8 profiler when we're idle

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -203,6 +203,23 @@ inline uv_idle_t* Environment::immediate_idle_handle() {
   return &immediate_idle_handle_;
 }
 
+inline Environment* Environment::from_idle_prepare_handle(
+    uv_prepare_t* handle) {
+  return CONTAINER_OF(handle, Environment, idle_prepare_handle_);
+}
+
+inline uv_prepare_t* Environment::idle_prepare_handle() {
+  return &idle_prepare_handle_;
+}
+
+inline Environment* Environment::from_idle_check_handle(uv_check_t* handle) {
+  return CONTAINER_OF(handle, Environment, idle_check_handle_);
+}
+
+inline uv_check_t* Environment::idle_check_handle() {
+  return &idle_check_handle_;
+}
+
 inline uv_loop_t* Environment::event_loop() const {
   return isolate_data()->event_loop();
 }

--- a/src/env.h
+++ b/src/env.h
@@ -232,6 +232,13 @@ class Environment {
   static inline Environment* from_immediate_check_handle(uv_check_t* handle);
   inline uv_check_t* immediate_check_handle();
   inline uv_idle_t* immediate_idle_handle();
+
+  static inline Environment* from_idle_prepare_handle(uv_prepare_t* handle);
+  inline uv_prepare_t* idle_prepare_handle();
+
+  static inline Environment* from_idle_check_handle(uv_check_t* handle);
+  inline uv_check_t* idle_check_handle();
+
   inline DomainFlag* domain_flag();
   inline TickInfo* tick_info();
 
@@ -274,6 +281,8 @@ class Environment {
   IsolateData* const isolate_data_;
   uv_check_t immediate_check_handle_;
   uv_idle_t immediate_idle_handle_;
+  uv_prepare_t idle_prepare_handle_;
+  uv_check_t idle_check_handle_;
   DomainFlag domain_flag_;
   TickInfo tick_info_;
   uv_timer_t cares_timer_handle_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -2293,6 +2293,40 @@ static void NeedImmediateCallbackSetter(
 }
 
 
+void SetIdle(uv_prepare_t* handle, int) {
+  Environment* env = Environment::from_idle_prepare_handle(handle);
+  env->isolate()->GetCpuProfiler()->SetIdle(true);
+}
+
+
+void ClearIdle(uv_check_t* handle, int) {
+  Environment* env = Environment::from_idle_check_handle(handle);
+  env->isolate()->GetCpuProfiler()->SetIdle(false);
+}
+
+
+void StartProfilerIdleNotifier(Environment* env) {
+  uv_prepare_start(env->idle_prepare_handle(), SetIdle);
+  uv_check_start(env->idle_check_handle(), ClearIdle);
+}
+
+
+void StopProfilerIdleNotifier(Environment* env) {
+  uv_prepare_stop(env->idle_prepare_handle());
+  uv_check_stop(env->idle_check_handle());
+}
+
+
+void StartProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
+  StartProfilerIdleNotifier(Environment::GetCurrent(args.GetIsolate()));
+}
+
+
+void StopProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
+  StopProfilerIdleNotifier(Environment::GetCurrent(args.GetIsolate()));
+}
+
+
 #define READONLY_PROPERTY(obj, str, var)                                      \
   do {                                                                        \
     obj->Set(OneByteString(node_isolate, str), var, v8::ReadOnly);            \
@@ -2464,6 +2498,12 @@ void SetupProcessObject(Environment* env,
                        DebugPortSetter);
 
   // define various internal methods
+  NODE_SET_METHOD(process,
+                  "_startProfilerIdleNotifier",
+                  StartProfilerIdleNotifier);
+  NODE_SET_METHOD(process,
+                  "_stopProfilerIdleNotifier",
+                  StopProfilerIdleNotifier);
   NODE_SET_METHOD(process, "_getActiveRequests", GetActiveRequests);
   NODE_SET_METHOD(process, "_getActiveHandles", GetActiveHandles);
   NODE_SET_METHOD(process, "reallyExit", Exit);
@@ -3195,18 +3235,6 @@ void EmitExit(Environment* env) {
 }
 
 
-void SetIdle(uv_prepare_t* handle, int) {
-  Environment* env = Environment::from_idle_prepare_handle(handle);
-  env->isolate()->GetCpuProfiler()->SetIdle(true);
-}
-
-
-void ClearIdle(uv_check_t* handle, int) {
-  Environment* env = Environment::from_idle_check_handle(handle);
-  env->isolate()->GetCpuProfiler()->SetIdle(false);
-}
-
-
 Environment* CreateEnvironment(Isolate* isolate,
                                int argc,
                                const char* const* argv,
@@ -3222,15 +3250,6 @@ Environment* CreateEnvironment(Isolate* isolate,
   uv_unref(
       reinterpret_cast<uv_handle_t*>(env->immediate_check_handle()));
   uv_idle_init(env->event_loop(), env->immediate_idle_handle());
-
-  Local<FunctionTemplate> process_template = FunctionTemplate::New();
-  process_template->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "process"));
-
-  Local<Object> process_object = process_template->GetFunction()->NewInstance();
-  env->set_process_object(process_object);
-
-  SetupProcessObject(env, argc, argv, exec_argc, exec_argv);
-  Load(env);
 
   // Inform V8's CPU profiler when we're idle.  The profiler is sampling-based
   // but not all samples are created equal; mark the wall clock time spent in
@@ -3250,6 +3269,15 @@ Environment* CreateEnvironment(Isolate* isolate,
     uv_check_init(env->event_loop(), env->idle_check_handle());
     uv_check_start(env->idle_check_handle(), ClearIdle);
   }
+
+  Local<FunctionTemplate> process_template = FunctionTemplate::New();
+  process_template->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "process"));
+
+  Local<Object> process_object = process_template->GetFunction()->NewInstance();
+  env->set_process_object(process_object);
+
+  SetupProcessObject(env, argc, argv, exec_argc, exec_argv);
+  Load(env);
 
   return env;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -51,6 +51,7 @@
 #include "string_bytes.h"
 #include "uv.h"
 #include "v8-debug.h"
+#include "v8-profiler.h"
 #include "zlib.h"
 
 #include <assert.h>
@@ -3182,6 +3183,18 @@ void EmitExit(Environment* env) {
 }
 
 
+void SetIdle(uv_prepare_t* handle, int) {
+  Environment* env = Environment::from_idle_prepare_handle(handle);
+  env->isolate()->GetCpuProfiler()->SetIdle(true);
+}
+
+
+void ClearIdle(uv_check_t* handle, int) {
+  Environment* env = Environment::from_idle_check_handle(handle);
+  env->isolate()->GetCpuProfiler()->SetIdle(false);
+}
+
+
 Environment* CreateEnvironment(Isolate* isolate,
                                int argc,
                                const char* const* argv,
@@ -3206,6 +3219,25 @@ Environment* CreateEnvironment(Isolate* isolate,
 
   SetupProcessObject(env, argc, argv, exec_argc, exec_argv);
   Load(env);
+
+  // Inform V8's CPU profiler when we're idle.  The profiler is sampling-based
+  // but not all samples are created equal; mark the wall clock time spent in
+  // epoll_wait() and friends so profiling tools can filter it out.  The samples
+  // still end up in v8.log but with state=IDLE rather than state=EXTERNAL.
+  // TODO(bnoordhuis): Only start when profiling.  OTOH, the performance impact
+  // is probably negligible.
+  // TODO(bnoordhuis) Depends on a libuv implementation detail that we should
+  // probably fortify in the API contract, namely that the last started prepare
+  // or check watcher runs first.  It's not 100% foolproof; if an add-on starts
+  // a prepare or check watcher after us, any samples attributed to its callback
+  // will be recorded with state=IDLE.
+  uv_prepare_init(env->event_loop(), env->idle_prepare_handle());
+  uv_prepare_start(env->idle_prepare_handle(), SetIdle);
+  uv_unref(reinterpret_cast<uv_handle_t*>(env->idle_prepare_handle()));
+
+  uv_check_init(env->event_loop(), env->idle_check_handle());
+  uv_check_start(env->idle_check_handle(), ClearIdle);
+  uv_unref(reinterpret_cast<uv_handle_t*>(env->idle_check_handle()));
 
   return env;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -130,6 +130,7 @@ static const char* eval_string = NULL;
 static bool use_debug_agent = false;
 static bool debug_wait_connect = false;
 static int debug_port = 5858;
+static bool v8_is_profiling = false;
 
 // used by C++ modules as well
 bool no_deprecation = false;
@@ -3075,6 +3076,17 @@ void Init(int* argc,
   const char** v8_argv;
   ParseArgs(argc, argv, exec_argc, exec_argv, &v8_argc, &v8_argv);
 
+  // TODO(bnoordhuis) Intercept --prof arguments and start the CPU profiler
+  // manually?  That would give us a little more control over its runtime
+  // behavior but it could also interfere with the user's intentions in ways
+  // we fail to anticipate.  Dillema.
+  for (int i = 1; i < v8_argc; ++i) {
+    if (strncmp(v8_argv[i], "--prof", sizeof("--prof") - 1) == 0) {
+      v8_is_profiling = true;
+      break;
+    }
+  }
+
   // The const_cast doesn't violate conceptual const-ness.  V8 doesn't modify
   // the argv array or the elements it points to.
   V8::SetFlagsFromCommandLine(&v8_argc, const_cast<char**>(v8_argv), true);
@@ -3224,8 +3236,6 @@ Environment* CreateEnvironment(Isolate* isolate,
   // but not all samples are created equal; mark the wall clock time spent in
   // epoll_wait() and friends so profiling tools can filter it out.  The samples
   // still end up in v8.log but with state=IDLE rather than state=EXTERNAL.
-  // TODO(bnoordhuis): Only start when profiling.  OTOH, the performance impact
-  // is probably negligible.
   // TODO(bnoordhuis) Depends on a libuv implementation detail that we should
   // probably fortify in the API contract, namely that the last started prepare
   // or check watcher runs first.  It's not 100% foolproof; if an add-on starts
@@ -3234,10 +3244,12 @@ Environment* CreateEnvironment(Isolate* isolate,
   uv_prepare_init(env->event_loop(), env->idle_prepare_handle());
   uv_prepare_start(env->idle_prepare_handle(), SetIdle);
   uv_unref(reinterpret_cast<uv_handle_t*>(env->idle_prepare_handle()));
-
-  uv_check_init(env->event_loop(), env->idle_check_handle());
-  uv_check_start(env->idle_check_handle(), ClearIdle);
   uv_unref(reinterpret_cast<uv_handle_t*>(env->idle_check_handle()));
+
+  if (v8_is_profiling) {
+    uv_check_init(env->event_loop(), env->idle_check_handle());
+    uv_check_start(env->idle_check_handle(), ClearIdle);
+  }
 
   return env;
 }


### PR DESCRIPTION
Inform V8's CPU profiler when we're idle.  The profiler is
sampling-based but not all samples are created equal; mark the wall
clock time spent in epoll_wait() and friends so profiling tools can
filter it out.  The samples still end up in v8.log but with state=IDLE
rather than state=EXTERNAL.
