### PR TITLE
benchmark: Correct bufferSize to highWaterMark

### DIFF
--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -38,7 +38,7 @@ function main(conf) {
 function runTest() {
   assert(fs.statSync(filename).size === filesize);
   var rs = fs.createReadStream(filename, {
-    bufferSize: size,
+    highWaterMark: size,
     encoding: encoding
   });
 


### PR DESCRIPTION
The bufferSize has been removed. Use highWaterMark instead of.

It make the benchmark test result incorrect:

```
fs/read-stream-throughput.js type=buf size=1024: 699.70
fs/read-stream-throughput.js type=buf size=4096: 701.41
fs/read-stream-throughput.js type=buf size=65535: 713.00
fs/read-stream-throughput.js type=buf size=1048576: 704.68
```

the real result is:

```
fs/read-stream-throughput.js type=buf size=1024: 51.328
fs/read-stream-throughput.js type=buf size=4096: 161.40
fs/read-stream-throughput.js type=buf size=65535: 679.61
fs/read-stream-throughput.js type=buf size=1048576: 858.80
```
