### PR TITLE
Added support for toggling debug mode/exposed debug mode status flag

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -139,7 +139,7 @@ bool no_deprecation = false;
 // process-relative uptime base, initialized at start-up
 static double prog_start_time;
 
-static volatile bool debugger_running = false;
+volatile bool debugger_running = false;
 static uv_async_t dispatch_debug_messages_async;
 static uv_async_t emit_debug_enabled_async;
 

--- a/src/node.h
+++ b/src/node.h
@@ -253,6 +253,10 @@ node_module_struct* get_builtin_module(const char *name);
  */
 NODE_EXTERN void AtExit(void (*cb)(void* arg), void* arg = 0);
 
+/* Accessor method for debug mode status
+ */
+NODE_EXTERN bool DebuggerRunning(v8::Isolate *isolate);
+
 }  // namespace node
 
 #endif  // SRC_NODE_H_


### PR DESCRIPTION
Changes:
1. Exposed debug mode flag.
Reason- allowing monitr (https://npmjs.org/package/monitr) to send the debug mode status to process-watcher(https://npmjs.org/package/process-watcher) so that process-watcher does not kill a node worker when a debug session is in progress)
1. Added support to toggle debug mode:.
   Reason- Developers need to switch in and out of debug mode on production hosts running node.
