### PR TITLE
build: add -Wno-unused-local-typedefs for Linux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -150,7 +150,7 @@
         'ldflags': [ '-pthread' ],
       }],
       [ 'OS in "linux freebsd openbsd solaris android"', {
-        'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+        'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-Wno-unused-local-typedefs', ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
         'ldflags': [ '-rdynamic' ],
         'target_conditions': [


### PR DESCRIPTION
This has come up since Ubuntu 13.10. I don't know if it's a local config or a new gcc thing:

``` sh
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/4.8/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu/Linaro 4.8.1-10ubuntu8' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 4.8.1 (Ubuntu/Linaro 4.8.1-10ubuntu8) 
```

V8 is causing compile warnings when attempting to compile anything that brings in v8.h:

```
In file included from /home/rvagg/.node-gyp/0.11.9/src/node.h:61:0,
                 from ../cpp/returnnull.cpp:1:
/home/rvagg/.node-gyp/0.11.9/deps/v8/include/v8.h: In member function ‘void v8::ReturnValue<T>::Set(uint32_t)’:
/home/rvagg/.node-gyp/0.11.9/deps/v8/include/v8.h:5816:31: warning: typedef ‘I’ locally defined but not used [-Wunused-local-typedefs]
   typedef internal::Internals I;
                               ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-xunused-local-typedefs" [enabled by default]
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-xunused-local-typedefs" [enabled by default]
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-xunused-local-typedefs" [enabled by default]
```
