### PR TITLE
http client: pull last chunk on socket close

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -187,6 +187,12 @@ function socketCloseListener() {
   var parser = socket.parser;
   var req = socket._httpMessage;
   debug('HTTP socket close');
+
+  // Pull through final chunk, if anything is buffered.
+  // the ondata function will handle it properly, and this
+  // is a no-op if no final chunk remains.
+  socket.read();
+
   req.emit('close');
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.

--- a/test/simple/test-https-truncate.js
+++ b/test/simple/test-https-truncate.js
@@ -1,0 +1,74 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var fs = require('fs');
+var https = require('https');
+var path = require('path');
+
+var resultFile = path.resolve(common.tmpDir, 'result');
+
+var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
+var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+
+var PORT = common.PORT;
+
+// number of bytes discovered empirically to trigger the bug
+var data = new Buffer(1024 * 32 + 1);
+
+httpsTest();
+
+function httpsTest() {
+  var sopt = { key: key, cert: cert };
+
+  var server = https.createServer(sopt, function(req, res) {
+    res.setHeader('content-length', data.length);
+    res.end(data);
+    server.close();
+  });
+
+  server.listen(PORT, function() {
+    var opts = { port: PORT, rejectUnauthorized: false };
+    https.get(opts).on('response', function(res) {
+      test(res);
+    });
+  });
+}
+
+
+function test(res) {
+  res.on('end', function() {
+    assert.equal(res._readableState.length, 0);
+    assert.equal(bytes, data.length);
+    console.log('ok');
+  });
+
+  // Pause and then resume on each chunk, to ensure that there will be
+  // a lone byte hanging out at the very end.
+  var bytes = 0;
+  res.on('data', function(chunk) {
+    bytes += chunk.length;
+    this.pause();
+    setTimeout(this.resume.bind(this));
+  });
+}


### PR DESCRIPTION
When the socket closes, the client's http incoming message object was
emitting an 'aborted' event if it had not yet been ended.

However, it's possible, when a response is being repeatedly paused and
resumed (eg, if piped to a slow FS write stream), that there will be a
final chunk remaining in the js-land buffer when the socket is torn
down.

When that happens, the socketCloseListener function detects that we have
not yet reached the end of the response message data, and treats this as
an abrupt abort, immediately (and forcibly) ending the incoming message
data stream, and discarding that final chunk of data.

The result is that, for example, npm will have problems because tarballs
are missing a few bytes off the end, every time.

Closes GH-6402
