### PR TITLE
tls: reset NPN callbacks after SNI

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -190,6 +190,8 @@ class Connection : ObjectWrap {
   static v8::Handle<v8::Value> Start(const v8::Arguments& args);
   static v8::Handle<v8::Value> Close(const v8::Arguments& args);
 
+  static void InitNPN(SecureContext* sc, bool is_server);
+
 #ifdef OPENSSL_NPN_NEGOTIATED
   // NPN
   static v8::Handle<v8::Value> GetNegotiatedProto(const v8::Arguments& args);

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -28,7 +28,8 @@ if (!process.features.tls_npn) {
 var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),
-    tls = require('tls');
+    tls = require('tls'),
+    crypto = require('crypto');
 
 function filenamePEM(n) {
   return require('path').join(common.fixturesDir, 'keys', n + '.pem');
@@ -42,6 +43,13 @@ var serverOptions = {
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   crl: loadPEM('ca2-crl'),
+  SNICallback: function() {
+    return crypto.createCredentials({
+      key: loadPEM('agent2-key'),
+      cert: loadPEM('agent2-cert'),
+      crl: loadPEM('ca2-crl'),
+    }).context;
+  },
   NPNProtocols: ['a', 'b', 'c']
 };
 


### PR DESCRIPTION
SNI callback selects new SSL_CTX for the connection, which don't have
NPN callbacks setted up on it.

/cc @bnoordhuis
