### PR TITLE
#3977 Node.js crash on Windows when no read permissions for the root

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1227,8 +1227,17 @@ fs.realpathSync = function realpathSync(p, cache) {
       // some known symbolic link.  no need to stat again.
       resolvedLink = cache[base];
     } else {
-      var stat = fs.lstatSync(base);
-      if (!stat.isSymbolicLink()) {
+      var stat = null;
+      try {
+        stat = fs.lstatSync(base);
+      } catch (e) {
+        // Windows throws an exception if NTFS permissions are missing
+        if (!isWindows || e.code != 'EPERM') {
+          throw e;
+        }
+      }
+
+      if (stat == null || !stat.isSymbolicLink()) {
         knownHard[base] = true;
         if (cache) cache[base] = base;
         continue;


### PR DESCRIPTION
Fixing an error that was occurring if node was hosted on Azure or shared hosting, and the website user didn't have read NTFS persmissions on the root folder.

Examples:
https://github.com/joyent/node/issues/3977
http://stackoverflow.com/questions/12718488/error-eperm-operation-not-permitted-with-node-js-and-etherpad-lite
