### PR TITLE
http client: DELETE method should not use chunked encoding by default

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -87,7 +87,8 @@ function ClientRequest(options, cb) {
                    new Buffer(options.auth).toString('base64'));
   }
 
-  if (method === 'GET' || method === 'HEAD' || method === 'CONNECT') {
+  if (method === 'GET' || method === 'HEAD' ||
+      method === 'DELETE' || method === 'CONNECT') {
     self.useChunkedEncodingByDefault = false;
   } else {
     self.useChunkedEncodingByDefault = true;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -87,8 +87,10 @@ function ClientRequest(options, cb) {
                    new Buffer(options.auth).toString('base64'));
   }
 
-  if (method === 'GET' || method === 'HEAD' ||
-      method === 'DELETE' || method === 'CONNECT') {
+  if (method === 'GET' ||
+      method === 'HEAD' ||
+      method === 'DELETE' ||
+      method === 'CONNECT') {
     self.useChunkedEncodingByDefault = false;
   } else {
     self.useChunkedEncodingByDefault = true;

--- a/test/simple/test-http-client-default-headers-exist.js
+++ b/test/simple/test-http-client-default-headers-exist.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var expectedHeaders = {
+  'DELETE': ['host', 'connection'],
+  'GET': ['host', 'connection'],
+  'HEAD': ['host', 'connection'],
+  'POST': ['host', 'connection', 'transfer-encoding'],
+  'PUT': ['host', 'connection', 'transfer-encoding']
+};
+
+var requestCount = 0;
+
+var server = http.createServer(function(req, res) {
+  requestCount++;
+  res.end();
+
+  assert((req.method in expectedHeaders),
+         req.method + ' was an unexpected method');
+
+  Object.keys(req.headers).forEach(function(header) {
+    assert((expectedHeaders[req.method].indexOf(header.toLowerCase()) >= 0),
+           header + ' shoud not exist for method ' + req.method);
+  });
+
+  if (Object.keys(expectedHeaders).length === requestCount)
+    server.close();
+});
+
+server.listen(common.PORT, function() {
+  Object.keys(expectedHeaders).forEach(function(method) {
+    http.request({
+      method: method,
+      port: common.PORT
+    }).end();
+  });
+});

--- a/test/simple/test-http-client-default-headers-exist.js
+++ b/test/simple/test-http-client-default-headers-exist.js
@@ -39,16 +39,16 @@ var server = http.createServer(function(req, res) {
   requestCount++;
   res.end();
 
-  assert((req.method in expectedHeaders),
+  assert(expectedHeaders.hasOwnProperty(req.method),
          req.method + ' was an unexpected method');
 
   var requestHeaders = Object.keys(req.headers);
   requestHeaders.forEach(function(header) {
-    assert((expectedHeaders[req.method].indexOf(header.toLowerCase()) !== -1),
+    assert(expectedHeaders[req.method].indexOf(header.toLowerCase()) !== -1,
            header + ' shoud not exist for method ' + req.method);
   });
 
-  assert((requestHeaders.length === expectedHeaders[req.method].length),
+  assert(requestHeaders.length === expectedHeaders[req.method].length,
          'some headers were missing for method: ' + req.method);
 
   if (expectedMethods.length === requestCount)

--- a/test/simple/test-http-client-default-headers-exist.js
+++ b/test/simple/test-http-client-default-headers-exist.js
@@ -31,6 +31,8 @@ var expectedHeaders = {
   'PUT': ['host', 'connection', 'transfer-encoding']
 };
 
+var expectedMethods = Object.keys(expectedHeaders);
+
 var requestCount = 0;
 
 var server = http.createServer(function(req, res) {
@@ -40,23 +42,21 @@ var server = http.createServer(function(req, res) {
   assert((req.method in expectedHeaders),
          req.method + ' was an unexpected method');
 
-
-  var validHeadersSeen = Object.keys(req.headers).reduce(function(arr, header) {
+  var requestHeaders = Object.keys(req.headers);
+  requestHeaders.forEach(function(header) {
     assert((expectedHeaders[req.method].indexOf(header.toLowerCase()) !== -1),
-           header + ' should not exist for method ' + req.method);
-    arr.push(header);
-    return arr;
-  }, []);
+           header + ' shoud not exist for method ' + req.method);
+  });
 
-  assert((validHeadersSeen.length === expectedHeaders[req.method].length),
+  assert((requestHeaders.length === expectedHeaders[req.method].length),
          'some headers were missing for method: ' + req.method);
 
-  if (Object.keys(expectedHeaders).length === requestCount)
+  if (expectedMethods.length === requestCount)
     server.close();
 });
 
 server.listen(common.PORT, function() {
-  Object.keys(expectedHeaders).forEach(function(method) {
+  expectedMethods.forEach(function(method) {
     http.request({
       method: method,
       port: common.PORT

--- a/test/simple/test-http-client-default-headers-exist.js
+++ b/test/simple/test-http-client-default-headers-exist.js
@@ -40,10 +40,16 @@ var server = http.createServer(function(req, res) {
   assert((req.method in expectedHeaders),
          req.method + ' was an unexpected method');
 
-  Object.keys(req.headers).forEach(function(header) {
-    assert((expectedHeaders[req.method].indexOf(header.toLowerCase()) >= 0),
-           header + ' shoud not exist for method ' + req.method);
-  });
+
+  var validHeadersSeen = Object.keys(req.headers).reduce(function(arr, header) {
+    assert((expectedHeaders[req.method].indexOf(header.toLowerCase()) !== -1),
+           header + ' should not exist for method ' + req.method);
+    arr.push(header);
+    return arr;
+  }, []);
+
+  assert((validHeadersSeen.length === expectedHeaders[req.method].length),
+         'some headers were missing for method: ' + req.method);
 
   if (Object.keys(expectedHeaders).length === requestCount)
     server.close();


### PR DESCRIPTION
this addresses #6185

According to RFC-2616 http://tools.ietf.org/html/rfc2616

Section 14.41 (Transfer-Encoding) states:

>   The Transfer-Encoding general-header field indicates what (if any) type of transformation has been applied to the message body in order to safely transfer it between the sender and the recipient. This differs from the content-coding in that the transfer-coding is a property of the message, not of the entity.

Section 4.3 (Message Body) states:

>   The presence of a message-body in a request is signaled by the inclusion of a Content-Length or Transfer-Encoding header field in the request's message-headers. A message-body MUST NOT be included in a request if the specification of the request method (section 5.1.1) does not allow sending an entity-body in requests. A server SHOULD read and forward a message-body on any request; if the request method does not include defined semantics for an entity-body, then the message-body SHOULD be ignored when handling the request.

Since a message body is permissible for the DELETE method, deciding whether the `transfer-encoding` header should be set by default comes down to general usage and acceptance. Since DELETE requests generally do not have a message body this header should not be added by default. This remains consistent with the docs:

> request.write(chunk, [encoding])
> Sends a chunk of the body. By calling this method many times, the user can stream a request body to a server--in that case it is suggested to use the ['Transfer-Encoding', 'chunked'] header line when creating the request.
