### PR TITLE
test: terminate gracefully in cluster-net-send

### DIFF
--- a/test/simple/test-cluster-net-send.js
+++ b/test/simple/test-cluster-net-send.js
@@ -38,6 +38,9 @@ if (process.argv[2] !== 'child') {
     handle.on('data', function(data) {
       called = true;
       assert.equal(data.toString(), 'hello');
+    });
+
+    handle.on('end', function() {
       worker.kill();
     });
   });


### PR DESCRIPTION
Killing the worker without ensuring the socket was closed
was causing intermittent ECONNRESET errors.
