### PR TITLE
util: format to not inspect strings if first argument is non-string

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -22,11 +22,7 @@
 var formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (!isString(f)) {
-    var objects = [];
-    for (var i = 0; i < arguments.length; i++) {
-      objects.push(inspect(arguments[i]));
-    }
-    return objects.join(' ');
+    return inspectArr(arguments);
   }
 
   var i = 1;
@@ -48,15 +44,22 @@ exports.format = function(f) {
         return x;
     }
   });
-  for (var x = args[i]; i < len; x = args[++i]) {
-    if (isNull(x) || !isObject(x)) {
-      str += ' ' + x;
-    } else {
-      str += ' ' + inspect(x);
-    }
+
+  if (i < len) {
+    str += ' ' + inspectArr(args, i);
   }
   return str;
 };
+
+function inspectArr(arr, start) {
+  var objects = [];
+  var i = start || 0;
+  var len = arr.length;
+  for (var x = arr[i]; i < len; x = arr[++i]) {
+    objects.push(isString(x) ? x : inspect(x));
+  }
+  return objects.join(' ');
+}
 
 
 // Mark that a method should not be used.

--- a/test/simple/test-util-format.js
+++ b/test/simple/test-util-format.js
@@ -37,6 +37,7 @@ assert.equal(util.format('test'), 'test');
 
 // CHECKME this is for console.log() compatibility - but is it *right*?
 assert.equal(util.format('foo', 'bar', 'baz'), 'foo bar baz');
+assert.equal(util.format({}, 'foo', 'bar'), '{} foo bar');
 
 assert.equal(util.format('%d', 42.0), '42');
 assert.equal(util.format('%d', 42), '42');


### PR DESCRIPTION
current:

```
util.format('a', 'b'); // "a b"
util.format({}, 'a', 'b'); // "{} 'a' 'b'"
```

changed to:

```
util.format('a', 'b'); // "a b"
util.format({}, 'a', 'b'); // "{} a b"
```
