### PR TITLE
tls: fix premature connection termination

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1400,7 +1400,7 @@ function pipe(pair, socket) {
       // Encrypted should be unpiped from socket to prevent possible
       // write after destroy.
       pair.encrypted.unpipe(socket);
-      socket.destroy();
+      socket.destroySoon();
     });
   });
 


### PR DESCRIPTION
Destroying the TLS session implies destroying the underlying socket but
before this commit, that was done with net.Socket#destroy() rather than
net.Socket#destroySoon().  The former closes the connection right away,
even when there is still data to write.  In other words, sometimes the
final TLS record got truncated.

Fixes #6107.

Suggested reviewer: @indutny.  Note that lib/tls.js calls Socket#destroy() in two other places.  In both cases it's to abort the connection.  Still, you should probably take a good hard look at them and decide if the current behavior is correct.
