### PR TITLE
querystring: remove `name` from `stringify()`

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -125,7 +125,7 @@ var stringifyPrimitive = function(v) {
 };
 
 
-QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
+QueryString.stringify = QueryString.encode = function(obj, sep, eq) {
   sep = sep || '&';
   eq = eq || '=';
   if (util.isNull(obj)) {
@@ -145,10 +145,7 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
     }).join(sep);
 
   }
-
-  if (!name) return '';
-  return QueryString.escape(stringifyPrimitive(name)) + eq +
-         QueryString.escape(stringifyPrimitive(obj));
+  return '';
 };
 
 // Parse a key=val string.

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -124,7 +124,7 @@ qsWeirdObjects.forEach(function(testCase) {
 });
 
 qsNoMungeTestCases.forEach(function(testCase) {
-  assert.deepEqual(testCase[0], qs.stringify(testCase[1], '&', '=', false));
+  assert.deepEqual(testCase[0], qs.stringify(testCase[1], '&', '='));
 });
 
 // test the nested qs-in-qs case


### PR DESCRIPTION
fixd #6771
