### PR TITLE
doc: encoding is ignored if input is a Buffer

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -101,6 +101,7 @@ Returned by `crypto.createHash`.
 Updates the hash content with the given `data`, the encoding of which
 is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
 `'binary'`.  If no encoding is provided, then a buffer is expected.
+If `data` is `Buffer` - `input_encoding` is ignored.
 
 This can be called many times with new data as it is streamed.
 
@@ -191,6 +192,7 @@ methods are also supported.
 Updates the cipher with `data`, the encoding of which is given in
 `input_encoding` and can be `'utf8'`, `'ascii'` or `'binary'`.  If no
 encoding is provided, then a buffer is expected.
+If `data` is `Buffer` - `input_encoding` is ignored.
 
 The `output_encoding` specifies the output format of the enciphered
 data, and can be `'binary'`, `'base64'` or `'hex'`.  If no encoding is
@@ -243,6 +245,7 @@ plain-text data on the the readable side.  The legacy `update` and
 Updates the decipher with `data`, which is encoded in `'binary'`,
 `'base64'` or `'hex'`.  If no encoding is provided, then a buffer is
 expected.
+If `data` is `Buffer` - `input_encoding` is ignored.
 
 The `output_decoding` specifies in what format to return the
 deciphered plaintext: `'binary'`, `'ascii'` or `'utf8'`.  If no


### PR DESCRIPTION
NOTE: it wasn't in 0.8

fix #6386
