### PR TITLE
http: fix parser double-free in _http_client.js

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -184,7 +184,6 @@ function createHangUpError() {
 
 function socketCloseListener() {
   var socket = this;
-  var parser = socket.parser;
   var req = socket._httpMessage;
   debug('HTTP socket close');
 
@@ -193,6 +192,9 @@ function socketCloseListener() {
   // is a no-op if no final chunk remains.
   socket.read();
 
+  // NOTE: Its important to get parse here, because it could be freed by
+  // the `socketOnData`.
+  var parser = socket.parser;
   req.emit('close');
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -269,7 +269,7 @@ function socketOnData(d) {
   var req = this._httpMessage;
   var parser = this.parser;
 
-  assert(parser);
+  assert(parser && parser.socket === this);
 
   var ret = parser.execute(d);
   if (ret instanceof Error) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -192,7 +192,7 @@ function socketCloseListener() {
   // is a no-op if no final chunk remains.
   socket.read();
 
-  // NOTE: Its important to get parse here, because it could be freed by
+  // NOTE: Its important to get parser here, because it could be freed by
   // the `socketOnData`.
   var parser = socket.parser;
   req.emit('close');

--- a/test/simple/test-http-client-parser-double-free.js
+++ b/test/simple/test-http-client-parser-double-free.js
@@ -1,0 +1,61 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var http_common = require('_http_common');
+
+var receivedError = 0;
+var receivedClose = 0;
+
+var buf = new Buffer(64 * 1024);
+buf.fill('A');
+
+var server = http.createServer(function(req, res) {
+  res.write(buf, function() {
+    res.socket.write(buf);
+    res.end(function() {
+      req.socket.destroy();
+      server.close();
+    });
+  });
+}).listen(common.PORT, function() {
+  var req = http.request({ port: common.PORT, agent: false }, function(res) {
+    res.once('readable', function() {
+      /* read only one buffer */
+      res.read(1);
+    });
+  });
+  req.end();
+  req.on('close', function() {
+    receivedClose++;
+  });
+  req.on('error', function() {
+    receivedError++;
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(receivedError, 1);
+  assert.equal(receivedClose, 1);
+  assert.equal(http_common.parsers.list.length, 2);
+});


### PR DESCRIPTION
HTTP Parser instance was freed twice, leading to the reusal of it
in several different requests simultaneously. After adding some
debugging code, following stack traces were found:

```
Double freed parser
Trace
    at exports.FreeList.free (freelist.js:45:9)
    at freeParser (_http_common.js:202:13)
    at TLSSocket.socketCloseListener (_http_client.js:223:5)
    at TLSSocket.EventEmitter.emit (events.js:120:20)
    at TCP.close (net.js:459:12)
Previously freed at
Error
    at exports.FreeList.free (freelist.js:50:18)
    at freeParser (_http_common.js:202:13)
    at TLSSocket.socketOnData (_http_client.js:318:5)
    at TLSSocket.EventEmitter.emit (events.js:98:17)
    at TLSSocket.Readable.read (_stream_readable.js:366:10)
    at TLSSocket.socketCloseListener (_http_client.js:194:10)
    at TLSSocket.EventEmitter.emit (events.js:120:20)
    at TCP.close (net.js:459:12)
```

The problem is that `socketCloseListener` is calling `socket.read()` to
ensure that all data is received by the `socketOnData` listener, but
since `socketCloseListener` gets `socket.parser` before calling
`socket.read()`, it can't see that the parser is already freed by
`socketOnData`.

fix #6451

/cc @bnoordhuis @isaacs @tjfontaine
