### PR TITLE
TLS Compression is used for CRIME attacks, not BEAST.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4060,7 +4060,7 @@ void InitCryptoOnce() {
   CRYPTO_set_locking_callback(crypto_lock_cb);
   CRYPTO_THREADID_set_callback(crypto_threadid_cb);
 
-  // Turn off compression. Saves memory and protects against BEAST attacks.
+  // Turn off compression. Saves memory and protects against CRIME & other chosen plain text attacks based on TLS Compression.
 #if !defined(OPENSSL_NO_COMP)
 #if OPENSSL_VERSION_NUMBER < 0x00908000L
   STACK_OF(SSL_COMP)* comp_methods = SSL_COMP_get_compression_method();


### PR DESCRIPTION
This is a comment change, where it originally says disabling TLS Compression protects against BEAST attack. But in fact, it is the CRIME attack(Compression Ratio Info-leak Made Easy) that makes use of TLS Compression and not BEAST. 

BEAST(Browser Exploit Against SSL/TLS) is an entirely another variant making use of the chosen boundary attack against CBC mode in encryption.

Just making sure, that the exact reason for disabling TLS compression must be made clear and not be misleading with some other attack. Will surely be useful down the years.
