### PR TITLE
domains mishandle thrown nulls

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -56,8 +56,10 @@ var listenerObj = {
     if (domain._disposed)
       return true;
 
-    er.domain = domain;
-    er.domainThrown = true;
+    if (util.isObject(er) || util.isFunction(er)) {
+      er.domain = domain;
+      er.domainThrown = true;
+    }
     // wrap this in a try/catch so we don't get infinite throwing
     try {
       // One of three things will happen here.

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -56,7 +56,7 @@ var listenerObj = {
     if (domain._disposed)
       return true;
 
-    if (util.isObject(er) || util.isFunction(er)) {
+    if (!util.isPrimitive(er)) {
       er.domain = domain;
       er.domainThrown = true;
     }

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -263,7 +263,7 @@ d.add(fst)
 expectCaught++;
 
 
-;[42, null, undefined, false, function(){}, 'string'].forEach(function(something) {
+[42, null, undefined, false, function(){}, 'string'].forEach(function(something) {
   var d = new domain.Domain();
   d.run(function() {
     process.nextTick(function() {

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -263,7 +263,7 @@ d.add(fst)
 expectCaught++;
 
 
-;[42, /*NaN,*/ null, undefined, function(){}, 'string'].forEach(function(something) {
+;[42, null, undefined, false, function(){}, 'string'].forEach(function(something) {
   var d = new domain.Domain();
   d.run(function() {
     process.nextTick(function() {

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -261,3 +261,20 @@ assert.equal(result, 'return value');
 var fst = fs.createReadStream('stream for nonexistent file')
 d.add(fst)
 expectCaught++;
+
+
+;[42, /*NaN,*/ null, undefined, function(){}, 'string'].forEach(function(something) {
+  var d = new domain.Domain();
+  d.run(function() {
+    process.nextTick(function() {
+      throw something;
+    });
+    expectCaught++;
+  });
+
+  d.on('error', function(er) {
+    assert.strictEqual(something, er);
+    caught++;
+  });
+});
+


### PR DESCRIPTION
This code throws user out of repl in 0.11.x:

```
bash$ node
> process.nextTick(function(){throw null})
undefined
> 
repl:1
(process.nextTick(function(){throw null})
                             ^
null
bash$
```

... as opposed to "throw 42" that doesn't.

Yeah, I know, throwing non-errors isn't nice, and shame on anybody who does that in real code.

_Note unrelated to this project: this pull request was created without any issues and/or previous discussions created anywhere. I don't expect to find anybody who gives a damn about that ([ref](https://github.com/nzakas/eslint/pull/470#issuecomment-31127265))._
