### PR TITLE
doc: fix missing backtick in 2e16037

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -177,7 +177,7 @@ on more than one address.
 
 The `addressType` is one of:
 
-* `4' (TCPv4)
+* `4` (TCPv4)
 * `6` (TCPv6)
 * `-1` (unix domain socket)
 * `"udp4"` or `"udp6"` (UDP v4 or v6)


### PR DESCRIPTION
Address https://github.com/joyent/node/commit/2e16037#commitcomment-4355623 by @Mithgol

Also applies to master.
