### PR TITLE
build: adding settings for VS 2013 to vcbuild.bat

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -99,6 +99,15 @@ ENDLOCAL
 @rem Skip project generation if requested.
 if defined nobuild goto sign
 
+@rem Look for Visual Studio 2013
+if not defined VS120COMNTOOLS goto vc-set-2012
+if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2012
+call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if not defined VCINSTALLDIR goto msbuild-not-found
+set GYP_MSVS_VERSION=2013
+goto msbuild-found
+
+:vc-set-2012
 @rem Look for Visual Studio 2012
 if not defined VS110COMNTOOLS goto vc-set-2010
 if not exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2010


### PR DESCRIPTION
Searches for VS2013 compiler 1st, before falling back to older ones. This
allows compiling using the latest VS2013.
