### PR TITLE
windows: fix dns lookup of localhost with ipv6

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -120,15 +120,6 @@ exports.lookup = function(hostname, family, callback) {
     return {};
   }
 
-  // Hack required for Windows because Win7 removed the
-  // localhost entry from c:\WINDOWS\system32\drivers\etc\hosts
-  // See http://daniel.haxx.se/blog/2011/02/21/localhost-hack-on-windows/
-  // TODO Remove this once c-ares handles this problem.
-  if (process.platform == 'win32' && hostname == 'localhost') {
-    callback(null, '127.0.0.1', 4);
-    return {};
-  }
-
   var matchedFamily = net.isIP(hostname);
   if (matchedFamily) {
     callback(null, hostname, matchedFamily);


### PR DESCRIPTION
Removing a hack intended to shortcut the resolution of 'localhost'
but which doesn't work for ipv6.
This was introduced in 2876141c4292791bc12c0b8701dbcc366dde7297.
However it seems that the problems that this was trying to
circumvent has gone away ages ago, when dns resolution on
Windows started relying on Win32 GetAddrInfoW, which was
probably with be2320d408de89054b254a0c812280054d946490.

Fixes test-net-connect-options-ipv6.js on Windows.
