### PR TITLE
fs: move makeCallback and maybeCallback to util

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -55,47 +55,17 @@ var O_WRONLY = constants.O_WRONLY || 0;
 
 var isWindows = process.platform === 'win32';
 
-var DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 var errnoException = util._errnoException;
 
 
-function rethrow() {
-  // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
-  // is fairly slow to generate.
-  if (DEBUG) {
-    var backtrace = new Error;
-    return function(err) {
-      if (err) {
-        backtrace.stack = err.name + ': ' + err.message +
-                          backtrace.stack.substr(backtrace.name.length);
-        err = backtrace;
-        throw err;
-      }
-    };
-  }
-
-  return function(err) {
-    if (err) {
-      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
-    }
-  };
-}
+var rethrow = util._makeRethrow('fs');
 
 function maybeCallback(cb) {
-  return util.isFunction(cb) ? cb : rethrow();
+  return util._maybeCallback(rethrow, cb);
 }
 
-// Ensure that callbacks run in the global context. Only use this function
-// for callbacks that are passed to the binding layer, callbacks that are
-// invoked from JS already run in the proper scope.
 function makeCallback(cb) {
-  if (!util.isFunction(cb)) {
-    return rethrow();
-  }
-
-  return function() {
-    return cb.apply(null, arguments);
-  };
+  return util._makeCallback(rethrow, cb);
 }
 
 function assertEncoding(encoding) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -745,3 +745,56 @@ exports._errnoException = function(err, syscall, original) {
   e.syscall = syscall;
   return e;
 };
+
+
+exports._makeRethrow = function _makeRethrow(moduleName) {
+  var DEBUG = process.env.NODE_DEBUG &&
+      process.env.NODE_DEBUG.indexOf(moduleName) !== -1;
+
+  return function rethrow() {
+    var backtrace;
+
+    function rethrowWithBacktrace(err) {
+      if (err) {
+        backtrace.stack = err.name + ': ' + err.message +
+                          backtrace.stack.substr(backtrace.name.length);
+        err = backtrace;
+        throw err;
+      }
+    };
+
+    function rethrowWithoutBacktrace(err) {
+      if (err) {
+        console.error('Forgot a callback but don\'t know where? ' +
+            'Use NODE_DEBUG=%s', moduleName);
+
+        throw err;
+      }
+    };
+
+    // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
+    // is fairly slow to generate.
+    if (DEBUG) {
+      backtrace = new Error;
+    }
+
+    return DEBUG ? rethrowWithBacktrace : rethrowWithoutBacktrace;
+  }
+};
+
+
+exports._maybeCallback = function _maybeCallback(rethrow, cb) {
+  return isFunction(cb) ? cb : rethrow();
+};
+
+
+// Ensure that callbacks run in the global context. Only use this function
+// for callbacks that are passed to the binding layer, callbacks that are
+// invoked from JS already run in the proper scope.
+exports._makeCallback = function _makeCallback(rethrow, cb) {
+  function runCallbackInGlobalContext() {
+    return cb.apply(null, arguments);
+  }
+
+  return isFunction(cb) ? runCallbackInGlobalContext : rethrow();
+};


### PR DESCRIPTION
`makeCallback()`, `maybeCallback()`, and `rethrow()` declared in **fs** can also be used in other places.

Related to [#6225](https://github.com/joyent/node/issues/6525)

I don't know why the tests are failing but apparently the failures are not related to my changes.  

PS:
I already signed the CLA.
