### PR TITLE
test: close debug client in test-debugger-client

### DIFF
--- a/test/simple/test-debugger-client.js
+++ b/test/simple/test-debugger-client.js
@@ -201,9 +201,14 @@ function doTest(cb, done) {
           connectCount++;
           console.log('ready!');
           cb(c, function() {
-            console.error('>>> killing node process %d\n\n', nodeProcess.pid);
-            nodeProcess.kill();
-            done();
+            c.end();
+            c.on('end', function() {
+              console.error(
+                  '>>> killing node process %d\n\n',
+                  nodeProcess.pid);
+              nodeProcess.kill();
+              done();
+            });
           });
         });
         c.on('error', function(err) {


### PR DESCRIPTION
Killing the debuggee without first closing the socket can result
in an ECONNRESET error.
