### PR TITLE
Make domain.create().exit() safe

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -136,15 +136,13 @@ Domain.prototype.enter = function() {
 
 
 Domain.prototype.exit = function() {
-  if (this._disposed) return;
+  // skip disposed domains, as usual, but also don't do anything if this
+  // domain is not on the stack.
+  var index = stack.lastIndexOf(this);
+  if (this._disposed || index === -1) return;
 
   // exit all domains until this one.
-  var index = stack.lastIndexOf(this);
-  if (index !== -1)
-    stack.splice(index);
-  else
-    stack.length = 0;
-  _domain_flag[0] = stack.length;
+  stack.splice(index);
 
   exports.active = stack[stack.length - 1];
   process.domain = exports.active;

--- a/test/simple/test-domain-safe-exit.js
+++ b/test/simple/test-domain-safe-exit.js
@@ -1,0 +1,36 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Make sure the domain stack doesn't get clobbered by un-matched .exit()
+
+var assert = require('assert');
+var domain = require('domain');
+
+var a = domain.create();
+var b = domain.create();
+
+a.enter(); // push
+b.enter(); // push
+assert.deepEqual(domain._stack, [a, b], 'b not pushed');
+
+domain.create().exit(); // no-op
+assert.deepEqual(domain._stack, [a, b], 'stack mangled!');


### PR DESCRIPTION
Calling `.exit()` on a domain that isn't in the domain stack should not clear the domain stack. It should do nothing.

Given:

``` JavaScript
var domain = require('domain');

var a = domain.create();    a.name = 'a';
var b = domain.create();    b.name = 'b';
var c = domain.create();    c.name = 'c';

a.enter();    dumpDomains();
b.enter();    dumpDomains();
c.enter();    dumpDomains();

domain
  .create()
  .exit();    dumpDomains();

function dumpDomains() {
  console.log(domain._stack.map(function(d){ return d.name; }));
}
```

Expected output:

```
[ 'a' ]
[ 'a', 'b' ]
[ 'a', 'b', 'c' ]
[ 'a', 'b', 'c' ]
```

Actual output:

```
[ 'a' ]
[ 'a', 'b' ]
[ 'a', 'b', 'c' ]
[]
```

Fixes #6819
