### PR TITLE
module: missing scan for `node_modules`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -494,11 +494,15 @@ Module.runMain = function() {
 
 Module._initPaths = function() {
   var isWindows = process.platform === 'win32';
+  var homeDir;
+  var npmDir;
 
   if (isWindows) {
-    var homeDir = process.env.USERPROFILE;
+    homeDir = process.env.USERPROFILE;
+    npmDir = path.resolve(process.execPath, '..', 'node_modules');
   } else {
-    var homeDir = process.env.HOME;
+    homeDir = process.env.HOME;
+    npmDir = path.resolve(process.execPath, '..', '..', 'lib', 'node_modules');
   }
 
   var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];
@@ -510,6 +514,8 @@ Module._initPaths = function() {
 
   if (process.env['NODE_PATH']) {
     paths = process.env['NODE_PATH'].split(path.delimiter).concat(paths);
+  } else {
+    paths = [npmDir].concat(paths);
   }
 
   modulePaths = paths;


### PR DESCRIPTION
`/usr/local/lib` has 2 sub-directories: `node` and `node_modules`.
I found `module` would not scan the npm default `globalDir`, `/usr/local/lib/node_modules`, but `/usr/local/lib/node`

Should node add `/usr/local/lib/node_modules` to its `paths`?

\cc @isaacs @indutny 
