### PR TITLE
win: fix ObjectWrap for latest v8

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -342,6 +342,7 @@ Here we expose the method `plusOne` by adding it to the constructor's
 prototype:
 
     #include <node.h>
+    #include <node_object_wrap.h>
     #include "myobject.h"
 
     using namespace v8;
@@ -490,12 +491,8 @@ The implementation is similar to the above in `myobject.cc`:
       // Prototype
       tpl->PrototypeTemplate()->Set(String::NewSymbol("plusOne"),
           FunctionTemplate::New(PlusOne)->GetFunction());
-<<<<<<< HEAD
 
       constructor = Persistent<Function>::New(isolate, tpl->GetFunction());
-=======
-      constructor = Persistent<Function>::New(tpl->GetFunction());
->>>>>>> upstream/v0.10
     }
 
     Handle<Value> MyObject::New(const Arguments& args) {
@@ -560,6 +557,7 @@ In the following `addon.cc` we introduce a function `add()` that can take on two
 `MyObject` objects:
 
     #include <node.h>
+    #include <node_object_wrap.h>
     #include "myobject.h"
 
     using namespace v8;
@@ -602,6 +600,7 @@ can probe private values after unwrapping the object:
     #define MYOBJECT_H
 
     #include <node.h>
+    #include <node_object_wrap.h>
 
     class MyObject : public node::ObjectWrap {
      public:
@@ -642,12 +641,8 @@ The implementation of `myobject.cc` is similar as before:
       Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
       tpl->SetClassName(String::NewSymbol("MyObject"));
       tpl->InstanceTemplate()->SetInternalFieldCount(1);
-<<<<<<< HEAD
 
       constructor = Persistent<Function>::New(isolate, tpl->GetFunction());
-=======
-      constructor = Persistent<Function>::New(tpl->GetFunction());
->>>>>>> upstream/v0.10
     }
 
     Handle<Value> MyObject::New(const Arguments& args) {

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -22,22 +22,13 @@
 #ifndef SRC_NODE_OBJECT_WRAP_H_
 #define SRC_NODE_OBJECT_WRAP_H_
 
-#include "node.h"
 #include "v8.h"
 #include <assert.h>
-
-// Explicitly instantiate some template classes, so we're sure they will be
-// present in the binary / shared object. There isn't much doubt that they will
-// be, but MSVC tends to complain about these things.
-#ifdef _MSC_VER
-  template class NODE_EXTERN v8::Persistent<v8::Object>;
-  template class NODE_EXTERN v8::Persistent<v8::FunctionTemplate>;
-#endif
 
 
 namespace node {
 
-class NODE_EXTERN ObjectWrap {
+class ObjectWrap {
  public:
   ObjectWrap() {
     refs_ = 0;


### PR DESCRIPTION
We need to keep ObjectWrap around for module authors (we think), but
v8 3.21 broke node_object_wrap.h with respect to MSVC. Coincidentally,
we no longer use ObjectWrap at all in core, and native modules might
as well use their own entirely internal implementation if they need it.
