### PR TITLE
doc: fix default maxHeadersCount

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -186,7 +186,7 @@ Stops the server from accepting new connections.  See [net.Server.close()][].
 
 ### server.maxHeadersCount
 
-Limits maximum incoming headers count, equal to 1000 by default. If set to 0 -
+Limits maximum incoming headers count, equal to 2000 by default. If set to 0 -
 no limit will be applied.
 
 ### server.setTimeout(msecs, callback)


### PR DESCRIPTION
[v0.8](https://github.com/joyent/node/blob/v0.8/lib/http.js#L1643), [v0.10](https://github.com/joyent/node/blob/v0.10/lib/http.js#L1750), and [master](https://github.com/joyent/node/blob/master/lib/_http_server.js#L341) use a default of 2000 for maxHeadersCount.
