### PR TITLE
build: Simplify the logic in vcbuild.bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ non-standard name, run the following instead:
 
 Prerequisites (Windows only):
 
-    * Python 2.6 or 2.7
-    * Visual Studio 2010 or 2012
+    * [Python for Microsoft Windows 2.7x](http://www.python.org/getit/windows/)
+    * [Visual Studio Express 2013 for Windows Desktop](http://www.microsoft.com/visualstudio/eng/downloads#d-2013-express)
 
 Windows:
+Open a visual studio command prompt
 
     vcbuild nosign
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -88,7 +88,6 @@ if defined NIGHTLY set TAG=nightly-%NIGHTLY%
 
 @rem Generate the VS project.
 SETLOCAL
-  if defined VS100COMNTOOLS call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
   python configure %debug_arg% %nosnapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
   if errorlevel 1 goto create-msvs-files-failed
   if not exist node.sln goto create-msvs-files-failed
@@ -99,19 +98,16 @@ ENDLOCAL
 @rem Skip project generation if requested.
 if defined nobuild goto sign
 
-@rem Look for Visual Studio 2012
+@rem Look for Visual Studio Command Prompt
+if not defined VS120COMNTOOLS goto vc-set-2012
+goto msbuild-found
+
+:vc-set-2012
 if not defined VS110COMNTOOLS goto vc-set-2010
-if not exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2010
-call "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat"
-if not defined VCINSTALLDIR goto msbuild-not-found
-set GYP_MSVS_VERSION=2012
 goto msbuild-found
 
 :vc-set-2010
 if not defined VS100COMNTOOLS goto msbuild-not-found
-if not exist "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat" goto msbuild-not-found
-call "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat"
-if not defined VCINSTALLDIR goto msbuild-not-found
 goto msbuild-found
 
 :msbuild-not-found


### PR DESCRIPTION
While adding support for Visual Studio 2013, I noticed duplicate
logic for VS detection in gyp (MSVS*.py), nodejs (vcbuild.bat),
and node-gyp (lib/configure.js).  The detection logic in gyp is
sufficient for our needs, so I am simplifing the logic in nodejs
and node-gyp.

This change requires node to be built from a VS Command Prompt
as it checks for the existence of VS1x0COMNTOOLS and relies on
msbuild being on the path.

This change also updates the README to specify using a command
prompt, note the support of VS 2013, and add hyperlinks to the
downloads.
