### PR TITLE
Add tests for Domain.enter()/.exit() stack

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -129,7 +129,7 @@ Domain.prototype.exit = function() {
   // exit all domains until this one.
   var index = stack.lastIndexOf(this);
   if (index !== -1)
-    stack.splice(index + 1);
+    stack.splice(index);
   else
     stack.length = 0;
 

--- a/test/simple/test-domain-enter-exit.js
+++ b/test/simple/test-domain-enter-exit.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Make sure the domain stack is a stack
+
+var assert = require('assert');
+var domain = require('domain');
+
+function names(array) {
+  return array.map(function(d) {
+    return d.name
+  }).join(', ');
+}
+
+var a = domain.create();
+a.name = 'a';
+var b = domain.create();
+b.name = 'b';
+var c = domain.create();
+c.name = 'c';
+
+a.enter(); // push
+assert.deepEqual(domain._stack, [a],
+                 'a not pushed: ' + names(domain._stack));
+
+b.enter(); // push
+assert.deepEqual(domain._stack, [a, b],
+                 'b not pushed: ' + names(domain._stack));
+
+c.enter(); // push
+assert.deepEqual(domain._stack, [a, b, c],
+                 'c not pushed: ' + names(domain._stack));
+
+b.exit(); // pop
+assert.deepEqual(domain._stack, [a],
+                 'b and c not popped: ' + names(domain._stack));
+
+b.enter(); // push
+assert.deepEqual(domain._stack, [a, b],
+                 'b not pushed: ' + names(domain._stack));


### PR DESCRIPTION
`Domain.exit()` should pop the given domain off the domain stack as well as the domains after it. Looks like an off-by-one error.

Given:

``` javascript
var domain = require('domain');

var a = domain.create();   a.name = 'a';
var b = domain.create();   b.name = 'b';
var c = domain.create();   c.name = 'c';

a.enter();   dumpDomains();
b.enter();   dumpDomains();
c.enter();   dumpDomains();
b.exit();    dumpDomains();

function dumpDomains() {
  console.log( domain._stack.map(function(d) { return d.name; }) );
}
```

v0.10.24:

```
[ 'a' ]
[ 'a', 'b' ]
[ 'a', 'b', 'c' ]
[ 'a' ]
```

v0.11.11-pre

```
[ 'a' ]
[ 'a', 'b' ]
[ 'a', 'b', 'c' ]
[ 'a', 'b' ]
```

Possibly introduced in bc39bdd9, found while working on #6819.
