### PR TITLE
FIX: FreeBSD7.x and FreeBSD8.x fail at the "./configure" step

### DIFF
--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -53,5 +53,8 @@ if __name__ == '__main__':
 
   args.append('-Dcomponent=static_library')
   args.append('-Dlibrary=static_library')
+  # Standard FreeBSD7.x and FreeBSD8.x builds cannot support parallel option
+  if ( sys.platform.startswith('freebsd7') or sys.platform.startswith('freebsd8') ):
+    args.append('--no-parallel')
   gyp_args = list(args)
   run_gyp(gyp_args)


### PR DESCRIPTION
gyp is triggerred using the --no-parallel option for these platforms

issue : https://github.com/joyent/node/issues/6640
