### PR TITLE
http: parse the status message in a http response.

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -993,6 +993,12 @@ you can use the `require('querystring').parse` function, or pass
 
 The 3-digit HTTP response status code. E.G. `404`.
 
+### message.statusMessage
+
+**Only valid for response obtained from `http.ClientRequest`.**
+
+The HTTP response status message (reason phrase). E.G. `OK` or `Internal Server Error`.
+
 ### message.socket
 
 The `net.Socket` object associated with the connection.

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -95,7 +95,7 @@ function parserOnHeadersComplete(info) {
   } else {
     // client only
     parser.incoming.statusCode = info.statusCode;
-    // CHECKME dead code? we're always a request parser
+    parser.incoming.statusMessage = info.statusMessage;
   }
 
   parser.incoming.upgrade = info.upgrade;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -64,6 +64,7 @@ function IncomingMessage(socket) {
 
   // response (client) only
   this.statusCode = null;
+  this.statusMessage = null;
   this.client = this.socket;
 
   // flag for backwards compatibility grossness.

--- a/src/env.h
+++ b/src/env.h
@@ -121,6 +121,7 @@ namespace node {
   V(smalloc_p_string, "_smalloc_p")                                           \
   V(sni_context_string, "sni_context")                                        \
   V(status_code_string, "statusCode")                                         \
+  V(status_message_string, "statusMessage")                                   \
   V(subject_string, "subject")                                                \
   V(subjectaltname_string, "subjectaltname")                                  \
   V(syscall_string, "syscall")                                                \

--- a/test/simple/test-http-parser.js
+++ b/test/simple/test-http-parser.js
@@ -141,6 +141,7 @@ function expectBody(expected) {
     assert.equal(info.versionMajor, 1);
     assert.equal(info.versionMinor, 1);
     assert.equal(info.statusCode, 200);
+    assert.equal(info.statusMessage, "OK");
   });
 
   parser[kOnBody] = mustCall(function(buf, start, len) {
@@ -167,6 +168,7 @@ function expectBody(expected) {
     assert.equal(info.versionMajor, 1);
     assert.equal(info.versionMinor, 0);
     assert.equal(info.statusCode, 200);
+    assert.equal(info.statusMessage, "Connection established");
     assert.deepEqual(info.headers || parser.headers, []);
   });
 

--- a/test/simple/test-http-response-status-message.js
+++ b/test/simple/test-http-response-status-message.js
@@ -1,0 +1,79 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+
+var testsComplete = 0;
+
+var testCases = [
+  { path: "/200", statusMessage: "OK", response: 'HTTP/1.1 200 OK\r\n\r\n' },
+  { path: "/500", statusMessage: "Internal Server Error", response: 'HTTP/1.1 500 Internal Server Error\r\n\r\n' },
+  { path: "/302", statusMessage: "Moved Temporarily", response: 'HTTP/1.1 302 Moved Temporarily\r\n\r\n' },
+  { path: "/missing", statusMessage: "", response: 'HTTP/1.1 200 \r\n\r\n' },
+  { path: "/missing-no-space", statusMessage: "", response: 'HTTP/1.1 200\r\n\r\n' }
+];
+testCases.findByPath = function(path) {
+  var matching = this.filter(function(testCase) { return testCase.path === path; });
+  if (matching.length === 0) { throw "failed to find test case with path " + path; }
+  return matching[0];
+};
+
+var server = net.createServer(function(connection) {
+  connection.on('data', function(data) {
+    var path = data.toString().match(/GET (.*) HTTP.1.1/)[1];
+    var testCase = testCases.findByPath(path);
+
+    connection.write(testCase.response);
+    connection.end();
+  });
+});
+
+var runTest = function(testCaseIndex) {
+  var testCase = testCases[testCaseIndex];
+
+  http.get({ port: common.PORT, path: testCase.path }, function(response) {
+    console.log('client: expected status message: ' + testCase.statusMessage);
+    console.log('client: actual status message: ' + response.statusMessage);
+    assert.equal(testCase.statusMessage, response.statusMessage);
+
+    response.on('end', function() {
+      testsComplete++;
+
+      if (testCaseIndex + 1 < testCases.length) {
+        runTest(testCaseIndex + 1);
+      } else {
+        server.close();
+      }
+    });
+
+    response.resume();
+  });
+};
+
+server.listen(common.PORT, function() { runTest(0); });
+
+process.on('exit', function() {
+  assert.equal(testCases.length, testsComplete);
+});
+


### PR DESCRIPTION
Add the ability to retrieve the status message (reason phrase) from a http response.

This change has a dependency on joyent/http-parser#152. The dependent change allows the http parser to parse the status message and make it available to node via a callback. This change causes node to listen for that callback and attach the result to the "statusMessage" property of the IncomingMessage object. 

While the W3C names this property "reasonPhrase", "statusMessage" has been chosen to mirror the recent change that allows statusMessage to be written to a http response SHA: 54910044b33a6405c72ad085915a55c575c027fc.
