### PR TITLE
src: return empty set on ENOSYS for interfaces

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -207,10 +207,13 @@ static Handle<Value> GetInterfaceAddresses(const Arguments& args) {
 
   uv_err_t err = uv_interface_addresses(&interfaces, &count);
 
+  ret = Object::New();
+
+  if (err.code == UV_ENOSYS)
+    return scope.Close(ret);
+
   if (err.code != UV_OK)
     return ThrowException(UVException(err.code, "uv_interface_addresses"));
-
-  ret = Object::New();
 
   for (i = 0; i < count; i++) {
     name = String::New(interfaces[i].name);


### PR DESCRIPTION
If node was compiled with --no-ifaddrs to support older operating
systems, don't throw instead simply return an empty object

Fixes #6846
