### PR TITLE
doc: fs: clarify fs.symlink Windows specific args

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -212,8 +212,8 @@ Synchronous link(2).
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
-`type` argument can be either `'dir'`, `'file'`, or `'junction'` (default is `'file'`).  It is only 
-used on Windows (ignored on other platforms).
+The `type` argument can be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only 
+available on Windows (ignored on other platforms).
 Note that Windows junction points require the destination path to be absolute.  When using
 `'junction'`, the `destination` argument will automatically be normalized to absolute path.
 


### PR DESCRIPTION
The original wording in the documentation of fs.symlink gives the impression that the method only works on windows. New Node.js users get confused by the current description. It has been updated to make it clear that the `type` argument (not the whole function) can only be used on Windows.

**BEFORE:**

`type` argument can be either `'dir'`, `'file'`, or `'junction'` (default is `'file'`).  It is only used on Windows (ignored on other platforms).

**AFTER:**

The `type` argument can be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
