### PR TITLE
text: give more time to test-next-tick-error-spin

### DIFF
--- a/test/simple/test-next-tick-error-spin.js
+++ b/test/simple/test-next-tick-error-spin.js
@@ -29,7 +29,7 @@ if (process.argv[2] !== 'child') {
   });
   var timer = setTimeout(function() {
     throw new Error('child is hung');
-  }, 500);
+  }, 3000);
   child.on('exit', function(code) {
     console.error('ok');
     assert(!code);


### PR DESCRIPTION
The previous timeout was too short for certain execution conditions
(Windows, debug build, first execution).
