### PR TITLE
tls: reintroduce socket.encrypted

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -540,6 +540,11 @@ If `tlsSocket.authorized === false` then the error can be found in
 `tlsSocket.authorizationError`. Also if NPN was used - you can check
 `tlsSocket.npnProtocol` for negotiated protocol.
 
+### tlsSocket.encrypted
+
+Static boolean value, always `true`. May be used to distinguish TLS sockets
+from regular ones.
+
 ### tlsSocket.authorized
 
 A boolean that is `true` if the peer certificate was signed by one of the

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -172,6 +172,10 @@ function TLSSocket(socket, options) {
   this.authorized = false;
   this.authorizationError = null;
 
+  // Just a documented property to make secure sockets
+  // distinguishable from regular ones.
+  this.encrypted = true;
+
   this.on('error', this._tlsError);
 
   if (!this._handle)


### PR DESCRIPTION
Just a property that is always `true` for TLS sockets.

fix #6735

/cc @tjfontaine or @trevnorris . I'm open for discussion of this.
