### PR TITLE
util: format as Error if instanceof Error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -496,7 +496,8 @@ function isDate(d) {
 exports.isDate = isDate;
 
 function isError(e) {
-  return isObject(e) && objectToString(e) === '[object Error]';
+  return isObject(e) &&
+      (objectToString(e) === '[object Error]' || e instanceof Error);
 }
 exports.isError = isError;
 

--- a/test/simple/test-util-format.js
+++ b/test/simple/test-util-format.js
@@ -66,3 +66,13 @@ assert.equal(util.format('%%%s%%%%', 'hi'), '%hi%%');
   o.o = o;
   assert.equal(util.format('%j', o), '[Circular]');
 })();
+
+// Errors
+assert.equal(util.format(new Error('foo')), '[Error: foo]');
+function CustomError(msg) {
+  Error.call(this);
+  Object.defineProperty(this, 'message', { value: msg, enumerable: false });
+  Object.defineProperty(this, 'name', { value: 'CustomError', enumerable: false });
+}
+util.inherits(CustomError, Error);
+assert.equal(util.format(new CustomError('bar')), '[CustomError: bar]');

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -68,7 +68,7 @@ assert.equal(true, util.isError(new (context('SyntaxError'))));
 assert.equal(false, util.isError({}));
 assert.equal(false, util.isError({ name: 'Error', message: '' }));
 assert.equal(false, util.isError([]));
-assert.equal(false, util.isError(Object.create(Error.prototype)));
+assert.equal(true, util.isError(Object.create(Error.prototype)));
 
 // isObject
 assert.ok(util.isObject({}) === true);


### PR DESCRIPTION
Duplicate of #6350 but against master as per [comment](https://github.com/joyent/node/pull/6350#issuecomment-26314644)

> Custom errors, subclasses of `Error` at least, should show up as errors and not empty objects with `util.format()` / `console.log()`. The `objectToString()` / `Object.prototype.toString()` call reaches in to the `instance_class_name` which I'm pretty sure we can't set in JS-land to make it return `[object Error]` hence the switch to `instanceof`.
> 
> Background: errors produced by [errno's custom error utility](https://github.com/rvagg/node-errno/blob/master/custom.js) produce `'{}'` with `console.log()`.
