### PR TITLE
events: don't call once twice

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -170,9 +170,15 @@ EventEmitter.prototype.once = function(type, listener) {
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');
 
+  var fired = false;
+
   function g() {
     this.removeListener(type, g);
-    listener.apply(this, arguments);
+
+    if (!fired) {
+      fired = true;
+      listener.apply(this, arguments);
+    }
   }
 
   g.listener = listener;

--- a/test/simple/test-event-emitter-once.js
+++ b/test/simple/test-event-emitter-once.js
@@ -47,3 +47,19 @@ process.on('exit', function() {
   assert.equal(1, times_hello_emited);
 });
 
+var times_recurse_emitted = 0;
+
+e.once('e', function() {
+	e.emit('e');
+	times_recurse_emitted++;
+});
+
+e.once('e', function() {
+	times_recurse_emitted++;
+});
+
+e.emit('e');
+
+process.on('exit', function() {
+  assert.equal(2, times_recurse_emitted);
+});


### PR DESCRIPTION
Emitting an event within a `EventEmitter#once` callback of the same event name will cause subsequent `EventEmitter#once` listeners of the same name to be called multiple times.

``` js
var events = require('events');
var emitter = new events.EventEmitter();

emitter.once('e', function () {
    emitter.emit('e');
    console.log(1);
});

emitter.once('e', function () {
    console.log(2);
});

emitter.emit('e');

// Output
// 2
// 1
// 2
```

This fixes the issue, only calling the listener method if it was not already called.

A real world example of this happening is at https://github.com/yeoman/generator/pull/402.
