### PR TITLE
Child process spawn pr

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -531,7 +531,7 @@ amount of data allowed on stdout or stderr - if this value is exceeded then
 the child process is killed.
 
 
-## child_process.execFile(file, args, options, callback)
+## child_process.execFile(file, [args], [options], [callback])
 
 * `file` {String} The filename of the program to run
 * `args` {Array} List of string arguments

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -564,8 +564,10 @@ leaner than `child_process.exec`. It has the same options.
   * `execPath` {String} Executable used to create the child process
   * `execArgv` {Array} List of string arguments passed to the executable
     (Default: `process.execArgv`)
-  * `silent` {Boolean} If true, prevent stdout and stderr in the spawned node
-    process from being associated with the parent's (default is false)
+  * `silent` {Boolean} If true, stdin, stdout, and stderr of the child will be
+    piped to the parent, otherwise they will be inherited from the parent, see
+    the "pipe" and "inherit" options for `spawn()`'s `stdio` for more details
+    (default is false)
 * Return: ChildProcess object
 
 This is a special case of the `spawn()` functionality for spawning Node

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -695,8 +695,16 @@ exports.execFile = function(file /* args, options, callback */) {
 };
 
 
-var spawn = exports.spawn = function(file, args, options) {
-  args = args ? args.slice(0) : [];
+var spawn = exports.spawn = function(file /*, args, options*/) {
+  var args, options;
+  if (Array.isArray(arguments[1])) {
+    args = arguments[1].slice(0);
+    options = arguments[2];
+  } else {
+    args = [];
+    options = arguments[1];
+  }
+
   args.unshift(file);
 
   var env = (options ? options.env : null) || process.env;


### PR DESCRIPTION
Fix mismatches between docs and code.

This is a behaviour change to v0.10, in that code like:

```
> child_process.spawn('node', {});
TypeError: Object #<Object> has no method 'slice'
```

No longer errors, and instead behaves as documented, but I hope that is considered a bug fix, not an API change.

/to @tjfontaine
