### PR TITLE
tls: fix pool usage race

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -499,7 +499,7 @@ CryptoStream.prototype._push = function() {
         last = start;
 
     do {
-      assert(last === start);
+      assert(last === this._buffer.offset);
       chunkBytes = this._buffer.use(this, this._pusher);
       if (chunkBytes > 0) bytesRead += chunkBytes;
       last = this._buffer.offset;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -495,20 +495,23 @@ CryptoStream.prototype._push = function() {
   while (!this._paused) {
     var chunkBytes = 0,
         bytesRead = 0,
-        start = this._buffer.offset;
+        start = this._buffer.offset,
+        last = start;
 
     do {
+      assert(last === start);
       chunkBytes = this._buffer.use(this, this._pusher);
       if (chunkBytes > 0) bytesRead += chunkBytes;
+      last = this._buffer.offset;
 
       if (this.pair.ssl && this.pair.ssl.error) {
         this.pair.error();
         return;
       }
 
-      this.pair.maybeInitFinished();
-
     } while (chunkBytes > 0 && !this._buffer.isFull);
+
+    this.pair.maybeInitFinished();
 
     var pool = this._buffer.pool;
 

--- a/test/simple/test-tls-interleave.js
+++ b/test/simple/test-tls-interleave.js
@@ -1,0 +1,65 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var tls = require('tls');
+var fs = require('fs');
+
+var PORT = common.PORT;
+var dir = common.fixturesDir;
+var options = { key: fs.readFileSync(dir + '/test_key.pem'),
+                cert: fs.readFileSync(dir + '/test_cert.pem'),
+                ca: [ fs.readFileSync(dir + '/test_ca.pem') ] };
+
+var writes = [
+  'some server data',
+  'and a separate packet',
+  'and one more',
+];
+var receivedWrites = 0;
+
+var server = tls.createServer(options, function(c) {
+  writes.forEach(function(str) {
+    c.write(str);
+  });
+}).listen(PORT, function() {
+  var c = tls.connect(PORT, { rejectUnauthorized: false }, function() {
+    c.write('some client data');
+    c.on('data', function(data) {
+      data = data.toString();
+      while (data.length !== 0) {
+        assert.strictEqual(data.indexOf(writes[receivedWrites]), 0);
+        data = data.slice(writes[receivedWrites].length);
+
+        if (++receivedWrites === writes.length) {
+          c.end();
+          server.close();
+        }
+      }
+    });
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(receivedWrites, writes.length);
+});


### PR DESCRIPTION
When calling `encOut` in loop, `maybeInitFinished()` may invoke
`clearOut`'s loop, leading to the writing of interleaved data
(encrypted and cleartext) into the one shared pool.

Move `maybeInitFinished()` out of the loop and add assertion for
future.

backport of 60f777d

Please do a release with this.
