### PR TITLE
tls: more accurate wrapping of connecting socket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -158,6 +158,10 @@ function TLSSocket(socket, options) {
     writable: socket.writable
   });
 
+  // To prevent assertion in afterConnect()
+  if (socket)
+    this._connecting = socket._connecting;
+
   this._tlsOptions = options;
   this._secureEstablished = false;
   this._controlReleased = false;
@@ -716,10 +720,21 @@ exports.connect = function(/* [port, host], options, cb */) {
     result = socket;
   }
 
-  if (socket._handle)
+  if (socket._handle && !socket._connecting) {
     onHandle();
-  else
+  } else {
+    // Not even started connecting yet (or probably resolving dns address),
+    // catch socket errors and assign handle.
+    if (!legacy && options.socket) {
+      options.socket.once('connect', function() {
+        assert(options.socket._handle);
+        socket._handle = options.socket._handle;
+        socket._handle.owner = socket;
+        socket.emit('connect');
+      });
+    }
     socket.once('connect', onHandle);
+  }
 
   if (cb)
     result.once('secureConnect', cb);


### PR DESCRIPTION
When socket, passed in `tls.connect()` `options` argument is not yet
connected to the server, `_handle` gets assigned to a `net.Socket`,
instead of `TLSSocket`.

When socket is connecting to the remote server (i.e. not yet connected,
but already past dns resolve phase), derive `_connecting` property from
it, because otherwise `afterConnect()` will throw an assertion.

fix #6443

Suggested reviewer: @isaacs, @piscisaureus or @bnoordhuis?
