### PR TITLE
debug client: connect after child is ready

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -25,6 +25,7 @@ var util = require('util'),
     vm = require('vm'),
     repl = require('repl'),
     inherits = util.inherits,
+    assert = require('assert'),
     spawn = require('child_process').spawn;
 
 exports.start = function(argv, stdin, stdout) {
@@ -1612,6 +1613,7 @@ Interface.prototype.trySpawn = function(cb) {
       childArgs = this.args;
 
   this.killChild();
+  assert(!this.child);
 
   if (this.args.length === 2) {
     var match = this.args[1].match(/^([^:]+):(\d+)$/);
@@ -1647,12 +1649,10 @@ Interface.prototype.trySpawn = function(cb) {
     }
   }
 
-  if (!this.child) {
-    this.child = spawn(process.execPath, childArgs);
+  this.child = spawn(process.execPath, childArgs);
 
-    this.child.stdout.on('data', this.childPrint.bind(this));
-    this.child.stderr.on('data', this.childPrint.bind(this));
-  }
+  this.child.stdout.on('data', this.childPrint.bind(this));
+  this.child.stderr.on('data', this.childPrint.bind(this));
 
   this.pause();
 
@@ -1709,8 +1709,10 @@ Interface.prototype.trySpawn = function(cb) {
     client.connect(port, host);
   }
 
-  setTimeout(function() {
-    self.print('connecting to port ' + port + '..', true);
-    attemptConnect();
-  }, 50);
+  this.child.stderr.once('data', function() {
+    setImmediate(function() {
+      self.print('connecting to port ' + port + '..', true);
+      attemptConnect();
+    });
+  });
 };

--- a/test/simple/helper-debugger-repl.js
+++ b/test/simple/helper-debugger-repl.js
@@ -91,7 +91,7 @@ function startDebugger(scriptToDebug) {
     });
 
     quit();
-  }, 5000).unref();
+  }, 10000).unref();
 
   process.once('uncaughtException', function(e) {
     console.error('UncaughtException', e, e.stack);


### PR DESCRIPTION
We now wait to connect to the debuggee until we know that
its error stream has data, to ensure that the output message
"connecting..... ok" appears after "Debugger listening on port xyz"

I also increased the test timeout to let the more complex
tests finish in time on Windows

This change fixes the following unit tests on Windows:
  test-debugger-repl.js
  test-debugger-repl-term.js
  test-debugger-repl-utf8.js
  test-debugger-repl-restart.js
