### PR TITLE
http: use writev on chunked encoding

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -438,14 +438,18 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
       else
         len = chunk.length;
 
-      if (this.connection)
+      if (this.connection && !this.connection.corked) {
         this.connection.cork();
+        var conn = this.connection;
+        process.nextTick(function connectionCork() {
+          if (conn)
+            conn.uncork();
+        });
+      }
       this._send(len.toString(16), 'binary', null);
       this._send(crlf_buf, null, null);
       this._send(chunk, encoding, null);
       ret = this._send(crlf_buf, null, callback);
-      if (this.connection)
-        this.connection.uncork();
     }
   } else {
     ret = this._send(chunk, encoding, callback);


### PR DESCRIPTION
Now will process all write() that were done on a single tick in a single
writev().

There's still a strange decision about only using writev on chunked encoding if the input was a Buffer. Why it wouldn't be allowed for strings I find strange. Going to also fix that.
