### PR TITLE
stream_wrap: pass unhandled accepted_fd to JavaScript

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -587,6 +587,8 @@ void StreamWrapCallbacks::DoRead(uv_stream_t* handle,
     pending_obj = AcceptHandle<UDPWrap, uv_udp_t>(env, handle);
   } else {
     assert(pending == UV_UNKNOWN_HANDLE);
+    argv[2] = Integer::New(handle->accepted_fd);
+    handle->accepted_fd = -1;
   }
 
   if (!pending_obj.IsEmpty()) {


### PR DESCRIPTION
Currently, an unhandled fd that was received from another process is ignored. It was already accepted by the process, though, and will thus leak.

We should better report it as raw (Integer) fd to JavaScript, so the application can decide what to do about it. This will also allow to pass raw fds around, which is needed, e.g., to let the main process run without any privileges and have other processes (with root or with an appropriate process.setuid/process.setgid) open files for it.
