### PR TITLE
events: add event observers

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -23,11 +23,6 @@ var util = require('util');
 var EventEmitter = require('events');
 var inherits = util.inherits;
 
-// communicate with events module, but don't require that
-// module to have to load this one, since this module has
-// a few side effects.
-EventEmitter.usingDomains = true;
-
 exports.Domain = Domain;
 
 exports.create = exports.createDomain = function() {
@@ -96,6 +91,14 @@ var listenerObj = {
 };
 
 
+var observerObj = EventEmitter.createObserver({
+  create: function dCreate(context, storage) {
+    if (exports.active && !(context instanceof Domain))
+      context.domain = exports.active;
+  }
+});
+
+
 inherits(Domain, EventEmitter);
 
 function Domain() {
@@ -118,12 +121,14 @@ Domain.prototype.enter = function() {
   stack.push(this);
 
   process.addAsyncListener(this._listener);
+  EventEmitter.addObserver(observerObj);
 };
 
 
 Domain.prototype.exit = function() {
   if (this._disposed) return;
 
+  EventEmitter.removeObserver(observerObj);
   process.removeAsyncListener(this._listener);
 
   // exit all domains until this one.
@@ -165,6 +170,7 @@ Domain.prototype.add = function(ee) {
 
   ee.domain = this;
   this.members.push(ee);
+  EventEmitter.attachObserver(ee, observerObj);
 
   // Adding the domain._listener to the Wrap associated with the event
   // emitter instance will be done automatically either on class

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -98,11 +98,12 @@ var observerObj = EventEmitter.createObserver({
   },
   error: function dError(context, storage, er) {
     if (!context.domain)
-      throw er;
+      return false;
     er.domainEmitter = context;
     er.domain = context.domain;
     er.domainThrown = false;
     context.domain.emit('error', er);
+    return true;
   }
 });
 

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -95,6 +95,14 @@ var observerObj = EventEmitter.createObserver({
   create: function dCreate(context, storage) {
     if (exports.active && !(context instanceof Domain))
       context.domain = exports.active;
+  },
+  error: function dError(context, storage, er) {
+    if (!context.domain)
+      throw er;
+    er.domainEmitter = context;
+    er.domain = context.domain;
+    er.domainThrown = false;
+    context.domain.emit('error', er);
   }
 });
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -472,7 +472,6 @@ function attachObserver(ee, obj, storage) {
 }
 
 
-// TODO(trevnorris): There is no API to "detach" an observer.
 // TODO(trevnorris): Should any "create" callbacks be run against the
 // emitter that we're attaching to?
 EventEmitter.attachObserver = function(ee, obj, storage) {
@@ -482,4 +481,31 @@ EventEmitter.attachObserver = function(ee, obj, storage) {
     throw new TypeError('argument obj must be an observer');
 
   attachObserver(ee, obj, storage);
+};
+
+
+EventEmitter.detachObserver = function detachObserver(ee, obj) {
+  if (!(ee instanceof EventEmitter))
+    throw new TypeError('argument ee must be instance of EventEmitter');
+  if (!(obj instanceof ObserverInst))
+    throw new TypeError('argument obj must be an observer');
+
+  if (!ee._observers)
+    return;
+
+  var idx = ee._observers.indexOf(obj);
+
+  if (idx < 0) {
+    return;
+  } else if (ee._observers.length === 1) {
+    ee._observers = undefined;
+    ee._flags = 0;
+    return;
+  }
+
+  ee._observers.splice(idx, 1);
+  ee._flags = 0;
+
+  for (var i = 0; i < ee._observers.length; i++)
+    ee._flags |= ee._observers[i].flags;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -48,8 +48,6 @@ EventEmitter.prototype._events = undefined;
 EventEmitter.prototype._observers = undefined;
 EventEmitter.prototype._maxListeners = undefined;
 EventEmitter.prototype._storage = undefined;
-// TODO(trevnorris): The instance will need a quick flag check. So every
-// time an observer is added/removed this state will need to be changed.
 EventEmitter.prototype._flags = 0;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
@@ -107,7 +105,7 @@ EventEmitter.prototype.emit = function(type) {
     if ((this._flags & HAS_ERROR_OBS) > 0) {
       for (j = 0; j < this._observers.length; j++) {
         item = this._observers[j];
-        if (typeof item.error === 'function')
+        if ((item.flags & HAS_ERROR_OBS) > 0)
           item.error(this, this._storage[item.uid], er);
       }
     }
@@ -131,7 +129,7 @@ EventEmitter.prototype.emit = function(type) {
     if ((this._flags & HAS_BEFORE_OBS) > 0) {
       for (j = 0; j < this._observers.length; j++) {
         item = this._observers[j];
-        if (typeof item.before === 'function')
+        if ((item.flags & HAS_BEFORE_OBS) > 0)
           item.before(this, this._storage[item.uid]);
       }
     }
@@ -159,7 +157,7 @@ EventEmitter.prototype.emit = function(type) {
     if ((this._flags & HAS_AFTER_OBS) > 0) {
       for (j = 0; j < this._observers.length; j++) {
         item = this._observers[j];
-        if (typeof item.after === 'function')
+        if ((item.flags & HAS_AFTER_OBS) > 0)
           item.after(this, this._storage[item.uid]);
       }
     }
@@ -175,7 +173,7 @@ EventEmitter.prototype.emit = function(type) {
       if ((this._flags & HAS_BEFORE_OBS) > 0) {
         for (j = 0; j < this._observers.length; j++) {
           item = this._observers[j];
-          if (typeof item.before === 'function')
+          if ((item.flags & HAS_BEFORE_OBS) > 0)
             item.before(this, this._storage[item.uid]);
         }
       }
@@ -185,7 +183,7 @@ EventEmitter.prototype.emit = function(type) {
       if ((this._flags & HAS_AFTER_OBS) > 0) {
         for (j = 0; j < this._observers.length; j++) {
           item = this._observers[j];
-          if (typeof item.after === 'function')
+          if ((item.flags & HAS_AFTER_OBS) > 0)
             item.after(this, this._storage[item.uid]);
         }
       }
@@ -417,10 +415,9 @@ EventEmitter.createObserver = function(obj, storage) {
 };
 
 
-// TODO(trevnorris): Currently if an observer is pre-created then passing
-// a storage value will be ignored on addObserver. By allowing the
-// storage value to be overridden it would also require creating a new
-// observer instance. I believe this would complicate the API.
+// The same observer can only be added once.
+// If the observer is pre-created then any storage value passed will be
+// ignored.
 EventEmitter.addObserver = function(obj, storage) {
   if (!(obj instanceof ObserverInst))
     obj = new ObserverInst(obj, storage);
@@ -454,6 +451,11 @@ EventEmitter.removeObserver = function(obj) {
 };
 
 
+// TODO(trevnorris): Possibility of adding the same observer multiple
+// times and allowing one of the following:
+//    1) Keep a reference count and only allow the callbacks to run once.
+//    2) Continue to add them, knowing the "storage" can't change after
+//    the instance has been instantiated and the "create" callback has run.
 function attachObserver(ee, obj, storage) {
   if (!ee._observers)
     ee._observers = [obj];
@@ -472,9 +474,8 @@ function attachObserver(ee, obj, storage) {
 }
 
 
-// TODO(trevnorris): Should any "create" callbacks be run against the
-// emitter that we're attaching to?
-EventEmitter.attachObserver = function(ee, obj, storage) {
+// The same observer can only be attached once.
+EventEmitter.attachObserver = function _attachObserver(ee, obj, storage) {
   if (!(ee instanceof EventEmitter))
     throw new TypeError('argument ee must be instance of EventEmitter');
   if (!(obj instanceof ObserverInst))
@@ -484,7 +485,7 @@ EventEmitter.attachObserver = function(ee, obj, storage) {
 };
 
 
-EventEmitter.detachObserver = function detachObserver(ee, obj) {
+EventEmitter.detachObserver = function _detachObserver(ee, obj) {
   if (!(ee instanceof EventEmitter))
     throw new TypeError('argument ee must be instance of EventEmitter');
   if (!(obj instanceof ObserverInst))

--- a/lib/events.js
+++ b/lib/events.js
@@ -25,10 +25,12 @@ var util = require('util');
 // Queue of all active observers.
 var observerQueue = [];
 var observerFlags = 0;
-var obsUid = 0;
+var observerUid = 0;
 
 // Flags to help quickly determine what observers are available.
 var HAS_CREATE_OBS = 1 << 0;
+var HAS_BEFORE_OBS = 1 << 1;
+var HAS_AFTER_OBS = 1 << 2;
 
 function EventEmitter() {
   EventEmitter.init.call(this);
@@ -45,6 +47,9 @@ EventEmitter.prototype._events = undefined;
 EventEmitter.prototype._observers = undefined;
 EventEmitter.prototype._maxListeners = undefined;
 EventEmitter.prototype._storage = undefined;
+// TODO(trevnorris): The instance will need a quick flag check. So every
+// time an observer is added/removed this state will need to be changed.
+EventEmitter.prototype._flags = 0;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
 // added to it. This is a useful default which helps finding memory leaks.
@@ -62,8 +67,22 @@ EventEmitter.init = function() {
   this._events = this._events || {};
   this._maxListeners = this._maxListeners || undefined;
 
-  if (observerFlags & HAS_CREATE_OBS > 0)
-    execCreators(this, observerQueue);
+  if (observerFlags === 0)
+    return;
+
+  var item, storage;
+  for (var i = 0; i < observerQueue.length; i++) {
+    item = observerQueue[i];
+    attachObserver(this, item);
+    // TODO(trevnorris): If the "create" callback throws then how should
+    // it be handled?
+    if ((observerFlags & HAS_CREATE_OBS) > 0 &&
+        typeof item.create === 'function') {
+      storage = item.create(this, item.storage);
+      if (typeof storage !== 'undefined')
+        this._storage[item.uid] = storage;
+    }
+  }
 };
 
 // Obviously not all Emitters should be limited to 10. This function allows
@@ -76,7 +95,7 @@ EventEmitter.prototype.setMaxListeners = function(n) {
 };
 
 EventEmitter.prototype.emit = function(type) {
-  var er, handler, len, args, i, listeners;
+  var er, handler, len, args, i, j, listeners, item;
 
   if (!this._events)
     this._events = {};
@@ -105,6 +124,14 @@ EventEmitter.prototype.emit = function(type) {
     return false;
 
   if (util.isFunction(handler)) {
+    if ((this._flags & HAS_BEFORE_OBS) > 0) {
+      for (j = 0; j < this._observers.length; j++) {
+        item = this._observers[j];
+        if (typeof item.before === 'function')
+          item.before(this, this._storage[item.uid]);
+      }
+    }
+
     switch (arguments.length) {
       // fast cases
       case 1:
@@ -124,6 +151,14 @@ EventEmitter.prototype.emit = function(type) {
           args[i - 1] = arguments[i];
         handler.apply(this, args);
     }
+
+    if ((this._flags & HAS_AFTER_OBS) > 0) {
+      for (j = 0; j < this._observers.length; j++) {
+        item = this._observers[j];
+        if (typeof item.after === 'function')
+          item.after(this, this._storage[item.uid]);
+      }
+    }
   } else if (util.isObject(handler)) {
     len = arguments.length;
     args = new Array(len - 1);
@@ -132,8 +167,25 @@ EventEmitter.prototype.emit = function(type) {
 
     listeners = handler.slice();
     len = listeners.length;
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i++) {
+      if ((this._flags & HAS_BEFORE_OBS) > 0) {
+        for (j = 0; j < this._observers.length; j++) {
+          item = this._observers[j];
+          if (typeof item.before === 'function')
+            item.before(this, this._storage[item.uid]);
+        }
+      }
+
       listeners[i].apply(this, args);
+
+      if ((this._flags & HAS_AFTER_OBS) > 0) {
+        for (j = 0; j < this._observers.length; j++) {
+          item = this._observers[j];
+          if (typeof item.after === 'function')
+            item.after(this, this._storage[item.uid]);
+        }
+      }
+    }
   }
 
   return true;
@@ -319,40 +371,6 @@ EventEmitter.listenerCount = function(emitter, type) {
 };
 
 
-// The "create" callback is unique because if a value is returned then
-// it will override the "storage" value on the ObserverInst instance.
-function execCreators(context, list) {
-  var item, storage;
-  context._storage = [];
-  for (var i = 0; i < list.length; i++) {
-    item = list[i];
-    if (typeof item.create === 'function') {
-      storage = item.create(context, item.storage);
-
-      if (storage)
-        context._storage[item.uid] = storage;
-      else
-        context._storage[item.uid] = item.storage;
-    }
-  }
-  context._observers = list;
-}
-
-
-// type - type of callback to execute (e.g. before/after/etc.)
-// context - "this" of the event emitter instance
-// list - the array that contains list of callbacks
-function execObservers(type, context, list) {
-  var item;
-  for (var i = 0; i < list.length; i++) {
-    item = list[i];
-    if (typeof item[type] === 'function') {
-      item[type](context, context._storage);
-    }
-  }
-}
-
-
 function ObserverInst(obj, storage) {
   if (!obj)
     return;
@@ -361,12 +379,22 @@ function ObserverInst(obj, storage) {
     this.create = obj.create;
     this.flags |= HAS_CREATE_OBS;
   }
-  // TODO(trevnorris): add before/after/error/add/remove callbacks.
+  if (typeof obj.before === 'function') {
+    this.before = obj.before;
+    this.flags |= HAS_BEFORE_OBS;
+  }
+  if (typeof obj.after === 'function') {
+    this.after = obj.after;
+    this.flags |= HAS_AFTER_OBS;
+  }
+  // TODO(trevnorris): add error/add/remove callbacks.
 
-  this.uid = ++obsUid;
+  this.uid = ++observerUid;
   this.storage = storage;
 }
 ObserverInst.prototype.create = undefined;
+ObserverInst.prototype.before = undefined;
+ObserverInst.prototype.after = undefined;
 ObserverInst.prototype.storage = undefined;
 ObserverInst.prototype.uid = undefined;
 ObserverInst.prototype.flags = 0;
@@ -417,23 +445,32 @@ EventEmitter.removeObserver = function(obj) {
 };
 
 
+function attachObserver(ee, obj, storage) {
+  if (!ee._observers)
+    ee._observers = [obj];
+  else if (ee._observers.indexOf(obj) === -1)
+    ee._observers.push(obj);
+  else
+    return;
+
+  if (typeof storage === 'undefined')
+    storage = obj.storage;
+  if (!ee._storage)
+    ee._storage = [];
+
+  ee._storage[obj.uid] = storage;
+  ee._flags |= obj.flags;
+}
+
+
+// TODO(trevnorris): There is no API to "detach" an observer.
+// TODO(trevnorris): Should any "create" callbacks be run against the
+// emitter that we're attaching to?
 EventEmitter.attachObserver = function(ee, obj, storage) {
   if (!(ee instanceof EventEmitter))
     throw new TypeError('argument ee must be instance of EventEmitter');
   if (!(obj instanceof ObserverInst))
     throw new TypeError('argument obj must be an observer');
 
-  if (!ee._observers)
-    ee._observers = [];
-  else if (ee._observers.indexOf(obj) >= 0)
-    return;
-
-  ee._observers.push(obj);
-
-  if (storage == null)
-    storage = obj.storage;
-  if (!ee._storage)
-    ee._storage = [];
-
-  ee._storage[obj.uid] = storage;
+  attachObserver(ee, obj, storage);
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -31,6 +31,7 @@ var observerUid = 0;
 var HAS_CREATE_OBS = 1 << 0;
 var HAS_BEFORE_OBS = 1 << 1;
 var HAS_AFTER_OBS = 1 << 2;
+var HAS_ERROR_OBS = 1 << 3;
 
 function EventEmitter() {
   EventEmitter.init.call(this);
@@ -102,18 +103,21 @@ EventEmitter.prototype.emit = function(type) {
 
   // If there is no 'error' event listener then throw.
   if (type === 'error' && !this._events.error) {
-    er = arguments[1];
+    er = arguments[1] || new Error('Uncaught, unspecified "error" event.');
+    if ((this._flags & HAS_ERROR_OBS) > 0) {
+      for (j = 0; j < this._observers.length; j++) {
+        item = this._observers[j];
+        if (typeof item.error === 'function')
+          item.error(this, this._storage[item.uid], er);
+      }
+    }
     if (this.domain) {
-      if (!er)
-        er = new Error('Uncaught, unspecified "error" event.');
       er.domainEmitter = this;
       er.domain = this.domain;
       er.domainThrown = false;
       this.domain.emit('error', er);
-    } else if (er instanceof Error) {
-      throw er; // Unhandled 'error' event
     } else {
-      throw Error('Uncaught, unspecified "error" event.');
+      throw er; // Unhandled 'error' event
     }
     return false;
   }
@@ -387,7 +391,11 @@ function ObserverInst(obj, storage) {
     this.after = obj.after;
     this.flags |= HAS_AFTER_OBS;
   }
-  // TODO(trevnorris): add error/add/remove callbacks.
+  if (typeof obj.error === 'function') {
+    this.error = obj.error;
+    this.flags |= HAS_ERROR_OBS;
+  }
+  // TODO(trevnorris): add add/remove callbacks.
 
   this.uid = ++observerUid;
   this.storage = storage;
@@ -395,6 +403,7 @@ function ObserverInst(obj, storage) {
 ObserverInst.prototype.create = undefined;
 ObserverInst.prototype.before = undefined;
 ObserverInst.prototype.after = undefined;
+ObserverInst.prototype.error = undefined;
 ObserverInst.prototype.storage = undefined;
 ObserverInst.prototype.uid = undefined;
 ObserverInst.prototype.flags = 0;

--- a/lib/events.js
+++ b/lib/events.js
@@ -233,9 +233,6 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
 
-    if ((this.flags & HAS_REMOVE_OBS) > 0)
-      runRemoveObservers(this, type, listener);
-
   } else if (util.isObject(list)) {
     for (i = length; i-- > 0;) {
       if (list[i] === listener ||
@@ -257,10 +254,10 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
-
-    if ((this.flags & HAS_REMOVE_OBS) > 0)
-      runRemoveObservers(this, type, listener);
   }
+
+  if ((this.__flags & HAS_REMOVE_OBS) > 0)
+    runRemoveObservers(this, type, listener);
 
   return this;
 };
@@ -272,7 +269,7 @@ EventEmitter.prototype.removeAllListeners = function(type) {
     return this;
 
   // not listening for removeListener, no need to emit
-  if (!this._events.removeListener) {
+  if (!this._events.removeListener && (this.__flags & HAS_REMOVE_OBS) === 0) {
     if (arguments.length === 0)
       this._events = {};
     else if (this._events[type])

--- a/lib/events.js
+++ b/lib/events.js
@@ -78,9 +78,9 @@ EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error' && !this._events.error) {
     er = arguments[1] || new Error('Uncaught, unspecified "error" event.');
-    if ((this.__flags & HAS_ERROR_OBS) > 0)
-      runErrorObservers(this, er);
-    else
+    // Check if error observers are available and if they are, execute
+    // them and see if the error was handled.
+    if ((this.__flags & HAS_ERROR_OBS) === 0 || !runErrorObservers(this, er))
       throw er; // Unhandled 'error' event
     return false;
   }
@@ -410,13 +410,16 @@ function runAfterObservers(context) {
 
 
 function runErrorObservers(context, er) {
+  var handled = false;
   var item, i;
 
   for (i = 0; i < context.__observers.length; i++) {
     item = context.__observers[i];
     if ((item.flags & HAS_ERROR_OBS) > 0)
-      item.error(context, context.__storage[item.uid], er);
+      handled = item.error(context, context.__storage[item.uid], er) || handled;
   }
+
+  return handled;
 }
 
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -68,22 +68,8 @@ EventEmitter.init = function() {
   this._events = this._events || {};
   this._maxListeners = this._maxListeners || undefined;
 
-  if (observerFlags === 0)
-    return;
-
-  var item, storage;
-  for (var i = 0; i < observerQueue.length; i++) {
-    item = observerQueue[i];
-    attachObserver(this, item);
-    // TODO(trevnorris): If the "create" callback throws then how should
-    // it be handled?
-    if ((observerFlags & HAS_CREATE_OBS) > 0 &&
-        typeof item.create === 'function') {
-      storage = item.create(this, item.storage);
-      if (typeof storage !== 'undefined')
-        this._storage[item.uid] = storage;
-    }
-  }
+  if (observerFlags > 0)
+    runCreateObservers(this);
 };
 
 // Obviously not all Emitters should be limited to 10. This function allows
@@ -104,13 +90,9 @@ EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error' && !this._events.error) {
     er = arguments[1] || new Error('Uncaught, unspecified "error" event.');
-    if ((this._flags & HAS_ERROR_OBS) > 0) {
-      for (j = 0; j < this._observers.length; j++) {
-        item = this._observers[j];
-        if ((item.flags & HAS_ERROR_OBS) > 0)
-          item.error(this, this._storage[item.uid], er);
-      }
-    }
+    if ((this._flags & HAS_ERROR_OBS) > 0)
+      runErrorObservers(this, er);
+
     if (this.domain) {
       er.domainEmitter = this;
       er.domain = this.domain;
@@ -128,13 +110,8 @@ EventEmitter.prototype.emit = function(type) {
     return false;
 
   if (util.isFunction(handler)) {
-    if ((this._flags & HAS_BEFORE_OBS) > 0) {
-      for (j = 0; j < this._observers.length; j++) {
-        item = this._observers[j];
-        if ((item.flags & HAS_BEFORE_OBS) > 0)
-          item.before(this, this._storage[item.uid]);
-      }
-    }
+    if ((this._flags & HAS_BEFORE_OBS) > 0)
+      runBeforeObservers(this);
 
     switch (arguments.length) {
       // fast cases
@@ -156,13 +133,9 @@ EventEmitter.prototype.emit = function(type) {
         handler.apply(this, args);
     }
 
-    if ((this._flags & HAS_AFTER_OBS) > 0) {
-      for (j = 0; j < this._observers.length; j++) {
-        item = this._observers[j];
-        if ((item.flags & HAS_AFTER_OBS) > 0)
-          item.after(this, this._storage[item.uid]);
-      }
-    }
+    if ((this._flags & HAS_AFTER_OBS) > 0)
+      runAfterObservers(this);
+
   } else if (util.isObject(handler)) {
     len = arguments.length;
     args = new Array(len - 1);
@@ -172,23 +145,13 @@ EventEmitter.prototype.emit = function(type) {
     listeners = handler.slice();
     len = listeners.length;
     for (i = 0; i < len; i++) {
-      if ((this._flags & HAS_BEFORE_OBS) > 0) {
-        for (j = 0; j < this._observers.length; j++) {
-          item = this._observers[j];
-          if ((item.flags & HAS_BEFORE_OBS) > 0)
-            item.before(this, this._storage[item.uid]);
-        }
-      }
+      if ((this._flags & HAS_BEFORE_OBS) > 0)
+        runBeforeObservers(this);
 
       listeners[i].apply(this, args);
 
-      if ((this._flags & HAS_AFTER_OBS) > 0) {
-        for (j = 0; j < this._observers.length; j++) {
-          item = this._observers[j];
-          if ((item.flags & HAS_AFTER_OBS) > 0)
-            item.after(this, this._storage[item.uid]);
-        }
-      }
+      if ((this._flags & HAS_AFTER_OBS) > 0)
+        runAfterObservers(this);
     }
   }
 
@@ -221,13 +184,8 @@ EventEmitter.prototype.addListener = function(type, listener) {
     // Adding the second element, need to change to array.
     this._events[type] = [this._events[type], listener];
 
-  if ((this._flags & HAS_ADD_OBS) > 0) {
-    for (i = 0; i < this._observers.length; i++) {
-      item = this._observers[i];
-      if ((item.flags & HAS_ADD_OBS) > 0)
-        item.add(this, this._storage[item.uid], type, listener);
-    }
-  }
+  if ((this._flags & HAS_ADD_OBS) > 0)
+    runAddObservers(this, type, listener);
 
   // Check for listener leak
   if (util.isObject(this._events[type]) && !this._events[type].warned) {
@@ -294,13 +252,8 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
 
-    if ((this.flags & HAS_REMOVE_OBS) > 0) {
-      for (j = 0; j < this._observers.length; j++) {
-        item = this._observers[j];
-        if ((item.flags & HAS_REMOVE_OBS) > 0)
-          item.remove(this, this._storage[item.uid], type, listener);
-      }
-    }
+    if ((this.flags & HAS_REMOVE_OBS) > 0)
+      runRemoveObservers(this, type, listener);
 
   } else if (util.isObject(list)) {
     for (i = length; i-- > 0;) {
@@ -324,13 +277,8 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
 
-    if ((this.flags & HAS_REMOVE_OBS) > 0) {
-      for (j = 0; j < this._observers.length; j++) {
-        item = this._observers[j];
-        if ((item.flags & HAS_REMOVE_OBS) > 0)
-          item.remove(this, this._storage[item.uid], type, listener);
-      }
-    }
+    if ((this.flags & HAS_REMOVE_OBS) > 0)
+      runRemoveObservers(this, type, listener);
   }
 
   return this;
@@ -440,6 +388,79 @@ ObserverInst.prototype.remove = undefined;
 ObserverInst.prototype.storage = undefined;
 ObserverInst.prototype.uid = undefined;
 ObserverInst.prototype.flags = 0;
+
+
+// These functions are not DRY, but they're much faster than accessing
+// the object properties via a passed string.
+function runCreateObservers(context) {
+  var item, i, storage;
+
+  for (i = 0; i < observerQueue.length; i++) {
+    item = observerQueue[i];
+    attachObserver(context, item);
+    if ((observerFlags & HAS_CREATE_OBS) > 0 &&
+        (item.flags & HAS_CREATE_OBS) > 0) {
+      storage = item.create(context, item.storage);
+      if (typeof storage !== 'undefined')
+        context._storage[item.uid] = storage;
+    }
+  }
+}
+
+
+function runBeforeObservers(context) {
+  var item, i;
+
+  for (i = 0; i < context._observers.length; i++) {
+    item = context._observers[i];
+    if ((item.flags & HAS_BEFORE_OBS) > 0)
+      item.before(context, context._storage[item.uid]);
+  }
+}
+
+
+function runAfterObservers(context) {
+  var item, i;
+
+  for (i = 0; i < context._observers.length; i++) {
+    item = context._observers[i];
+    if ((item.flags & HAS_AFTER_OBS) > 0)
+      item.after(context, context._storage[item.uid]);
+  }
+}
+
+
+function runErrorObservers(context, er) {
+  var item, i;
+
+  for (i = 0; i < context._observers.length; i++) {
+    item = context._observers[i];
+    if ((item.flags & HAS_ERROR_OBS) > 0)
+      item.error(context, context._storage[item.uid], er);
+  }
+}
+
+
+function runAddObservers(context, type, listener) {
+  var item, i;
+
+  for (i = 0; i < context._observers.length; i++) {
+    item = context._observers[i];
+    if ((item.flags & HAS_ADD_OBS) > 0)
+      item.add(context, context._storage[item.uid], type, listener);
+  }
+}
+
+
+function runRemoveObservers(context, type, listener) {
+  var item, i;
+
+  for (i = 0; i < context._observers.length; i++) {
+    item = context._observers[i];
+    if ((item.flags & HAS_REMOVE_OBS) > 0)
+      item.remove(context, context._storage[item.uid], type, listener);
+  }
+}
 
 
 EventEmitter.createObserver = function(obj, storage) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -555,3 +555,8 @@ EventEmitter.detachObserver = function _detachObserver(ee, obj) {
   for (var i = 0; i < ee.__observers.length; i++)
     ee.__flags |= ee.__observers[i].flags;
 };
+
+
+EventEmitter.observers = function _observers() {
+  return observerQueue.slice(0);
+};

--- a/lib/events.js
+++ b/lib/events.js
@@ -376,6 +376,7 @@ ObserverInst.prototype.remove = undefined;
 ObserverInst.prototype.storage = undefined;
 ObserverInst.prototype.uid = undefined;
 ObserverInst.prototype.flags = 0;
+ObserverInst.prototype.refs = 0;
 
 
 // These functions are not DRY, but they're much faster than accessing
@@ -459,15 +460,15 @@ EventEmitter.createObserver = function(obj, storage) {
 };
 
 
-// The same observer can only be added once.
+// The same observer can only be added and executed once.
 // If the observer is pre-created then any storage value passed will be
 // ignored.
 EventEmitter.addObserver = function(obj, storage) {
   if (!(obj instanceof ObserverInst))
     obj = new ObserverInst(obj, storage);
 
-  // Check observer has callbacks and that it doesn't exist in the queue.
-  if (obj.flags === 0 || observerQueue.indexOf(obj) >= 0)
+  // Check observer has callbacks or that it doesn't exist in the queue.
+  if (obj.flags === 0 || ++obj.refs > 1)
     return obj;
 
   observerQueue.push(obj);
@@ -483,7 +484,7 @@ EventEmitter.removeObserver = function(obj) {
 
   var idx = observerQueue.indexOf(obj);
 
-  if (idx < 0)
+  if (idx < 0 || --obj.refs > 0)
     return;
 
   observerQueue.splice(idx, 1);

--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,14 @@
 var domain;
 var util = require('util');
 
+// Queue of all active observers.
+var observerQueue = [];
+var observerFlags = 0;
+var obsUid = 0;
+
+// Flags to help quickly determine what observers are available.
+var HAS_CREATE_OBS = 1 << 0;
+
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
@@ -34,7 +42,9 @@ EventEmitter.usingDomains = false;
 
 EventEmitter.prototype.domain = undefined;
 EventEmitter.prototype._events = undefined;
+EventEmitter.prototype._observers = undefined;
 EventEmitter.prototype._maxListeners = undefined;
+EventEmitter.prototype._storage = undefined;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
 // added to it. This is a useful default which helps finding memory leaks.
@@ -51,6 +61,9 @@ EventEmitter.init = function() {
   }
   this._events = this._events || {};
   this._maxListeners = this._maxListeners || undefined;
+
+  if (observerFlags & HAS_CREATE_OBS > 0)
+    execCreators(this, observerQueue);
 };
 
 // Obviously not all Emitters should be limited to 10. This function allows
@@ -303,4 +316,88 @@ EventEmitter.listenerCount = function(emitter, type) {
   else
     ret = emitter._events[type].length;
   return ret;
+};
+
+
+// The "create" callback is unique because if a value is returned then
+// it will override the "storage" value on the ObserverInst instance.
+function execCreators(context, list) {
+  var item, storage;
+  context._storage = [];
+  for (var i = 0; i < list.length; i++) {
+    item = list[i];
+    if (typeof item.create === 'function') {
+      storage = item.create(context, item.storage);
+
+      if (storage)
+        context._storage[item.uid] = storage;
+      else
+        context._storage[item.uid] = item.storage;
+    }
+  }
+  context._observers = list;
+}
+
+
+function ObserverInst(obj, storage) {
+  if (!obj)
+    return;
+
+  if (typeof obj.create === 'function') {
+    this.create = obj.create;
+    this.flags |= HAS_CREATE_OBS;
+  }
+  // TODO(trevnorris): add before/after/error/add/remove callbacks.
+
+  this.uid = ++obsUid;
+  this.storage = storage;
+}
+ObserverInst.prototype.create = undefined;
+ObserverInst.prototype.storage = undefined;
+ObserverInst.prototype.uid = undefined;
+ObserverInst.prototype.flags = 0;
+
+
+EventEmitter.createObserver = function(obj, storage) {
+  if (!(obj instanceof ObserverInst))
+    return new ObserverInst(obj, storage);
+  else
+    return obj;
+};
+
+
+// TODO(trevnorris): Currently if an observer is pre-created then passing
+// a storage value will be ignored on addObserver. By allowing the
+// storage value to be overridden it would also require creating a new
+// observer instance. I believe this would complicate the API.
+EventEmitter.addObserver = function(obj, storage) {
+  if (!(obj instanceof ObserverInst))
+    obj = new ObserverInst(obj, storage);
+
+  // Check observer has callbacks and that it doesn't exist in the queue.
+  if (obj.flags === 0 || observerQueue.indexOf(obj) >= 0)
+    return obj;
+
+  observerQueue.push(obj);
+  observerFlags |= obj.flags;
+
+  return obj;
+};
+
+
+EventEmitter.removeObserver = function(obj) {
+  if (!(obj instanceof ObserverInst) || observerQueue.length === 0)
+    return;
+
+  var idx = observerQueue.indexOf(obj);
+
+  if (idx < 0)
+    return;
+
+  observerQueue.splice(idx, 1);
+  observerFlags = 0;
+
+  // Rebuild flags from all queued observers.
+  for (var i = 0; i < observerQueue.length; i++)
+    observerFlags |= observerQueue[i].flags;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var domain;
 var util = require('util');
 
 // Queue of all active observers.
@@ -79,16 +78,10 @@ EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error' && !this._events.error) {
     er = arguments[1] || new Error('Uncaught, unspecified "error" event.');
-    if ((this.__flags & HAS_ERROR_OBS) > 0) {
+    if ((this.__flags & HAS_ERROR_OBS) > 0)
       runErrorObservers(this, er);
-    } else if (this.domain) {
-      er.domainEmitter = this;
-      er.domain = this.domain;
-      er.domainThrown = false;
-      this.domain.emit('error', er);
-    } else {
+    else
       throw er; // Unhandled 'error' event
-    }
     return false;
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -32,6 +32,8 @@ var HAS_CREATE_OBS = 1 << 0;
 var HAS_BEFORE_OBS = 1 << 1;
 var HAS_AFTER_OBS = 1 << 2;
 var HAS_ERROR_OBS = 1 << 3;
+var HAS_ADD_OBS = 1 << 4;
+var HAS_REMOVE_OBS = 1 << 5;
 
 function EventEmitter() {
   EventEmitter.init.call(this);
@@ -194,7 +196,7 @@ EventEmitter.prototype.emit = function(type) {
 };
 
 EventEmitter.prototype.addListener = function(type, listener) {
-  var m;
+  var i, item;
 
   if (!util.isFunction(listener))
     throw TypeError('listener must be a function');
@@ -218,6 +220,14 @@ EventEmitter.prototype.addListener = function(type, listener) {
   else
     // Adding the second element, need to change to array.
     this._events[type] = [this._events[type], listener];
+
+  if ((this._flags & HAS_ADD_OBS) > 0) {
+    for (i = 0; i < this._observers.length; i++) {
+      item = this._observers[i];
+      if ((item.flags & HAS_ADD_OBS) > 0)
+        item.add(this, this._storage[item.uid], type, listener);
+    }
+  }
 
   // Check for listener leak
   if (util.isObject(this._events[type]) && !this._events[type].warned) {
@@ -266,7 +276,7 @@ EventEmitter.prototype.once = function(type, listener) {
 
 // emits a 'removeListener' event iff the listener was removed
 EventEmitter.prototype.removeListener = function(type, listener) {
-  var list, position, length, i;
+  var list, position, length, i, j, item;
 
   if (!util.isFunction(listener))
     throw TypeError('listener must be a function');
@@ -283,6 +293,14 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     delete this._events[type];
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
+
+    if ((this.flags & HAS_REMOVE_OBS) > 0) {
+      for (j = 0; j < this._observers.length; j++) {
+        item = this._observers[j];
+        if ((item.flags & HAS_REMOVE_OBS) > 0)
+          item.remove(this, this._storage[item.uid], type, listener);
+      }
+    }
 
   } else if (util.isObject(list)) {
     for (i = length; i-- > 0;) {
@@ -305,6 +323,14 @@ EventEmitter.prototype.removeListener = function(type, listener) {
 
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
+
+    if ((this.flags & HAS_REMOVE_OBS) > 0) {
+      for (j = 0; j < this._observers.length; j++) {
+        item = this._observers[j];
+        if ((item.flags & HAS_REMOVE_OBS) > 0)
+          item.remove(this, this._storage[item.uid], type, listener);
+      }
+    }
   }
 
   return this;
@@ -393,7 +419,14 @@ function ObserverInst(obj, storage) {
     this.error = obj.error;
     this.flags |= HAS_ERROR_OBS;
   }
-  // TODO(trevnorris): add add/remove callbacks.
+  if (typeof obj.add === 'function') {
+    this.add = obj.add;
+    this.flags |= HAS_ADD_OBS;
+  }
+  if (typeof obj.remove === 'function') {
+    this.remove = obj.remove;
+    this.flags |= HAS_REMOVE_OBS;
+  }
 
   this.uid = ++observerUid;
   this.storage = storage;
@@ -402,6 +435,8 @@ ObserverInst.prototype.create = undefined;
 ObserverInst.prototype.before = undefined;
 ObserverInst.prototype.after = undefined;
 ObserverInst.prototype.error = undefined;
+ObserverInst.prototype.add = undefined;
+ObserverInst.prototype.remove = undefined;
 ObserverInst.prototype.storage = undefined;
 ObserverInst.prototype.uid = undefined;
 ObserverInst.prototype.flags = 0;

--- a/lib/events.js
+++ b/lib/events.js
@@ -44,10 +44,10 @@ module.exports = EventEmitter;
 EventEmitter.EventEmitter = EventEmitter;
 
 EventEmitter.prototype._events = undefined;
-EventEmitter.prototype._observers = undefined;
 EventEmitter.prototype._maxListeners = undefined;
-EventEmitter.prototype._storage = undefined;
-EventEmitter.prototype._flags = 0;
+EventEmitter.prototype.__observers = undefined;
+EventEmitter.prototype.__storage = undefined;
+EventEmitter.prototype.__flags = 0;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
 // added to it. This is a useful default which helps finding memory leaks.
@@ -79,10 +79,9 @@ EventEmitter.prototype.emit = function(type) {
   // If there is no 'error' event listener then throw.
   if (type === 'error' && !this._events.error) {
     er = arguments[1] || new Error('Uncaught, unspecified "error" event.');
-    if ((this._flags & HAS_ERROR_OBS) > 0)
+    if ((this.__flags & HAS_ERROR_OBS) > 0) {
       runErrorObservers(this, er);
-
-    if (this.domain) {
+    } else if (this.domain) {
       er.domainEmitter = this;
       er.domain = this.domain;
       er.domainThrown = false;
@@ -99,7 +98,7 @@ EventEmitter.prototype.emit = function(type) {
     return false;
 
   if (util.isFunction(handler)) {
-    if ((this._flags & HAS_BEFORE_OBS) > 0)
+    if ((this.__flags & HAS_BEFORE_OBS) > 0)
       runBeforeObservers(this);
 
     switch (arguments.length) {
@@ -122,7 +121,7 @@ EventEmitter.prototype.emit = function(type) {
         handler.apply(this, args);
     }
 
-    if ((this._flags & HAS_AFTER_OBS) > 0)
+    if ((this.__flags & HAS_AFTER_OBS) > 0)
       runAfterObservers(this);
 
   } else if (util.isObject(handler)) {
@@ -134,12 +133,12 @@ EventEmitter.prototype.emit = function(type) {
     listeners = handler.slice();
     len = listeners.length;
     for (i = 0; i < len; i++) {
-      if ((this._flags & HAS_BEFORE_OBS) > 0)
+      if ((this.__flags & HAS_BEFORE_OBS) > 0)
         runBeforeObservers(this);
 
       listeners[i].apply(this, args);
 
-      if ((this._flags & HAS_AFTER_OBS) > 0)
+      if ((this.__flags & HAS_AFTER_OBS) > 0)
         runAfterObservers(this);
     }
   }
@@ -173,7 +172,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
     // Adding the second element, need to change to array.
     this._events[type] = [this._events[type], listener];
 
-  if ((this._flags & HAS_ADD_OBS) > 0)
+  if ((this.__flags & HAS_ADD_OBS) > 0)
     runAddObservers(this, type, listener);
 
   // Check for listener leak
@@ -391,7 +390,7 @@ function runCreateObservers(context) {
         (item.flags & HAS_CREATE_OBS) > 0) {
       storage = item.create(context, item.storage);
       if (typeof storage !== 'undefined')
-        context._storage[item.uid] = storage;
+        context.__storage[item.uid] = storage;
     }
   }
 }
@@ -400,10 +399,10 @@ function runCreateObservers(context) {
 function runBeforeObservers(context) {
   var item, i;
 
-  for (i = 0; i < context._observers.length; i++) {
-    item = context._observers[i];
+  for (i = 0; i < context.__observers.length; i++) {
+    item = context.__observers[i];
     if ((item.flags & HAS_BEFORE_OBS) > 0)
-      item.before(context, context._storage[item.uid]);
+      item.before(context, context.__storage[item.uid]);
   }
 }
 
@@ -411,10 +410,10 @@ function runBeforeObservers(context) {
 function runAfterObservers(context) {
   var item, i;
 
-  for (i = 0; i < context._observers.length; i++) {
-    item = context._observers[i];
+  for (i = 0; i < context.__observers.length; i++) {
+    item = context.__observers[i];
     if ((item.flags & HAS_AFTER_OBS) > 0)
-      item.after(context, context._storage[item.uid]);
+      item.after(context, context.__storage[item.uid]);
   }
 }
 
@@ -422,10 +421,10 @@ function runAfterObservers(context) {
 function runErrorObservers(context, er) {
   var item, i;
 
-  for (i = 0; i < context._observers.length; i++) {
-    item = context._observers[i];
+  for (i = 0; i < context.__observers.length; i++) {
+    item = context.__observers[i];
     if ((item.flags & HAS_ERROR_OBS) > 0)
-      item.error(context, context._storage[item.uid], er);
+      item.error(context, context.__storage[item.uid], er);
   }
 }
 
@@ -433,10 +432,10 @@ function runErrorObservers(context, er) {
 function runAddObservers(context, type, listener) {
   var item, i;
 
-  for (i = 0; i < context._observers.length; i++) {
-    item = context._observers[i];
+  for (i = 0; i < context.__observers.length; i++) {
+    item = context.__observers[i];
     if ((item.flags & HAS_ADD_OBS) > 0)
-      item.add(context, context._storage[item.uid], type, listener);
+      item.add(context, context.__storage[item.uid], type, listener);
   }
 }
 
@@ -444,10 +443,10 @@ function runAddObservers(context, type, listener) {
 function runRemoveObservers(context, type, listener) {
   var item, i;
 
-  for (i = 0; i < context._observers.length; i++) {
-    item = context._observers[i];
+  for (i = 0; i < context.__observers.length; i++) {
+    item = context.__observers[i];
     if ((item.flags & HAS_REMOVE_OBS) > 0)
-      item.remove(context, context._storage[item.uid], type, listener);
+      item.remove(context, context.__storage[item.uid], type, listener);
   }
 }
 
@@ -502,20 +501,20 @@ EventEmitter.removeObserver = function(obj) {
 //    2) Continue to add them, knowing the "storage" can't change after
 //    the instance has been instantiated and the "create" callback has run.
 function attachObserver(ee, obj, storage) {
-  if (!ee._observers)
-    ee._observers = [obj];
-  else if (ee._observers.indexOf(obj) === -1)
-    ee._observers.push(obj);
+  if (!ee.__observers)
+    ee.__observers = [obj];
+  else if (ee.__observers.indexOf(obj) === -1)
+    ee.__observers.push(obj);
   else
     return;
 
   if (typeof storage === 'undefined')
     storage = obj.storage;
-  if (!ee._storage)
-    ee._storage = new Array();
+  if (!ee.__storage)
+    ee.__storage = new Array();
 
-  ee._storage[obj.uid] = storage;
-  ee._flags |= obj.flags;
+  ee.__storage[obj.uid] = storage;
+  ee.__flags |= obj.flags;
 }
 
 
@@ -536,22 +535,22 @@ EventEmitter.detachObserver = function _detachObserver(ee, obj) {
   if (!(obj instanceof ObserverInst))
     throw new TypeError('argument obj must be an observer');
 
-  if (!ee._observers)
+  if (!ee.__observers)
     return;
 
-  var idx = ee._observers.indexOf(obj);
+  var idx = ee.__observers.indexOf(obj);
 
   if (idx < 0) {
     return;
-  } else if (ee._observers.length === 1) {
-    ee._observers = undefined;
-    ee._flags = 0;
+  } else if (ee.__observers.length === 1) {
+    ee.__observers = undefined;
+    ee.__flags = 0;
     return;
   }
 
-  ee._observers.splice(idx, 1);
-  ee._flags = 0;
+  ee.__observers.splice(idx, 1);
+  ee.__flags = 0;
 
-  for (var i = 0; i < ee._observers.length; i++)
-    ee._flags |= ee._observers[i].flags;
+  for (var i = 0; i < ee.__observers.length; i++)
+    ee.__flags |= ee.__observers[i].flags;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -43,9 +43,6 @@ module.exports = EventEmitter;
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
 
-EventEmitter.usingDomains = false;
-
-EventEmitter.prototype.domain = undefined;
 EventEmitter.prototype._events = undefined;
 EventEmitter.prototype._observers = undefined;
 EventEmitter.prototype._maxListeners = undefined;
@@ -57,16 +54,8 @@ EventEmitter.prototype._flags = 0;
 EventEmitter.defaultMaxListeners = 10;
 
 EventEmitter.init = function() {
-  this.domain = null;
-  if (EventEmitter.usingDomains) {
-    // if there is an active domain, then attach to it.
-    domain = domain || require('domain');
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
-  }
-  this._events = this._events || {};
-  this._maxListeners = this._maxListeners || undefined;
+  if (typeof this._events !== 'object')
+    this._events = {};
 
   if (observerFlags > 0)
     runCreateObservers(this);
@@ -523,7 +512,7 @@ function attachObserver(ee, obj, storage) {
   if (typeof storage === 'undefined')
     storage = obj.storage;
   if (!ee._storage)
-    ee._storage = [];
+    ee._storage = new Array();
 
   ee._storage[obj.uid] = storage;
   ee._flags |= obj.flags;

--- a/lib/events.js
+++ b/lib/events.js
@@ -339,6 +339,20 @@ function execCreators(context, list) {
 }
 
 
+// type - type of callback to execute (e.g. before/after/etc.)
+// context - "this" of the event emitter instance
+// list - the array that contains list of callbacks
+function execObservers(type, context, list) {
+  var item;
+  for (var i = 0; i < list.length; i++) {
+    item = list[i];
+    if (typeof item[type] === 'function') {
+      item[type](context, context._storage);
+    }
+  }
+}
+
+
 function ObserverInst(obj, storage) {
   if (!obj)
     return;
@@ -400,4 +414,26 @@ EventEmitter.removeObserver = function(obj) {
   // Rebuild flags from all queued observers.
   for (var i = 0; i < observerQueue.length; i++)
     observerFlags |= observerQueue[i].flags;
+};
+
+
+EventEmitter.attachObserver = function(ee, obj, storage) {
+  if (!(ee instanceof EventEmitter))
+    throw new TypeError('argument ee must be instance of EventEmitter');
+  if (!(obj instanceof ObserverInst))
+    throw new TypeError('argument obj must be an observer');
+
+  if (!ee._observers)
+    ee._observers = [];
+  else if (ee._observers.indexOf(obj) >= 0)
+    return;
+
+  ee._observers.push(obj);
+
+  if (storage == null)
+    storage = obj.storage;
+  if (!ee._storage)
+    ee._storage = [];
+
+  ee._storage[obj.uid] = storage;
 };

--- a/test/simple/test-event-emitter-observer-after.js
+++ b/test/simple/test-event-emitter-observer-after.js
@@ -1,0 +1,105 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var actual = 0;
+var expected = 0;
+
+process.on('exit', function() {
+  assert.equal(actual, expected);
+});
+
+function noop() { }
+function noop2() { }
+
+var s = [];
+var obs = events.createObserver({
+  after: function after(context, storage) {
+    assert.equal(s, storage);
+    assert.equal(s[0], context);
+    actual++;
+  }
+}, s);
+
+
+// Check after callback works when attaching to existing emitter.
+var e = new events();
+e.on('test', noop);
+events.attachObserver(e, obs);
+s[0] = e;
+e.emit('test');
+expected++;
+
+
+// Check running multiple emitters.
+events.addObserver(obs);
+
+var e1 = new events();
+var e2 = new events();
+
+e1.on('test', noop);
+e2.on('test', noop);
+
+s[0] = e1;
+e1.emit('test');
+expected++;
+
+s[0] = e2;
+e2.emit('test');
+expected++;
+
+events.removeObserver(obs);
+
+
+// Check after callback works when attaching to existing emitter with
+// multiple listeners on the same event.
+var e = new events();
+e.on('test', noop);
+e.on('test', noop2);
+events.attachObserver(e, obs);
+s[0] = e;
+e.emit('test');
+expected += 2;
+
+
+// Check running multiple emitters with multiple listeners.
+events.addObserver(obs);
+
+var e1 = new events();
+var e2 = new events();
+
+e1.on('test', noop);
+e1.on('test', noop2);
+e2.on('test', noop);
+e2.on('test', noop2);
+
+s[0] = e1;
+e1.emit('test');
+expected += 2;
+
+s[0] = e2;
+e2.emit('test');
+expected += 2;
+
+events.removeObserver(obs);

--- a/test/simple/test-event-emitter-observer-attach.js
+++ b/test/simple/test-event-emitter-observer-attach.js
@@ -23,21 +23,16 @@ var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 
-// Check observers are created correctly.
+// Check observer can be added after creation.
 var obs = events.createObserver({
   create: function(context, storage) {
     assert.equal(storage, 'test storage');
   }
 }, 'test storage');
 
-assert.equal(typeof obs.create, 'function');
-assert.equal(obs.flags, 1);
-assert.equal(obs.storage, 'test storage');
-assert.equal(typeof obs.uid, 'number');
-
-events.addObserver(obs);
-
 var ee = new events();
+
+events.attachObserver(ee, obs);
 
 assert.ok(ee._observers);
 assert.equal(ee._observers.length, 1);
@@ -51,51 +46,20 @@ assert.equal(item.storage, 'test storage');
 assert.equal(ee._storage[obs.uid], item.storage);
 
 
-// Check the observer is removed properly.
-events.removeObserver(obs);
+// Check observer can be added after creation and storage changed.
+var obs = events.createObserver({
+  create: function(context, storage) { }
+}, 'test storage');
 
 var ee = new events();
 
-assert.ok(!ee._observers);
-assert.ok(!ee._storage);
-
-
-// Check the storage value can be overridden, and the observer
-// is properly created on addObserver.
-var obs = events.addObserver({
-  create: function(context, storage) {
-    context.testValue = true;
-    return 'this works';
-  }
-}, 'remove me');
-
-var ee = new events();
+events.attachObserver(ee, obs, 'new storage');
 
 assert.ok(ee._observers);
 assert.equal(ee._observers.length, 1);
 assert.equal(ee._observers[0], obs);
-assert.equal(ee._storage[obs.uid], 'this works');
-assert.ok(ee.testValue);
 
 var item = ee._observers[0];
 assert.equal(typeof item.create, 'function');
 assert.equal(item.flags, 1);
-assert.equal(item.storage, 'remove me');
-
-
-// Check the same observer can only be added once.
-events.addObserver(obs);
-
-var ee = new events();
-
-assert.ok(ee._observers);
-assert.equal(ee._observers.length, 1);
-
-// Check the storage value isn't overridden if observer was
-// previously created.
-events.removeObserver(obs);
-events.addObserver(obs, 'not existent');
-
-assert.equal(obs.storage, 'remove me');
-
-events.removeObserver(obs);
+assert.equal(ee._storage[obs.uid], 'new storage');

--- a/test/simple/test-event-emitter-observer-attach.js
+++ b/test/simple/test-event-emitter-observer-attach.js
@@ -34,16 +34,16 @@ var ee = new events();
 
 events.attachObserver(ee, obs);
 
-assert.ok(ee._observers);
-assert.equal(ee._observers.length, 1);
-assert.equal(ee._observers[0], obs);
-assert.equal(ee._storage[obs.uid], obs.storage);
+assert.ok(ee.__observers);
+assert.equal(ee.__observers.length, 1);
+assert.equal(ee.__observers[0], obs);
+assert.equal(ee.__storage[obs.uid], obs.storage);
 
-var item = ee._observers[0];
+var item = ee.__observers[0];
 assert.equal(typeof item.create, 'function');
 assert.equal(item.flags, 1);
 assert.equal(item.storage, 'test storage');
-assert.equal(ee._storage[obs.uid], item.storage);
+assert.equal(ee.__storage[obs.uid], item.storage);
 
 
 // Check observer can be added after creation and storage changed.
@@ -55,11 +55,11 @@ var ee = new events();
 
 events.attachObserver(ee, obs, 'new storage');
 
-assert.ok(ee._observers);
-assert.equal(ee._observers.length, 1);
-assert.equal(ee._observers[0], obs);
+assert.ok(ee.__observers);
+assert.equal(ee.__observers.length, 1);
+assert.equal(ee.__observers[0], obs);
 
-var item = ee._observers[0];
+var item = ee.__observers[0];
 assert.equal(typeof item.create, 'function');
 assert.equal(item.flags, 1);
-assert.equal(ee._storage[obs.uid], 'new storage');
+assert.equal(ee.__storage[obs.uid], 'new storage');

--- a/test/simple/test-event-emitter-observer-before.js
+++ b/test/simple/test-event-emitter-observer-before.js
@@ -1,0 +1,105 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var actual = 0;
+var expected = 0;
+
+process.on('exit', function() {
+  assert.equal(actual, expected);
+});
+
+function noop() { }
+function noop2() { }
+
+var s = [];
+var obs = events.createObserver({
+  before: function before(context, storage) {
+    assert.equal(s, storage);
+    assert.equal(s[0], context);
+    actual++;
+  }
+}, s);
+
+
+// Check before callback works when attaching to existing emitter.
+var e = new events();
+e.on('test', noop);
+events.attachObserver(e, obs);
+s[0] = e;
+e.emit('test');
+expected++;
+
+
+// Check running multiple emitters.
+events.addObserver(obs);
+
+var e1 = new events();
+var e2 = new events();
+
+e1.on('test', noop);
+e2.on('test', noop);
+
+s[0] = e1;
+e1.emit('test');
+expected++;
+
+s[0] = e2;
+e2.emit('test');
+expected++;
+
+events.removeObserver(obs);
+
+
+// Check before callback works when attaching to existing emitter with
+// multiple listeners on the same event.
+var e = new events();
+e.on('test', noop);
+e.on('test', noop2);
+events.attachObserver(e, obs);
+s[0] = e;
+e.emit('test');
+expected += 2;
+
+
+// Check running multiple emitters with multiple listeners.
+events.addObserver(obs);
+
+var e1 = new events();
+var e2 = new events();
+
+e1.on('test', noop);
+e1.on('test', noop2);
+e2.on('test', noop);
+e2.on('test', noop2);
+
+s[0] = e1;
+e1.emit('test');
+expected += 2;
+
+s[0] = e2;
+e2.emit('test');
+expected += 2;
+
+events.removeObserver(obs);

--- a/test/simple/test-event-emitter-observer-create.js
+++ b/test/simple/test-event-emitter-observer-create.js
@@ -39,16 +39,16 @@ events.addObserver(obs);
 
 var ee = new events();
 
-assert.ok(ee._observers);
-assert.equal(ee._observers.length, 1);
-assert.equal(ee._observers[0], obs);
-assert.equal(ee._storage[obs.uid], obs.storage);
+assert.ok(ee.__observers);
+assert.equal(ee.__observers.length, 1);
+assert.equal(ee.__observers[0], obs);
+assert.equal(ee.__storage[obs.uid], obs.storage);
 
-var item = ee._observers[0];
+var item = ee.__observers[0];
 assert.equal(typeof item.create, 'function');
 assert.equal(item.flags, 1);
 assert.equal(item.storage, 'test storage');
-assert.equal(ee._storage[obs.uid], item.storage);
+assert.equal(ee.__storage[obs.uid], item.storage);
 
 
 // Check the observer is removed properly.
@@ -56,8 +56,8 @@ events.removeObserver(obs);
 
 var ee = new events();
 
-assert.ok(!ee._observers);
-assert.ok(!ee._storage);
+assert.ok(!ee.__observers);
+assert.ok(!ee.__storage);
 
 
 // Check the storage value can be overridden, and the observer
@@ -71,13 +71,13 @@ var obs = events.addObserver({
 
 var ee = new events();
 
-assert.ok(ee._observers);
-assert.equal(ee._observers.length, 1);
-assert.equal(ee._observers[0], obs);
-assert.equal(ee._storage[obs.uid], 'this works');
+assert.ok(ee.__observers);
+assert.equal(ee.__observers.length, 1);
+assert.equal(ee.__observers[0], obs);
+assert.equal(ee.__storage[obs.uid], 'this works');
 assert.ok(ee.testValue);
 
-var item = ee._observers[0];
+var item = ee.__observers[0];
 assert.equal(typeof item.create, 'function');
 assert.equal(item.flags, 1);
 assert.equal(item.storage, 'remove me');
@@ -88,8 +88,8 @@ events.addObserver(obs);
 
 var ee = new events();
 
-assert.ok(ee._observers);
-assert.equal(ee._observers.length, 1);
+assert.ok(ee.__observers);
+assert.equal(ee.__observers.length, 1);
 
 // Check the storage value isn't overridden if observer was
 // previously created.

--- a/test/simple/test-event-emitter-observer-create.js
+++ b/test/simple/test-event-emitter-observer-create.js
@@ -1,0 +1,100 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+// Check observers are created correctly.
+var obs = events.createObserver({
+  create: function(context, storage) {
+    assert.equal(storage, 'test storage');
+  }
+}, 'test storage');
+
+assert.equal(typeof obs.create, 'function');
+assert.equal(obs.flags, 1);
+assert.equal(obs.storage, 'test storage');
+assert.equal(typeof obs.uid, 'number');
+
+events.addObserver(obs);
+
+var ee = new events();
+
+assert.ok(ee._observers);
+assert.equal(ee._observers.length, 1);
+assert.equal(ee._observers[0], obs);
+assert.equal(ee._storage[obs.uid], obs.storage);
+
+var item = ee._observers[0];
+assert.equal(typeof item.create, 'function');
+assert.equal(item.flags, 1);
+assert.equal(item.storage, 'test storage');
+assert.equal(ee._storage[obs.uid], item.storage);
+
+
+// Check the observer is removed properly.
+events.removeObserver(obs);
+
+var ee = new events();
+
+assert.ok(!ee._observers);
+assert.ok(!ee._storage);
+
+
+// Check the storage value can be overridden, and the observer
+// is properly created on addObserver.
+var obs = events.addObserver({
+  create: function(context, storage) {
+    context.testValue = true;
+    return 'this works';
+  }
+}, 'remove me');
+
+var ee = new events();
+
+assert.ok(ee._observers);
+assert.equal(ee._observers.length, 1);
+assert.equal(ee._observers[0], obs);
+assert.equal(ee._storage[obs.uid], 'this works');
+assert.ok(ee.testValue);
+
+var item = ee._observers[0];
+assert.equal(typeof item.create, 'function');
+assert.equal(item.flags, 1);
+assert.equal(item.storage, 'remove me');
+
+
+// Check the same observer can only be added once.
+events.addObserver(obs);
+
+var ee = new events();
+
+assert.ok(ee._observers);
+assert.equal(ee._observers.length, 1);
+
+
+// Check the storage value isn't overridden if observer was
+// previously created.
+events.removeObserver(obs);
+events.addObserver(obs, 'not existent');
+
+assert.equal(obs.storage, 'remove me');

--- a/test/simple/test-event-emitter-observer-detach.js
+++ b/test/simple/test-event-emitter-observer-detach.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+// Check observer can be added after creation.
+var obs = events.createObserver({
+  create: function(context, storage) {
+    assert.equal(storage, 'test storage');
+  }
+}, 'test storage');
+
+var ee = new events();
+
+events.attachObserver(ee, obs);
+events.detachObserver(ee, obs);
+
+assert.ok(!ee._observers);
+assert.equal(ee._flags, 0);

--- a/test/simple/test-event-emitter-observer-detach.js
+++ b/test/simple/test-event-emitter-observer-detach.js
@@ -35,5 +35,5 @@ var ee = new events();
 events.attachObserver(ee, obs);
 events.detachObserver(ee, obs);
 
-assert.ok(!ee._observers);
-assert.equal(ee._flags, 0);
+assert.ok(!ee.__observers);
+assert.equal(ee.__flags, 0);

--- a/test/simple/test-observer-base.js
+++ b/test/simple/test-observer-base.js
@@ -1,0 +1,85 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+var ee, ee_created, observer, stor, err;
+var events = [];
+function empty() {
+  events.push('event');
+}
+var handlers = {
+  create: function(context, storage) {
+    ee_created = context;
+    assert.equal(storage, stor);
+    events.push('create');
+  },
+  before: function(context, storage) {
+    assert.equal(context, ee);
+    assert.equal(storage, stor);
+    events.push('before');
+  },
+  after: function(context, storage) {
+    assert.equal(context, ee);
+    assert.equal(storage, stor);
+    events.push('after');
+  },
+  error: function(context, storage, error) {
+    assert.equal(context, ee);
+    assert.equal(storage, stor);
+    assert.equal(error, err);
+    events.push('error');
+    return true;
+  },
+  add: function(context, storage) {
+    assert.equal(context, ee);
+    assert.equal(storage, stor);
+    events.push('add');
+  },
+  remove: function(context, storage) {
+    assert.equal(context, ee);
+    assert.equal(storage, stor);
+    events.push('remove');
+  }
+};
+
+stor = { tag: 'storage' };
+observer = EventEmitter.addObserver(handlers, stor);
+
+ee = new EventEmitter();
+assert.equal(ee_created, ee);
+
+ee.addListener('happy', empty);
+ee.emit('happy');
+ee.removeListener('happy', empty);
+ee.emit('error', err = new Error());
+
+assert.equal(events.shift(), 'create');
+assert.equal(events.shift(), 'add');
+assert.equal(events.shift(), 'before');
+assert.equal(events.shift(), 'event');
+assert.equal(events.shift(), 'after');
+assert.equal(events.shift(), 'remove');
+assert.equal(events.shift(), 'error');
+
+console.log('ok');

--- a/test/simple/test-observer-dynamic.js
+++ b/test/simple/test-observer-dynamic.js
@@ -1,0 +1,86 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+var handler_log, ee;
+
+var handlers = {
+  create: function() {
+    handler_log.push('create');
+  },
+  before: function() {
+    handler_log.push('before');
+  },
+  after: function() {
+    handler_log.push('after');
+  },
+  error: function() {
+    handler_log.push('error');
+  },
+  add: function() {
+    handler_log.push('add');
+  },
+  remove: function() {
+    handler_log.push('remove');
+  }
+};
+
+var observer = EventEmitter.addObserver(handlers);
+
+//
+// test detaching an observer mid-flight
+//
+handler_log = [];
+ee = new EventEmitter();
+ee.on('done', function() {
+  // this event should run without observers
+  handler_log.push('done');
+});
+
+ee.on('go', function() {
+  handler_log.push('go');
+  // no more observers should be called
+  EventEmitter.detachObserver(ee, observer);
+  ee.emit('done');
+});
+ee.emit('go');
+assert.equal(handler_log.pop(), 'done');
+assert.equal(handler_log.length, 5); // create, add, add, before, go
+
+//
+// test observer runs on pre-existing EEs after being removed globally
+//
+handler_log = [];
+ee = new EventEmitter();
+EventEmitter.removeObserver(handlers);
+ee.on('go', function() {
+  // the observers for this event should run, since the EE was defined
+  // while the observer was in play
+  handler_log.push('go');
+});
+ee.emit('go');
+assert.equal(handler_log.length, 5); // create, add, before, go, after
+
+// yay everything worked
+console.log('ok');

--- a/test/simple/test-observer-errors.js
+++ b/test/simple/test-observer-errors.js
@@ -1,0 +1,63 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+var handlers_catch_ok = false;
+var handlers_catch = {
+  error: function() {
+    handlers_catch_ok = true;
+
+    // stop the error even from throwing
+    return true;
+  }
+};
+
+var handlers_throw_ok = false;
+var handlers_throw = {
+  error: function() {
+    handlers_throw_ok = true;
+    // let the error event bubble
+    // and possibly throw
+  }
+};
+
+var ob_catch = EventEmitter.createObserver(handlers_catch);
+var ob_throw = EventEmitter.createObserver(handlers_throw);
+
+var ee_catch = new EventEmitter();
+var ee_throw = new EventEmitter();
+
+EventEmitter.attachObserver(ee_catch, ob_catch);
+EventEmitter.attachObserver(ee_throw, ob_throw);
+
+// this error event should now throw because the observer catches it
+ee_catch.emit('error');
+assert.equal(handlers_catch_ok, true);
+
+// the next error event should throw
+assert.throws(function() {
+  ee_throw.emit('error');
+});
+
+console.log('ok');

--- a/test/simple/test-observer-repeat.js
+++ b/test/simple/test-observer-repeat.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+console;
+
+var handlers1 = {
+  create: function () {
+    // this observer should be removed before its ever called
+    throw new Error();
+  }
+};
+
+var handlers2 = {
+  create: function () {
+    // this observer will stand the test of time
+    // it is the one who will bring balance to the force
+    console.log('ok');
+  }
+}
+
+var observer;
+
+observer = EventEmitter.addObserver(handlers1);
+EventEmitter.removeObserver(observer);
+
+observer = EventEmitter.addObserver(handlers2);
+
+new EventEmitter();

--- a/test/simple/test-observer-storage.js
+++ b/test/simple/test-observer-storage.js
@@ -1,0 +1,176 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+// the storage returned by 'create' should be passed to listener
+// instances when their observers are called
+(function() {
+  var storage  = { tag: 'default' };
+  var expected;
+
+  var handlers = {
+    create: function(emitter, _storage) {
+      // should receive the default observer storage here
+      assert.equal(storage, _storage);
+      return expected = {name: 'default'};
+    },
+
+    // should receive instance-specific storage for all these
+
+    before: function(emitter, _storage) {
+      assert.equal(expected, _storage);
+    },
+    after: function(emitter, _storage) {
+      assert.equal(expected, _storage);
+    },
+    error: function(emitter, _storage, error) {
+      assert.equal(expected, _storage);
+      return true;
+    },
+    add: function(emitter, _storage) {
+      assert.equal(expected, _storage);
+    },
+    remove: function(emitter, _storage) {
+      assert.equal(expected, _storage);
+    }
+  };
+
+  var observer = EventEmitter.addObserver(handlers, storage);
+
+  var ee, okay;
+  function empty() {
+    okay = true;
+  }
+
+  ee = new EventEmitter();
+  ee.addListener('happy', empty);
+  ee.emit('happy');
+  ee.removeListener('happy', empty);
+  ee.emit('error');
+
+  // instance storage should be different from the default storage
+  assert.notEqual(storage, expected);
+  assert(okay);
+
+  EventEmitter.removeObserver(observer);
+})();
+
+// the default storage should propagate through to the individual
+// event emitter instances when nothing is returned by 'create'
+(function() {
+  var storage  = {};
+
+  var handlers = {
+    create: function(emitter, _storage) {
+      // should receive the default observer storage here
+      assert.equal(storage, _storage);
+    },
+
+    // should receive default storage for all these
+
+    before: function(emitter, _storage) {
+      assert.equal(storage, _storage);
+    },
+    after: function(emitter, _storage) {
+      assert.equal(storage, _storage);
+    },
+    error: function(emitter, _storage, error) {
+      assert.equal(storage, _storage);
+      return true;
+    },
+    add: function(emitter, _storage) {
+      assert.equal(storage, _storage);
+    },
+    remove: function(emitter, _storage) {
+      assert.equal(storage, _storage);
+    }
+  };
+
+  var observer = EventEmitter.addObserver(handlers, storage);
+
+  var ee, okay;
+  function empty() {
+    okay = true;
+  }
+
+  ee = new EventEmitter();
+  ee.addListener('happy', empty);
+  ee.emit('happy');
+  ee.removeListener('happy', empty);
+  ee.emit('error');
+
+  EventEmitter.removeObserver(observer);
+
+  assert(okay);
+})();
+
+// test that multiple EE instances receive independent
+// storage objects when not using default storage
+(function() {
+  var storage  = { tag: 'default' };
+  var last;
+  var i = 0;
+
+  var handlers = {
+    create: function(emitter, _storage) {
+      return {
+        id: i++
+      }
+    },
+
+    // should receive instance-specific storage for all these
+
+    add: function(emitter, _storage) {
+      last = _storage;
+    },
+    error: function(emitter, _storage, error) {
+      last = _storage;
+      return true;
+    }
+  };
+
+  var observer = EventEmitter.addObserver(handlers, storage);
+
+  var e1, e2, okay, test;
+  function empty() { }
+
+  e1 = new EventEmitter();
+  e2 = new EventEmitter();
+
+  // each instance should receive a different storage
+  e1.addListener('happy', empty);
+  test = last;
+  e2.addListener('happy', empty);
+  assert.notStrictEqual(test, last);
+
+  // also check error case, because errors are weird
+  e1.emit('error');
+  test = last;
+  e2.emit('error');
+  assert.notStrictEqual(test, last);
+
+  EventEmitter.removeObserver(observer);
+})();
+
+console.log('ok');


### PR DESCRIPTION
This patch adds an API that is similar to AsyncListeners. It will allow users to add "observers" that will be called at key times in the EventEmitter's life cycle.
