### PR TITLE
doc: cluster:complemented the cluster.settings

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -95,6 +95,8 @@ the worker pool for your application's needs.
 
 * {Object}
   * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `execArgv` {Array} list of string arguments passed to executable `exec`. 
+    (Default=`process.execArgv`)
   * `args` {Array} string arguments passed to worker.
     (Default=`process.argv.slice(2)`)
   * `silent` {Boolean} whether or not to send output to parent's stdio.


### PR DESCRIPTION
I found the https://github.com/joyent/node/blob/master/lib/cluster.js#L220 is missing, then complemented it.
^.^
