### PR TITLE
build: include postmortem symbols on linux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -79,9 +79,11 @@
             ],
           }],
           ['OS=="solaris"', {
-            'cflags': [ '-fno-omit-frame-pointer' ],
             # pull in V8's postmortem metadata
             'ldflags': [ '-Wl,-z,allextract' ]
+          }],
+          ['OS!="mac" and OS!="win"', {
+            'cflags': [ '-fno-omit-frame-pointer' ],
           }],
         ],
         'msvs_settings': {

--- a/node.gyp
+++ b/node.gyp
@@ -290,6 +290,12 @@
             'PLATFORM="sunos"',
           ],
         }],
+        [
+          'OS=="linux"', {
+            'ldflags': [
+              '-Wl,--whole-archive <(PRODUCT_DIR)/obj.target/deps/v8/tools/gyp/libv8_base.a -Wl,--no-whole-archive',
+            ],
+        }],
       ],
       'msvs_settings': {
         'VCLinkerTool': {


### PR DESCRIPTION
Previously we were building the symbols, but the linker was garbage
collecting the symbols because they weren't used. Inform the linker
that we want to keep all symbols from v8 around.
