### PR TITLE
doc: properly document the callback parameter

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -433,7 +433,7 @@ If `data` is specified, it is equivalent to calling `response.write(data, encodi
 followed by `response.end()`.
 
 
-## http.request(options, callback)
+## http.request(options, [callback])
 
 Node maintains several connections per server to make HTTP requests.
 This function allows one to transparently issue requests.
@@ -468,6 +468,8 @@ Options:
 - `keepAliveMsecs`: {Integer} When using HTTP KeepAlive, how often to
   send TCP KeepAlive packets over sockets being kept alive.  Default =
   `1000`.  Only relevant if `keepAlive` is set to `true`.
+
+The optional `callback` parameter will be added as a one time listener for the ['response'][] event. 
 
 `http.request()` returns an instance of the [http.ClientRequest][]
 class. The `ClientRequest` instance is a writable stream. If one needs to
@@ -523,7 +525,7 @@ There are a few special headers that should be noted.
 * Sending an Authorization header will override using the `auth` option
   to compute basic authentication.
 
-## http.get(options, callback)
+## http.get(options, [callback])
 
 Since most requests are GET requests without bodies, Node provides this
 convenience method. The only difference between this method and `http.request()`
@@ -1008,6 +1010,7 @@ authentication details.
 
 ['checkContinue']: #http_event_checkcontinue
 ['listening']: net.html#net_event_listening
+['response']: #http_event_response
 [Agent]: #http_class_http_agent
 [Buffer]: buffer.html#buffer_buffer
 [EventEmitter]: events.html#events_class_events_eventemitter


### PR DESCRIPTION
Right now you can only guess what this callback does by looking at the example, and it looks like it's required when it's actually optional.
