### PR TITLE
Clarified HTTP client callback handling

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -421,6 +421,10 @@ This function allows one to transparently issue requests.
 `options` can be an object or a string. If `options` is a string, it is
 automatically parsed with [url.parse()][].
 
+`callback` should be a function. If `callback` is provided, it is
+added as one-time `'response'` callback to the `ClientRequest`
+instance returned by `request()`.
+
 Options:
 
 - `host`: A domain name or IP address of the server to issue the request to.


### PR DESCRIPTION
Current HTTP client documentation doesn't specify what happens to the callback parameter of request(). Added documentation based on current code base.
