### PR TITLE
src: Remove unused refs to node_object_wrap.h

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -60,7 +60,6 @@
 
 #include "v8.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
-#include "node_object_wrap.h"
 
 // Forward-declare these functions now to stop MSVS from becoming
 // terminally confused when it's done in node_internals.h

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -23,7 +23,6 @@
 #define SRC_NODE_CONTEXTIFY_H_
 
 #include "node.h"
-#include "node_object_wrap.h"
 #include "v8.h"
 #include "uv.h"
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -25,7 +25,6 @@
 #include "node.h"
 #include "node_crypto_clienthello.h"  // ClientHelloParser
 #include "node_crypto_clienthello-inl.h"
-#include "node_object_wrap.h"
 
 #ifdef OPENSSL_NPN_NEGOTIATED
 #include "node_buffer.h"

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -22,9 +22,8 @@
 #ifndef SRC_NODE_STAT_WATCHER_H_
 #define SRC_NODE_STAT_WATCHER_H_
 
-#include "node_object_wrap.h"
-
 #include "env.h"
+#include "node.h"
 #include "uv.h"
 #include "v8.h"
 #include "weak-object.h"


### PR DESCRIPTION
Turns out that we don't use node_object_wrap.h any more in core,
and, with v8 3.21, it's breaking our Windows build. Removing refs
to it everywhere (and adding node.h in one case where it was the
only way node.h was being included), we have restored the Windows
build.
