### PR TITLE
util: more strict type check for bool/number/string

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -118,7 +118,7 @@ var stringifyPrimitive = function(v) {
   if (util.isString(v))
     return v;
   if (util.isBoolean(v))
-    return v ? 'true' : 'false';
+    return v == true ? 'true' : 'false';
   if (util.isNumber(v))
     return isFinite(v) ? v : '';
   return '';

--- a/lib/util.js
+++ b/lib/util.js
@@ -451,7 +451,7 @@ function isArray(ar) {
 exports.isArray = isArray;
 
 function isBoolean(arg) {
-  return typeof arg === 'boolean';
+  return typeof arg === 'boolean' || objectToString(arg) === '[object Boolean]';
 }
 exports.isBoolean = isBoolean;
 
@@ -466,12 +466,12 @@ function isNullOrUndefined(arg) {
 exports.isNullOrUndefined = isNullOrUndefined;
 
 function isNumber(arg) {
-  return typeof arg === 'number';
+  return typeof arg === 'number' || objectToString(arg) === '[object Number]';
 }
 exports.isNumber = isNumber;
 
 function isString(arg) {
-  return typeof arg === 'string';
+  return typeof arg === 'string' || objectToString(arg) === '[object String]';
 }
 exports.isString = isString;
 

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -83,7 +83,7 @@ var qsWeirdObjects = [
   [{e: extendedFunction}, 'e=', {'e': ''}],
   [{d: new Date()}, 'd=', {'d': ''}],
   [{d: Date}, 'd=', {'d': ''}],
-  [{f: new Boolean(false), t: new Boolean(true)}, 'f=&t=', {'f': '', 't': ''}],
+  [{f: new Boolean(false), t: new Boolean(true)}, 'f=false&t=true', {'f': 'false', 't': 'true'}],
   [{f: false, t: true}, 'f=false&t=true', {'f': 'false', 't': 'true'}],
   [{n: null}, 'n=', {'n': ''}],
   [{nan: NaN}, 'nan=', {'nan': ''}],

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -25,6 +25,35 @@ var assert = require('assert');
 var util = require('util');
 var context = require('vm').runInNewContext;
 
+// isBoolean
+assert.equal(true, util.isBoolean(true));
+assert.equal(true, util.isBoolean(false));
+assert.equal(true, util.isBoolean(Boolean()));
+assert.equal(true, util.isBoolean(new Boolean()));
+assert.equal(true, util.isBoolean(new Boolean(true)));
+assert.equal(true, util.isBoolean(context('Boolean')()));
+assert.equal(false, util.isBoolean({}));
+assert.equal(false, util.isBoolean(/regexp/));
+
+// isNumber
+assert.equal(true, util.isNumber(0));
+assert.equal(true, util.isNumber(NaN));
+assert.equal(true, util.isNumber(Number()));
+assert.equal(true, util.isNumber(new Number()));
+assert.equal(true, util.isNumber(new Number(10)));
+assert.equal(true, util.isNumber(context('Number')()));
+assert.equal(false, util.isNumber({}));
+assert.equal(false, util.isNumber(/regexp/));
+
+// isString
+assert.equal(true, util.isString('string'));
+assert.equal(true, util.isString(String()));
+assert.equal(true, util.isString(new String()));
+assert.equal(true, util.isString(new String(10)));
+assert.equal(true, util.isString(context('String')()));
+assert.equal(false, util.isString({}));
+assert.equal(false, util.isString(/regexp/));
+
 // isArray
 assert.equal(true, util.isArray([]));
 assert.equal(true, util.isArray(Array()));


### PR DESCRIPTION
See below code first: 

``` javascript
var util = require('util');
var num = new Number(10);
util.isNumber(num);  // false, because typeof num is an object
```

Like above what I annotated, the result of `typeof num` is `object`, so we need a more stringent way, that using `Object.prototype.toString.call()` to fix these bugs, yep, same problems in `isBoolean` and `isString` would be fixed, too.
