### PR TITLE
node: change AsyncListener API

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -42,9 +42,6 @@ exports._stack = stack;
 exports.active = null;
 
 
-function noop() { }
-
-
 var listenerObj = {
   error: function errorHandler(domain, er) {
     var caught = false;
@@ -104,7 +101,7 @@ inherits(Domain, EventEmitter);
 function Domain() {
   EventEmitter.call(this);
   this.members = [];
-  this._listener = process.createAsyncListener(noop, listenerObj, this);
+  this._listener = process.createAsyncListener(listenerObj, this);
 }
 
 Domain.prototype.members = undefined;

--- a/test/simple/test-asynclistener-error-add-after.js
+++ b/test/simple/test-asynclistener-error-add-after.js
@@ -30,8 +30,6 @@ var caught = 0;
 var expectCaught = 0;
 var exitCbRan = false;
 
-function asyncL() { }
-
 var callbacksObj = {
   error: function(value, er) {
     var idx = errorMsgs.indexOf(er.message);
@@ -48,7 +46,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.createAsyncListener(asyncL, callbacksObj);
+var listener = process.createAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   // Just in case.

--- a/test/simple/test-asynclistener-error-multiple-handled.js
+++ b/test/simple/test-asynclistener-error-multiple-handled.js
@@ -33,17 +33,24 @@ function onAsync1() {
   return 1;
 }
 
+function onError(stor) {
+  results.push(stor);
+  return true;
+}
+
 var results = [];
-var asyncNoHandleError = {
-  error: function(stor) {
-    results.push(stor);
-    return true;
-  }
+var asyncNoHandleError0 = {
+  create: onAsync0,
+  error: onError
+};
+var asyncNoHandleError1 = {
+  create: onAsync1,
+  error: onError
 };
 
 var listeners = [
-  process.addAsyncListener(onAsync0, asyncNoHandleError),
-  process.addAsyncListener(onAsync1, asyncNoHandleError)
+  process.addAsyncListener(asyncNoHandleError0),
+  process.addAsyncListener(asyncNoHandleError1)
 ];
 
 process.nextTick(function() {

--- a/test/simple/test-asynclistener-error-multiple-mix.js
+++ b/test/simple/test-asynclistener-error-multiple-mix.js
@@ -22,8 +22,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-function onAsync() {}
-
 var results = [];
 var asyncNoHandleError = {
   error: function(stor) {
@@ -39,8 +37,8 @@ var asyncHandleError = {
 };
 
 var listeners = [
-  process.addAsyncListener(onAsync, asyncHandleError),
-  process.addAsyncListener(onAsync, asyncNoHandleError)
+  process.addAsyncListener(asyncHandleError),
+  process.addAsyncListener(asyncNoHandleError)
 ];
 
 // Even if an error handler returns true, both should fire.

--- a/test/simple/test-asynclistener-error-multiple-unhandled.js
+++ b/test/simple/test-asynclistener-error-multiple-unhandled.js
@@ -30,16 +30,23 @@ function onAsync1() {
   return 1;
 }
 
+function onError(stor) {
+  results.push(stor);
+}
+
 var results = [];
-var asyncNoHandleError = {
-  error: function(stor) {
-    results.push(stor);
-  }
+var asyncNoHandleError0 = {
+  create: onAsync0,
+  error: onError
+};
+var asyncNoHandleError1 = {
+  create: onAsync1,
+  error: onError
 };
 
 var listeners = [
-  process.addAsyncListener(onAsync0, asyncNoHandleError),
-  process.addAsyncListener(onAsync1, asyncNoHandleError)
+  process.addAsyncListener(asyncNoHandleError0),
+  process.addAsyncListener(asyncNoHandleError1)
 ];
 
 var uncaughtFired = false;

--- a/test/simple/test-asynclistener-error-net.js
+++ b/test/simple/test-asynclistener-error-net.js
@@ -29,8 +29,6 @@ var errorMsgs = [];
 var caught = 0;
 var expectCaught = 0;
 
-function asyncL() { }
-
 var callbacksObj = {
   error: function(value, er) {
     var idx = errorMsgs.indexOf(er.message);
@@ -47,7 +45,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.addAsyncListener(asyncL, callbacksObj);
+var listener = process.addAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   process.removeAsyncListener(listener);

--- a/test/simple/test-asynclistener-error-throw-in-after.js
+++ b/test/simple/test-asynclistener-error-throw-in-after.js
@@ -23,7 +23,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var once = 0;
-function onAsync0() { }
 
 var results = [];
 var handlers = {
@@ -38,7 +37,7 @@ var handlers = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, handlers);
+var key = process.addAsyncListener(handlers);
 
 var uncaughtFired = false;
 process.on('uncaughtException', function(err) {

--- a/test/simple/test-asynclistener-error-throw-in-before-multiple.js
+++ b/test/simple/test-asynclistener-error-throw-in-before-multiple.js
@@ -23,8 +23,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var once = 0;
-function onAsync0() { }
-function onAsync1() { }
 
 var results = [];
 var handlers = {
@@ -52,8 +50,8 @@ var handlers1 = {
 }
 
 var listeners = [
-  process.addAsyncListener(onAsync0, handlers),
-  process.addAsyncListener(onAsync1, handlers1)
+  process.addAsyncListener(handlers),
+  process.addAsyncListener(handlers1)
 ];
 
 var uncaughtFired = false;

--- a/test/simple/test-asynclistener-error-throw-in-before.js
+++ b/test/simple/test-asynclistener-error-throw-in-before.js
@@ -23,7 +23,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var once = 0;
-function onAsync0() {}
 
 var results = [];
 var handlers = {
@@ -38,7 +37,7 @@ var handlers = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, handlers);
+var key = process.addAsyncListener(handlers);
 
 var uncaughtFired = false;
 process.on('uncaughtException', function(err) {

--- a/test/simple/test-asynclistener-error-throw-in-error.js
+++ b/test/simple/test-asynclistener-error-throw-in-error.js
@@ -34,7 +34,7 @@ else
 function runChild() {
   var cntr = 0;
 
-  var key = process.addAsyncListener(function() { }, {
+  var key = process.addAsyncListener({
     error: function onError() {
       cntr++;
       throw new Error('onError');

--- a/test/simple/test-asynclistener-error.js
+++ b/test/simple/test-asynclistener-error.js
@@ -33,8 +33,6 @@ var caught = 0;
 var expectCaught = 0;
 var exitCbRan = false;
 
-function asyncL() { }
-
 var callbacksObj = {
   error: function(value, er) {
     var idx = errorMsgs.indexOf(er.message);
@@ -48,7 +46,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.createAsyncListener(asyncL, callbacksObj);
+var listener = process.createAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   removeListener(listener);

--- a/test/simple/test-asynclistener-multi-timeout.js
+++ b/test/simple/test-asynclistener-multi-timeout.js
@@ -27,8 +27,6 @@ var removeListener = process.removeAsyncListener;
 var caught = [];
 var expect = [];
 
-function asyncL(a) {}
-
 var callbacksObj = {
   error: function(value, er) {
     process._rawDebug('caught', er.message);
@@ -37,7 +35,7 @@ var callbacksObj = {
   }
 };
 
-var listener = process.createAsyncListener(asyncL, callbacksObj);
+var listener = process.createAsyncListener(callbacksObj);
 
 process.on('exit', function(code) {
   removeListener(listener);

--- a/test/simple/test-asynclistener-remove-add-in-before.js
+++ b/test/simple/test-asynclistener-remove-add-in-before.js
@@ -23,6 +23,9 @@ var common = require('../common');
 var assert = require('assert');
 var val;
 var callbacks = {
+  create: function() {
+    return 42;
+  },
   before: function() {
     process.removeAsyncListener(listener);
     process.addAsyncListener(listener);
@@ -32,14 +35,12 @@ var callbacks = {
   }
 };
 
-var listener = process.addAsyncListener(function() {
-  return 66;
-}, callbacks);
+var listener = process.addAsyncListener(callbacks);
 
 process.nextTick(function() {});
 
 process.on('exit', function(status) {
   process.removeAsyncListener(listener);
   assert.equal(status, 0);
-  assert.equal(val, 66);
+  assert.equal(val, 42);
 });

--- a/test/simple/test-asynclistener-remove-after.js
+++ b/test/simple/test-asynclistener-remove-after.js
@@ -27,7 +27,7 @@ var net = require('net');
 // TODO(trevnorris): Test has the flaw that it's not checking if the async
 // flag has been removed on the class instance. Though currently there's
 // no way to do that.
-var listener = process.addAsyncListener(function() { });
+var listener = process.addAsyncListener({ create: function() { }});
 
 
 // Test timers

--- a/test/simple/test-asynclistener-remove-before.js
+++ b/test/simple/test-asynclistener-remove-before.js
@@ -23,8 +23,6 @@ var common = require('../common');
 var assert = require('assert');
 var set = 0;
 
-function onAsync0() { }
-
 var asyncNoHandleError = {
   before: function() {
     set++;
@@ -34,7 +32,7 @@ var asyncNoHandleError = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, asyncNoHandleError);
+var key = process.addAsyncListener(asyncNoHandleError);
 
 process.removeAsyncListener(key);
 

--- a/test/simple/test-asynclistener-remove-in-before.js
+++ b/test/simple/test-asynclistener-remove-in-before.js
@@ -31,7 +31,7 @@ var callbacks = {
   }
 };
 
-var listener = process.addAsyncListener(function() {}, callbacks);
+var listener = process.addAsyncListener(callbacks);
 
 process.nextTick(function() {});
 

--- a/test/simple/test-asynclistener-remove-inflight-error.js
+++ b/test/simple/test-asynclistener-remove-inflight-error.js
@@ -22,8 +22,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-function onAsync0() { }
-
 var set = 0;
 var asyncNoHandleError = {
   error: function() {
@@ -31,7 +29,7 @@ var asyncNoHandleError = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, asyncNoHandleError);
+var key = process.addAsyncListener(asyncNoHandleError);
 
 process.nextTick(function() {
   throw 1;

--- a/test/simple/test-asynclistener-remove-inflight.js
+++ b/test/simple/test-asynclistener-remove-inflight.js
@@ -22,8 +22,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-function onAsync0() { }
-
 var set = 0;
 var asyncNoHandleError = {
   before: function() {
@@ -34,7 +32,7 @@ var asyncNoHandleError = {
   }
 }
 
-var key = process.addAsyncListener(onAsync0, asyncNoHandleError);
+var key = process.addAsyncListener(asyncNoHandleError);
 
 process.nextTick(function() { });
 

--- a/test/simple/test-asynclistener-throw-before-infinite-recursion.js
+++ b/test/simple/test-asynclistener-throw-before-infinite-recursion.js
@@ -31,7 +31,7 @@ var assert = require('assert');
 var cntr = 0;
 
 
-process.addAsyncListener(function() { }, {
+process.addAsyncListener({
   before: function() {
     if (++cntr > 1) {
       // Can't throw since uncaughtException will also catch that.

--- a/test/simple/test-asynclistener.js
+++ b/test/simple/test-asynclistener.js
@@ -30,11 +30,13 @@ var removeListener = process.removeAsyncListener;
 var actualAsync = 0;
 var expectAsync = 0;
 
-function onAsync() {
-  actualAsync++;
-}
+var callbacks = {
+  create: function onAsync() {
+    actualAsync++;
+  }
+};
 
-var listener = process.createAsyncListener(onAsync);
+var listener = process.createAsyncListener(callbacks);
 
 process.on('exit', function() {
   process._rawDebug('expected', expectAsync);


### PR DESCRIPTION
There was a flaw in the old API that has been fixed. Now the
asyncListener callback is now the "create" object property in the
callback object, and is optional.
