### PR TITLE
tls: make cert/pfx optional in tls.createServer()

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -475,10 +475,6 @@ function Server(/* [options], listener */) {
   // Handle option defaults:
   this.setOptions(options);
 
-  if (!self.pfx && (!self.cert || !self.key)) {
-    throw new Error('Missing PFX or certificate + private key.');
-  }
-
   var sharedCreds = crypto.createCredentials({
     pfx: self.pfx,
     key: self.key,

--- a/test/simple/test-tls-no-cert-required.js
+++ b/test/simple/test-tls-no-cert-required.js
@@ -25,14 +25,11 @@ if (!process.versions.openssl) {
 }
 
 var common = require('../common');
-var assert = require('assert');
-var https = require('https');
 var tls = require('tls');
 
-assert.throws(function() {
-  tls.createServer({ /* empty */}).listen(0);
-}, /missing.+certificate/i);
-
-assert.throws(function() {
-  https.createServer({ /* empty */}).listen(0);
-}, /missing.+certificate/i);
+// Omitting the cert or pfx option to tls.createServer() should not throw.
+// AECDH-NULL-SHA is a no-authentication/no-encryption cipher and hence
+// doesn't need a certificate.
+tls.createServer({ ciphers: 'AECDH-NULL-SHA' }).listen(0, function() {
+  this.close();
+});


### PR DESCRIPTION
Not all ciphers require the presence of a certificate.  Remove the
check in lib/_tls_wrap.js.

Fixes #6887.

Suggested reviewer: @indutny.  GH makes something special of the changes to test/.  I removed test A and added a new test B but it's showing it like I modified test A.
