### PR TITLE
cluster, v8: fix --logfile=%p.log

### DIFF
--- a/deps/v8/src/log-utils.cc
+++ b/deps/v8/src/log-utils.cc
@@ -105,6 +105,10 @@ void Log::Initialize() {
                 // one character so we can escape the loop properly.
                 p--;
                 break;
+              case 'p':
+                // %p expands to the process ID.
+                stream.Add("%d", OS::GetCurrentProcessId());
+                break;
               case 't': {
                 // %t expands to the current time in milliseconds.
                 double time = OS::TimeCurrentMillis();


### PR DESCRIPTION
The %p is replaced with the current PID.  This used to work in node.js
v0.9.7 but it seems to have been lost somewhere along the way.

This commit makes the fix from 6b713b52 ("cluster: make --prof work for
workers") work again.  Without it, all log data ends up in a single
file and is unusable because the addresses are all wrong.

Suggested reviewer: @tjfontaine
