### PR TITLE
Fix when GYP crashes on standard FreeBSD7.x and FreeBSD8.x builds

### DIFF
--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -53,5 +53,8 @@ if __name__ == '__main__':
 
   args.append('-Dcomponent=static_library')
   args.append('-Dlibrary=static_library')
+  #  GYP will crash on standard FreeBSD7.x and FreeBSD8.x builds as they cannot support gyp parallel option
+  if ( sys.platform.startswith('freebsd7') or sys.platform.startswith('freebsd8') ):
+    args.append('--no-parallel')
   gyp_args = list(args)
   run_gyp(gyp_args)


### PR DESCRIPTION
The build process crashes at the ./configure step due to this error. The
workround is to use gyp's --no-parallel option whenever the system.platform
is either freebsd7 or freebsd8.

Below is the error wthout the fix,

'target_defaults': { 'cflags': [],
                       'default_configuration': 'Release',
                       'defines': ['OPENSSL_NO_SSL2=1'],
                       'include_dirs': [],
                       'libraries': []},
  'variables': { 'clang': 0,
                 'gcc_version': 42,
                 'host_arch': 'x64',
                 'node_install_npm': 'true',
                 'node_prefix': '',
                 'node_shared_cares': 'false',
                 'node_shared_http_parser': 'false',
                 'node_shared_libuv': 'false',
                 'node_shared_openssl': 'false',
                 'node_shared_v8': 'false',
                 'node_shared_zlib': 'false',
                 'node_tag': '',
                 'node_use_dtrace': 'false',
                 'node_use_etw': 'false',
                 'node_use_mdb': 'false',
                 'node_use_openssl': 'true',
                 'node_use_perfctr': 'false',
                 'python': '/usr/local/bin/python',
                 'target_arch': 'x64',
                 'v8_enable_gdbjit': 0,
                 'v8_enable_i18n_support': 0,
                 'v8_no_strict_aliasing': 1,
                 'v8_optimized_debug': 0,
                 'v8_random_seed': 0,
                 'v8_use_snapshot': 'true'}}
creating  ./config.gypi
creating  ./config.mk
Traceback (most recent call last):
  File "tools/gyp_node.py", line 57, in <module>
    run_gyp(gyp_args)
  File "tools/gyp_node.py", line 18, in run_gyp
    rc = gyp.main(args)
  File "./tools/gyp/pylib/gyp/**init**.py", line 527, in main
    return gyp_main(args)
  File "./tools/gyp/pylib/gyp/**init**.py", line 503, in gyp_main
    options.circular_check)
  File "./tools/gyp/pylib/gyp/**init**.py", line 129, in Load
    params['parallel'], params['root_targets'])
  File "./tools/gyp/pylib/gyp/input.py", line 2687, in Load
    generator_input_info)
  File "./tools/gyp/pylib/gyp/input.py", line 594, in LoadTargetBuildFilesParallel
    parallel_state.pool = multiprocessing.Pool(8)
  File "/usr/local/lib/python2.7/multiprocessing/**init**.py", line 232, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild)
  File "/usr/local/lib/python2.7/multiprocessing/pool.py", line 115, in **init**
    self._setup_queues()
  File "/usr/local/lib/python2.7/multiprocessing/pool.py", line 209, in _setup_queues
    from .queues import SimpleQueue
  File "/usr/local/lib/python2.7/multiprocessing/queues.py", line 48, in <module>
    from multiprocessing.synchronize import Lock, BoundedSemaphore, Semaphore, Condition
  File "/usr/local/lib/python2.7/multiprocessing/synchronize.py", line 59, in <module>
    " function, see issue 3770.")
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.
