### PR TITLE
test:  fix test-cluster-disconnect

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -352,7 +352,7 @@ function setupChannel(target, channel) {
 
     } else {
       this.buffering = false;
-      target.disconnect();
+      target._disconnect();
       channel.onread = nop;
       channel.close();
       maybeClose(target);
@@ -509,6 +509,9 @@ function setupChannel(target, channel) {
 
   target._disconnect = function() {
     assert(this._channel);
+
+    // Do not allow any new messages to be written.
+    this.connected = false;
 
     // This marks the fact that the channel is actually disconnected.
     this._channel = null;

--- a/test/simple/test-cluster-disconnect.js
+++ b/test/simple/test-cluster-disconnect.js
@@ -35,6 +35,7 @@ if (cluster.isWorker) {
   }).listen(common.PORT + 1, '127.0.0.1');
 
 } else if (cluster.isMaster) {
+  var servers = 2;
 
   // test a single TCP server
   var testConnection = function(port, cb) {
@@ -52,7 +53,6 @@ if (cluster.isWorker) {
 
   // test both servers created in the cluster
   var testCluster = function(cb) {
-    var servers = 2;
     var done = 0;
 
     for (var i = 0, l = servers; i < l; i++) {
@@ -76,7 +76,7 @@ if (cluster.isWorker) {
       var worker = cluster.fork();
       worker.on('listening', function() {
         online += 1;
-        if (online === workers) {
+        if (online === workers * servers) {
           cb();
         }
       });


### PR DESCRIPTION
The first commit fixes the test.
The second commit is not absolutely critical, however I discovered thanks to the broken test that when a channel is closed that has a handle queue on it, the disconnect event will never fire.
