### PR TITLE
Fix cluster 0.11 api changes mostly introduced during round-robin refactoring

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -474,7 +474,7 @@ function workerInit() {
       cluster.worker.state = 'listening';
       var address = obj.address();
       message.act = 'listening';
-      message.port = address && address.port || port,
+      message.port = address && address.port || port;
       send(message);
     });
   };

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -269,7 +269,9 @@ function masterInit() {
         process._debugProcess(cluster.workers[key].process.pid);
     });
 
-    cluster.emit('setup');
+    process.nextTick(function() {
+      cluster.emit('setup');
+    });
   };
 
   var ids = 0;

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -343,8 +343,8 @@ function masterInit() {
     signo = signo || 'SIGTERM';
     var proc = this.process;
     if (proc.connected) {
-      proc.once('disconnect', proc.kill.bind(proc, signo));
-      proc.disconnect();
+      this.once('disconnect', proc.kill.bind(proc, signo));
+      this.disconnect();
       return;
     }
     proc.kill(signo);
@@ -444,7 +444,13 @@ function workerInit() {
     worker.id = +process.env.NODE_UNIQUE_ID | 0;
     worker.state = 'online';
     worker.process = process;
-    process.once('disconnect', process.exit.bind(null, 0));
+    process.once('disconnect', function() {
+      if (!worker.suicide) {
+        // Unexpected disconnect, master exited, or some such nastiness, so
+        // worker exits immediately.
+        process.exit(0);
+      }
+    });
     process.on('internalMessage', internal(worker, onmessage));
     send({ act: 'online' });
     function onmessage(message, handle) {
@@ -554,6 +560,7 @@ function workerInit() {
   }
 
   Worker.prototype.disconnect = function() {
+    this.suicide = true;
     for (var key in handles) {
       var handle = handles[key];
       delete handles[key];
@@ -563,6 +570,7 @@ function workerInit() {
   };
 
   Worker.prototype.destroy = function() {
+    this.suicide = true;
     if (!process.connected) process.exit(0);
     var exit = process.exit.bind(null, 0);
     send({ act: 'suicide' }, exit);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -310,9 +310,14 @@ function masterInit() {
   };
 
   cluster.disconnect = function(cb) {
-    for (var key in cluster.workers) {
-      var worker = cluster.workers[key];
-      worker.disconnect();
+    var workers = Object.keys(cluster.workers);
+    if (workers.length === 0) {
+      process.nextTick(intercom.emit.bind(intercom, 'disconnect'));
+    } else {
+      for (var key in workers) {
+        key = workers[key];
+        cluster.workers[key].disconnect();
+      }
     }
     if (cb) intercom.once('disconnect', cb);
   };

--- a/test/fixtures/clustered-server/app.js
+++ b/test/fixtures/clustered-server/app.js
@@ -13,9 +13,6 @@ if (cluster.isMaster) {
   cluster.on('online', function() {
     if (++workersOnline === NUMBER_OF_WORKERS) {
       console.error('all workers are running');
-      for (var key in cluster.workers) {
-        cluster.workers[key].disconnect();
-      }
     }
   });
 

--- a/test/simple/test-cluster-disconnect-with-no-workers.js
+++ b/test/simple/test-cluster-disconnect-with-no-workers.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var cluster = require('cluster');
+
+var disconnected;
+
+process.on('exit', function() {
+  assert(disconnected);
+});
+
+cluster.disconnect(function() {
+  disconnected = true;
+});

--- a/test/simple/test-cluster-setup-master.js
+++ b/test/simple/test-cluster-setup-master.js
@@ -39,6 +39,12 @@ if (cluster.isWorker) {
 
   var totalWorkers = 2;
 
+  // Setup master
+  cluster.setupMaster({
+    args: ['custom argument'],
+    silent: true
+  });
+
   cluster.once('setup', function() {
     checks.setupEvent = true;
 
@@ -49,12 +55,6 @@ if (cluster.isWorker) {
         settings.exec === process.argv[1]) {
       checks.settingsObject = true;
     }
-  });
-
-  // Setup master
-  cluster.setupMaster({
-    args: ['custom argument'],
-    silent: true
   });
 
   var correctIn = 0;

--- a/test/simple/test-cluster-worker-forced-exit.js
+++ b/test/simple/test-cluster-worker-forced-exit.js
@@ -19,14 +19,60 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var common = require('../common');
 var assert = require('assert');
-var cluster = require('cluster');
+var cluster = require('cluster')
+var net = require('net');
 
-if (cluster.isMaster) {
-  cluster.fork();
-  cluster.fork();
-  cluster.disconnect(common.mustCall(function() {
-    assert.deepEqual(Object.keys(cluster.workers), []);
-  }));
+var SENTINEL = 42;
+
+// workers forcibly exit when control channel is disconnected, if
+// their .suicide flag isn't set
+//
+// test this by:
+//
+// 1 setup worker to wait a short time after disconnect, and exit
+//   with a sentinel value
+// 2 disconnect worker with cluster's disconnect, confirm sentinel
+// 3 disconnect worker with child_process's disconnect, confirm
+//   no sentinel value
+if (cluster.isWorker) {
+  process.on('disconnect', function(msg) {
+    setTimeout(function() {
+      process.exit(SENTINEL);
+    }, 10);
+  });
+  return;
+}
+
+var unforcedOk;
+var forcedOk;
+
+process.on('exit', function() {
+  assert(forcedOk);
+  assert(unforcedOk);
+});
+
+checkUnforced();
+checkForced();
+
+function checkUnforced() {
+  cluster.fork()
+  .on('online', function() {
+    this.disconnect();
+  })
+  .on('exit', function(status) {
+    assert.equal(status, SENTINEL);
+    unforcedOk = true;
+  });
+}
+
+function checkForced() {
+  cluster.fork()
+  .on('online', function() {
+    this.process.disconnect();
+  })
+  .on('exit', function(status) {
+    assert.equal(status, 0);
+    forcedOk = true;
+  });
 }

--- a/test/simple/test-cluster-worker-no-exit.js
+++ b/test/simple/test-cluster-worker-no-exit.js
@@ -1,0 +1,72 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var cluster = require('cluster')
+var net = require('net');
+
+var destroyed;
+var success;
+var worker;
+var server;
+
+// workers do not exit on disconnect, they exit under normal node rules: when
+// they have nothing keeping their loop alive, like an active connection
+//
+// test this by:
+//
+// 1 creating a server, so worker can make a connection to something
+// 2 disconnecting worker
+// 3 wait to confirm it did not exit
+// 4 destroy connection
+// 5 confirm it does exit
+if (cluster.isMaster) {
+  server = net.createServer(function(conn) {
+    server.close();
+    worker.disconnect()
+    worker.once('disconnect', function() {
+      setTimeout(function() {
+        conn.destroy();
+        destroyed = true;
+      }, 1000);
+    }).once('exit', function() {
+      // worker should not exit while it has a connection
+      assert(destroyed, 'worker exited before connection destroyed');
+      success = true;
+    });
+
+  }).listen(0, function() {
+    var port = this.address().port;
+
+    worker = cluster.fork()
+      .on('online', function() {
+        this.send({port: port});
+      });
+  });
+  process.on('exit', function() {
+    assert(success);
+  });
+} else {
+  process.on('message', function(msg) {
+    // we shouldn't exit, not while a network connection exists
+    net.connect(msg.port);
+  });
+}

--- a/test/simple/test-debug-cluster.js
+++ b/test/simple/test-debug-cluster.js
@@ -35,9 +35,14 @@ child.stderr.on('data', function(data) {
 
   if (line === 'all workers are running') {
     assertOutputLines();
+    process.exit();
   } else {
     outputLines = outputLines.concat(lines);
   }
+});
+
+process.on('exit', function onExit() {
+  child.kill();
 });
 
 var assertOutputLines = common.mustCall(function() {

--- a/test/simple/test-debug-port-cluster.js
+++ b/test/simple/test-debug-port-cluster.js
@@ -41,9 +41,14 @@ child.stderr.on('data', function(data) {
 
   if (line === 'all workers are running') {
     assertOutputLines();
+    process.exit();
   } else {
     outputLines = outputLines.concat(lines);
   }
+});
+
+process.on('exit', function onExit() {
+  child.kill();
 });
 
 var assertOutputLines = common.mustCall(function() {


### PR DESCRIPTION
A side-effect of the round robin feature and the general code clean-up Ben did, were changes to the API, particularly to the worker exit criteria (meaning of suicide and disconnect).

It didn't look to me like these changes were intentional (they weren't documented or discussed, AFAICT), so I propose these small changes to make the cluster API in v0.11 be backwards compatible to v0.10.

/cc @bnoorduis
