### PR TITLE
repl: do not insert duplicates into completions

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -641,7 +641,7 @@ REPLServer.prototype.complete = function(line, callback) {
         group.sort();
         for (var j = 0; j < group.length; j++) {
           c = group[j];
-          if (!hasOwnProperty(c)) {
+          if (!hasOwnProperty(uniq, c)) {
             completions.push(c);
             uniq[c] = true;
           }

--- a/test/simple/test-repl-tab-complete.js
+++ b/test/simple/test-repl-tab-complete.js
@@ -55,6 +55,9 @@ putIn.run([
 testMe.complete('inner.o', function(error, data) {
   assert.deepEqual(data, doesNotBreak);
 });
+testMe.complete('console.lo', function(error, data) {
+  assert.deepEqual(data, [['console.log'], 'console.lo']);
+});
 
 // Tab Complete will return globaly scoped variables
 putIn.run(['};']);


### PR DESCRIPTION
Fix invalid `hasOwnProperty` function usage.

Fixes #6255.

cc @bnoordhuis @auds1n
