### PR TITLE
doc: Fix doc heading for 'response' event

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -704,7 +704,7 @@ which has been transmitted are equal or not.
 The request implements the [Writable Stream][] interface. This is an
 [EventEmitter][] with the following events:
 
-### Event 'response'
+### Event: 'response'
 
 `function (response) { }`
 


### PR DESCRIPTION
Add colon to event heading to ensure it matches other events.

Fixes joyent/node#5687
