### PR TITLE
tls: add serialNumber to getPeerCertificate()

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -573,7 +573,8 @@ Example:
          CN: 'localhost' },
       valid_from: 'Nov 11 09:52:22 2009 GMT',
       valid_to: 'Nov  6 09:52:22 2029 GMT',
-      fingerprint: '2A:7A:C2:DD:E5:F9:CC:53:72:35:99:7A:02:5A:71:38:52:EC:8A:DF' }
+      fingerprint: '2A:7A:C2:DD:E5:F9:CC:53:72:35:99:7A:02:5A:71:38:52:EC:8A:DF',
+      serialNumber: 'B9B0D332A1AA5635' }
 
 If the peer does not provide a certificate, it returns `null` or an empty
 object.

--- a/src/env.h
+++ b/src/env.h
@@ -111,6 +111,7 @@ namespace node {
   V(rdev_string, "rdev")                                                      \
   V(rename_string, "rename")                                                  \
   V(rss_string, "rss")                                                        \
+  V(serial_number_string, "serialNumber")                                     \
   V(servername_string, "servername")                                          \
   V(session_id_string, "sessionId")                                           \
   V(should_keep_alive_string, "shouldKeepAlive")                              \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1066,6 +1066,17 @@ void SSLWrap<Base>::GetPeerCertificate(
       info->Set(env->ext_key_usage_string(), ext_key_usage);
     }
 
+    if (ASN1_INTEGER* serial_number = X509_get_serialNumber(peer_cert)) {
+      if (BIGNUM* bn = ASN1_INTEGER_to_BN(serial_number, NULL)) {
+        if (char* buf = BN_bn2hex(bn)) {
+          info->Set(env->serial_number_string(),
+                    OneByteString(node_isolate, buf));
+          OPENSSL_free(buf);
+        }
+        BN_free(bn);
+      }
+    }
+
     X509_free(peer_cert);
   }
 

--- a/test/simple/test-tls-peer-certificate.js
+++ b/test/simple/test-tls-peer-certificate.js
@@ -50,6 +50,7 @@ server.listen(common.PORT, function() {
     common.debug(util.inspect(peerCert));
     assert.equal(peerCert.subject.subjectAltName,
         'uniformResourceIdentifier:http://localhost:8000/alice.foaf#me');
+    assert.equal(peerCert.serialNumber, 'B9B0D332A1AA5635');
     verified = true;
     server.close();
   });


### PR DESCRIPTION
Add a 'serialNumber' property to the object that is returned by
tls.CryptoStream#getPeerCertificate().  Contains the certificate's
serial number encoded as a hex string.  The format is identical to
`openssl x509 -serial -in path/to/certificate`.

Fixes #6583.

Suggested reviewer: @indutny.  It's kind of sad that the 'valid_from' and 'valid_to' fields are called like that.  I couldn't bring myself to name it 'serial_number' though, even more so because subjectAltName is still subjectAltName.
