### PR TITLE
Fix path.relative on windows network shares

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -269,7 +269,7 @@ if (isWindows) {
       }
 
       if (start > end) return [];
-      return arr.slice(start, end - start + 1);
+      return arr.slice(start, end + 1);
     }
 
     var toParts = trim(to.split('\\'));


### PR DESCRIPTION
Array.prototype.slice takes `(startIndex, endIndex)` rather than `(startIndex, length)`.  If your path starts with `//`  or `\\` there will be two empty spaces at the start, which would lead to the last two parts of the path being chopped off.
