### PR TITLE
docs(assert) call signature of doesNotThrow should be equivalent to thro...

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -319,7 +319,7 @@ assert.throws = function(block, /*optional*/error, /*optional*/message) {
 };
 
 // EXTENSION! This is annoying to write outside this module.
-assert.doesNotThrow = function(block, /*optional*/message) {
+assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
   _throws.apply(this, [false].concat(pSlice.call(arguments)));
 };
 


### PR DESCRIPTION
...ws.

The body is identical:

```
assert.throws = function(block, /*optional*/error, /*optional*/message) {
  _throws.apply(this, [true].concat(pSlice.call(arguments)));
};

// EXTENSION! This is annoying to write outside this module.
assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
  _throws.apply(this, [false].concat(pSlice.call(arguments)));
};
```
