### PR TITLE
crypto: support custom pbkdf2 digest methods

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -446,13 +446,25 @@ Example (obtaining a shared secret):
     /* alice_secret and bob_secret should be the same */
     console.log(alice_secret == bob_secret);
 
-## crypto.pbkdf2(password, salt, iterations, keylen, callback)
+## crypto.pbkdf2(password, salt, iterations, keylen, [digest], callback)
 
-Asynchronous PBKDF2 applies pseudorandom function HMAC-SHA1 to derive
-a key of given length from the given password, salt and iterations.
-The callback gets two arguments `(err, derivedKey)`.
+Asynchronous PBKDF2 function.  Applies the selected HMAC digest function
+(default: SHA1) to derive a key of the requested length from the password,
+salt and number of iterations.  The callback gets two arguments:
+`(err, derivedKey)`.
 
-## crypto.pbkdf2Sync(password, salt, iterations, keylen)
+Example:
+
+    crypto.pbkdf2('secret', 'salt', 4096, 512, 'sha256', function(err, key) {
+      if (err)
+        throw err;
+      console.log(key.toString('hex'));  // 'c5e478d...1469e50'
+    });
+
+You can get a list of supported digest functions with
+[crypto.getHashes()](#crypto_crypto_gethashes).
+
+## crypto.pbkdf2Sync(password, salt, iterations, keylen, [digest])
 
 Synchronous PBKDF2 function.  Returns derivedKey or throws error.
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -626,25 +626,5 @@ exports.pseudoRandomBytes = pseudoRandomBytes;
 exports.rng = randomBytes;
 exports.prng = pseudoRandomBytes;
 
-
-exports.getCiphers = function() {
-  return filterDuplicates(getCiphers.call(null, arguments));
-};
-
-
-exports.getHashes = function() {
-  return filterDuplicates(getHashes.call(null, arguments));
-
-};
-
-
-function filterDuplicates(names) {
-  // Drop all-caps names in favor of their lowercase aliases,
-  // for example, 'sha1' instead of 'SHA1'.
-  var ctx = {};
-  names.forEach(function(name) {
-    if (/^[0-9A-Z\-]+$/.test(name)) name = name.toLowerCase();
-    ctx[name] = true;
-  });
-  return Object.getOwnPropertyNames(ctx).sort();
-}
+exports.getCiphers = getCiphers;
+exports.getHashes = getHashes;

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -545,36 +545,51 @@ DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
 
 
 
-exports.pbkdf2 = function(password, salt, iterations, keylen, callback) {
+exports.pbkdf2 = function(password,
+                          salt,
+                          iterations,
+                          keylen,
+                          digest,
+                          callback) {
+  if (util.isFunction(digest)) {
+    callback = digest;
+    digest = undefined;
+  }
+
   if (!util.isFunction(callback))
     throw new Error('No callback provided to pbkdf2');
 
-  return pbkdf2(password, salt, iterations, keylen, callback);
+  return pbkdf2(password, salt, iterations, keylen, digest, callback);
 };
 
 
-exports.pbkdf2Sync = function(password, salt, iterations, keylen) {
-  return pbkdf2(password, salt, iterations, keylen);
+exports.pbkdf2Sync = function(password, salt, iterations, keylen, digest) {
+  return pbkdf2(password, salt, iterations, keylen, digest);
 };
 
 
-function pbkdf2(password, salt, iterations, keylen, callback) {
+function pbkdf2(password, salt, iterations, keylen, digest, callback) {
   password = toBuf(password);
   salt = toBuf(salt);
 
   if (exports.DEFAULT_ENCODING === 'buffer')
-    return binding.PBKDF2(password, salt, iterations, keylen, callback);
+    return binding.PBKDF2(password, salt, iterations, keylen, digest, callback);
 
   // at this point, we need to handle encodings.
   var encoding = exports.DEFAULT_ENCODING;
   if (callback) {
-    binding.PBKDF2(password, salt, iterations, keylen, function(er, ret) {
+    binding.PBKDF2(password,
+                   salt,
+                   iterations,
+                   keylen,
+                   digest,
+                   function(er, ret) {
       if (ret)
         ret = ret.toString(encoding);
       callback(er, ret);
     });
   } else {
-    var ret = binding.PBKDF2(password, salt, iterations, keylen);
+    var ret = binding.PBKDF2(password, salt, iterations, keylen, digest);
     return ret.toString(encoding);
   }
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3325,6 +3325,7 @@ class PBKDF2Request : public AsyncWrap {
  public:
   PBKDF2Request(Environment* env,
                 Local<Object> object,
+                const EVP_MD* digest,
                 ssize_t passlen,
                 char* pass,
                 ssize_t saltlen,
@@ -3332,6 +3333,7 @@ class PBKDF2Request : public AsyncWrap {
                 ssize_t iter,
                 ssize_t keylen)
       : AsyncWrap(env, object),
+        digest_(digest),
         error_(0),
         passlen_(passlen),
         pass_(pass),
@@ -3350,6 +3352,10 @@ class PBKDF2Request : public AsyncWrap {
 
   uv_work_t* work_req() {
     return &work_req_;
+  }
+
+  inline const EVP_MD* digest() const {
+    return digest_;
   }
 
   inline ssize_t passlen() const {
@@ -3401,6 +3407,7 @@ class PBKDF2Request : public AsyncWrap {
   uv_work_t work_req_;
 
  private:
+  const EVP_MD* digest_;
   int error_;
   ssize_t passlen_;
   char* pass_;
@@ -3413,12 +3420,13 @@ class PBKDF2Request : public AsyncWrap {
 
 
 void EIO_PBKDF2(PBKDF2Request* req) {
-  req->set_error(PKCS5_PBKDF2_HMAC_SHA1(
+  req->set_error(PKCS5_PBKDF2_HMAC(
     req->pass(),
     req->passlen(),
     reinterpret_cast<unsigned char*>(req->salt()),
     req->saltlen(),
     req->iter(),
+    req->digest(),
     req->keylen(),
     reinterpret_cast<unsigned char*>(req->key())));
   memset(req->pass(), 0, req->passlen());
@@ -3463,6 +3471,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
+  const EVP_MD* digest = NULL;
   const char* type_error = NULL;
   char* pass = NULL;
   char* salt = NULL;
@@ -3475,7 +3484,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   PBKDF2Request* req = NULL;
   Local<Object> obj;
 
-  if (args.Length() != 4 && args.Length() != 5) {
+  if (args.Length() != 5 && args.Length() != 6) {
     type_error = "Bad parameter";
     goto err;
   }
@@ -3530,11 +3539,32 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
     goto err;
   }
 
-  obj = Object::New();
-  req = new PBKDF2Request(env, obj, passlen, pass, saltlen, salt, iter, keylen);
+  if (args[4]->IsString()) {
+    String::Utf8Value digest_name(args[4]);
+    digest = EVP_get_digestbyname(*digest_name);
+    if (digest == NULL) {
+      type_error = "Bad digest name";
+      goto err;
+    }
+  }
 
-  if (args[4]->IsFunction()) {
-    obj->Set(env->ondone_string(), args[4]);
+  if (digest == NULL) {
+    digest = EVP_sha1();
+  }
+
+  obj = Object::New();
+  req = new PBKDF2Request(env,
+                          obj,
+                          digest,
+                          passlen,
+                          pass,
+                          saltlen,
+                          salt,
+                          iter,
+                          keylen);
+
+  if (args[5]->IsFunction()) {
+    obj->Set(env->ondone_string(), args[5]);
     uv_queue_work(env->event_loop(),
                   req->work_req(),
                   EIO_PBKDF2,

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -912,6 +912,19 @@ testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
            '\x56\xfa\x6a\xa7\x55\x48\x09\x9d\xcc\x37\xd7\xf0\x34' +
            '\x25\xe0\xc3');
 
+(function() {
+  var expected =
+      '64c486c55d30d4c5a079b8823b7d7cb37ff0556f537da8410233bcec330ed956';
+  var key = crypto.pbkdf2Sync('password', 'salt', 32, 32, 'sha256');
+  assert.equal(key.toString('hex'), expected);
+
+  crypto.pbkdf2('password', 'salt', 32, 32, 'sha256', common.mustCall(ondone));
+  function ondone(err, key) {
+    if (err) throw err;
+    assert.equal(key.toString('hex'), expected);
+  }
+})();
+
 function assertSorted(list) {
   assert.deepEqual(list, list.sort());
 }

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -24,6 +24,7 @@
 
 var common = require('../common');
 var assert = require('assert');
+var util = require('util');
 
 try {
   var crypto = require('crypto');
@@ -926,7 +927,9 @@ testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
 })();
 
 function assertSorted(list) {
-  assert.deepEqual(list, list.sort());
+  // Array#sort() modifies the list in place so make a copy.
+  var sorted = util._extend([], list).sort();
+  assert.deepEqual(list, sorted);
 }
 
 // Assume that we have at least AES-128-CBC.

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -932,7 +932,7 @@ function assertSorted(list) {
 // Assume that we have at least AES-128-CBC.
 assert.notEqual(0, crypto.getCiphers().length);
 assert.notEqual(-1, crypto.getCiphers().indexOf('aes-128-cbc'));
-assert.equal(-1, crypto.getCiphers().indexOf('AES-128-CBC'));
+assert.notEqual(-1, crypto.getCiphers().indexOf('AES-128-CBC'));
 assertSorted(crypto.getCiphers());
 
 // Assume that we have at least AES256-SHA.
@@ -942,12 +942,11 @@ assert.notEqual(-1, tls.getCiphers().indexOf('aes256-sha'));
 assert.equal(-1, tls.getCiphers().indexOf('AES256-SHA'));
 assertSorted(tls.getCiphers());
 
-// Assert that we have sha and sha1 but not SHA and SHA1.
 assert.notEqual(0, crypto.getHashes().length);
-assert.notEqual(-1, crypto.getHashes().indexOf('sha1'));
+assert.notEqual(-1, crypto.getHashes().indexOf('SHA'));
 assert.notEqual(-1, crypto.getHashes().indexOf('sha'));
-assert.equal(-1, crypto.getHashes().indexOf('SHA1'));
-assert.equal(-1, crypto.getHashes().indexOf('SHA'));
+assert.notEqual(-1, crypto.getHashes().indexOf('DSA'));
+assert.equal(-1, crypto.getHashes().indexOf('dsa'));  // No lowercase variant.
 assertSorted(crypto.getHashes());
 
 // Base64 padding regression test, see #4837.


### PR DESCRIPTION
Make the HMAC digest method configurable.  Update crypto.pbkdf2() and
crypto.pbkdf2Sync() to take an extra, optional digest argument.

Before this commit, SHA-1 (admittedly the most common method) was used
exclusively.

Fixes #6553.

Suggested reviewer: @indutny

While going over the code I realized that crypto.getHashes() indiscriminately removes uppercase spellings of cipher/digest names.  That's problematic because some (like DSA) don't have lowercase aliases.

I've added two proposed solutions: one removes the filtering entirely, the other tries various spellings of ciphers/digests.  Comments welcome.
