### PR TITLE
node: WIP begin reimplementing AsyncListeners

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -682,44 +682,44 @@ a diff reading, useful for benchmarks and measuring intervals:
 
     Stability: 1 - Experimental
 
-The `AsyncListener` API is the JavaScript interface for the `AsyncWrap`
-class which allows developers to be notified about key events in the
-lifetime of an asynchronous event. Node performs a lot of asynchronous
-events internally, and significant use of this API will have a **dramatic
-performance impact** on your application.
+The `AsyncListener` API is the JavaScript interface to track paths of
+asynchronous function calls. Users will be notified of specified events
+during the lifetime of the asynchronous call chain.
+
+Node performs a lot of asynchronous events internally. Significant use of
+this API will have a **dramatic performance impact** on your application.
 
 
-## process.createAsyncListener(asyncListener[, callbacksObj[, storageValue]])
+## process.createAsyncListener(asyncCallbacks[, storageValue])
 
-* `asyncListener` {Function} callback fired when an asynchronous event is
-instantiated.
-* `callbacksObj` {Object} optional callbacks that will fire at specific
+* `asyncCallbacks` {Object} optional callbacks that will fire at specific
 times in the lifetime of the asynchronous event.
-* `storageValue` {Value} a value that will be passed as the first argument
-when the `asyncListener` callback is run, and to all subsequent callback.
 
 Returns a constructed `AsyncListener` object.
 
-To begin capturing asynchronous events pass the object to
+To begin capturing asynchronous events, pass the object to
 [`process.addAsyncListener()`][]. The same `AsyncListener` instance can
 only be added once to the active queue, and subsequent attempts to add the
 instance will be ignored.
 
-To stop capturing pass the object to [`process.removeAsyncListener()`][].
+To stop capturing, pass the object to [`process.removeAsyncListener()`][].
 This does _not_ mean the `AsyncListener` previously added will stop
-triggering callbacks. Once attached to an asynchronous event it will
-persist with the lifetime of the asynchronous call stack.
+executing callbacks on the asynchronous call-stack on which it was called.
+
+Once an `Object` has been passed, `AsyncListener` makes the assumption
+that the four required fields will not change. Meaning, the user will not
+reassign those properties to another callback or any other value.
 
 Explanation of function parameters:
 
-`asyncListener(storageValue)`: A `Function` called when an asynchronous
+`asyncCallbacks`: An `Object` which may contain four optional fields:
+
+* `create(storageValue)`: A `Function` called when an asynchronous
 event is instantiated. If a `Value` is returned then it will be attached
 to the event and overwrite any value that had been passed to
 `process.createAsyncListener()`'s `storageValue` argument. If an initial
 `storageValue` was passed when created, then `asyncListener()` will
 receive that as a function argument.
-
-`callbacksObj`: An `Object` which may contain three optional fields:
 
 * `before(context, storageValue)`: A `Function` that is called immediately
 before the asynchronous callback is about to run. It will be passed both
@@ -731,6 +731,9 @@ either occurred).
 the asynchronous event's callback has run. Note this will not be called
 if the callback throws and the error is not handled.
 
+**TODO(trevnorris):** Should `after` be fired if the event-callback thew,
+but was handled?
+
 * `error(storageValue, error)`: A `Function` called if the event's
 callback threw. If `error` returns `true` then Node will assume the error
 has been properly handled and resume execution normally. When multiple
@@ -738,28 +741,38 @@ has been properly handled and resume execution normally. When multiple
 needs to return `true` for `AsyncListener` to accept that the error has
 been handled.
 
+If all four fields are left empty then nothing will be added to the
+`AsyncListener` queue, and `null` will be returned.
+
+**Note:** Be careful not to run asynchronous events from any of the
+`asyncCallbacks`. This may cause an infinite loop to execute and cause
+your program to crash. The exception are functions on `console` that write
+to `stdout` or `stderr`.
+
 `storageValue`: A `Value` (i.e. anything) that will be, by default,
 attached to all new event instances. This will be overwritten if a `Value`
 is returned by `asyncListener()`.
 
 Here is an example of overwriting the `storageValue`:
 
-    process.createAsyncListener(function listener(value) {
-      // value === true
-      return false;
-    }, {
-      before: function before(context, value) {
-        // value === false
-      }
-    }, true);
+```
+process.createAsyncListener({
+  create: function asyncCreate(value) {
+    // value === true
+    return false;
+  },
+  before: function before(context, value) {
+    // value === false
+  }
+}, true);
+```
 
-**Note:** The [EventEmitter][], while used to emit status of an asynchronous
-event, is not itself asynchronous. So `asyncListener()` will not fire when
-an event is added, and `before`/`after` will not fire when emitted
-callbacks are called.
+**Note:** The [EventEmitter][], while used to emit status of an
+asynchronous events, is not itself asynchronous. So no `asyncCallbacks`
+will be fired in the lifetime of the `EventEmitter`.
 
 
-## process.addAsyncListener(asyncListener[, callbacksObj[, storageValue]])
+## process.addAsyncListener(callbacksObj[, storageValue])
 ## process.addAsyncListener(asyncListener)
 
 Returns a constructed `AsyncListener` object and immediately adds it to
@@ -771,47 +784,42 @@ object.
 
 Example usage for capturing errors:
 
-    var cntr = 0;
-    var key = process.addAsyncListener(function() {
-      return { uid: cntr++ };
-    }, {
-      before: function onBefore(context, storage) {
-        // Need to remove the listener while logging or will end up
-        // with an infinite call loop.
-        process.removeAsyncListener(key);
-        console.log('uid: %s is about to run', storage.uid);
-        process.addAsyncListener(key);
-      },
-      after: function onAfter(context, storage) {
-        process.removeAsyncListener(key);
-        console.log('uid: %s is about to run', storage.uid);
-        process.addAsyncListener(key);
-      },
-      error: function onError(storage, err) {
-        // Handle known errors
-        if (err.message === 'really, it\'s ok') {
-          process.removeAsyncListener(key);
-          console.log('handled error just threw:');
-          console.log(err.stack);
-          process.addAsyncListener(key);
-          return true;
-        }
-      }
-    });
+```
+var cntr = 0;
+var key = process.addAsyncListener({
+  create: function asyncCreate() {
+    return { uid: cntr++ };
+  },
+  before: function onBefore(context, storage) {
+    console.log('uid: %s is about to run', storage.uid);
+  },
+  after: function onAfter(context, storage) {
+    console.log('uid: %s is about to run', storage.uid);
+  },
+  error: function onError(storage, err) {
+    // Handle known errors
+    if (err.message === 'really, it\'s ok') {
+      console.log('handled error just threw:');
+      console.log(err.stack);
+      return true;
+    }
+  }
+});
 
-    process.nextTick(function() {
-      throw new Error('really, it\'s ok');
-    });
+process.nextTick(function() {
+  throw new Error('really, it\'s ok');
+});
 
-    // Output:
-    // uid: 0 is about to run
-    // handled error just threw:
-    // Error: really, it's ok
-    //     at /tmp/test2.js:27:9
-    //     at process._tickCallback (node.js:583:11)
-    //     at Function.Module.runMain (module.js:492:11)
-    //     at startup (node.js:123:16)
-    //     at node.js:1012:3
+// Output:
+// uid: 0 is about to run
+// handled error just threw:
+// Error: really, it's ok
+//     at /script/path/test.js:27:9
+//     at process._tickCallback (node.js:583:11)
+//     at Function.Module.runMain (module.js:492:11)
+//     at startup (node.js:123:16)
+//     at node.js:1012:3
+```
 
 ## process.removeAsyncListener(asyncListener)
 
@@ -822,34 +830,35 @@ events called during its execution scope will stop firing callbacks. Once
 attached to an event it will persist for the entire asynchronous call
 stack. For example:
 
-    var key = process.createAsyncListener(function asyncListener() {
-      // To log we must stop listening or we'll enter infinite recursion.
-      process.removeAsyncListener(key);
-      console.log('You summoned me?');
-      process.addAsyncListener(key);
+```
+var key = process.createAsyncListener({
+  create: function asyncCreate() {
+    console.log('You summoned me?');
+  }
+});
+
+// We want to begin capturing async events some time in the future.
+setTimeout(function() {
+  process.addAsyncListener(key);
+
+  // Perform a few additional async events.
+  setTimeout(function() {
+    setImmediate(function() {
+      process.nextTick(function() { });
     });
+  });
 
-    // We want to begin capturing async events some time in the future.
-    setTimeout(function() {
-      process.addAsyncListener(key);
+  // Removing the listener doesn't mean to stop capturing events that
+  // have already been added.
+  process.removeAsyncListener(key);
+}, 100);
 
-      // Perform a few additional async events.
-      setTimeout(function() {
-        setImmediate(function() {
-          process.nextTick(function() { });
-        });
-      });
-
-      // Removing the listener doesn't mean to stop capturing events that
-      // have already been added.
-      process.removeAsyncListener(key);
-    }, 100);
-
-    // Output:
-    // You summoned me?
-    // You summoned me?
-    // You summoned me?
-    // You summoned me?
+// Output:
+// You summoned me?
+// You summoned me?
+// You summoned me?
+// You summoned me?
+```
 
 The fact that we logged 4 asynchronous events is an implementation detail
 of Node's [Timers][].
@@ -858,28 +867,27 @@ To stop capturing from a specific asynchronous event stack
 `process.removeAsyncListener()` must be called from within the call
 stack itself. For example:
 
-    var key = process.createAsyncListener(function asyncListener() {
-      // To log we must stop listening or we'll enter infinite recursion.
-      process.removeAsyncListener(key);
-      console.log('You summoned me?');
-      process.addAsyncListener(key);
-    });
+```
+var key = process.createAsyncListener(function asyncListener() {
+  console.log('You summoned me?');
+});
 
-    // We want to begin capturing async events some time in the future.
-    setTimeout(function() {
-      process.addAsyncListener(key);
+// We want to begin capturing async events some time in the future.
+setTimeout(function() {
+  process.addAsyncListener(key);
 
-      // Perform a few additional async events.
-      setImmediate(function() {
-        // Stop capturing from this call stack.
-        process.removeAsyncListener(key);
+  // Perform a few additional async events.
+  setImmediate(function() {
+    // Stop capturing from this call stack.
+    process.removeAsyncListener(key);
 
-        process.nextTick(function() { });
-      });
-    }, 100);
+    process.nextTick(function() { });
+  });
+}, 100);
 
-    // Output:
-    // You summoned me?
+// Output:
+// You summoned me?
+```
 
 The user must be explicit and always pass the `AsyncListener` they wish
 to remove. It is not possible to simply remove all listeners at once.
@@ -887,6 +895,6 @@ to remove. It is not possible to simply remove all listeners at once.
 
 [EventEmitter]: events.html#events_class_events_eventemitter
 [Timers]: timers.html
-[`process.createAsyncListener()`]: #process_process_createasynclistener_asynclistener_callbacksobj_storagevalue
+[`process.createAsyncListener()`]: #process_process_createasynclistener_asynccallbacks_storagevalue
 [`process.addAsyncListener()`]: #process_process_addasynclistener_asynclistener
 [`process.removeAsyncListener()`]: #process_process_removeasynclistener_asynclistener

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -42,9 +42,6 @@ exports._stack = stack;
 exports.active = null;
 
 
-function noop() { }
-
-
 var listenerObj = {
   error: function errorHandler(domain, er) {
     var caught = false;
@@ -104,7 +101,7 @@ inherits(Domain, EventEmitter);
 function Domain() {
   EventEmitter.call(this);
   this.members = [];
-  this._listener = process.createAsyncListener(noop, listenerObj, this);
+  this._listener = process.createAsyncListener(listenerObj, this);
 }
 
 Domain.prototype.members = undefined;

--- a/test/simple/test-asynclistener-error-add-after.js
+++ b/test/simple/test-asynclistener-error-add-after.js
@@ -30,8 +30,6 @@ var caught = 0;
 var expectCaught = 0;
 var exitCbRan = false;
 
-function asyncL() { }
-
 var callbacksObj = {
   error: function(value, er) {
     var idx = errorMsgs.indexOf(er.message);
@@ -48,7 +46,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.createAsyncListener(asyncL, callbacksObj);
+var listener = process.createAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   // Just in case.

--- a/test/simple/test-asynclistener-error-multiple-handled.js
+++ b/test/simple/test-asynclistener-error-multiple-handled.js
@@ -25,25 +25,28 @@ var assert = require('assert');
 var active = null;
 var cntr = 0;
 
-function onAsync0() {
-  return 0;
-}
-
-function onAsync1() {
-  return 1;
+function onError(stor) {
+  results.push(stor);
+  return true;
 }
 
 var results = [];
-var asyncNoHandleError = {
-  error: function(stor) {
-    results.push(stor);
-    return true;
-  }
+var asyncNoHandleError0 = {
+  create: function onCreate0() {
+    return 0;
+  },
+  error: onError
+};
+var asyncNoHandleError1 = {
+  create: function onCreate1() {
+    return 1;
+  },
+  error: onError
 };
 
 var listeners = [
-  process.addAsyncListener(onAsync0, asyncNoHandleError),
-  process.addAsyncListener(onAsync1, asyncNoHandleError)
+  process.addAsyncListener(asyncNoHandleError0),
+  process.addAsyncListener(asyncNoHandleError1)
 ];
 
 process.nextTick(function() {

--- a/test/simple/test-asynclistener-error-multiple-mix.js
+++ b/test/simple/test-asynclistener-error-multiple-mix.js
@@ -22,8 +22,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-function onAsync() {}
-
 var results = [];
 var asyncNoHandleError = {
   error: function(stor) {
@@ -39,8 +37,8 @@ var asyncHandleError = {
 };
 
 var listeners = [
-  process.addAsyncListener(onAsync, asyncHandleError),
-  process.addAsyncListener(onAsync, asyncNoHandleError)
+  process.addAsyncListener(asyncHandleError),
+  process.addAsyncListener(asyncNoHandleError)
 ];
 
 // Even if an error handler returns true, both should fire.

--- a/test/simple/test-asynclistener-error-multiple-unhandled.js
+++ b/test/simple/test-asynclistener-error-multiple-unhandled.js
@@ -22,24 +22,27 @@
 var common = require('../common');
 var assert = require('assert');
 
-function onAsync0() {
-  return 0;
-}
-
-function onAsync1() {
-  return 1;
+function onError(stor) {
+  results.push(stor);
 }
 
 var results = [];
-var asyncNoHandleError = {
-  error: function(stor) {
-    results.push(stor);
-  }
+var asyncNoHandleError0 = {
+  create: function onCreate0() {
+    return 0;
+  },
+  error: onError
+};
+var asyncNoHandleError1 = {
+  create: function onCreate1() {
+    return 1;
+  },
+  error: onError
 };
 
 var listeners = [
-  process.addAsyncListener(onAsync0, asyncNoHandleError),
-  process.addAsyncListener(onAsync1, asyncNoHandleError)
+  process.addAsyncListener(asyncNoHandleError0),
+  process.addAsyncListener(asyncNoHandleError1)
 ];
 
 var uncaughtFired = false;

--- a/test/simple/test-asynclistener-error-net.js
+++ b/test/simple/test-asynclistener-error-net.js
@@ -29,8 +29,6 @@ var errorMsgs = [];
 var caught = 0;
 var expectCaught = 0;
 
-function asyncL() { }
-
 var callbacksObj = {
   error: function(value, er) {
     var idx = errorMsgs.indexOf(er.message);
@@ -47,7 +45,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.addAsyncListener(asyncL, callbacksObj);
+var listener = process.addAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   process.removeAsyncListener(listener);

--- a/test/simple/test-asynclistener-error-throw-in-after.js
+++ b/test/simple/test-asynclistener-error-throw-in-after.js
@@ -23,14 +23,13 @@ var common = require('../common');
 var assert = require('assert');
 
 var once = 0;
-function onAsync0() { }
 
 var results = [];
 var handlers = {
-  after: function() {
+  after: function asyncAfter() {
     throw 1;
   },
-  error: function(stor, err) {
+  error: function asyncError(stor, err) {
     // Error handler must be called exactly *once*.
     once++;
     assert.equal(err, 1);
@@ -38,7 +37,7 @@ var handlers = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, handlers);
+var key = process.addAsyncListener(handlers);
 
 var uncaughtFired = false;
 process.on('uncaughtException', function(err) {

--- a/test/simple/test-asynclistener-error-throw-in-before-multiple.js
+++ b/test/simple/test-asynclistener-error-throw-in-before-multiple.js
@@ -23,9 +23,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var once = 0;
-function onAsync0() { }
-function onAsync1() { }
-
 var results = [];
 var handlers = {
   before: function() {
@@ -52,8 +49,8 @@ var handlers1 = {
 }
 
 var listeners = [
-  process.addAsyncListener(onAsync0, handlers),
-  process.addAsyncListener(onAsync1, handlers1)
+  process.addAsyncListener(handlers),
+  process.addAsyncListener(handlers1)
 ];
 
 var uncaughtFired = false;

--- a/test/simple/test-asynclistener-error-throw-in-before.js
+++ b/test/simple/test-asynclistener-error-throw-in-before.js
@@ -23,7 +23,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var once = 0;
-function onAsync0() {}
 
 var results = [];
 var handlers = {
@@ -38,7 +37,7 @@ var handlers = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, handlers);
+var key = process.addAsyncListener(handlers);
 
 var uncaughtFired = false;
 process.on('uncaughtException', function(err) {

--- a/test/simple/test-asynclistener-error-throw-in-error.js
+++ b/test/simple/test-asynclistener-error-throw-in-error.js
@@ -34,7 +34,7 @@ else
 function runChild() {
   var cntr = 0;
 
-  var key = process.addAsyncListener(function() { }, {
+  var key = process.addAsyncListener({
     error: function onError() {
       cntr++;
       throw new Error('onError');

--- a/test/simple/test-asynclistener-error.js
+++ b/test/simple/test-asynclistener-error.js
@@ -33,8 +33,6 @@ var caught = 0;
 var expectCaught = 0;
 var exitCbRan = false;
 
-function asyncL() { }
-
 var callbacksObj = {
   error: function(value, er) {
     var idx = errorMsgs.indexOf(er.message);
@@ -48,7 +46,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.createAsyncListener(asyncL, callbacksObj);
+var listener = process.createAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   removeListener(listener);

--- a/test/simple/test-asynclistener-multi-timeout.js
+++ b/test/simple/test-asynclistener-multi-timeout.js
@@ -27,8 +27,6 @@ var removeListener = process.removeAsyncListener;
 var caught = [];
 var expect = [];
 
-function asyncL(a) {}
-
 var callbacksObj = {
   error: function(value, er) {
     process._rawDebug('caught', er.message);
@@ -37,7 +35,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.createAsyncListener(asyncL, callbacksObj);
+var listener = process.createAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   removeListener(listener);

--- a/test/simple/test-asynclistener-remove-add-in-before.js
+++ b/test/simple/test-asynclistener-remove-add-in-before.js
@@ -22,19 +22,20 @@
 var common = require('../common');
 var assert = require('assert');
 var val;
-var callbacks = {
-  before: function() {
+var asyncCallback = {
+  create: function asyncCreate() {
+    return 66;
+  },
+  before: function asyncBefore() {
     process.removeAsyncListener(listener);
     process.addAsyncListener(listener);
   },
-  after: function(context, storage) {
+  after: function asyncAfter(context, storage) {
     val = storage;
   }
 };
 
-var listener = process.addAsyncListener(function() {
-  return 66;
-}, callbacks);
+var listener = process.addAsyncListener(asyncCallbacks);
 
 process.nextTick(function() {});
 

--- a/test/simple/test-asynclistener-remove-after.js
+++ b/test/simple/test-asynclistener-remove-after.js
@@ -27,7 +27,7 @@ var net = require('net');
 // TODO(trevnorris): Test has the flaw that it's not checking if the async
 // flag has been removed on the class instance. Though currently there's
 // no way to do that.
-var listener = process.addAsyncListener(function() { });
+var listener = process.addAsyncListener({ create: function() { } });
 
 
 // Test timers

--- a/test/simple/test-asynclistener.js
+++ b/test/simple/test-asynclistener.js
@@ -30,11 +30,13 @@ var removeListener = process.removeAsyncListener;
 var actualAsync = 0;
 var expectAsync = 0;
 
-function onAsync() {
-  actualAsync++;
+var asyncCallbacks = {
+  create: function asyncCreate() {
+    actualAsync++;
+  }
 }
 
-var listener = process.createAsyncListener(onAsync);
+var listener = process.createAsyncListener(asyncCallbacks);
 
 process.on('exit', function() {
   process._rawDebug('expected', expectAsync);


### PR DESCRIPTION
There is a slight API change that should be made before the initial
release in v0.12.

Starting we're switching the docs and tests to the new API for testing
as development goes forward.

Still a complete WIP. The major change is that the `asyncListener` callback is now called `create` in the async callbacks object.
