### PR TITLE
node: fix removing `AsyncListener` in callback

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -341,7 +341,7 @@
       var item, before, i;
 
       asyncStack.push(asyncQueue);
-      asyncQueue = queue;
+      asyncQueue = queue.slice();
       // Since the async listener callback is required, the number of
       // objects in the asyncQueue implies the number of async listeners
       // there are to be processed.
@@ -363,12 +363,13 @@
     // Unload one level of the async stack. Returns true if there are
     // still listeners somewhere in the stack.
     function unloadAsyncQueue(context) {
+      var queue = context._asyncQueue;
       var item, after, i;
 
       // Run "after" callbacks.
       inAsyncTick = true;
-      for (i = 0; i < asyncQueue.length; i++) {
-        item = asyncQueue[i];
+      for (i = 0; i < queue.length; i++) {
+        item = queue[i];
         if (!item.callbacks)
           continue;
         after = item.callbacks.after;

--- a/test/simple/test-asynclistener-remove-add-in-before.js
+++ b/test/simple/test-asynclistener-remove-add-in-before.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var val;
+var callbacks = {
+  before: function() {
+    process.removeAsyncListener(listener);
+    process.addAsyncListener(listener);
+  },
+  after : function(context, storage) {
+    val = storage;
+  }
+};
+
+var listener = process.addAsyncListener(function(){
+  return 66;
+}, callbacks);
+
+process.nextTick(function () {});
+
+process.on('exit', function () {
+  assert.equal(val, 66);
+});

--- a/test/simple/test-asynclistener-remove-in-before.js
+++ b/test/simple/test-asynclistener-remove-in-before.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var done = false;
+var callbacks = {
+  before: function() {
+    process.removeAsyncListener(listener);
+  },
+  after : function() {
+    done = true;
+  }
+};
+
+var listener = process.addAsyncListener(function(){}, callbacks);
+
+process.nextTick(function () {});
+
+process.on('exit', function () {
+  assert.ok(done);
+});


### PR DESCRIPTION
Currently removing `AsyncListener` inside `before` callback (or original event callback itself) prevents `after` callback from firing. Re-adding listener makes it fire, but `storageValue` is `undefined`.

This also makes example from docs incorrect: 

``` javascript
 {
  before: function onBefore(context, storage) {
    // Need to remove the listener while logging or will end up
    // with an infinite call loop.
    process.removeAsyncListener(key);
    console.log('uid: %s is about to run', storage.uid);
    process.addAsyncListener(key);
  },
  after: function onAfter(context, storage) {
    process.removeAsyncListener(key);
    console.log('uid: %s is about to run', storage.uid);
    process.addAsyncListener(key);
  }
}
```

In this example `after` is never called because of an error in callback, but if you remove it the code will crash with `TypeError: Cannot read property 'uid' of undefined`.
