### PR TITLE
doc: added a notice loadavg regarding windows

### DIFF
--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -42,7 +42,7 @@ Returns the system uptime in seconds.
 ## os.loadavg()
 
 Returns an array containing the 1, 5, and 15 minute load averages.  
-Note that this statement will always return 0 values when under windows as it is not applicable to that architecture. 
+Note that this statement will always return zero values when under windows as it is not applicable to the architecture. 
 
 ## os.totalmem()
 

--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -41,7 +41,8 @@ Returns the system uptime in seconds.
 
 ## os.loadavg()
 
-Returns an array containing the 1, 5, and 15 minute load averages.
+Returns an array containing the 1, 5, and 15 minute load averages.  
+Note that this statement will always return 0 values when under windows as it is not applicable to that architecture. 
 
 ## os.totalmem()
 


### PR DESCRIPTION
the loadavg statement will always return a array filled with zero 
values. this commit adds a notice regarding that fact.
