### PR TITLE
doc: skip type parsing inside code blocks

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -122,9 +122,15 @@ function parseLists(input) {
 
 
 function parseListItem(text) {
-  text = text.replace(/\{([^\}]+)\}/, '<span class="type">$1</span>');
+  var parts = text.split('`');
+  var i;
+
+  for (i = 0; i < parts.length; i += 2) {
+    parts[i] = parts[i].replace(/\{([^\}]+)\}/, '<span class="type">$1</span>');
+  }
+
   //XXX maybe put more stuff here?
-  return text;
+  return parts.join('`');
 }
 
 function parseAPIHeader(text) {


### PR DESCRIPTION
Since types are denoted with curly braces it can cause erroneous replaces in code blocks, like this: http://nodejs.org/docs/v0.11.9/api/stream.html#stream_writable_writev_chunks_callback.
