### PR TITLE
doc: Missing word 'are' in documentation

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -696,7 +696,7 @@ instances of [Date][MDN-Date] object and to compare the values of
 these objects you should use appropriate methods. For most general
 uses [getTime()][MDN-Date-getTime] will return the number of
 milliseconds elapsed since _1 January 1970 00:00:00 UTC_ and this
-integer should be sufficient for any comparison, however there
+integer should be sufficient for any comparison, however there are
 additional methods which can be used for displaying fuzzy information.
 More details can be found in the [MDN JavaScript Reference][MDN-Date]
 page.


### PR DESCRIPTION
Fixed simple spelling mistake in documentation.

Fixes joyent/node#5808
