### PR TITLE
stream: check for state.decoder.end() (0.8 compat)

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -369,7 +369,7 @@ function chunkInvalid(state, chunk) {
 
 
 function onEofChunk(stream, state) {
-  if (state.decoder && !state.ended) {
+  if (state.decoder && !state.ended && state.decoder.end) {
     var chunk = state.decoder.end();
     if (chunk && chunk.length) {
       state.buffer.push(chunk);


### PR DESCRIPTION
See https://github.com/isaacs/readable-stream/commit/5aec72b01618ddfc46ad09cdbc66dc8d26211e52

This is fixed in master/0.11, just not here.
