### PR TITLE
crypto: add OPENSSL_no_config in `InitCryptoOnce`.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4051,6 +4051,7 @@ void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
 
 void InitCryptoOnce() {
   SSL_library_init();
+  OPENSSL_no_config();
   OpenSSL_add_all_algorithms();
   SSL_load_error_strings();
   ERR_load_crypto_strings();


### PR DESCRIPTION
I checked `node_crypto*.cc`, and no configuration in openssl has been searched, hence, I would like to use `OPENSSL_no_config` to flag this.

`OPENSSL_no_config` assigned the internal variable `openssl_configured` to 1.
It is just a precaution of the `openssl_configured`.
