### PR TITLE
lib: child_process spawn handle ENOENT correctly

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -952,10 +952,7 @@ ChildProcess.prototype.spawn = function(options) {
 
   var err = this._handle.spawn(options);
 
-  if (!constants)
-    constants = process.binding('constants');
-
-  if (-err == constants.ENOENT) {
+  if (err == uv.UV_ENOENT) {
     process.nextTick(function() {
       self._handle.onexit(err);
     });


### PR DESCRIPTION
child_process spawn wasn't handlig ENOENT correctly on Windows.
This is half a fix for test-child-process-cwd.js.
The other half is going into libuv.
