### PR TITLE
querystring: fix a bug in `parse()`

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -157,7 +157,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   eq = eq || '=';
   var obj = {};
 
-  if (!util.isString(qs) || qs.length === 0) {
+  if (!qs || !util.isString(qs.valueOf()) || qs.length === 0) {
     return obj;
   }
 

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -57,7 +57,9 @@ var qsTestCases = [
       valueOf: 'bar',
       __defineGetter__: 'baz' }],
   // See: https://github.com/joyent/node/issues/3058
-  ['foo&bar=baz', 'foo=&bar=baz', { foo: '', bar: 'baz' }]
+  ['foo&bar=baz', 'foo=&bar=baz', { foo: '', bar: 'baz' }],
+  [new String('foo&bar=baz'), 
+   new String('foo=&bar=baz'), { foo: '', bar: 'baz' }]
 ];
 
 // [ wonkyQS, canonicalQS, obj ]


### PR DESCRIPTION
`parse(new String('foo=10'))` maybe returns an empty object `{}`
