### PR TITLE
src: emit 'beforeExit' event on process object

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3237,6 +3237,19 @@ void AtExit(void (*cb)(void* arg), void* arg) {
 }
 
 
+void EmitBeforeExit(Environment* env) {
+  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env->isolate());
+  Local<Object> process_object = env->process_object();
+  Local<String> exit_code = FIXED_ONE_BYTE_STRING(env->isolate(), "exitCode");
+  Local<Value> args[] = {
+    FIXED_ONE_BYTE_STRING(env->isolate(), "beforeExit"),
+    process_object->Get(exit_code)->ToInteger()
+  };
+  MakeCallback(env, process_object, "emit", ARRAY_SIZE(args), args);
+}
+
+
 void EmitExit(Environment* env) {
   // process.emit('exit')
   Context::Scope context_scope(env->context());
@@ -3330,7 +3343,14 @@ int Start(int argc, char** argv) {
         CreateEnvironment(node_isolate, argc, argv, exec_argc, exec_argv);
     Context::Scope context_scope(env->context());
     HandleScope handle_scope(env->isolate());
-    uv_run(env->event_loop(), UV_RUN_DEFAULT);
+    bool more;
+    do {
+      more = uv_run(env->event_loop(), UV_RUN_ONCE);
+      if (more == false) {
+        EmitBeforeExit(env);
+        more = uv_run(env->event_loop(), UV_RUN_NOWAIT);
+      }
+    } while (more == true);
     EmitExit(env);
     RunAtExit(env);
     env->Dispose();

--- a/test/simple/test-process-before-exit.js
+++ b/test/simple/test-process-before-exit.js
@@ -1,0 +1,34 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common');
+
+var N = 5;
+var n = 0;
+
+function f() {
+  if (++n < N) setTimeout(f, 5);
+}
+process.on('beforeExit', f);
+process.on('exit', function() {
+  assert.equal(n, N + 1);  // The sixth time we let it through.
+});

--- a/test/simple/test-process-exit-from-before-exit.js
+++ b/test/simple/test-process-exit-from-before-exit.js
@@ -1,0 +1,29 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common');
+
+process.on('beforeExit', common.mustCall(function() {
+  setTimeout(assert.fail, 5);
+  process.exit(0);  // Should execute immediately even if we schedule new work.
+  assert.fail();
+}));


### PR DESCRIPTION
Unlike the 'exit' event, this event allows the user to schedule more
work and thereby postpone the exit.  That also means that the
'beforeExit' event may be emitted many times, see the attached test
case for an example.

Refs #6305.

TODO: Still needs documentation.
Suggested reviewers: @tjfontaine @sam-github
