### PR TITLE
test: increase timeout in readable stream test

### DIFF
--- a/test/simple/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/simple/test-stream2-readable-empty-buffer-no-eof.js
@@ -50,15 +50,15 @@ function test1() {
       case 1:
         return r.push(buf);
       case 2:
-        setTimeout(r.read.bind(r, 0), 10);
+        setTimeout(r.read.bind(r, 0), 50);
         return r.push(new Buffer(0)); // Not-EOF!
       case 3:
-        setTimeout(r.read.bind(r, 0), 10);
+        setTimeout(r.read.bind(r, 0), 50);
         return process.nextTick(function() {
           return r.push(new Buffer(0));
         });
       case 4:
-        setTimeout(r.read.bind(r, 0), 10);
+        setTimeout(r.read.bind(r, 0), 50);
         return setTimeout(function() {
           return r.push(new Buffer(0));
         });


### PR DESCRIPTION
A slightly higher timeout is needed for the test to pass on
Windows debug builds.
