### PR TITLE
EventEmitter: move constructor guts to EventEmitter.init

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -23,16 +23,7 @@ var domain;
 var util = require('util');
 
 function EventEmitter() {
-  this.domain = null;
-  if (EventEmitter.usingDomains) {
-    // if there is an active domain, then attach to it.
-    domain = domain || require('domain');
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
-  }
-  this._events = this._events || {};
-  this._maxListeners = this._maxListeners || undefined;
+  EventEmitter.init.call(this);
 }
 module.exports = EventEmitter;
 
@@ -49,6 +40,18 @@ EventEmitter.prototype._maxListeners = undefined;
 // added to it. This is a useful default which helps finding memory leaks.
 EventEmitter.defaultMaxListeners = 10;
 
+EventEmitter.init = function() {
+  this.domain = null;
+  if (EventEmitter.usingDomains) {
+    // if there is an active domain, then attach to it.
+    domain = domain || require('domain');
+    if (domain.active && !(this instanceof domain.Domain)) {
+      this.domain = domain.active;
+    }
+  }
+  this._events = this._events || {};
+  this._maxListeners = this._maxListeners || undefined;
+};
 
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.


### PR DESCRIPTION
After landing 6ed861d it is no longer possible to reliably monkey-patch
the EventEmitter constructor. However there's valid use cases for that,
and makes for easier debugging. Therefore, move the guts of the
constructor to a separate function which is monkey-patchable.

The idea was signed off by @isaacs already. Here's the implementation.
suggested reviewers: @trevnorris @tjfontaine 
