### PR TITLE
doc: Add 'finish' event on http.ServerResponse

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -235,6 +235,17 @@ The response implements the [Writable Stream][] interface. This is an
 Indicates that the underlying connection was terminated before
 [response.end()][] was called or able to flush.
 
+### Event: 'finish'
+
+`function () { }`
+
+Emitted when the response has been sent. More specifically, this event is
+emitted when the last segment of the response headers and body have been
+handed off to the operating system for transmission over the network. It
+does not imply that the client has received anything yet.
+
+After this event, no more events will be emitted on the response object.
+
 ### response.writeContinue()
 
 Sends a HTTP/1.1 100 Continue message to the client, indicating that


### PR DESCRIPTION
I was looking for this event and noticed it wasn't in the documentation (found it in the source code). Grabbed block from https://github.com/joyent/node/issues/4494
