### PR TITLE
Clarify fs.symlink() method description

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -212,8 +212,8 @@ Synchronous link(2).
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
-`type` argument can be either `'dir'`, `'file'`, or `'junction'` (default is `'file'`).  It is only 
-used on Windows (ignored on other platforms).
+The `type` argument can be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only 
+available on Windows (ignored on other platforms).
 Note that Windows junction points require the destination path to be absolute.  When using
 `'junction'`, the `destination` argument will automatically be normalized to absolute path.
 


### PR DESCRIPTION
The original wording gives the impression that fs.symlink() only works on windows. It has been updated to make it clear that the `type` argument (not the whole function) can only be used on windows.

**BEFORE:**

`type` argument can be either `'dir'`, `'file'`, or `'junction'` (default is `'file'`).  It is only used on Windows (ignored on other platforms).

**AFTER:**

The `type` argument can be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
