### PR TITLE
tls: reuse hostname from underlying net.Socket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -683,7 +683,10 @@ exports.connect = function(/* [port, host], options, cb */) {
   };
   options = util._extend(defaults, options || {});
 
-  var hostname = options.servername || options.host || 'localhost',
+  var hostname = options.servername ||
+                 options.host ||
+                 options.socket && options.socket._host ||
+                 'localhost',
       NPN = {},
       credentials = crypto.createCredentials(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -685,8 +685,7 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var hostname = options.servername ||
                  options.host ||
-                 options.socket && options.socket._host ||
-                 'localhost',
+                 options.socket && options.socket._host,
       NPN = {},
       credentials = crypto.createCredentials(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);

--- a/lib/net.js
+++ b/lib/net.js
@@ -134,6 +134,7 @@ function Socket(options) {
   this._connecting = false;
   this._hadError = false;
   this._handle = null;
+  this._host = null;
 
   if (util.isNumber(options))
     options = { fd: options }; // Legacy interface.
@@ -859,12 +860,14 @@ Socket.prototype.connect = function(options, cb) {
 
   } else if (!options.host) {
     debug('connect: missing host');
+    self._host = '127.0.0.1';
     connect(self, '127.0.0.1', options.port, 4);
 
   } else {
     var host = options.host;
     var family = options.family || 4;
     debug('connect: find host ' + host);
+    self._host = host;
     require('dns').lookup(host, family, function(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1708,7 +1708,7 @@ void Connection::New(const FunctionCallbackInfo<Value>& args) {
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   if (is_server) {
     SSL_CTX_set_tlsext_servername_callback(sc->ctx_, SelectSNIContextCallback_);
-  } else {
+  } else if (args[2]->IsString()) {
     const String::Utf8Value servername(args[2]);
     SSL_set_tlsext_host_name(conn->ssl_, *servername);
   }

--- a/test/internet/test-tls-reuse-host-from-socket.js
+++ b/test/internet/test-tls-reuse-host-from-socket.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var tls = require('tls');
+var net = require('net');
+var connected = false;
+var secure = false;
+
+process.on('exit', function() {
+  assert(connected);
+  assert(secure);
+  console.log('ok');
+});
+
+var socket = net.connect(443, 'www.google.com', function() {
+  connected = true;
+  var secureSocket = tls.connect({ socket: socket }, function() {
+    secure = true;
+    secureSocket.destroy();
+  });
+});


### PR DESCRIPTION
When `tls.connect()` is called with `socket` option, it should try to
reuse hostname previously passed to `net.connect()` and only after that
fall back to `'localhost'`.

fix #6409

Suggested reviewer: @isaacs or @bnoordhuis
