### PR TITLE
src: raise maximum file descriptor limit

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -72,6 +72,7 @@
 #define umask _umask
 typedef int mode_t;
 #else
+#include <sys/resource.h>  // getrlimit, setrlimit
 #include <unistd.h>  // setuid, getuid
 #endif
 
@@ -3103,6 +3104,27 @@ void Init(int* argc,
   node_isolate = Isolate::GetCurrent();
 
 #ifdef __POSIX__
+  {
+    struct rlimit lim;
+    if (getrlimit(RLIMIT_NOFILE, &lim) == 0 && lim.rlim_cur != lim.rlim_max) {
+      // Do a binary search for the file descriptor limit.
+      rlim_t min = lim.rlim_cur;
+      rlim_t max = 1 << 20;
+      // But if there's a defined upper bound, don't search, just set it.
+      if (lim.rlim_max != RLIM_INFINITY) {
+        min = lim.rlim_max;
+        max = lim.rlim_max;
+      }
+      do {
+        lim.rlim_cur = min + (max - min) / 2;
+        if (setrlimit(RLIMIT_NOFILE, &lim)) {
+          max = lim.rlim_cur;
+        } else {
+          min = lim.rlim_cur;
+        }
+      } while (min + 1 < max);
+    }
+  }
   // Ignore SIGPIPE
   RegisterSignalHandler(SIGPIPE, SIG_IGN);
   RegisterSignalHandler(SIGINT, SignalExit);


### PR DESCRIPTION
Do a binary search for the maximum RLIMIT_NOFILE.  Works around the
low, low limits on certain high, high-priced devices from Cupertino, CA.

Suggested reviewers: @indutny and @tjfontaine?
