### PR TITLE
test: give test-net-GH-5504 more time to run

### DIFF
--- a/test/simple/test-net-GH-5504.js
+++ b/test/simple/test-net-GH-5504.js
@@ -93,7 +93,7 @@ function parent() {
     setTimeout(function() {
       throw new Error('hang');
     });
-  }, 1000).unref();
+  }, 4000).unref();
 
   var s = spawn(node, [__filename, 'server'], opt);
   var c;


### PR DESCRIPTION
On Windows debug builds, the test was failing because the timeout
was too short.
