### PR TITLE
test: give repl-timeout-throw more time to run

### DIFF
--- a/test/simple/test-repl-timeout-throw.js
+++ b/test/simple/test-repl-timeout-throw.js
@@ -65,7 +65,7 @@ child.stdout.once('data', function() {
                       '  });\n' +
                       '});"";\n');
 
-    setTimeout(child.stdin.end.bind(child.stdin), 50);
+    setTimeout(child.stdin.end.bind(child.stdin), 200);
   }
 });
 


### PR DESCRIPTION
Short timeout was causing the test to fail on Windows debug builds.
