### PR TITLE
doc: clarify process.nextTick vs. setImmediate (was: Fixes #6718)

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -570,10 +570,11 @@ sooner if nextTick handlers are currently being processed (i.e., if the caller
 is part of a nextTick handler).
 
 At the end of each tick the `process.nextTick` handlers are executed until there
-are none left.  Because of this, it's dangerous to invoke `process.nextTick`
-*from* a nextTick handler.  If you do this enough times, you can starve the main
-event loop, meaning that filesystem and network I/O events will not be processed
-(because nextTick handlers keep being added).
+are none left -- and that includes any handlers which were added as part of
+processing earlier handlers.  Because of this, it's dangerous to invoke
+`process.nextTick` *from* a nextTick handler.  If you do this enough times, you
+can starve the main event loop, meaning that filesystem and network I/O events
+will not be processed (because nextTick handlers keep being added).
 
 **You should not use `process.nextTick` to invoke an arbitrary callback that
 you've been given by a caller.**  For that, use `setImmediate`, which avoids

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -61,7 +61,8 @@ fire until the next event loop iteration.
 
 `setImmediate` is useful in developing APIs where you want to give the user the
 chance to assign event handlers after an object has been constructed, but before
-any I/O has occurred.
+you've kicked off any asynchronous operations of your own (e.g., started a TCP
+connection):
 
     function MyThing(options) {
       this.setupOptions(options);


### PR DESCRIPTION
This documentation change clarifies the potential issue with process.nextTick and steers users towards setImmediate instead for arbitrary callbacks.
