### PR TITLE
cluster.disconnect callback getting called too early in 0.11

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -323,7 +323,8 @@ function masterInit() {
       var handle = handles[key];
       if (handle.remove(worker)) delete handles[key];
     }
-    if (Object.keys(handles).length === 0 && Object.keys(cluster.workers).length === 0) {
+    var workerCount = Object.keys(cluster.workers).length;
+    if (Object.keys(handles).length === 0 && workerCount === 0) {
       intercom.emit('disconnect');
     }
   });

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -323,7 +323,7 @@ function masterInit() {
       var handle = handles[key];
       if (handle.remove(worker)) delete handles[key];
     }
-    if (Object.keys(handles).length === 0) {
+    if (Object.keys(handles).length === 0 && Object.keys(cluster.workers).length === 0) {
       intercom.emit('disconnect');
     }
   });


### PR DESCRIPTION
``` JavaScript
var cluster = require('cluster');

if (cluster.isMaster) {
  // Fork workers.
  cluster.fork();
  cluster.fork();

  // "called when all workers are disconnected [...]"
  cluster.disconnect(function(){
    for(var prop in cluster.workers){
      var worker = cluster.workers[prop];
      console.log(worker.state);
    }
  });

} else {
  require('net').createServer().listen(8000);
}
```

It seems like the disconnect callback is getting called to early. If I loop through the workers I still get one with the 'online' state. This does not happen on 0.10

Expected output: nothing or disconnect/exit
got: online

node version: v0.11.7
OS: Ubuntu Linux 64bit

**Edit:**

Sorry for the pull request hassle. I'm not so familiar with the way github handles them.
