### PR TITLE
src: only access stack of non-null errors

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1178,7 +1178,7 @@ static void ReportException(Handle<Value> er, Handle<Message> message) {
 
   Local<Value> trace_value;
 
-  if (er->IsUndefined()) {
+  if (er->IsUndefined() || er->IsNull()) {
     trace_value = Undefined(node_isolate);
   } else {
     trace_value =

--- a/test/message/throw_null.js
+++ b/test/message/throw_null.js
@@ -1,0 +1,25 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+throw null;

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -1,0 +1,5 @@
+
+*test*message*throw_null.js:25
+throw null;
+^      
+null


### PR DESCRIPTION
Avoid segmentation fault when `null` is thrown

The same as #6649, but for `null`.

/cc @tjfontaine @rlidwka
