### PR TITLE
path: path.relative() not working with network shares

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -269,7 +269,7 @@ if (isWindows) {
       }
 
       if (start > end) return [];
-      return arr.slice(start, end - start + 1);
+      return arr.slice(start, end + 1);
     }
 
     var toParts = trim(to.split('\\'));

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -380,7 +380,10 @@ if (isWindows) {
        ['c:/aaaa/bbbb', 'c:/aaaa/cccc', '..\\cccc'],
        ['c:/aaaa/', 'c:/aaaa/cccc', 'cccc'],
        ['c:/', 'c:\\aaaa\\bbbb', 'aaaa\\bbbb'],
-       ['c:/aaaa/bbbb', 'd:\\', 'd:\\']];
+       ['c:/aaaa/bbbb', 'd:\\', 'd:\\'],
+       ['\\\\aaaa\bbbb', '\\\\aaaa', '..'],
+       ['\\\\aaaa', '\\\\aaaa\\cccc', 'cccc'],
+       ['\\\\aaaa', '\\\\aaaa\\bbbb\\cccc', 'bbbb\\cccc']];
 } else {
   // posix
   var relativeTests =


### PR DESCRIPTION
As noted in issue https://github.com/joyent/node/issues/6401, path.relative() don't work with network shares.

The problem was that on line 272 "Array.slice(start, end)" was wrongly used. The end parameter must be the index until where the array should be spliced and not the length.
