### PR TITLE
http: Change regex to a simple indexOf test

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -276,13 +276,13 @@ Agent.prototype.request = function(options, cb) {
     options.host = options.hostname;
   }
 
-  if (options && options.path && / /.test(options.path)) {
-    // The actual regex is more like /[^A-Za-z0-9\-._~!$&'()*+,;=/:@]/
-    // with an additional rule for ignoring percentage-escaped characters
-    // but that's a) hard to capture in a regular expression that performs
-    // well, and b) possibly too restrictive for real-world usage. That's
-    // why it only scans for spaces because those are guaranteed to create
-    // an invalid request.
+  if (options && options.path && options.path.indexOf(' ') !== -1)) {
+    // A more fitting test would be to use the regex 
+    // /[^A-Za-z0-9\-._~!$&'()*+,;=/:@]/ with an additional rule for
+    // ignoring percentage-escaped characters but that's a) hard to capture
+    // in a regular expression that performs well, and b) possibly too
+    // restrictive for real-world usage. That's why we only scans for
+    // spaces because those are guaranteed to create an invalid request.
     throw new TypeError('Request path contains unescaped characters.');
   } else if (options.protocol && options.protocol !== this.protocol) {
     throw new Error('Protocol:' + options.protocol + ' not supported.');


### PR DESCRIPTION
No need to use a regular expression to test for the presence of a space character, when the `indexOf` function does a far more sufficient job.

This could also have been written using the shorter syntax `~options.path.indexOf(' ')`, but some might find that harder to read.
