### PR TITLE
debugger: count space for line numbers correctly

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1018,27 +1018,12 @@ Interface.prototype.debugEval = function(code, context, filename, callback) {
 
 // Utils
 
-// Returns number of digits (+1)
-function intChars(n) {
-  // TODO dumb:
-  if (n < 50) {
-    return 3;
-  } else if (n < 950) {
-    return 4;
-  } else if (n < 9950) {
-    return 5;
-  } else {
-    return 6;
-  }
-}
-
 // Adds spaces and prefix to number
-function leftPad(n, prefix) {
+// maxN is a maximum number we should have space for
+function leftPad(n, prefix, maxN) {
   var s = n.toString(),
-      nchars = intChars(n),
+      nchars = Math.max(2, String(maxN).length) + 1,
       nspaces = nchars - s.length - 1;
-
-  prefix || (prefix = ' ');
 
   for (var i = 0; i < nspaces; i++) {
     prefix += ' ';
@@ -1160,7 +1145,7 @@ Interface.prototype.list = function(delta) {
         prefixChar = '*';
       }
 
-      self.print(leftPad(lineno, prefixChar) + ' ' + line);
+      self.print(leftPad(lineno, prefixChar, to) + ' ' + line);
     }
     self.resume();
   });
@@ -1322,7 +1307,8 @@ Interface.prototype.watchers = function() {
       if (verbose) self.print('Watchers:');
 
       self._watchers.forEach(function(watcher, i) {
-        self.print(leftPad(i, ' ') + ': ' + watcher + ' = ' +
+        self.print(leftPad(i, ' ', self._watchers.length - 1) +
+                   ': ' + watcher + ' = ' +
                    JSON.stringify(values[i]));
       });
 


### PR DESCRIPTION
Fixed weird behaviour of line numbers around 50th, 950th, 9950th line:

```
break in script:50
 48     }
 49 }
  50 debugger;
  51 if (!config.user_agent) config.user_agent = 'package/'+pkg.version;
  52 if (!config.self_path) config.self_path = config_path;
```

Also, one less TODO in the code now which is usually a good thing.
