### PR TITLE
http.agent: don't remove reusable socket

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -86,7 +86,7 @@ function Agent(options) {
         if (self.sockets[name])
           count += self.sockets[name].length;
 
-        if (count >= self.maxSockets || freeLen >= self.maxFreeSockets) {
+        if (count >= self.maxSockets + 1 || freeLen >= self.maxFreeSockets) {
           self.removeSocket(socket, options);
           socket.destroy();
         } else {


### PR DESCRIPTION
Removing a socket when the request has finished and connections
must be reused, causes freeSockets stack to be decreased on
one element
