### PR TITLE
node: fix AV with -p arg

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2714,7 +2714,9 @@ static void ParseArgs(int* argc,
           fprintf(stderr, "%s: %s requires an argument\n", argv[0], arg);
           exit(9);
         }
-      } else if (argv[index + 1] != NULL && argv[index + 1][0] != '-') {
+      } else if ((index + 1 < nargs) &&
+                 argv[index + 1] != NULL &&
+                 argv[index + 1][0] != '-') {
         args_consumed += 1;
         eval_string = argv[index + 1];
         if (strncmp(eval_string, "\\-", 2) == 0) {


### PR DESCRIPTION
node -p would cause an access violation.

Fixes test\message\stdin_messages.js on Windows.
