### PR TITLE
build: add libicu i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Unix/Macintosh:
     make
     make install
 
+With libicu i18n support:
+
+    svn checkout --force --revision 214189 \
+        http://src.chromium.org/svn/trunk/deps/third_party/icu46 \
+        deps/v8/third_party/icu46
+    ./configure --with-icu-path=deps/v8/third_party/icu46
+    make
+    make install
+
 If your python binary is in a non-standard location or has a
 non-standard name, run the following instead:
 

--- a/common.gypi
+++ b/common.gypi
@@ -14,8 +14,10 @@
     # Enable V8's post-mortem debugging only on unix flavors.
     'conditions': [
       ['OS == "win"', {
+        'os_posix': 0,
         'v8_postmortem_support': 'false'
       }, {
+        'os_posix': 1,
         'v8_postmortem_support': 'true'
       }]
     ],

--- a/configure
+++ b/configure
@@ -220,6 +220,11 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
+parser.add_option('--with-icu-path',
+    action='store',
+    dest='with_icu_path',
+    help='Path to icu.gyp (ICU i18n, Chromium version only.)')
+
 parser.add_option('--with-perfctr',
     action='store_true',
     dest='with_perfctr',
@@ -564,7 +569,6 @@ def configure_libuv(o):
 def configure_v8(o):
   o['variables']['node_shared_v8'] = b(options.shared_v8)
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
-  o['variables']['v8_enable_i18n_support'] = 0  # Don't require libicu.
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
@@ -627,6 +631,13 @@ def configure_winsdk(o):
         'from tools/msvs/genfiles.')
 
 
+def configure_icu(o):
+  have_icu_path = bool(options.with_icu_path)
+  o['variables']['v8_enable_i18n_support'] = int(have_icu_path)
+  if have_icu_path:
+    o['variables']['icu_gyp_path'] = options.with_icu_path
+
+
 # determine the "flavor" (operating system) we're building for,
 # leveraging gyp's GetFlavor function
 flavor_params = {}
@@ -650,7 +661,7 @@ configure_libuv(output)
 configure_v8(output)
 configure_openssl(output)
 configure_winsdk(output)
-
+configure_icu(output)
 
 # variables should be a root level element,
 # move everything else to target_defaults


### PR DESCRIPTION
Adds a --with-icu-path= switch to the configure script.  Requires that the user
checks out the copy of libicu that's bundled with chromium to a fixed directory.
It's still a little rough around the edges but it works.

Fixes #6371.

Suggested reviewers: @tjfontaine @trevnorris
