### PR TITLE
doc: child_process: add execArgv in cp.fork()

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -559,6 +559,7 @@ leaner than `child_process.exec`. It has the same options.
   * `env` {Object} Environment key-value pairs
   * `encoding` {String} (Default: 'utf8')
   * `execPath` {String} Executable used to create the child process
+  * `execArgv` {Array} List of string arguments for that executable `execPath`
   * `silent` {Boolean} If true, prevent stdout and stderr in the spawned node
     process from being associated with the parent's (default is false)
 * Return: ChildProcess object


### PR DESCRIPTION
see http://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options, plaese.
I updated this doc, then it tells noders can pass a `execArgv` to add some like `--expose-gc` nodejs options for `.fork()` function.
