### PR TITLE
fix(zlib) add check is callback is function

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -185,13 +185,18 @@ function zlibBuffer(engine, buffer, callback) {
   function onError(err) {
     engine.removeListener('end', onEnd);
     engine.removeListener('readable', flow);
-    callback(err);
+    if (util.isFunction(callback)) {
+      callback(err);
+    }
   }
 
   function onEnd() {
     var buf = Buffer.concat(buffers, nread);
     buffers = [];
-    callback(null, buf);
+    if (util.isFunction(callback)) {
+      callback(null, buf);
+    }
+    
     engine.close();
   }
 }


### PR DESCRIPTION
Add check is callback is function to prevent next error.

``` js
zlib.js:160
    callback(err);
    ^
TypeError: undefined is not a function
    at Unzip.onError (zlib.js:160:5)
    at Unzip.EventEmitter.emit (events.js:95:17)
    at Zlib._binding.onerror (zlib.js:298:10)
```

I have one suggestion. Could be used construction like this:

``` js
function exec (callback, params) {
    if (util.isFunction(callback))
       callback(params);
}
```

Like it's done [here](https://github.com/coderaiser/util.io/blob/9370aad67e5bd79a4588bdf209c326a1687d071a/lib/util.js#L851). So there is would be less code.
