### PR TITLE
doc: Fix missing backtick in debugger doc

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -166,4 +166,4 @@ with the node debugger. Either connect to the `pid` or the URI to the debugger.
 The syntax is:
 
 * `node debug -p <pid>` - Connects to the process via the `pid`
-* `node debug <URI> - Connects to the process via the URI such as localhost:5858
+* `node debug <URI>` - Connects to the process via the URI such as localhost:5858


### PR DESCRIPTION
/to @trevnorris @isaacs

https://github.com/joyent/node/commit/7d654be627f187f10c8df6b2a1020f88860202be

applies to v0.10
