### PR TITLE
src: enable fips support

### DIFF
--- a/configure
+++ b/configure
@@ -152,6 +152,11 @@ parser.add_option('--shared-openssl-libpath',
     dest='shared_openssl_libpath',
     help='a directory to search for the shared OpenSSL DLLs')
 
+parser.add_option('--shared-openssl-fips',
+    action='store_true',
+    dest='shared_openssl_fips',
+    help='enable FIPS mode for shared OpenSSL DLLs')
+
 parser.add_option('--shared-v8',
     action='store_true',
     dest='shared_v8',
@@ -609,6 +614,9 @@ def configure_openssl(o):
       o['include_dirs'] += [options.shared_openssl_includes]
     else:
       o['cflags'] += cflags.split()
+
+    if options.shared_openssl_fips:
+      o['defines'] += ['OPENSSL_FIPS']
 
 
 def configure_winsdk(o):

--- a/src/node.cc
+++ b/src/node.cc
@@ -33,6 +33,9 @@
 
 #if HAVE_OPENSSL
 #include "node_crypto.h"
+#ifdef OPENSSL_FIPS
+#include "crypto.h"
+#endif
 #endif
 
 #if defined HAVE_DTRACE || defined HAVE_ETW || defined HAVE_SYSTEMTAP
@@ -2420,6 +2423,14 @@ void SetupProcessObject(Environment* env,
       versions,
       "openssl",
       OneByteString(node_isolate, &OPENSSL_VERSION_TEXT[i], j - i));
+
+#ifdef OPENSSL_FIPS
+  if(!FIPS_mode_set(1)) {
+    fprintf(stderr,"OpenSSL shared library does not support FIPS mode");
+    exit(1);
+  } 
+#endif
+
 #endif
 
   // process.arch


### PR DESCRIPTION
FIPS 140-2 support for enterprise, especially government is very important.  OpenSSL supported FIPS with OpenSSL FIPS Object Module.  To enable NodeJS to support FIPS, all we need to do is to compile with OpenSSL shared library which built with OpenSSL FIPS Object Module and call FIPS_mode_set() to enable FIPS mode.

to test if NodeJS has turned on FIPS mode, we can use the script below.  since bf is an unsupported algorithm, node will core dumped.

```
#!/usr/bin/env node

'use strict';

var crypto = require('crypto');

var cipher = crypto.createCipher('bf','12345');
var encrypted = cipher.update('encrypt this very long string' , 'utf8', 'base64');
encrypted = encrypted + cipher.final('base64');

var decipher = crypto.createDecipher('bf','12345');
var decrypted = decipher.update(encrypted, 'base64', 'utf8');
decrypted = decrypted + decipher.final('utf8');

console.log( 'encrypted: ' + encrypted );
console.log( 'decrypted: ' + decrypted );
```

configure is modified to add --shared-openssl-fips to turn on FIPS mode.

more info on OpenSSl FIPS http://www.openssl.org/docs/fips/fipsnotes.html
