### PR TITLE
doc: Fix typo in cluster page

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -156,7 +156,7 @@ True if the process is not a master (it is the negation of `cluster.isMaster`).
 * `worker` {Worker object}
 
 When a new worker is forked the cluster module will emit a 'fork' event.
-This can be used to log worker activity, and create you own timeout.
+This can be used to log worker activity, and create your own timeout.
 
     var timeouts = [];
     function errorMsg() {


### PR DESCRIPTION
This solves #6810
