### PR TITLE
events: type check setMaxListeners, n must be a positive integer

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -45,9 +45,10 @@ exports.EventEmitter = EventEmitter;
 // that to be increased. Set to zero for unlimited.
 var defaultMaxListeners = 10;
 EventEmitter.prototype.setMaxListeners = function(n) {
-  if (typeof n !== 'number' || n < 0)
-    throw TypeError('n must be a positive number');
-  this._maxListeners = n;
+  if (parseInt(n) > 0)
+    this._maxListeners = n;
+  else
+    throw TypeError('n must be a positive integer');
 };
 
 EventEmitter.prototype.emit = function(type) {


### PR DESCRIPTION
You may check this issue before: https://github.com/joyent/node/commit/dd171d24df4fd6361e7db11dc7b6fd15e68934ab

`setMaxListeners` will now make sure a positive `integer` is passed and reduce a logic operator. Also
throwing more definitive Error types.
