### PR TITLE
doc: document node signal handling

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -81,19 +81,18 @@ Note:
 
 - `SIGUSR1` is reserved by node.js to start the debugger.  It's possible to
   install a listener but that won't stop the debugger from starting.
-- `SIGTERM` and `SIGINT` have default handlers on non-windows platforms that resets
+- `SIGTERM` and `SIGINT` have default handlers on non-Windows platforms that resets
   the terminal mode before exiting with code `128 + signal number`. If one of
   these signals has a listener installed, its default behaviour will be removed
   (node will no longer exit).
 - `SIGPIPE` is ignored by default, it can have a listener installed.
-- `SIGHUP` is generated on windows when the console window is closed, and on other
+- `SIGHUP` is generated on Windows when the console window is closed, and on other
   platforms under various similar conditions, see signal(7). It can have a
   listener installed, however node will be unconditionally terminated by Windows
   about 10 seconds later. On non-Windows platforms, the default behaviour of
   `SIGHUP` is to terminate node, but once a listener has been installed its
   default behaviour will be removed.
-- `SIGTERM` is not supported on Windows, it can be listened on, but there is no
-  way to send or generate it.
+- `SIGTERM` is not supported on Windows, it can be listened on.
 - `SIGINT` is supported on all platforms, and can usually be generated with
   `CTRL+C` (though this may be configurable). It is not generated when terminal
   raw mode is enabled.
@@ -104,6 +103,7 @@ Note:
   readable tty is used in raw mode.
 - `SIGKILL` cannot have a listener installed, it will unconditionally terminate
   node on all platforms.
+- `SIGSTOP` cannot have a listener installed.
 
 ## process.stdout
 

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -77,8 +77,33 @@ Example of listening for `SIGINT`:
 An easy way to send the `SIGINT` signal is with `Control-C` in most terminal
 programs.
 
-Note: SIGUSR1 is reserved by node.js to kickstart the debugger.  It's possible
-to install a listener but that won't stop the debugger from starting.
+Note:
+
+- `SIGUSR1` is reserved by node.js to start the debugger.  It's possible to
+  install a listener but that won't stop the debugger from starting.
+- `SIGTERM` and `SIGINT` have default handlers on non-windows platforms that resets
+  the terminal mode before exiting with code `128 + signal number`. If one of
+  these signals has a listener installed, its default behaviour will be removed
+  (node will no longer exit).
+- `SIGPIPE` is ignored by default, it can have a listener installed.
+- `SIGHUP` is generated on windows when the console window is closed, and on other
+  platforms under various similar conditions, see signal(7). It can have a
+  listener installed, however node will be unconditionally terminated by Windows
+  about 10 seconds later. On non-Windows platforms, the default behaviour of
+  `SIGHUP` is to terminate node, but once a listener has been installed its
+  default behaviour will be removed.
+- `SIGTERM` is not supported on Windows, it can be listened on, but there is no
+  way to send or generate it.
+- `SIGINT` is supported on all platforms, and can usually be generated with
+  `CTRL+C` (though this may be configurable). It is not generated when terminal
+  raw mode is enabled.
+- `SIGBREAK` is delivered on Windows when `CTRL+BREAK` is pressed, on non-Windows
+  platforms it can be listened on, but there is no way to send or generate it.
+- `SIGWINCH` is delivered when the console has been resized. On Windows, this will
+  only happen on write to the console when the cursor is being moved, or when a
+  readable tty is used in raw mode.
+- `SIGKILL` cannot have a listener installed, it will unconditionally terminate
+  node on all platforms.
 
 ## process.stdout
 


### PR DESCRIPTION
Partly lifted from uv.h, partly from observation of node.cc.

/to @bnoordhuis @piscisaureus I think this is right (and also useful to know)
/cc @crandmck
cf. #956
