### PR TITLE
src: stop using v8::Isolate::GetCurrent()

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -121,10 +121,9 @@ NODE_EXTERN int Start(int argc, char *argv[]);
 #define NODE_UNIXTIME_V8(t) v8::Date::New(1000*static_cast<double>(t))
 #define NODE_V8_UNIXTIME(v) (static_cast<double>((v)->NumberValue())/1000.0);
 
-// Used to be a macro, hence the uppercase name.
 #define NODE_DEFINE_CONSTANT(target, constant)                                \
   do {                                                                        \
-    v8::Isolate* isolate = v8::Isolate::GetCurrent();                         \
+    v8::Isolate* isolate = (target)->CreationContext()->GetIsolate();         \
     v8::Local<v8::String> constant_name =                                     \
         v8::String::NewFromUtf8(isolate, #constant);                          \
     v8::Local<v8::Number> constant_value =                                    \
@@ -140,7 +139,7 @@ template <typename TypeName>
 inline void NODE_SET_METHOD(const TypeName& recv,
                             const char* name,
                             v8::FunctionCallback callback) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Isolate* isolate = recv->CreationContext()->GetIsolate();
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(callback);
   v8::Local<v8::Function> fn = t->GetFunction();

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -56,11 +56,6 @@ class ObjectWrap {
   }
 
 
-  inline v8::Local<v8::Object> handle() {
-    return handle(v8::Isolate::GetCurrent());
-  }
-
-
   inline v8::Local<v8::Object> handle(v8::Isolate* isolate) {
     return v8::Local<v8::Object>::New(isolate, persistent());
   }
@@ -76,7 +71,8 @@ class ObjectWrap {
     assert(persistent().IsEmpty());
     assert(handle->InternalFieldCount() > 0);
     handle->SetAlignedPointerInInternalField(0, this);
-    persistent().Reset(v8::Isolate::GetCurrent(), handle);
+    v8::Isolate* isolate = handle->CreationContext()->GetIsolate();
+    persistent().Reset(isolate, handle);
     MakeWeak();
   }
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -55,7 +55,8 @@ class TimerWrap : public HandleWrap {
     constructor->Set(FIXED_ONE_BYTE_STRING(node_isolate, "kOnTimeout"),
                      Integer::New(kOnTimeout, node_isolate));
 
-    NODE_SET_METHOD(constructor, "now", Now);
+    constructor->Set(FIXED_ONE_BYTE_STRING(node_isolate, "now"),
+                     FunctionTemplate::New(Now)->GetFunction());
 
     NODE_SET_PROTOTYPE_METHOD(constructor, "close", HandleWrap::Close);
     NODE_SET_PROTOTYPE_METHOD(constructor, "ref", HandleWrap::Ref);


### PR DESCRIPTION
v8::Isolate::GetCurrent() is on its way out in upstream V8. Let's be
proactive and stop using it now.

It's up for debate what to do with NODE_SET_PROTOTYPE_METHOD(): it
operates on v8::FunctionTemplate instances and those don't provide
a means to get the owning isolate.

/cc @indutny @tjfontaine @trevnorris - think of this PR as a discussion starter more than anything else.
