### PR TITLE
core: nextTick additional arguments

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -596,7 +596,10 @@
         if (hasQueue)
           _loadAsyncQueue(tock);
         try {
-          callback();
+          if (!!tock.args)
+            callback.apply(null, tock.args)
+          else
+            callback();
           threw = false;
         } finally {
           if (threw)
@@ -618,7 +621,10 @@
 
       var obj = {
         callback: callback,
-        _asyncQueue: undefined
+        _asyncQueue: undefined,
+        args: arguments.length > 1 ?
+              Array.prototype.slice.call(arguments, 1) :
+              undefined
       };
 
       if (asyncFlags[kCount] > 0)


### PR DESCRIPTION
Just wondering if this is worth considering? No tests or docs here because I'm testing the waters and am suspecting more than the normal amount of scrutiny considering this is very hot code.

`setImmediate()` and `setTimeout()` both have the ability to pass in extra args for the function being placed on the timer. This PR adds identical functionality to `process.nextTick()`.

``` js
process.nextTick(function (a, b) {
  console.log(a, b)
}, 'arg1', 'arg2')
```

Of course if you're using it like this then you're generally going to be passing off to a named function so you get to avoid the costs of a `.bind()` or the extra code to make a wrapping closure just to call out with args.

What think youz?
