### PR TITLE
added --enable-shared support for building libnode.so

### DIFF
--- a/configure
+++ b/configure
@@ -44,6 +44,11 @@ parser.add_option('--gdb',
     dest='gdb',
     help='add gdb support')
 
+parser.add_option('--enable-shared',
+    action='store_true',
+    dest='enable_shared',
+    help='build a node shared library')
+
 parser.add_option('--ninja',
     action='store_true',
     dest='use_ninja',
@@ -505,6 +510,11 @@ def configure_node(o):
     o['variables']['node_tag'] = '-' + options.tag
   else:
     o['variables']['node_tag'] = ''
+
+  if options.enable_shared:
+    o['cflags'] += ['-fPIC']
+    o['variables']['node_target'] = 'libnode'
+    o['variables']['node_type'] = 'shared_library'
 
 
 def configure_libz(o):

--- a/node.gyp
+++ b/node.gyp
@@ -16,6 +16,8 @@
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'node_use_mdb%': 'false',
+    'node_target': 'node',
+    'node_type': 'executable',
     'library_files': [
       'src/node.js',
       'lib/_debugger.js',
@@ -70,10 +72,25 @@
     ],
   },
 
+  'conditions': [
+    ['node_type=="shared_library"', {
+      'targets': [
+        {
+          'target_name': 'node',
+          'type': 'executable',
+          'sources': [ 'src/node_main_shared.c' ],
+          'ldflags': ['-L<(PRODUCT_DIR)/obj.target','-Wl,-rpath=<(node_prefix)/lib' ],
+          'libraries': ['-lnode'],
+          #'dependencies': [ 'libnode' ],
+        }
+      ]
+    }]
+  ],
+
   'targets': [
     {
-      'target_name': 'node',
-      'type': 'executable',
+      'target_name': '<(node_target)',
+      'type': '<(node_type)',
 
       'dependencies': [
         'node_js2c#host',
@@ -163,6 +180,11 @@
       ],
 
       'conditions': [
+        [ 'node_type=="shared_library"', {
+          'defines': [
+            'NODE_SHARED_LIBRARY=1'
+          ],
+        }],
         [ 'node_use_openssl=="true"', {
           'defines': [ 'HAVE_OPENSSL=1' ],
           'sources': [

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -22,7 +22,11 @@
 #include "node.h"
 
 #ifdef _WIN32
+#ifdef NODE_SHARED_LIBRARY
+extern "C" int node_wmain(int argc, wchar_t *wargv[]) {
+#else
 int wmain(int argc, wchar_t *wargv[]) {
+#endif
   // Convert argv to to UTF8
   char** argv = new char*[argc];
   for (int i = 0; i < argc; i++) {
@@ -61,7 +65,11 @@ int wmain(int argc, wchar_t *wargv[]) {
 }
 #else
 // UNIX
+#ifdef NODE_SHARED_LIBRARY
+extern "C" int node_main(int argc, char *argv[]) {
+#else
 int main(int argc, char *argv[]) {
+#endif
   return node::Start(argc, argv);
 }
 #endif

--- a/src/node_main_shared.c
+++ b/src/node_main_shared.c
@@ -1,0 +1,11 @@
+#ifdef _WIN32
+int node_wmain(int, wchar_t *[]);
+int wmain(int argc, wchar_t *wargv[]) {
+	return node_wmain(argc, wargv);
+}
+#else
+int node_main(int, char *[]);
+int main(int argc, char *argv[]) {
+	return node_main(argc, argv);
+}
+#endif

--- a/tools/install.py
+++ b/tools/install.py
@@ -120,6 +120,8 @@ def npm_files(action):
 
 def files(action):
   action(['out/Release/node'], 'bin/node')
+  if os.path.exists('out/Release/lib.target/libnode.so'):
+    action(['out/Release/lib.target/libnode.so'], 'lib/libnode.so')
 
   # install unconditionally, checking if the platform supports dtrace doesn't
   # work when cross-compiling and besides, there's at least one linux flavor


### PR DESCRIPTION
This patch adds a new 'configure' flags, named --enable-shared that build a libnode.so library and a 'node' executable using it.

The main purpose is allowing easy embedding of node in external apps:

```
#include <node.h>

void callback(uv_timer_s* t, int status) {
        printf("ciao %d\n", status);
}

void hello(uv_idle_t* handle, int status) {
        printf("hello %d\n", status);
        uv_idle_stop(handle);
}

int main() {
        int argc = 3;
        char *argv[4];
        argv[0] = (char *) "pipponode";
        argv[1] = (char *) "-e";
        argv[2] = (char *) "0";
        argv[3] = NULL;

        uv_timer_t timer_req;
        uv_idle_t check;

        uv_timer_init(uv_default_loop(), &timer_req);
        uv_timer_start(&timer_req, callback, 5000, 2000);

        uv_idle_init(uv_default_loop(), &check);
        uv_idle_start(&check, hello);

        node::Start(argc, argv);
}

```

the patch is already in use for my company attempt to embed node.js in uWSGI

Some note:

when building libso the main/wmail symbols are rewritten as node_main/node_wmain and exposed as C calls (this simplify management).

-rpath on node_prefix/lib is added to easily allow the node binary to find libnode.so
