### PR TITLE
dgram: fix abort when getting `fd` of closed dgram

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -144,7 +144,7 @@ Handle<Value> UDPWrap::GetFD(Local<String>, const AccessorInfo& args) {
   return v8::Null();
 #else
   HandleScope scope;
-  UNWRAP(UDPWrap)
+  UNWRAP_NO_ABORT(UDPWrap)
   int fd = (wrap == NULL) ? -1 : wrap->handle_.io_watcher.fd;
   return scope.Close(Integer::New(fd));
 #endif

--- a/test/simple/test-dgram-close.js
+++ b/test/simple/test-dgram-close.js
@@ -30,5 +30,14 @@ var buf = new Buffer(1024);
 buf.fill(42);
 
 var socket = dgram.createSocket('udp4');
+var handle = socket._handle;
 socket.send(buf, 0, buf.length, common.PORT, 'localhost');
 socket.close();
+socket = null;
+
+// Verify that accessing handle after closure doesn't throw
+setImmediate(function() {
+  setImmediate(function() {
+    console.log('Handle fd is: ', handle.fd);
+  });
+});


### PR DESCRIPTION
v8's `messages.js` file's `CallSiteGetMethodName` is running through all
object properties and getter to figure out method name of function that
appears in stack trace. This run-through will also read `fd` property of
`UDPWrap` instance's javascript object, making `UNWRAP()` fail.

As a simple alternative to the test case above, one could just keep
reference to the dgram handle and try accessing `handle.fd` after it has
been fully closed.

fix #6536

(@indutny Don't forget to merge this in master after landing in v0.10).
