### PR TITLE
test: fix flaky unit test test-fs-realpath.js

### DIFF
--- a/test/simple/test-fs-realpath.js
+++ b/test/simple/test-fs-realpath.js
@@ -410,6 +410,17 @@ function test_up_multiple(cb) {
     console.log('skipping symlink test (no privs)');
     return runNextTest();
   }
+  function cleanup() {
+    ['a/b',
+      'a'
+    ].forEach(function(folder) {
+      try {fs.rmdirSync(tmp(folder))} catch (ex) {}
+    });
+  }
+  function setup() {
+    cleanup();
+  }
+  setup();
   fs.mkdirSync(tmp('a'), 0755);
   fs.mkdirSync(tmp('a/b'), 0755);
   fs.symlinkSync('..', tmp('a/d'), 'dir');
@@ -432,6 +443,7 @@ function test_up_multiple(cb) {
       if (er) throw er;
       assert.equal(abedabed_real, real);
       cb();
+      cleanup();
     });
   });
 }


### PR DESCRIPTION
The test was not performing proper cleanup and so it would
fail if run more than one time on the same machine.
