### PR TITLE
stream: End writables before emitting 'end' event

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -458,6 +458,15 @@ Readable.prototype._read = function(n) {
   this.emit('error', new Error('not implemented'));
 };
 
+function registerEndFn(src, endFn) {
+  if (!src._endFns)
+    src._endFns = endFn;
+  else if (util.isObject(src._endFns))
+    src._endFns.push(endFn);
+  else
+    src._endFns = [src._endFns, endFn];
+}
+
 Readable.prototype.pipe = function(dest, pipeOpts) {
   var src = this;
   var state = this._readableState;
@@ -484,7 +493,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   if (state.endEmitted)
     process.nextTick(endFn);
   else
-    src.once('end', endFn);
+    registerEndFn(src, endFn);
 
   dest.on('unpipe', onunpipe);
   function onunpipe(readable) {
@@ -878,6 +887,23 @@ function fromList(n, state) {
   return ret;
 }
 
+function callEndFns(stream) {
+  var endFns = stream._endFns;
+
+  if (!endFns)
+    return;
+
+  if (util.isFunction(endFns)) {
+    endFns.call(stream);
+  } else {
+    var length = endFns.length;
+
+    for (var i = length; i-- > 0;) {
+      endFns[i].call(stream);
+    }
+  }
+}
+
 function endReadable(stream) {
   var state = stream._readableState;
 
@@ -893,6 +919,8 @@ function endReadable(stream) {
       if (!state.endEmitted && state.length === 0) {
         state.endEmitted = true;
         stream.readable = false;
+
+        callEndFns(stream);
         stream.emit('end');
       }
     });

--- a/test/simple/test-stream-write-after-end.js
+++ b/test/simple/test-stream-write-after-end.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common');
+var fs = require('fs');
+
+var reader = fs.createReadStream(__filename);
+var writer = fs.createWriteStream(common.tmpDir + '/dummy');
+var exceptionCount = 0;
+
+reader.on('end', function() {
+  writer.end('Goodbye\n');  // should be failed
+});
+reader.pipe(writer);
+
+process.on('uncaughtException', function() {
+  ++exceptionCount;
+});
+
+process.on('exit', function() {
+  process.removeAllListeners('uncaughtException');
+  assert.equal(exceptionCount, 1);
+});


### PR DESCRIPTION
There is a timing issue b/w the internal callback for ending writable
and the user callback of 'end' event because both of them are using
the same 'end' event.

So this fails:

```
reader.pipe(writer);
reader.on('end', function() {
  writer.end('Goodbye\n');  // should be failed
});
```

But this succeeds:

```
reader.on('end', function() {
  writer.end('Goodbye\n');  // should be failed
});
reader.pipe(writer);
```

This commit ends writables not using 'end' event.

Fixes #5603
