### PR TITLE
windows: case-insensitive lookup in module cache

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -271,8 +271,11 @@ Module._load = function(request, parent, isMain) {
   }
 
   var filename = Module._resolveFilename(request, parent);
+  var cacheKey = process.platform === 'win32' ?
+      filename.toLowerCase() :
+      filename;
 
-  var cachedModule = Module._cache[filename];
+  var cachedModule = Module._cache[cacheKey];
   if (cachedModule) {
     return cachedModule.exports;
   }
@@ -297,7 +300,7 @@ Module._load = function(request, parent, isMain) {
     module.id = '.';
   }
 
-  Module._cache[filename] = module;
+  Module._cache[cacheKey] = module;
 
   var hadException = true;
 
@@ -306,7 +309,7 @@ Module._load = function(request, parent, isMain) {
     hadException = false;
   } finally {
     if (hadException) {
-      delete Module._cache[filename];
+      delete Module._cache[cacheKey];
     }
   }
 


### PR DESCRIPTION
The module cache key is the resolved filename which should
be treated as case-insensitive on Windows.

Fixes test-module-loading.js on Windows.
