### PR TITLE
adding function isEmptyObject to util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -520,6 +520,11 @@ function isBuffer(arg) {
 }
 exports.isBuffer = isBuffer;
 
+function isEmptyObject(arg) {
+  return isObject(arg) && Object.keys(arg).length === 0;
+}
+exports.isEmptyObject = isEmptyObject;
+
 function objectToString(o) {
   return Object.prototype.toString.call(o);
 }

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -73,6 +73,13 @@ assert.equal(false, util.isError(Object.create(Error.prototype)));
 // isObject
 assert.ok(util.isObject({}) === true);
 
+// isEmptyObject
+assert.equal(true, util.isEmptyObject({}));
+assert.equal(true, util.isEmptyObject([]));
+assert.equal(false, util.isEmptyObject({a:1}));
+assert.equal(false, util.isEmptyObject(null));
+assert.equal(false, util.isEmptyObject(undefined));
+
 // _extend
 assert.deepEqual(util._extend({a:1}),             {a:1});
 assert.deepEqual(util._extend({a:1}, []),         {a:1});


### PR DESCRIPTION
Check if an object passed is an empty object.

So far this feature was implemented in user land, for example by the npm module check-types. Although since  `isObject` and other type checking methods are now implemented in `master` I though to include `isEmptyObject` for completeness.

Test have been added as well.
