### PR TITLE
doc: Fix argument typo in SimpleProtocol v1 ex.

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -789,7 +789,7 @@ util.inherits(SimpleProtocol, Readable);
 
 function SimpleProtocol(source, options) {
   if (!(this instanceof SimpleProtocol))
-    return new SimpleProtocol(options);
+    return new SimpleProtocol(source, options);
 
   Readable.call(this, options);
   this._inBody = false;


### PR DESCRIPTION
Fixes a typo with arguments in the streams SimpleProtocol v1 example.

I originally thought this was intentional and it had my very confused for a while.
