### PR TITLE
build: Adds node_lib target.

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -76,6 +76,24 @@
       'type': 'executable',
 
       'dependencies': [
+        'node_lib',
+      ],
+
+      'sources': [
+        'src/node_main.cc',
+      ],
+
+      'msvs_settings': {
+        'VCLinkerTool': {
+          'SubSystem': 1, # /subsystem:console
+        },
+      },
+    },
+    {
+      'target_name': 'node_lib',
+      'type': 'static_library',
+
+      'dependencies': [
         'node_js2c#host',
       ],
 
@@ -98,7 +116,6 @@
         'src/node_file.cc',
         'src/node_http_parser.cc',
         'src/node_javascript.cc',
-        'src/node_main.cc',
         'src/node_os.cc',
         'src/node_stat_watcher.cc',
         'src/node_watchdog.cc',
@@ -161,6 +178,16 @@
         'PLATFORM="<(OS)"',
         'NODE_TAG="<(node_tag)"',
       ],
+
+      'direct_dependent_settings': {
+        'include_dirs': [
+          'src',
+          'deps/uv/src/ares',
+        ],
+        'defines': [
+          'NODE_WANT_INTERNALS=1',
+        ],
+      },
 
       'conditions': [
         [ 'node_use_openssl=="true"', {
@@ -263,22 +290,27 @@
             'deps/v8/include/v8-debug.h',
           ],
           'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:v8' ],
+          'export_dependent_settings': [ 'deps/v8/tools/gyp/v8.gyp:v8' ],
         }],
 
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
+          'export_dependent_settings': [ 'deps/zlib/zlib.gyp:zlib' ],
         }],
 
         [ 'node_shared_http_parser=="false"', {
           'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
+          'export_dependent_settings': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
         }],
 
         [ 'node_shared_cares=="false"', {
           'dependencies': [ 'deps/cares/cares.gyp:cares' ],
+          'export_dependent_settings': [ 'deps/cares/cares.gyp:cares' ],
         }],
 
         [ 'node_shared_libuv=="false"', {
           'dependencies': [ 'deps/uv/uv.gyp:libuv' ],
+          'export_dependent_settings': [ 'deps/uv/uv.gyp:libuv' ],
         }],
 
         [ 'OS=="win"', {
@@ -331,11 +363,6 @@
             ],
         }],
       ],
-      'msvs_settings': {
-        'VCLinkerTool': {
-          'SubSystem': 1, # /subsystem:console
-        },
-      },
     },
     # generate ETW header and resource files
     {

--- a/src/node.h
+++ b/src/node.h
@@ -125,9 +125,27 @@ NODE_EXTERN v8::Handle<v8::Value> MakeCallback(
 
 namespace node {
 
+class Environment;
+
 NODE_EXTERN extern bool no_deprecation;
 
 NODE_EXTERN int Start(int argc, char *argv[]);
+NODE_EXTERN void Init(int* argc,
+                      const char** argv,
+                      int* exec_argc,
+                      const char*** exec_argv);
+NODE_EXTERN void SetupProcessObject(Environment* env,
+                                    int argc,
+                                    const char* const* argv,
+                                    int exec_argc,
+                                    const char* const* exec_argv);
+NODE_EXTERN void Load(Environment* env);
+NODE_EXTERN void EmitExit(Environment* env);
+NODE_EXTERN Environment* CreateEnvironment(v8::Isolate* isolate,
+                                           int argc,
+                                           const char* const* argv,
+                                           int exec_argc,
+                                           const char* const* exec_argv);
 
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(1000*static_cast<double>(t))


### PR DESCRIPTION
Adds a node_lib target that builds everything except the node_main.cc as a static library. And the node target would be depended on node_lib and compiles out the executable as usual.

With this other projects would be possible to include node as a third party library and embed a node engine in their applications.
