### PR TITLE
UnitTests: fix broken unit tests on Windows

### DIFF
--- a/test/simple/test-child-process-double-pipe.js
+++ b/test/simple/test-child-process-double-pipe.js
@@ -23,6 +23,7 @@ var is_windows = process.platform === 'win32';
 
 var common = require('../common');
 var assert = require('assert'),
+    os = require('os'),
     util = require('util'),
     spawn = require('child_process').spawn;
 
@@ -113,5 +114,5 @@ sed.stdout.on('data', function(data) {
 });
 
 sed.stdout.on('end', function(code) {
-  assert.equal(result, 'hellO\nnOde\nwOrld\n');
+  assert.equal(result, 'hellO' + os.EOL + 'nOde' + os.EOL  +'wOrld' + os.EOL);
 });

--- a/test/simple/test-child-process-exec-buffer.js
+++ b/test/simple/test-child-process-exec-buffer.js
@@ -22,6 +22,7 @@
 require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
+var os = require('os');
 
 var success_count = 0;
 
@@ -31,7 +32,7 @@ var str = 'hello';
 var child = exec("echo " + str, function(err, stdout, stderr) {
   assert.ok('string', typeof(stdout), 'Expected stdout to be a string');
   assert.ok('string', typeof(stderr), 'Expected stderr to be a string');
-  assert.equal(str + '\n', stdout);
+  assert.equal(str + os.EOL, stdout);
 
   success_count++;
 });
@@ -42,7 +43,7 @@ var child = exec("echo " + str, {
 }, function(err, stdout, stderr) {
   assert.ok(stdout instanceof Buffer, 'Expected stdout to be a Buffer');
   assert.ok(stderr instanceof Buffer, 'Expected stderr to be a Buffer');
-  assert.equal(str + '\n', stdout.toString());
+  assert.equal(str + os.EOL, stdout.toString());
 
   success_count++;
 });

--- a/test/simple/test-process-raw-debug.js
+++ b/test/simple/test-process-raw-debug.js
@@ -21,6 +21,7 @@
 
 var common = require('../common');
 var assert = require('assert');
+var os = require('os');
 
 switch (process.argv[2]) {
   case 'child':
@@ -44,7 +45,7 @@ function parent() {
   child.stderr.setEncoding('utf8');
 
   child.stderr.on('end', function() {
-    assert.equal(output, 'I can still debug!\n');
+    assert.equal(output, 'I can still debug!' + os.EOL);
     console.log('ok - got expected message');
   });
 


### PR DESCRIPTION
```
modified:   test/simple/test-child-process-double-pipe.js
modified:   test/simple/test-child-process-exec-buffer.js
modified:   test/simple/test-process-raw-debug.js
```

These tests are hardcoded to expect unix EOL character.
Trivial fix.
