### PR TITLE
events: fix TypeError in removeAllListeners

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -270,7 +270,7 @@ EventEmitter.prototype.removeAllListeners = function(type) {
 
   if (util.isFunction(listeners)) {
     this.removeListener(type, listeners);
-  } else {
+  } else if (util.isArray(listeners)) {
     // LIFO order
     while (listeners.length)
       this.removeListener(type, listeners[listeners.length - 1]);

--- a/test/simple/test-event-emitter-remove-all-listeners.js
+++ b/test/simple/test-event-emitter-remove-all-listeners.js
@@ -71,3 +71,10 @@ e2.removeAllListeners();
 console.error(e2);
 assert.deepEqual([], e2.listeners('foo'));
 assert.deepEqual([], e2.listeners('bar'));
+
+var e3 = new events.EventEmitter();
+e3.on('removeListener', listener);
+// check for regression where removeAllListeners throws when
+// there exists a removeListener listener, but there exists
+// no listeners for the provided event type
+assert.doesNotThrow(e3.removeAllListeners.bind(e3, 'foo'));


### PR DESCRIPTION
In the (very specific) situation in which an `EventEmitter` has a listener for the `removeListener` event, _and_ `removeAllListeners()` is called using an event type that doesn't exist, `removeAllListeners()` currently throws a TypeError on `listeners.length` (as `listeners` is undefined).
