### PR TITLE
test: fix simple/test-https-foafssl

### DIFF
--- a/test/simple/test-https-foafssl.js
+++ b/test/simple/test-https-foafssl.js
@@ -29,8 +29,8 @@ var assert = require('assert');
 var join = require('path').join;
 
 var fs = require('fs');
-var exec = require('child_process').exec;
 
+var spawn = require('child_process').spawn;
 var https = require('https');
 
 var options = {
@@ -40,6 +40,7 @@ var options = {
 };
 
 var reqCount = 0;
+var CRLF = '\r\n';
 var body = 'hello world\n';
 var cert;
 var subjectaltname;
@@ -60,19 +61,27 @@ var server = https.createServer(options, function(req, res) {
   res.end(body);
 });
 
-
 server.listen(common.PORT, function() {
-  var cmd = 'curl --insecure https://127.0.0.1:' + common.PORT + '/';
-  cmd += ' --cert ' + join(common.fixturesDir, 'foafssl.crt');
-  cmd += ' --key ' + join(common.fixturesDir, 'foafssl.key');
-  console.error('executing %j', cmd);
-  exec(cmd, function(err, stdout, stderr) {
-    if (err) throw err;
-    common.error(common.inspect(stdout));
-    assert.equal(body, stdout);
+  var args = ['s_client',
+              '-quiet',
+              '-connect', 'localhost:'+common.PORT,
+              '-cert', join(common.fixturesDir, 'foafssl.crt'),
+              '-key', join(common.fixturesDir, 'foafssl.key')];
+
+  var client = spawn(common.opensslCli, args);
+
+  client.stdout.on('data', function (data) {
+    var message = '' + data;
+    var contents = message.split(CRLF+CRLF).pop();
+    assert.equal(body, contents);
     server.close();
   });
 
+  client.stdin.write('GET /\n\n');
+
+  client.on('error', function(error) {
+    throw error;
+  });
 });
 
 process.on('exit', function() {

--- a/test/simple/test-https-foafssl.js
+++ b/test/simple/test-https-foafssl.js
@@ -63,14 +63,14 @@ var server = https.createServer(options, function(req, res) {
 server.listen(common.PORT, function() {
   var args = ['s_client',
               '-quiet',
-              '-connect', 'localhost:' + common.PORT,
+              '-connect', '127.0.0.1:' + common.PORT,
               '-cert', join(common.fixturesDir, 'foafssl.crt'),
               '-key', join(common.fixturesDir, 'foafssl.key')];
 
   var client = spawn(common.opensslCli, args);
 
   client.stdout.on('data', function(data) {
-    var message = '' + data;
+    var message = data.toString();
     var contents = message.split(CRLF + CRLF).pop();
     assert.equal(body, contents);
     server.close();

--- a/test/simple/test-https-foafssl.js
+++ b/test/simple/test-https-foafssl.js
@@ -29,7 +29,6 @@ var assert = require('assert');
 var join = require('path').join;
 
 var fs = require('fs');
-
 var spawn = require('child_process').spawn;
 var https = require('https');
 
@@ -64,15 +63,15 @@ var server = https.createServer(options, function(req, res) {
 server.listen(common.PORT, function() {
   var args = ['s_client',
               '-quiet',
-              '-connect', 'localhost:'+common.PORT,
+              '-connect', 'localhost:' + common.PORT,
               '-cert', join(common.fixturesDir, 'foafssl.crt'),
               '-key', join(common.fixturesDir, 'foafssl.key')];
 
   var client = spawn(common.opensslCli, args);
 
-  client.stdout.on('data', function (data) {
+  client.stdout.on('data', function(data) {
     var message = '' + data;
-    var contents = message.split(CRLF+CRLF).pop();
+    var contents = message.split(CRLF + CRLF).pop();
     assert.equal(body, contents);
     server.close();
   });


### PR DESCRIPTION
fixes #6647

Uses s_client. Does not depend on system's bin.
