### PR TITLE
events: speed boost on emit, no listeners

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -62,11 +62,9 @@ EventEmitter.prototype.setMaxListeners = function(n) {
 EventEmitter.prototype.emit = function(type) {
   var er, handler, len, args, i, listeners;
 
-  if (!this._events)
-    this._events = {};
-
   // If there is no 'error' event listener then throw.
-  if (type === 'error' && !this._events.error) {
+  if (type === 'error'
+      && (typeof this._events !== 'object' || !this._events.error)) {
     er = arguments[1];
     if (this.domain) {
       if (!er)
@@ -83,7 +81,8 @@ EventEmitter.prototype.emit = function(type) {
     return false;
   }
 
-  handler = this._events[type];
+  if(typeof this._events === 'object')
+    handler = this._events[type];
 
   if (util.isUndefined(handler))
     return false;


### PR DESCRIPTION
Speed increase is roughly 4-5x.
This makes emit with no listeners as fast as when there is listeners.

The following is "slow" with no listeners in the this._events:

```
handler = this._events[type];
```
