### PR TITLE
fs: fix fs.truncate() file content zeroing bug

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -556,7 +556,7 @@ fs.truncate = function(path, len, callback) {
     len = 0;
   }
   callback = maybeCallback(callback);
-  fs.open(path, 'w', function(er, fd) {
+  fs.open(path, 'r+', function(er, fd) {
     if (er) return callback(er);
     binding.ftruncate(fd, len, function(er) {
       fs.close(fd, function(er2) {
@@ -575,7 +575,7 @@ fs.truncateSync = function(path, len) {
     len = 0;
   }
   // allow error to be thrown, but still close fd.
-  var fd = fs.openSync(path, 'w');
+  var fd = fs.openSync(path, 'r+');
   try {
     var ret = fs.ftruncateSync(fd, len);
   } finally {

--- a/test/simple/test-fs-truncate-GH-6233.js
+++ b/test/simple/test-fs-truncate-GH-6233.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+
+var filename = common.tmpDir + '/truncate-file.txt';
+
+// Synchronous test.
+(function() {
+  fs.writeFileSync(filename, '0123456789');
+  assert.equal(fs.readFileSync(filename).toString(), '0123456789');
+  fs.truncateSync(filename, 5);
+  assert.equal(fs.readFileSync(filename).toString(), '01234');
+})();
+
+// Asynchronous test.
+(function() {
+  fs.writeFileSync(filename, '0123456789');
+  assert.equal(fs.readFileSync(filename).toString(), '0123456789');
+  fs.truncate(filename, 5, common.mustCall(function(err) {
+    if (err) throw err;
+    assert.equal(fs.readFileSync(filename).toString(), '01234');
+  }));
+})();


### PR DESCRIPTION
fs.truncate() and its synchronous sibling are implemented in terms of
open() + ftruncate().  Unfortunately, it opened the target file with
mode 'w' a.k.a. 'write-only and create or truncate at open'.

The subsequent call to ftruncate() then moved the end-of-file pointer
from zero to the requested offset with the net result of a file that's
neatly truncated at the right offset and filled with zero bytes only.

This bug was introduced in commit 168a5557 but in fairness, before that
commit fs.truncate() worked like fs.ftruncate() so it seems we've never
had a working fs.truncate() until now.

Fixes #6233.

Suggested reviewer: @indutny?
