### PR TITLE
benchmark: fixate `ciphers in tls benchmarks

### DIFF
--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -39,7 +39,8 @@ function main(conf) {
 
   options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
               cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
-              ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ] };
+              ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+              ciphers: 'AES256-GCM-SHA384' };
 
   server = tls.createServer(options, onConnection);
   setTimeout(done, dur * 1000);

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -23,7 +23,8 @@ function main(conf) {
   var cert_dir = path.resolve(__dirname, '../../test/fixtures'),
       options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
                   cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
-                  ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ] };
+                  ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+                  ciphers: 'AES256-GCM-SHA384' };
 
   server = tls.createServer(options, onConnection);
   server.listen(common.PORT, onListening);


### PR DESCRIPTION
Benchmark should always use the same cipher in order to be truthful.
