### PR TITLE
test: fix create-file test fixture

### DIFF
--- a/test/fixtures/create-file.js
+++ b/test/fixtures/create-file.js
@@ -24,4 +24,6 @@ var fs = require('fs');
 var file_name = process.argv[2];
 var file_size = parseInt(process.argv[3]);
 
-fs.truncateSync(file_name, file_size);
+var fd = fs.openSync(file_name, 'w');
+fs.ftruncateSync(fd, file_size);
+fs.closeSync(fd);


### PR DESCRIPTION
This was failing if the file didn't already exist.

Fixes unit tests on Windows:
- test\simple\test-http-curl-chunk-problem.js
- test\simple\test-pipe-file-to-http.js
