### PR TITLE
Add the escapeShellArg function to child_process

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -766,22 +766,25 @@ var spawn = exports.spawn = function(file, args, options) {
 };
 
 var escapeShellArg;
-var escapeShellArg;
 if (process.platform === 'win32') {
-	escapeShellArg = function(arg) {
-		if(/["<>\s\|]/.test(arg)) { // // If arg contains spaces or some special character...
-			return '"' + arg.replace(/(")/g, '"$1') + '"'; // Enclose arg in double quotes and escape double quotes.
-		}
-		return arg;
-	};
+  escapeShellArg = function(arg) {
+    // If arg contains spaces or some special character...
+    if (/["<>\s\|]/.test(arg)) {
+      // Enclose arg in double quotes and escape double quotes.
+      return '"' + arg.replace(/(")/g, '"$1') + '"';
+    }
+    return arg;
+  };
 }
 else {
-	escapeShellArg = function(arg) {
-		if(/[!"#$&'()*<>\s\\\|`{}]/.test(arg)) { // // If arg contains spaces or some special character...
-			return "'" + arg.replace(/(')/g, '\\$1') + "'"; // Enclose arg in single quotes and escape single quotes.
-		}
-		return arg;
-	};
+  escapeShellArg = function(arg) {
+    // If arg contains spaces or some special character...
+    if (/[!"#$&'()*<>\s\\\|`{}]/.test(arg)) {
+      // Enclose arg in single quotes and escape single quotes.
+      return "'" + arg.replace(/(')/g, '\\$1') + "'";
+    }
+    return arg;
+  };
 }
 exports.escapeShellArg = escapeShellArg;
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -765,6 +765,25 @@ var spawn = exports.spawn = function(file, args, options) {
   return child;
 };
 
+var escapeShellArg;
+var escapeShellArg;
+if (process.platform === 'win32') {
+	escapeShellArg = function(arg) {
+		if(/["<>\s\|]/.test(arg)) { // // If arg contains spaces or some special character...
+			return '"' + arg.replace(/(")/g, '"$1') + '"'; // Enclose arg in double quotes and escape the double quotes.
+		}
+		return arg;
+	};
+}
+else {
+	escapeShellArg = function(arg) {
+		if(/[!"#$&'()*<>\s\\\|`{}]/.test(arg)) { // // If arg contains spaces or some special character...
+			return "'" + arg.replace(/(')/g, '\\$1') + "'"; // Enclose arg in double quotes and escape the special characters.
+		}
+		return arg;
+	};
+}
+exports.escapeShellArg = escapeShellArg;
 
 function maybeClose(subprocess) {
   subprocess._closesGot++;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -770,7 +770,7 @@ var escapeShellArg;
 if (process.platform === 'win32') {
 	escapeShellArg = function(arg) {
 		if(/["<>\s\|]/.test(arg)) { // // If arg contains spaces or some special character...
-			return '"' + arg.replace(/(")/g, '"$1') + '"'; // Enclose arg in double quotes and escape the double quotes.
+			return '"' + arg.replace(/(")/g, '"$1') + '"'; // Enclose arg in double quotes and escape double quotes.
 		}
 		return arg;
 	};
@@ -778,7 +778,7 @@ if (process.platform === 'win32') {
 else {
 	escapeShellArg = function(arg) {
 		if(/[!"#$&'()*<>\s\\\|`{}]/.test(arg)) { // // If arg contains spaces or some special character...
-			return "'" + arg.replace(/(')/g, '\\$1') + "'"; // Enclose arg in double quotes and escape the special characters.
+			return "'" + arg.replace(/(')/g, '\\$1') + "'"; // Enclose arg in single quotes and escape single quotes.
 		}
 		return arg;
 	};

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -775,8 +775,7 @@ if (process.platform === 'win32') {
     }
     return arg;
   };
-}
-else {
+} else {
   escapeShellArg = function(arg) {
     // If arg contains spaces or some special character...
     if (/[!"#$&'()*<>\s\\\|`{}]/.test(arg)) {

--- a/test/simple/test-child-process-escapeshellarg.js
+++ b/test/simple/test-child-process-escapeshellarg.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 if (process.argv.length >= 3
-      && process.argv[2] === 'testing-child-process-escaleshellarg') {
+      && process.argv[2] === 'testing-child-process-escapeshellarg') {
   process.argv.forEach(function(arg, index) {
     if (index > 3) {
       process.stdout.write('\n');
@@ -54,7 +54,7 @@ var success_count = 0;
 
 testParameters.forEach(function(testParameter) {
   var commandLine = 'node ' + escapeShellArg(__filename)
-    + ' testing-child-process-escaleshellarg ' + escapeShellArg(testParameter);
+    + ' testing-child-process-escapeshellarg ' + escapeShellArg(testParameter);
   exec(commandLine, function(error, stdout, stderr) {
     if (error) {
       error_count++;

--- a/test/simple/test-child-process-escapeshellarg.js
+++ b/test/simple/test-child-process-escapeshellarg.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if(process.argv.length >= 3 && process.argv[2] === 'testing-child-process-escaleshellarg') {
+	for(var index in process.argv) {
+		if(index > 3) {
+			process.stdout.write('\n');
+		}
+		if(index > 2) {
+			process.stdout.write(process.argv[index]);
+		}
+	}
+	process.exit(0);
+}
+var assert = require('assert');
+var exec = require('child_process').exec;
+var escapeShellArg = require('child_process').escapeShellArg;
+
+var testParameters = ['simple', 'with some spaces', 'with "double quotes"', 'with <redirection> or |pipe|', 'with *some* $special \char/', '$1', '%1', 'Hi\tThere!', '/var/*', '\t'];
+
+var error_count = 0;
+var mismatched_count = 0;
+var success_count = 0;
+
+testParameters.forEach(function(testParameter) {
+	var commandLine = 'node ' + escapeShellArg(__filename) + ' testing-child-process-escaleshellarg ' + escapeShellArg(testParameter);
+	exec(commandLine, function(error, stdout, stderr) {
+		if(error) {
+			error_count++;
+			console.log('error!: ' + error.code);
+			console.log('stdout: ' + JSON.stringify(stdout));
+			console.log('stderr: ' + JSON.stringify(stderr));
+			assert.equal(false, error.killed);
+		}
+		else {
+			var received = stdout.toString();
+			if(received !== testParameter) {
+				mismatched_count++;
+				console.log(commandLine + '\nSent parameter: >' + testParameter + '< received parameter >' + received + '<');
+			}
+			else {
+				success_count++;
+			}
+		}
+	});
+});
+
+process.on('exit', function() {
+	assert.equal(0, error_count);
+	assert.equal(0, mismatched_count);
+	assert.equal(testParameters.length, success_count);
+});

--- a/test/simple/test-child-process-escapeshellarg.js
+++ b/test/simple/test-child-process-escapeshellarg.js
@@ -19,15 +19,16 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if (process.argv.length >= 3 && process.argv[2] === 'testing-child-process-escaleshellarg') {
-  for (var index in process.argv) {
+if (process.argv.length >= 3
+      && process.argv[2] === 'testing-child-process-escaleshellarg') {
+  process.argv.forEach(function(arg, index) {
     if (index > 3) {
       process.stdout.write('\n');
     }
     if (index > 2) {
-      process.stdout.write(process.argv[index]);
+      process.stdout.write(arg);
     }
-  }
+  });
   process.exit(0);
 }
 var assert = require('assert');
@@ -52,20 +53,21 @@ var mismatched_count = 0;
 var success_count = 0;
 
 testParameters.forEach(function(testParameter) {
-  var commandLine = 'node ' + escapeShellArg(__filename) + ' testing-child-process-escaleshellarg ' + escapeShellArg(testParameter);
+  var commandLine = 'node ' + escapeShellArg(__filename)
+    + ' testing-child-process-escaleshellarg ' + escapeShellArg(testParameter);
   exec(commandLine, function(error, stdout, stderr) {
-    if(error) {
+    if (error) {
       error_count++;
       console.log('error!: ' + error.code);
       console.log('stdout: ' + JSON.stringify(stdout));
       console.log('stderr: ' + JSON.stringify(stderr));
       assert.equal(false, error.killed);
-    }
-    else {
+    } else {
       var received = stdout.toString();
       if (received !== testParameter) {
         mismatched_count++;
-        console.log(commandLine + '\nSent parameter: >' + testParameter + '< received parameter >' + received + '<');
+        console.log(commandLine + '\nSent parameter: >' + testParameter
+		    + '< received parameter >' + received + '<');
       }
       else {
         success_count++;

--- a/test/simple/test-child-process-escapeshellarg.js
+++ b/test/simple/test-child-process-escapeshellarg.js
@@ -19,52 +19,63 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if(process.argv.length >= 3 && process.argv[2] === 'testing-child-process-escaleshellarg') {
-	for(var index in process.argv) {
-		if(index > 3) {
-			process.stdout.write('\n');
-		}
-		if(index > 2) {
-			process.stdout.write(process.argv[index]);
-		}
-	}
-	process.exit(0);
+if (process.argv.length >= 3 && process.argv[2] === 'testing-child-process-escaleshellarg') {
+  for (var index in process.argv) {
+    if (index > 3) {
+      process.stdout.write('\n');
+    }
+    if (index > 2) {
+      process.stdout.write(process.argv[index]);
+    }
+  }
+  process.exit(0);
 }
 var assert = require('assert');
 var exec = require('child_process').exec;
 var escapeShellArg = require('child_process').escapeShellArg;
 
-var testParameters = ['simple', 'with some spaces', 'with "double quotes"', 'with <redirection> or |pipe|', 'with *some* $special \char/', '$1', '%1', 'Hi\tThere!', '/var/*', '\t'];
+var testParameters = [
+  'simple',
+  'with some spaces',
+  'with "double quotes"',
+  'with <redirection> or |pipe|',
+  'with *some* $special \char/',
+  '$1',
+  '%1',
+  'Hi\tThere!',
+  '/var/*',
+  '\t'
+];
 
 var error_count = 0;
 var mismatched_count = 0;
 var success_count = 0;
 
 testParameters.forEach(function(testParameter) {
-	var commandLine = 'node ' + escapeShellArg(__filename) + ' testing-child-process-escaleshellarg ' + escapeShellArg(testParameter);
-	exec(commandLine, function(error, stdout, stderr) {
-		if(error) {
-			error_count++;
-			console.log('error!: ' + error.code);
-			console.log('stdout: ' + JSON.stringify(stdout));
-			console.log('stderr: ' + JSON.stringify(stderr));
-			assert.equal(false, error.killed);
-		}
-		else {
-			var received = stdout.toString();
-			if(received !== testParameter) {
-				mismatched_count++;
-				console.log(commandLine + '\nSent parameter: >' + testParameter + '< received parameter >' + received + '<');
-			}
-			else {
-				success_count++;
-			}
-		}
-	});
+  var commandLine = 'node ' + escapeShellArg(__filename) + ' testing-child-process-escaleshellarg ' + escapeShellArg(testParameter);
+  exec(commandLine, function(error, stdout, stderr) {
+    if(error) {
+      error_count++;
+      console.log('error!: ' + error.code);
+      console.log('stdout: ' + JSON.stringify(stdout));
+      console.log('stderr: ' + JSON.stringify(stderr));
+      assert.equal(false, error.killed);
+    }
+    else {
+      var received = stdout.toString();
+      if (received !== testParameter) {
+        mismatched_count++;
+        console.log(commandLine + '\nSent parameter: >' + testParameter + '< received parameter >' + received + '<');
+      }
+      else {
+        success_count++;
+      }
+    }
+  });
 });
 
 process.on('exit', function() {
-	assert.equal(0, error_count);
-	assert.equal(0, mismatched_count);
-	assert.equal(testParameters.length, success_count);
+  assert.equal(0, error_count);
+  assert.equal(0, mismatched_count);
+  assert.equal(testParameters.length, success_count);
 });


### PR DESCRIPTION
When we call external programs via `exec()`, we should escape parameters that may contain special characters.

Let's implement a function that escapes shell arguments.

Supersedes https://github.com/joyent/node/pull/6308
