### PR TITLE
stream: fix never close when a last chunk is empty

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -292,7 +292,7 @@ function onwrite(stream, er) {
     // Check if we're actually ready to finish, but don't emit yet
     var finished = needFinish(stream, state);
 
-    if (!finished &&
+    if (!(finished && state.pendingcb === 0) &&
         !state.corked &&
         !state.bufferProcessing &&
         state.buffer.length) {

--- a/test/simple/test-fs-write-stream-end.js
+++ b/test/simple/test-fs-write-stream-end.js
@@ -40,3 +40,15 @@ var fs = require('fs');
     assert.equal(content, 'a\n');
   }));
 })();
+
+(function() {
+  var file = path.join(common.tmpDir, 'write-end-test2.txt');
+  var stream = fs.createWriteStream(file);
+  stream.on('close', common.mustCall(function() {
+    var content = fs.readFileSync(file, 'utf8');
+    assert.equal(content, 'ab\n');
+  }));
+  stream.write('ab\n', 'utf8');
+  stream.write('', 'utf8');
+  stream.end();
+})();


### PR DESCRIPTION
In the following cases, Stream never finish.

```
var ws = fs.createWriteStream('/path/to/file');
ws.on('finish', function() {});
ws.write('abcd', 'utf8');
ws.write('', 'utf8');
ws.end();
```
