### PR TITLE
debugger: Fix bug in sb() with unnamed script

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1374,7 +1374,7 @@ Interface.prototype.setBreakpoint = function(script, line,
     if (script != +script && !this.client.scripts[script]) {
       var scripts = this.client.scripts;
       Object.keys(scripts).forEach(function(id) {
-        if (scripts[id] && scripts[id].name.indexOf(script) !== -1) {
+        if (scripts[id] && scripts[id].name && scripts[id].name.indexOf(script) !== -1) {
           if (scriptId) {
             ambiguous = true;
           }

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1374,8 +1374,8 @@ Interface.prototype.setBreakpoint = function(script, line,
     if (script != +script && !this.client.scripts[script]) {
       var scripts = this.client.scripts;
       Object.keys(scripts).forEach(function(id) {
-        if (scripts[id] && 
-            scripts[id].name && 
+        if (scripts[id] &&
+            scripts[id].name &&
             scripts[id].name.indexOf(script) !== -1) {
           if (scriptId) {
             ambiguous = true;

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1374,7 +1374,9 @@ Interface.prototype.setBreakpoint = function(script, line,
     if (script != +script && !this.client.scripts[script]) {
       var scripts = this.client.scripts;
       Object.keys(scripts).forEach(function(id) {
-        if (scripts[id] && scripts[id].name && scripts[id].name.indexOf(script) !== -1) {
+        if (scripts[id] && 
+            scripts[id].name && 
+            scripts[id].name.indexOf(script) !== -1) {
           if (scriptId) {
             ambiguous = true;
           }


### PR DESCRIPTION
sb() cause error when unnamed script is loaded
<b>Reproduce:</b>
test.js

``` javascript
//create some unnamed script
var f = Function("x", "y", "return x * y");
debugger;
```

node debug test
c
sb(2)

```
TypeError: Cannot call method 'indexOf' of undefined
    at _debugger.js:1377:45
    at Array.forEach (native)
    at Interface.setBreakpoint (_debugger.js:1376:28)
    at repl:1:2
    at Interface.controlEval (_debugger.js:969:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
```
