### PR TITLE
child_process: better error reporting for exec

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -698,6 +698,7 @@ exports.execFile = function(file /* args, options, callback */) {
         cmd += ' ' + args.join(' ');
 
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
+      ex.cmd = cmd;
       ex.killed = child.killed || killed;
       ex.code = code < 0 ? uv.errname(code) : code;
       ex.signal = signal;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -664,7 +664,7 @@ exports.execFile = function(file /* args, options, callback */) {
   var exited = false;
   var timeoutId;
 
-  var ex;
+  var ex = null;
 
   function exithandler(code, signal) {
     if (exited) return;
@@ -689,21 +689,25 @@ exports.execFile = function(file /* args, options, callback */) {
     }
 
     if (ex) {
-      callback(ex, stdout, stderr);
+      // Will be handled later
     } else if (code === 0 && signal === null) {
       callback(null, stdout, stderr);
-    } else {
-      var cmd = file;
-      if (args.length !== 0)
-        cmd += ' ' + args.join(' ');
+      return;
+    }
 
+    var cmd = file;
+    if (args.length !== 0)
+      cmd += ' ' + args.join(' ');
+
+    if (!ex) {
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
-      ex.cmd = cmd;
       ex.killed = child.killed || killed;
       ex.code = code < 0 ? uv.errname(code) : code;
       ex.signal = signal;
-      callback(ex, stdout, stderr);
     }
+
+    ex.cmd = cmd;
+    callback(ex, stdout, stderr);
   }
 
   function errorhandler(e) {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -693,7 +693,11 @@ exports.execFile = function(file /* args, options, callback */) {
     } else if (code === 0 && signal === null) {
       callback(null, stdout, stderr);
     } else {
-      ex = new Error('Command failed: ' + stderr);
+      var cmd = file;
+      if (args.length !== 0)
+        cmd += ' ' + args.join(' ');
+
+      ex = new Error('Command failed: ' + cmd + '\n' + stderr);
       ex.killed = child.killed || killed;
       ex.code = code < 0 ? uv.errname(code) : code;
       ex.signal = signal;

--- a/test/simple/test-child-process-exec-error.js
+++ b/test/simple/test-child-process-exec-error.js
@@ -28,7 +28,7 @@ function test(fun, code) {
 
   fun('does-not-exist', function(err) {
     assert.equal(err.code, code);
-    assert(err.code === 'ENOENT' || /does\-not\-exist/.test(err.cmd));
+    assert(/does\-not\-exist/.test(err.cmd));
     errors++;
   });
 

--- a/test/simple/test-child-process-exec-error.js
+++ b/test/simple/test-child-process-exec-error.js
@@ -28,6 +28,7 @@ function test(fun, code) {
 
   fun('does-not-exist', function(err) {
     assert.equal(err.code, code);
+    assert(err.code === 'ENOENT' || /does\-not\-exist/.test(err.cmd));
     errors++;
   });
 


### PR DESCRIPTION
Report path to executable and argv on error, stderr is not enough in
many cases.

fix #6796
