### PR TITLE
build: unconditionally disable -Werror

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -103,6 +103,10 @@
         },
       }
     },
+    # Forcibly disable -Werror.  We support a wide range of compilers, it's
+    # simply not feasible to squelch all warnings, never mind that the
+    # libraries in deps/ are not under our control.
+    'cflags!': ['-Werror'],
     'msvs_settings': {
       'VCCLCompilerTool': {
         'StringPooling': 'true', # pool string literals

--- a/node.gyp
+++ b/node.gyp
@@ -1,9 +1,6 @@
 {
   'variables': {
     'v8_use_snapshot%': 'true',
-    # Turn off -Werror in V8
-    # See http://codereview.chromium.org/8159015
-    'werror': '',
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',


### PR DESCRIPTION
Forcibly disable -Werror, the old { 'werror': '' } hack in node.gyp
no longer works with newer versions of V8.

We support a wide range of compilers, it's simply not feasible to
squelch all warnings, never mind that the libraries in deps/ are
not under our control.

Fixes #6817.

Suggested reviewer(s): @tjfontaine @trevnorris
