### PR TITLE
Add the escapeShellArg function to path

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -502,3 +502,14 @@ if (isWindows) {
     return path;
   };
 }
+
+if (isWindows ) {
+	exports.escapeShellArg = function(arg) {
+		return arg.match(/[\s\|<>\^]/) ? ('"' + arg.replace(/([\|<>\^"])/g,'^$1') + '"') : arg;
+	};
+}
+else {
+	exports.escapeShellArg = function(arg) {
+		return arg.match(/["\s'$`\\\|<>]/) ? ('"' + arg.replace(/(["\s'$`\\\|<>])/g, '\\$1') + '"') : arg;
+	};
+}


### PR DESCRIPTION
When we have to call external programs, we could need to pass them some arguments.

Let's implement a function to escape these arguments.
