### PR TITLE
console: Make console.log return first parameter.

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -51,6 +51,8 @@ function Console(stdout, stderr) {
 
 Console.prototype.log = function() {
   this._stdout.write(util.format.apply(this, arguments) + '\n');
+
+  return arguments[0];
 };
 
 


### PR DESCRIPTION
Make console.log return it's first parameter to make drop-in debugging a little easier. For example:

```
function formula(x, y) {
    return x * (y/3);
}

formula(2, 9); // 6
```

To log the outputted value of the above function, you have two options; log the value everytime the function is called or create a temporary variable, log it and return it. When debugging across multiple files on an unknown code base within a maze of loops, the pattern `var tmp = x * (y/3); console.log(tmp); return tmp` gets incredibly tedious. To alleviate this, make `console.log` return it's first argument so instead of creating the variable, we can just return the log.

```
function formula(x, y) {
    return console.log(z * (y/3));
}

formula(2, 9); // 6
```

Considering the fact that `console.log` currently never returns a value, it's potential to effect existing code is nil. The performance impact is also [close to nil](http://jsperf.com/returning-vs-non-returning-functions). The only obstacle is the fact that the API is frozen which I understand is a pretty large obstacle.
