### PR TITLE
src: revert domain using AsyncListeners

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -457,12 +457,8 @@ ClientRequest.prototype.onSocket = function(socket) {
   var req = this;
 
   process.nextTick(function() {
-    // If a domain was added to the request, attach it to the socket.
-    if (req.domain)
-      socket._handle.addAsyncListener(req.domain._listener);
     tickOnSocket(req, socket);
   });
-
 };
 
 ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -28,6 +28,26 @@ var inherits = util.inherits;
 // a few side effects.
 EventEmitter.usingDomains = true;
 
+// overwrite process.domain with a getter/setter that will allow for more
+// effective optimizations
+var _domain = [null];
+Object.defineProperty(process, 'domain', {
+  enumerable: true,
+  get: function() {
+    return _domain[0];
+  },
+  set: function(arg) {
+    return _domain[0] = arg;
+  }
+});
+
+// objects with external array data are excellent ways to communicate state
+// between js and c++ w/o much overhead
+var _domain_flag = {};
+
+// let the process know we're using domains
+process._setupDomainUse(_domain, _domain_flag);
+
 exports.Domain = Domain;
 
 exports.create = exports.createDomain = function() {
@@ -42,71 +62,66 @@ exports._stack = stack;
 exports.active = null;
 
 
-var listenerObj = {
-  error: function errorHandler(domain, er) {
-    var caught = false;
-    // ignore errors on disposed domains.
-    //
-    // XXX This is a bit stupid.  We should probably get rid of
-    // domain.dispose() altogether.  It's almost always a terrible
-    // idea.  --isaacs
-    if (domain._disposed)
-      return true;
-
-    er.domain = domain;
-    er.domainThrown = true;
-    // wrap this in a try/catch so we don't get infinite throwing
-    try {
-      // One of three things will happen here.
-      //
-      // 1. There is a handler, caught = true
-      // 2. There is no handler, caught = false
-      // 3. It throws, caught = false
-      //
-      // If caught is false after this, then there's no need to exit()
-      // the domain, because we're going to crash the process anyway.
-      caught = domain.emit('error', er);
-
-      if (stack.length === 0)
-        process.removeAsyncListener(domain._listener);
-
-      // Exit all domains on the stack.  Uncaught exceptions end the
-      // current tick and no domains should be left on the stack
-      // between ticks.
-      stack.length = 0;
-      exports.active = process.domain = null;
-    } catch (er2) {
-      // The domain error handler threw!  oh no!
-      // See if another domain can catch THIS error,
-      // or else crash on the original one.
-      // If the user already exited it, then don't double-exit.
-      if (domain === exports.active) {
-        stack.pop();
-      }
-      if (stack.length) {
-        exports.active = process.domain = stack[stack.length - 1];
-        caught = process._fatalException(er2);
-      } else {
-        caught = false;
-      }
-      return caught;
-    }
-    return caught;
-  }
-};
-
-
 inherits(Domain, EventEmitter);
 
 function Domain() {
   EventEmitter.call(this);
+
   this.members = [];
-  this._listener = process.createAsyncListener(listenerObj, this);
 }
 
 Domain.prototype.members = undefined;
 Domain.prototype._disposed = undefined;
-Domain.prototype._listener = undefined;
+
+
+// Called by process._fatalException in case an error was thrown.
+Domain.prototype._errorHandler = function errorHandler(er) {
+  var caught = false;
+  // ignore errors on disposed domains.
+  //
+  // XXX This is a bit stupid.  We should probably get rid of
+  // domain.dispose() altogether.  It's almost always a terrible
+  // idea.  --isaacs
+  if (this._disposed)
+    return true;
+
+  er.domain = this;
+  er.domainThrown = true;
+  // wrap this in a try/catch so we don't get infinite throwing
+  try {
+    // One of three things will happen here.
+    //
+    // 1. There is a handler, caught = true
+    // 2. There is no handler, caught = false
+    // 3. It throws, caught = false
+    //
+    // If caught is false after this, then there's no need to exit()
+    // the domain, because we're going to crash the process anyway.
+    caught = this.emit('error', er);
+
+    // Exit all domains on the stack.  Uncaught exceptions end the
+    // current tick and no domains should be left on the stack
+    // between ticks.
+    stack.length = 0;
+    exports.active = process.domain = null;
+  } catch (er2) {
+    // The domain error handler threw!  oh no!
+    // See if another domain can catch THIS error,
+    // or else crash on the original one.
+    // If the user already exited it, then don't double-exit.
+    if (this === exports.active) {
+      stack.pop();
+    }
+    if (stack.length) {
+      exports.active = process.domain = stack[stack.length - 1];
+      caught = process._fatalException(er2);
+    } else {
+      caught = false;
+    }
+    return caught;
+  }
+  return caught;
+};
 
 
 Domain.prototype.enter = function() {
@@ -116,15 +131,12 @@ Domain.prototype.enter = function() {
   // to push it onto the stack so that we can pop it later.
   exports.active = process.domain = this;
   stack.push(this);
-
-  process.addAsyncListener(this._listener);
+  _domain_flag[0] = stack.length;
 };
 
 
 Domain.prototype.exit = function() {
   if (this._disposed) return;
-
-  process.removeAsyncListener(this._listener);
 
   // exit all domains until this one.
   var index = stack.lastIndexOf(this);
@@ -132,6 +144,7 @@ Domain.prototype.exit = function() {
     stack.splice(index + 1);
   else
     stack.length = 0;
+  _domain_flag[0] = stack.length;
 
   exports.active = stack[stack.length - 1];
   process.domain = exports.active;
@@ -165,13 +178,6 @@ Domain.prototype.add = function(ee) {
 
   ee.domain = this;
   this.members.push(ee);
-
-  // Adding the domain._listener to the Wrap associated with the event
-  // emitter instance will be done automatically either on class
-  // instantiation or manually, like in cases of net listen().
-  // The reason it cannot be done here is because in specific cases the
-  // _handle is not created on EE instantiation, so there's no place to
-  // add the listener.
 };
 
 
@@ -180,24 +186,6 @@ Domain.prototype.remove = function(ee) {
   var index = this.members.indexOf(ee);
   if (index !== -1)
     this.members.splice(index, 1);
-
-  // First check if the ee is a handle itself.
-  if (ee.removeAsyncListener)
-    ee.removeAsyncListener(this._listener);
-
-  // Manually remove the asyncListener from the handle, if possible.
-  if (ee._handle && ee._handle.removeAsyncListener)
-    ee._handle.removeAsyncListener(this._listener);
-
-  // TODO(trevnorris): Are there cases where the handle doesn't live on
-  // the ee or the _handle.
-
-  // TODO(trevnorris): For debugging that we've missed adding AsyncWrap's
-  // methods to a handle somewhere on the native side.
-  if (ee._handle && !ee._handle.removeAsyncListener) {
-    process._rawDebug('Wrap handle is missing AsyncWrap methods');
-    process.abort();
-  }
 };
 
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -91,6 +91,9 @@ EventEmitter.prototype.emit = function(type) {
   if (util.isUndefined(handler))
     return false;
 
+  if (this.domain && this !== process)
+    this.domain.enter();
+
   if (util.isFunction(handler)) {
     switch (arguments.length) {
       // fast cases
@@ -122,6 +125,9 @@ EventEmitter.prototype.emit = function(type) {
     for (i = 0; i < len; i++)
       listeners[i].apply(this, args);
   }
+
+  if (this.domain && this !== process)
+    this.domain.exit();
 
   return true;
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -1089,20 +1089,9 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   // generate connection key, this should be unique to the connection
   this._connectionKey = addressType + ':' + address + ':' + port;
 
-  // If a domain is attached to the event emitter then we need to add
-  // the listener to the handle.
-  if (this.domain) {
-    this._handle.addAsyncListener(this.domain._listener);
-    process.addAsyncListener(this.domain._listener);
-  }
-
   process.nextTick(function() {
     self.emit('listening');
   });
-
-  if (this.domain) {
-    process.removeAsyncListener(this.domain._listener);
-  }
 };
 
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -112,7 +112,8 @@ function listOnTimeout() {
       // other timers that expire on this tick should still run.
       //
       // https://github.com/joyent/node/issues/2631
-      if (first.domain && first.domain._disposed)
+      var domain = first.domain;
+      if (domain && domain._disposed)
         continue;
 
       hasQueue = !!first._asyncQueue;
@@ -120,8 +121,12 @@ function listOnTimeout() {
       try {
         if (hasQueue)
           loadAsyncQueue(first);
+        if (domain)
+          domain.enter();
         threw = true;
         first._onTimeout();
+        if (domain)
+          domain.exit();
         if (hasQueue)
           unloadAsyncQueue(first);
         threw = false;
@@ -368,7 +373,7 @@ L.init(immediateQueue);
 
 function processImmediate() {
   var queue = immediateQueue;
-  var hasQueue, immediate;
+  var domain, hasQueue, immediate;
 
   immediateQueue = {};
   L.init(immediateQueue);
@@ -376,9 +381,12 @@ function processImmediate() {
   while (L.isEmpty(queue) === false) {
     immediate = L.shift(queue);
     hasQueue = !!immediate._asyncQueue;
+    domain = immediate.domain;
 
     if (hasQueue)
       loadAsyncQueue(immediate);
+    if (domain)
+      domain.enter();
 
     var threw = true;
     try {
@@ -398,6 +406,8 @@ function processImmediate() {
       }
     }
 
+    if (domain)
+      domain.exit();
     if (hasQueue)
       unloadAsyncQueue(immediate);
   }
@@ -481,7 +491,7 @@ function unrefTimeout() {
 
   debug('unrefTimer fired');
 
-  var diff, first, hasQueue, threw;
+  var diff, domain, first, hasQueue, threw;
   while (first = L.peek(unrefList)) {
     diff = now - first._idleStart;
     hasQueue = !!first._asyncQueue;
@@ -496,16 +506,21 @@ function unrefTimeout() {
 
     L.remove(first);
 
+    domain = first.domain;
+
     if (!first._onTimeout) continue;
-    if (first.domain && first.domain._disposed) continue;
+    if (domain && domain._disposed) continue;
 
     try {
       if (hasQueue)
         loadAsyncQueue(first);
+      if (domain) domain.enter();
       threw = true;
       debug('unreftimer firing timeout');
       first._onTimeout();
       threw = false;
+      if (domain)
+        domain.exit();
       if (hasQueue)
         unloadAsyncQueue(first);
     } finally {

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -88,10 +88,102 @@ inline bool AsyncWrap::has_async_queue() {
 }
 
 
+// I hate you domains.
+inline v8::Handle<v8::Value> AsyncWrap::MakeDomainCallback(
+    const v8::Handle<v8::Function> cb,
+    int argc,
+    v8::Handle<v8::Value>* argv) {
+  assert(env()->context() == env()->isolate()->GetCurrentContext());
+
+  v8::Local<v8::Object> context = object();
+  v8::Local<v8::Object> process = env()->process_object();
+  v8::Local<v8::Value> domain_v = context->Get(env()->domain_string());
+  v8::Local<v8::Object> domain;
+
+  v8::TryCatch try_catch;
+  try_catch.SetVerbose(true);
+
+  if (has_async_queue()) {
+    v8::Local<v8::Value> val = context.As<v8::Value>();
+    env()->async_listener_load_function()->Call(process, 1, &val);
+
+    if (try_catch.HasCaught())
+      return v8::Undefined(env()->isolate());
+  }
+
+  bool has_domain = domain_v->IsObject();
+  if (has_domain) {
+    domain = domain_v.As<v8::Object>();
+
+    if (domain->Get(env()->disposed_string())->IsTrue())
+      return Undefined(env()->isolate());
+
+    v8::Local<v8::Function> enter =
+      domain->Get(env()->enter_string()).As<v8::Function>();
+    assert(enter->IsFunction());
+    enter->Call(domain, 0, NULL);
+
+    if (try_catch.HasCaught())
+      return Undefined(env()->isolate());
+  }
+
+  v8::Local<v8::Value> ret = cb->Call(context, argc, argv);
+
+  if (try_catch.HasCaught()) {
+    return Undefined(env()->isolate());
+  }
+
+  if (has_domain) {
+    v8::Local<v8::Function> exit =
+      domain->Get(env()->exit_string()).As<v8::Function>();
+    assert(exit->IsFunction());
+    exit->Call(domain, 0, NULL);
+
+    if (try_catch.HasCaught())
+      return Undefined(env()->isolate());
+  }
+
+  if (has_async_queue()) {
+    v8::Local<v8::Value> val = context.As<v8::Value>();
+    env()->async_listener_unload_function()->Call(process, 1, &val);
+
+    if (try_catch.HasCaught())
+      return Undefined(env()->isolate());
+  }
+
+  Environment::TickInfo* tick_info = env()->tick_info();
+
+  if (tick_info->in_tick()) {
+    return ret;
+  }
+
+  if (tick_info->length() == 0) {
+    tick_info->set_index(0);
+    return ret;
+  }
+
+  tick_info->set_in_tick(true);
+
+  env()->tick_callback_function()->Call(process, 0, NULL);
+
+  tick_info->set_in_tick(false);
+
+  if (try_catch.HasCaught()) {
+    tick_info->set_last_threw(true);
+    return Undefined(env()->isolate());
+  }
+
+  return ret;
+}
+
+
 inline v8::Handle<v8::Value> AsyncWrap::MakeCallback(
     const v8::Handle<v8::Function> cb,
     int argc,
     v8::Handle<v8::Value>* argv) {
+  if (env()->using_domains())
+    return MakeDomainCallback(cb, argc, argv);
+
   assert(env()->context() == env()->isolate()->GetCurrentContext());
 
   v8::Local<v8::Object> context = object();

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -62,6 +62,13 @@ class AsyncWrap : public BaseObject {
                                             v8::Handle<v8::Value>* argv);
 
  private:
+  // TODO(trevnorris): BURN IN FIRE! Remove this as soon as a suitable
+  // replacement is committed.
+  inline v8::Handle<v8::Value> MakeDomainCallback(
+      const v8::Handle<v8::Function> cb,
+      int argc,
+      v8::Handle<v8::Value>* argv);
+
   // Add an async listener to an existing handle.
   template <typename Type>
   static inline void AddAsyncListener(

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -86,6 +86,22 @@ inline uint32_t Environment::AsyncListener::count() const {
   return fields_[kCount];
 }
 
+inline Environment::DomainFlag::DomainFlag() {
+  for (int i = 0; i < kFieldsCount; ++i) fields_[i] = 0;
+}
+
+inline uint32_t* Environment::DomainFlag::fields() {
+  return fields_;
+}
+
+inline int Environment::DomainFlag::fields_count() const {
+  return kFieldsCount;
+}
+
+inline uint32_t Environment::DomainFlag::count() const {
+  return fields_[kCount];
+}
+
 inline Environment::TickInfo::TickInfo() : in_tick_(false), last_threw_(false) {
   for (int i = 0; i < kFieldsCount; ++i)
     fields_[i] = 0;
@@ -163,6 +179,7 @@ inline Environment::Environment(v8::Local<v8::Context> context)
     : isolate_(context->GetIsolate()),
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate())),
       using_smalloc_alloc_cb_(false),
+      using_domains_(false),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());
@@ -191,6 +208,12 @@ inline v8::Isolate* Environment::isolate() const {
 inline bool Environment::has_async_listeners() const {
   // The const_cast is okay, it doesn't violate conceptual const-ness.
   return const_cast<Environment*>(this)->async_listener()->count() > 0;
+}
+
+inline bool Environment::in_domain() const {
+  // The const_cast is okay, it doesn't violate conceptual const-ness.
+  return using_domains() &&
+         const_cast<Environment*>(this)->domain_flag()->count() > 0;
 }
 
 inline Environment* Environment::from_immediate_check_handle(
@@ -231,6 +254,10 @@ inline Environment::AsyncListener* Environment::async_listener() {
   return &async_listener_count_;
 }
 
+inline Environment::DomainFlag* Environment::domain_flag() {
+  return &domain_flag_;
+}
+
 inline Environment::TickInfo* Environment::tick_info() {
   return &tick_info_;
 }
@@ -241,6 +268,14 @@ inline bool Environment::using_smalloc_alloc_cb() const {
 
 inline void Environment::set_using_smalloc_alloc_cb(bool value) {
   using_smalloc_alloc_cb_ = value;
+}
+
+inline bool Environment::using_domains() const {
+  return using_domains_;
+}
+
+inline void Environment::set_using_domains(bool value) {
+  using_domains_ = value;
 }
 
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3628,6 +3628,9 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
 
   if (args[4]->IsFunction()) {
     obj->Set(env->ondone_string(), args[4]);
+    // XXX(trevnorris): This will need to go with the rest of domains.
+    if (env->in_domain())
+      obj->Set(env->domain_string(), env->domain_array()->Get(0));
     uv_queue_work(env->event_loop(),
                   req->work_req(),
                   EIO_PBKDF2,
@@ -3789,6 +3792,9 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
 
   if (args[1]->IsFunction()) {
     obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "ondone"), args[1]);
+    // XXX(trevnorris): This will need to go with the rest of domains.
+    if (env->in_domain())
+      obj->Set(env->domain_string(), env->domain_array()->Get(0));
     uv_queue_work(env->event_loop(),
                   req->work_req(),
                   RandomBytesWork<pseudoRandom>,

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -39,6 +39,9 @@ class ReqWrap : public AsyncWrap {
  public:
   ReqWrap(Environment* env, v8::Handle<v8::Object> object)
       : AsyncWrap(env, object) {
+    if (env->in_domain())
+      object->Set(env->domain_string(), env->domain_array()->Get(0));
+
     QUEUE_INSERT_TAIL(&req_wrap_queue, &req_wrap_queue_);
   }
 


### PR DESCRIPTION
This is a slightly modified revert of bc39bdd.

Getting domains to use AsyncListeners became too much of a challenge
with many edge cases. While this is still a goal, it will have to be
deferred for now until more test coverage can be provided.
