### PR TITLE
http: concatenate duplicate headers by default

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -154,40 +154,31 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
       }
       break;
 
-    // Comma separate. Maybe make these arrays?
-    case 'accept':
-    case 'accept-charset':
-    case 'accept-encoding':
-    case 'accept-language':
-    case 'connection':
-    case 'cookie':
-    case 'pragma':
-    case 'link':
-    case 'www-authenticate':
-    case 'proxy-authenticate':
-    case 'sec-websocket-extensions':
-    case 'sec-websocket-protocol':
+    // list is taken from:
+    // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
+    case 'content-type':
+    case 'content-length':
+    case 'user-agent':
+    case 'referer':
+    case 'host':
+    case 'authorization':
+    case 'proxy-authorization':
+    case 'if-modified-since':
+    case 'if-unmodified-since':
+    case 'from':
+    case 'location':
+    case 'max-forwards':
+      // drop duplicates
+      if (util.isUndefined(dest[field])) dest[field] = value;
+      break;
+
+    default:
+      // make comma-separated list
       if (!util.isUndefined(dest[field])) {
         dest[field] += ', ' + value;
       } else {
         dest[field] = value;
       }
-      break;
-
-
-    default:
-      if (field.slice(0, 2) == 'x-') {
-        // except for x-
-        if (!util.isUndefined(dest[field])) {
-          dest[field] += ', ' + value;
-        } else {
-          dest[field] = value;
-        }
-      } else {
-        // drop duplicates
-        if (util.isUndefined(dest[field])) dest[field] = value;
-      }
-      break;
   }
 };
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -169,14 +169,15 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
     case 'location':
     case 'max-forwards':
       // drop duplicates
-      if (util.isUndefined(dest[field])) dest[field] = value;
+      if (util.isUndefined(dest[field]))
+        dest[field] = value;
       break;
 
     default:
       // make comma-separated list
-      if (!util.isUndefined(dest[field])) {
+      if (!util.isUndefined(dest[field]))
         dest[field] += ', ' + value;
-      } else {
+      else {
         dest[field] = value;
       }
   }

--- a/test/simple/test-http-server-multiheaders2.js
+++ b/test/simple/test-http-server-multiheaders2.js
@@ -1,0 +1,109 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Verify that the HTTP server implementation handles multiple instances
+// of the same header as per RFC2616: joining the handful of fields by ', '
+// that support it, and dropping duplicates for other fields.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var multipleAllowed = [
+  'Accept',
+  'Accept-Charset',
+  'Accept-Encoding',
+  'Accept-Language',
+  'Connection',
+  'Cookie',
+  'DAV', // GH-2750
+  'Pragma', // GH-715
+  'Link', // GH-1187
+  'WWW-Authenticate', // GH-1083
+  'Proxy-Authenticate', // GH-4052
+  'Sec-Websocket-Extensions', // GH-2764
+  'Sec-Websocket-Protocol', // GH-2764
+  'Via', // GH-6660
+
+  // not a special case, just making sure it's parsed correctly
+  'X-Forwarded-For',
+
+  // make sure that unspecified headers is treated as multiple
+  'Some-Random-Header',
+  'X-Some-Random-Header',
+];
+
+var multipleForbidden = [
+  'Content-Type',
+  'User-Agent',
+  'Referer',
+  'Host',
+  'Authorization',
+  'Proxy-Authorization',
+  'If-Modified-Since',
+  'If-Unmodified-Since',
+  'From',
+  'Location',
+  'Max-Forwards',
+
+  // special case, tested differently
+  //'Content-Length',
+];
+
+var srv = http.createServer(function(req, res) {
+  multipleForbidden.forEach(function(header) {
+    assert.equal(req.headers[header.toLowerCase()], 'foo', 'header parsed incorrectly: ' + header);
+  });
+  multipleAllowed.forEach(function(header) {
+    assert.equal(req.headers[header.toLowerCase()], 'foo, bar', 'header parsed incorrectly: ' + header);
+  });
+  assert.equal(req.headers['content-length'], 0);
+
+  res.writeHead(200, {'Content-Type' : 'text/plain'});
+  res.end('EOF');
+
+  srv.close();
+});
+
+function makeHeader(value) {
+  return function(header) {
+    return [header, value];
+  }
+}
+
+var headers = []
+  .concat(multipleAllowed.map(makeHeader('foo')))
+  .concat(multipleForbidden.map(makeHeader('foo')))
+  .concat(multipleAllowed.map(makeHeader('bar')))
+  .concat(multipleForbidden.map(makeHeader('bar')))
+  // content-length is a special case since node.js
+  // is dropping connetions with non-numeric headers
+  .concat([['content-length', 0], ['content-length', 123]]);
+
+srv.listen(common.PORT, function() {
+  http.get({
+    host: 'localhost',
+    port: common.PORT,
+    path: '/',
+    headers: headers,
+  });
+});
+


### PR DESCRIPTION
Currently node.js has a list of headers which are allowed to be duplicated, and is dropping any headers that aren't on that list (or start with `x-`). I'm suggesting to do the opposite: build a list of known singular headers and treat others as multiple.

Relevant discussion is in issue #2750 (note: I believe a bug with not concatenating DAV still exists).

I took a list of singular headers from [firefox source code](http://bonsai.mozilla.org/cvsblame.cgi?file=mozilla/netwerk/protocol/http/src/nsHttpHeaderArray.cpp&rev=1.16&mark=235#235), since firefox seem to do the same thing I'm suggesting here.

More detailed explanation. There are four kinds of headers:
1. known singular (i.e. `Content-Type`)
2. known multiple (i.e. `Accept`)
3. unknown regular (i.e. `FooBar`)
4. unknown starting with "x-" (i.e. `X-FooBar`)

Currently node.js treats 2 & 4 as multiple, and 1 & 3 as singular. Suggested change: treat 2 & 3 & 4 as multiple, 1 as singular.

Current behaviour creates a few issues:
- If there are unknown multiple regular (non-"x-") headers, they need to be included in the list. There were countless pull requests to do that in the past (#715, #1083, #1187, #2764, #4052), and more (#6660) are coming.
- Node.js is dropping perfectly valid headers until the patch to include a header is made. Old versions will still do that.
- If someone creates a custom header without `X-` prefix, it is treated as singular one. We can't possibly make a full list of multiple headers, because people can add custom ones.
- There is a difference between handling `X-` headers and regular ones. There should not be a difference according to [RFC 6648](http://tools.ietf.org/html/rfc6648). So current behaviour might be confusing, and is clearly violates this part of RFC:

```
   Implementations of application protocols MUST NOT make any
   assumptions about the status of a parameter, nor take automatic
   action regarding a parameter, based solely on the presence or absence
   of "X-" or a similar construct in the parameter's name.
```

Suggested approach will solve all of this at the cost of concatenating unknown singular headers (but those requests are invalid anyway).
