### PR TITLE
http: force socket encoding to be null

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -192,6 +192,7 @@ Agent.prototype.createSocket = function(req, options) {
   var name = self.getName(options);
 
   debug('createConnection', name, options);
+  options.encoding = null;
   var s = self.createConnection(options);
   if (!self.sockets[name]) {
     self.sockets[name] = [];

--- a/test/simple/test-http-client-encoding.js
+++ b/test/simple/test-http-client-encoding.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+http.createServer(function(req, res) {
+  res.end('ok\n');
+  this.close();
+}).listen(common.PORT, test);
+
+function test() {
+  http.request({
+    port: common.PORT,
+    encoding: 'utf8'
+  }, function(res) {
+    res.pipe(process.stdout);
+  }).end();
+}


### PR DESCRIPTION
Otherwise the string triggers an assertion error in node_http_parser.c
