### PR TITLE
child_process: buffer iterator to next before handler call

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -337,6 +337,8 @@ function setupChannel(target, channel) {
         var json = jsonBuffer.slice(start, i);
         var message = JSON.parse(json);
 
+        start = i + 1;
+
         // There will be at most one NODE_HANDLE message in every chunk we
         // read because SCM_RIGHTS messages don't get coalesced. Make sure
         // that we deliver the handle with the right message however.
@@ -344,8 +346,6 @@ function setupChannel(target, channel) {
           handleMessage(target, message, recvHandle);
         else
           handleMessage(target, message, undefined);
-
-        start = i + 1;
       }
       jsonBuffer = jsonBuffer.slice(start);
       this.buffering = jsonBuffer.length !== 0;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -337,8 +337,6 @@ function setupChannel(target, channel) {
         var json = jsonBuffer.slice(start, i);
         var message = JSON.parse(json);
 
-        start = i + 1;
-
         // There will be at most one NODE_HANDLE message in every chunk we
         // read because SCM_RIGHTS messages don't get coalesced. Make sure
         // that we deliver the handle with the right message however.
@@ -346,6 +344,8 @@ function setupChannel(target, channel) {
           handleMessage(target, message, recvHandle);
         else
           handleMessage(target, message, undefined);
+
+        start = i + 1;
       }
       jsonBuffer = jsonBuffer.slice(start);
       this.buffering = jsonBuffer.length !== 0;


### PR DESCRIPTION
When handler that bound to forked child_process throws error,
message iterator doesn't go next and when child_process send next message, unexpected message comes.  

See the code below.  

``` js
var assert = require('assert'), cluster = require('cluster');
var messages = ['1st', '2nd'], expected = [].concat(messages);

if(cluster.isMaster) {

  process.on('uncaughtException', function(e) {
    // avoid down
    console.log('catch exception: ', e.message);
  });

  var worker = cluster.fork();
  worker.on('online', function() {
    worker.on('message', function(m) {
      assert.equal(m, expected.shift());
      x; // <= throw error.
    });
  });

} else {

  while(messages.length)
    process.send(messages.shift());

}
```

We might expect the stdout result:  

``` js
catch exception:  x is not defined
catch exception:  x is not defined
```

actual result is:  

``` js
catch exception:  x is not defined
catch exception:  "1st" == "2nd"
```
