### PR TITLE
NOT READY-lib: exception in timer corrupts asyncListeners

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -94,6 +94,9 @@ function listOnTimeout() {
   var now = Timer.now();
   debug('now: %s', now);
 
+  var savedContext = {};
+  runAsyncQueue(savedContext);
+
   var diff, first, hasQueue, threw;
   while (first = L.peek(list)) {
     diff = now - first._idleStart;
@@ -127,9 +130,9 @@ function listOnTimeout() {
         threw = false;
       } finally {
         if (threw) {
-          process.nextTick(function() {
+          process._nextTick(function() {
             list[kOnTimeout]();
-          });
+          }, savedContext._asyncQueue);
         }
       }
     }
@@ -370,6 +373,9 @@ function processImmediate() {
   var queue = immediateQueue;
   var hasQueue, immediate;
 
+  var savedContext = {};
+  runAsyncQueue(savedContext);
+
   immediateQueue = {};
   L.init(immediateQueue);
 
@@ -393,7 +399,7 @@ function processImmediate() {
             L.append(queue, L.shift(immediateQueue));
           }
           immediateQueue = queue;
-          process.nextTick(processImmediate);
+          process._nextTick(processImmediate, savedContext._asyncQueue);
         }
       }
     }
@@ -479,6 +485,9 @@ function unrefTimeout() {
 
   debug('unrefTimer fired');
 
+  var savedContext = {};
+  runAsyncQueue(savedContext);
+
   var diff, first, hasQueue, threw;
   while (first = L.peek(unrefList)) {
     diff = now - first._idleStart;
@@ -507,7 +516,9 @@ function unrefTimeout() {
       if (hasQueue)
         unloadAsyncQueue(first);
     } finally {
-      if (threw) process.nextTick(unrefTimeout);
+      if (threw) {
+        process._nextTick(unrefTimeout, savedContext._asyncQueue);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes test\simple\test-asynclistener-error-add-after.js
- When an exception is thrown during a timer callback, we
  schedule the remaining timers on the same list to be processed
  during the next tick.
  However in doing so we end up potentially applying the same queue
  of async listeners from the faulting callback to other callbacks.
- Moved the line that updates the async listener count after popping
  the queue to popQueue(), to insure it's always called.
