### PR TITLE
buffer: remove unnecessary encoding within writeInt*

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -678,50 +678,11 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   return writeUInt32(this, value, offset, true);
 };
 
-
-/*
- * We now move onto our friends in the signed number category. Unlike unsigned
- * numbers, we're going to have to worry a bit more about how we put values into
- * arrays. Since we are only worrying about signed 32-bit values, we're in
- * slightly better shape. Unfortunately, we really can't do our favorite binary
- * & in this system. It really seems to do the wrong thing. For example:
- *
- * > -32 & 0xff
- * 224
- *
- * What's happening above is really: 0xe0 & 0xff = 0xe0. However, the results of
- * this aren't treated as a signed number. Ultimately a bad thing.
- *
- * What we're going to want to do is basically create the unsigned equivalent of
- * our representation and pass that off to the wuint* functions. To do that
- * we're going to do the following:
- *
- *  - if the value is positive
- *      we can pass it directly off to the equivalent wuint
- *  - if the value is negative
- *      we do the following computation:
- *         mb + val + 1, where
- *         mb   is the maximum unsigned value in that byte size
- *         val  is the Javascript negative integer
- *
- *
- * As a concrete value, take -128. In signed 16 bits this would be 0xff80. If
- * you do out the computations:
- *
- * 0xffff - 128 + 1
- * 0xffff - 127
- * 0xff80
- *
- * You can then encode this value as the signed version. This is really rather
- * hacky, but it should work and get the job done which is our goal here.
- */
-
 Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
   if (!noAssert)
     checkInt(this, value, offset, 1, 0x7f, -0x80);
-  if (value < 0) value = 0xff + value + 1;
   this[offset] = value;
   return offset + 1;
 };
@@ -732,7 +693,6 @@ Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
-  if (value < 0) value = 0xffff + value + 1;
   return writeUInt16(this, value, offset, false);
 };
 
@@ -742,7 +702,6 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
-  if (value < 0) value = 0xffff + value + 1;
   return writeUInt16(this, value, offset, true);
 };
 
@@ -752,7 +711,6 @@ Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
-  if (value < 0) value = 0xffffffff + value + 1;
   return writeUInt32(this, value, offset, false);
 };
 
@@ -762,6 +720,5 @@ Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
-  if (value < 0) value = 0xffffffff + value + 1;
   return writeUInt32(this, value, offset, true);
 };


### PR DESCRIPTION
On my machine it gives a performance of 2 times.
