### PR TITLE
debugger: fix unhandled error in setBreakpoint

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1356,6 +1356,12 @@ Interface.prototype.setBreakpoint = function(script, line,
     script = this.client.currentScript;
   }
 
+  if (script === undefined) {
+    this.print('Cannot determine the current script, ' +
+      'make sure the debugged process is paused.');
+    return;
+  }
+
   if (/\(\)$/.test(script)) {
     // setBreakpoint('functionname()');
     var req = {


### PR DESCRIPTION
Fix Interface.setBreakpoint() to correctly handle an attempt to set a
breakpoint in the current script when there is no current script. This usually
happens when the debugged process is not paused.

Close #6453

@bnoordhuis Please review. Is it worth adding a unit test for this change? It's more than just adding few lines to `test/simple/test-debugger-repl.js`, a new test fixture is needed.
