### PR TITLE
configure: always set `arm_float_abi`

### DIFF
--- a/configure
+++ b/configure
@@ -431,7 +431,7 @@ def configure_arm(o):
   elif is_arm_hard_float_abi():
     arm_float_abi = 'hard'
   else:
-    'default'
+    arm_float_abi = 'default'
   o['variables']['armv7'] = int(is_arch_armv7())
   o['variables']['arm_fpu'] = 'vfpv3'  # V8 3.18 no longer supports VFP2.
   o['variables']['arm_neon'] = int(is_arm_neon())


### PR DESCRIPTION
When not specified as a configure flag, and not derived from system
configuration, `arm_float_abi` should be set to `'default'`.

fix #6789
