### PR TITLE
crypto: duplicate digests algorithms

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4051,8 +4051,7 @@ void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
 
 void InitCryptoOnce() {
   SSL_library_init();
-  OpenSSL_add_all_algorithms();
-  OpenSSL_add_all_digests();
+  OpenSSL_add_all_algorithms(); 
   SSL_load_error_strings();
   ERR_load_crypto_strings();
 


### PR DESCRIPTION
See below ref:

> OpenSSL_add_all_algorithms() adds all algorithms to the table (digests and ciphers).

Then I think the second `OpenSSL_add_all_digests()` is to be removed.
