### PR TITLE
module: only cache package main

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -89,11 +89,11 @@ function statPath(path) {
 }
 
 // check if the directory is a package.json dir
-var packageCache = {};
+var packageMainCache = {};
 
 function readPackage(requestPath) {
-  if (hasOwnProperty(packageCache, requestPath)) {
-    return packageCache[requestPath];
+  if (hasOwnProperty(packageMainCache, requestPath)) {
+    return packageMainCache[requestPath];
   }
 
   var fs = NativeModule.require('fs');
@@ -105,7 +105,7 @@ function readPackage(requestPath) {
   }
 
   try {
-    var pkg = packageCache[requestPath] = JSON.parse(json);
+    var pkg = packageMainCache[requestPath] = JSON.parse(json).main;
   } catch (e) {
     e.path = jsonPath;
     e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
@@ -117,9 +117,9 @@ function readPackage(requestPath) {
 function tryPackage(requestPath, exts) {
   var pkg = readPackage(requestPath);
 
-  if (!pkg || !pkg.main) return false;
+  if (!pkg) return false;
 
-  var filename = path.resolve(requestPath, pkg.main);
+  var filename = path.resolve(requestPath, pkg);
   return tryFile(filename) || tryExtensions(filename, exts) ||
          tryExtensions(path.resolve(filename, 'index'), exts);
 }


### PR DESCRIPTION
Closes https://github.com/joyent/node/issues/6682

Locally, doing a simple server with hapi I observed 200kb of savings.  A package published to npm includes the README and LICENSE, so when we cache the entire package.json in this way we are adding a decent amount of memory to our procs that we don't need to.  Also, notice that `packageCache` was never exported or added to Module, so this isn't a breaking change. 
