### PR TITLE
querystring: tweak list of stringify's arguments

### DIFF
--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -7,11 +7,14 @@
 This module provides utilities for dealing with query strings.
 It provides the following methods:
 
-## querystring.stringify(obj, [sep], [eq])
+## querystring.stringify(obj, [sep], [eq], [name])
 
 Serialize an object to a query string.
 Optionally override the default separator (`'&'`) and assignment (`'='`)
-characters.
+characters. Another way to use this function, passing a primitive, an
+assignment character and a string as the `name`, maybe help you to create
+a simple querystring more quickly.
+
 
 Example:
 
@@ -22,6 +25,10 @@ Example:
     querystring.stringify({foo: 'bar', baz: 'qux'}, ';', ':')
     // returns
     'foo:bar;baz:qux'
+
+    querystring.stringify(true, ';', 'foo')
+    // returns
+    'foo;true'
 
 ## querystring.parse(str, [sep], [eq], [options])
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -146,7 +146,11 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
 
   }
 
-  if (!name) return '';
+  if (arguments.length !== 3) return '';
+  else {
+    name = eq;
+    eq = sep;
+  }
   return QueryString.escape(stringifyPrimitive(name)) + eq +
          QueryString.escape(stringifyPrimitive(obj));
 };


### PR DESCRIPTION
No need to pass a separator in calling this function within a name. And then I updated the related docs.
