### PR TITLE
node: allow nextTick infinite recursion

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -603,6 +603,8 @@
         }
         if (hasQueue)
           _unloadAsyncQueue(tock);
+        if (1e4 < tickInfo[kIndex])
+          tickDone();
       }
 
       tickDone();

--- a/test/pummel/test-next-tick-infinite-calls.js
+++ b/test/pummel/test-next-tick-infinite-calls.js
@@ -1,0 +1,37 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var complete = 0;
+
+// This will fail with:
+//  FATAL ERROR: JS Allocation failed - process out of memory
+// if the depth counter doesn't clear the nextTickQueue properly.
+(function runner() {
+  if (1e8 > ++complete)
+    process.nextTick(runner);
+}());
+
+setImmediate(function() {
+  console.log('ok');
+});


### PR DESCRIPTION
Removing the depth counter while processing the nextTickQueue made it
possible to run out of memory if in an infinite recursive loop using
nextTick(). There was also an edge case where too many callbacks were
pushed onto the nextTickQueue, while not actually being recursive.

This is being done to prevent possible cryptic FATAL ERROR messages from
popping up, and issues being posted about them.
