### PR TITLE
smalloc: track active number/size of smallocs

### DIFF
--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -23,9 +23,18 @@ var smalloc = process.binding('smalloc');
 var kMaxLength = smalloc.kMaxLength;
 var util = require('util');
 
+var infoBox = {};
+smalloc._setupSmalloc(infoBox);
+
 exports.alloc = alloc;
 exports.copyOnto = smalloc.copyOnto;
 exports.dispose = dispose;
+exports.count = count;
+exports.size = size;
+
+// *Must* match values in env.h
+var kCount = 0;
+var kSize = 1;
 
 // don't allow kMaxLength to accidentally be overwritten. it's a lot less
 // apparent when a primitive is accidentally changed.
@@ -86,4 +95,14 @@ function dispose(obj) {
     throw new TypeError('obj cannot be a Buffer');
 
   smalloc.dispose(obj);
+}
+
+
+function count() {
+  return infoBox[kCount];
+}
+
+
+function size() {
+  return infoBox[kSize];
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -122,6 +122,26 @@ inline void Environment::TickInfo::set_last_threw(uint32_t value) {
   fields_[kLastThrew] = value;
 }
 
+inline Environment::SmallocInfo::SmallocInfo() {
+  for (int i = 0; i < kFieldsCount; ++i) fields_[i] = 0;
+}
+
+inline uint32_t* Environment::SmallocInfo::fields() {
+  return fields_;
+}
+
+inline int Environment::SmallocInfo::fields_count() const {
+  return kFieldsCount;
+}
+
+inline void Environment::SmallocInfo::adjust_count(uint32_t value) {
+  fields_[kCount] += value;
+}
+
+inline void Environment::SmallocInfo::adjust_size(uint32_t value) {
+  fields_[kSize] += value;
+}
+
 inline Environment* Environment::New(v8::Local<v8::Context> context) {
   Environment* env = new Environment(context);
   context->SetAlignedPointerInEmbedderData(kContextEmbedderDataIndex, env);
@@ -230,6 +250,10 @@ inline Environment::DomainFlag* Environment::domain_flag() {
 
 inline Environment::TickInfo* Environment::tick_info() {
   return &tick_info_;
+}
+
+inline Environment::SmallocInfo* Environment::smalloc_info() {
+  return &smalloc_info_;
 }
 
 inline bool Environment::using_smalloc_alloc_cb() const {

--- a/src/env.h
+++ b/src/env.h
@@ -216,6 +216,28 @@ class Environment {
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };
 
+  class SmallocInfo {
+   public:
+    inline uint32_t* fields();
+    inline int fields_count() const;
+    inline void adjust_count(uint32_t value);
+    inline void adjust_size(uint32_t value);
+
+   private:
+    friend class Environment;  // So we can call the constructor.
+    inline SmallocInfo();
+
+    enum Fields {
+      kCount,
+      kSize,
+      kFieldsCount
+    };
+
+    uint32_t fields_[kFieldsCount];
+
+    DISALLOW_COPY_AND_ASSIGN(SmallocInfo);
+  };
+
   static inline Environment* GetCurrent(v8::Isolate* isolate);
   static inline Environment* GetCurrent(v8::Local<v8::Context> context);
   static inline Environment* GetCurrentChecked(v8::Isolate* isolate);
@@ -241,6 +263,7 @@ class Environment {
 
   inline DomainFlag* domain_flag();
   inline TickInfo* tick_info();
+  inline SmallocInfo* smalloc_info();
 
   static inline Environment* from_cares_timer_handle(uv_timer_t* handle);
   inline uv_timer_t* cares_timer_handle();
@@ -285,6 +308,7 @@ class Environment {
   uv_check_t idle_check_handle_;
   DomainFlag domain_flag_;
   TickInfo tick_info_;
+  SmallocInfo smalloc_info_;
   uv_timer_t cares_timer_handle_;
   ares_channel cares_channel_;
   ares_task_list cares_task_list_;


### PR DESCRIPTION
Two new APIs are introduced:

smalloc.count(): The number of object that are alive, that have been
allocated through smalloc.

smalloc.size(): The total byte size of live allocated object.

Still needs some cleanup, but basic idea is there.
