### PR TITLE
cluster: fix simple/test-cluster-bind-twice on Windows

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -62,10 +62,21 @@ function SharedHandle(key, address, port, addressType, backlog, fd) {
 
   // FIXME(bnoordhuis) Polymorphic return type for lack of a better solution.
   var rval;
-  if (addressType === 'udp4' || addressType === 'udp6')
+  if (addressType === 'udp4' || addressType === 'udp6') {
     rval = dgram._createSocketHandle(address, port, addressType, fd);
-  else
+  } else {
     rval = net._createServerHandle(address, port, addressType, fd);
+    if (!util.isNumber(rval) && process.platform === 'win32') {
+      // On Windows, we always listen to the socket before sending it to
+      // the worker (see uv_tcp_duplicate_socket). So we better do it here
+      // so that we can handle any bind-time or listen-time errors early.
+      var err = net._listen(rval);
+      if (err) {
+        rval.close();
+        rval = err;
+      }
+    }
+  }
 
   if (util.isNumber(rval))
     this.errno = rval;

--- a/lib/net.js
+++ b/lib/net.js
@@ -999,6 +999,13 @@ exports.Server = Server;
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
 
+function _listen(handle, backlog) {
+  // Use a backlog of 512 entries. We pass 511 to the listen() call because
+  // the kernel does: backlogsize = roundup_pow_of_two(backlogsize + 1);
+  // which will thus give us a backlog of 512 entries.
+  return handle.listen(backlog || 511);
+};
+exports._listen = _listen;
 
 var createServerHandle = exports._createServerHandle =
     function(address, port, addressType, fd) {
@@ -1074,10 +1081,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   self._handle.onconnection = onconnection;
   self._handle.owner = self;
 
-  // Use a backlog of 512 entries. We pass 511 to the listen() call because
-  // the kernel does: backlogsize = roundup_pow_of_two(backlogsize + 1);
-  // which will thus give us a backlog of 512 entries.
-  var err = self._handle.listen(backlog || 511);
+  var err = _listen(self._handle, backlog);
 
   if (err) {
     var ex = errnoException(err, 'listen');


### PR DESCRIPTION
This fix is 100% windows specific.

Before sending a socket from a cluster master to a worker,
we would call listen in UV but not handle the error.

I made the call to listen more explicit in cluster.js so we handle
the error early.

I also changed uv_tcp_duplicate_socket to reveal any bind-time errors
before calling listen().
