### PR TITLE
util: let `inherits` do more compatiblity

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -569,6 +569,7 @@ exports.log = function() {
  * @param {function} superCtor Constructor function to inherit prototype from.
  */
 exports.inherits = function(ctor, superCtor) {
+  var origin = ctor.prototype;
   ctor.super_ = superCtor;
   ctor.prototype = Object.create(superCtor.prototype, {
     constructor: {
@@ -577,7 +578,10 @@ exports.inherits = function(ctor, superCtor) {
       writable: true,
       configurable: true
     }
-  });
+  })
+  for (var name in origin) {
+    ctor.prototype[name] = origin[name];
+  };
 };
 
 exports._extend = function(origin, add) {

--- a/test/simple/test-util-inherits.js
+++ b/test/simple/test-util-inherits.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var util = require('util');
+
+// Classes Ready
+function SuperClass() {
+  this._flag = 'super';
+}
+
+SuperClass.prototype.beep = function() {
+  this._beep = 'super';
+}
+
+// test case 1
+function SubClassA() {
+  this._flag = 'subA';
+}
+util.inherits(SubClassA, SuperClass);
+
+SubClassA.prototype.beep = function() {
+  this._beep = 'subA';
+}
+
+// test case 2
+function SubClassB() {
+  this._flag = 'subB';
+}
+
+SubClassB.prototype.beep = function() {
+  this._beep = 'subB';
+}
+util.inherits(SubClassB, SuperClass);
+
+// start to assert
+var sup = new SuperClass();
+sup.beep();
+assert.equal(sup._flag, 'super');
+assert.equal(sup._beep, 'super');
+
+var subA = new SubClassA();
+subA.beep();
+assert.equal(subA._flag, 'subA');
+assert.equal(subA._beep, 'subA');
+
+var subB = new SubClassB();
+subB.beep();
+assert.equal(subB._flag, 'subB');
+assert.equal(subB._beep, 'subB');
+


### PR DESCRIPTION
See below:

``` javascript
function SuperClass() {
  // TODO
}
Super.prototype.beep = function() {
  this._beep = 'super';
}

function SubClass() {
  // TODO
}
SubClass.prototype.beep = function() {
  this._beep = 'sub_class';
}
util.inherits(SubClass, SuperClass);
```

And I would use the `SubClass` like following:

``` javascript
var sub = new SubClass();
sub.beep();

// print result
console.log(sub._beep)  // 'super', not 'sub_class'
```

The problem is a late call for the function `inherits`, if I call it before I defined my sub-class `prototype`, everything goes well. Then I tweaked several lines to eliminate this kind of confusion for others like me.

related line in node: https://github.com/joyent/node/blob/master/lib/util.js#L573
