### PR TITLE
doc: clarify child_process error behaviour

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -36,6 +36,10 @@ Emitted when:
 2. The process could not be killed, or
 3. Sending a message to the child process failed for whatever reason.
 
+Note that after this event has been fired the child process is considered dead
+and no more events will triggered. E.g. if an error occurs the `exit`-event
+will not be triggered.
+
 See also [`ChildProcess#kill()`](#child_process_child_kill_signal) and
 [`ChildProcess#send()`](#child_process_child_send_message_sendhandle).
 


### PR DESCRIPTION
Hi,

I was wondering whether or not the `exit` event would still be triggered after an `error` event on a child-process. Since I couldn't find this information in the documentation I wrote some tests in the node console and arrived in the conclusion that no more events will be triggered at all.

I still would like this to be in the documentation because 1) it's easier to find there and 2) since that behaviour otherwise would be undocumented I think that it would be bad practice relying on it.

The use case I had, which I think should be fairly common, is having a function that takes a callback and spawns a child process. E.g.

``` javascript
function cp(src, dest, cb) {
  var child = spawn('cp', [src, dest], { stdio: 'ignore' });
  child.on('exit', function (code) {
    if (code === 0) {
      cb(null);
    } else {
      cb(new Error('Unknown exit code'));
    }
  });
}
```

Now, the problem with this code is that it will throw an unhandled exception if `cp` can't be found in the path. Naturally  one would fix this with the following line:

``` javascript
  child.on('error', cb);
```

Everything is good, except that if the behaviour would change in the future (remember, it isn't specified anywhere) and the `exit` event would still be triggered after the `error` event, the callback would be called twice. Not good.

I hope that I managed to explain the problem and please comment with any questions, I will try and respond asap. Thanks for your time!
