### PR TITLE
crypto: remove most of the `node_isolate` uses

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -223,7 +223,7 @@ bool EntropySource(unsigned char* buffer, size_t length) {
 void SecureContext::Initialize(Environment* env, Handle<Object> target) {
   Local<FunctionTemplate> t = FunctionTemplate::New(SecureContext::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "SecureContext"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext"));
 
   NODE_SET_PROTOTYPE_METHOD(t, "init", SecureContext::Init);
   NODE_SET_PROTOTYPE_METHOD(t, "setKey", SecureContext::SetKey);
@@ -243,7 +243,7 @@ void SecureContext::Initialize(Environment* env, Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "getTicketKeys", SecureContext::GetTicketKeys);
   NODE_SET_PROTOTYPE_METHOD(t, "setTicketKeys", SecureContext::SetTicketKeys);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "SecureContext"),
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext"),
               t->GetFunction());
   env->set_secure_context_constructor_template(t);
 }
@@ -257,7 +257,7 @@ void SecureContext::New(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -383,7 +383,7 @@ static X509* LoadX509(Handle<Value> v) {
 
 
 void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -489,7 +489,7 @@ int SSL_CTX_use_certificate_chain(SSL_CTX *ctx, BIO *in) {
 
 
 void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -517,7 +517,7 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
   bool newCAStore = false;
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -546,7 +546,7 @@ void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -578,7 +578,7 @@ void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -615,7 +615,7 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -629,7 +629,7 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::SetECDHCurve(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -656,7 +656,7 @@ void SecureContext::SetECDHCurve(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -670,7 +670,7 @@ void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetSessionIdContext(
     const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -693,12 +693,12 @@ void SecureContext::SetSessionIdContext(
 
   bio = BIO_new(BIO_s_mem());
   if (bio == NULL) {
-    message = FIXED_ONE_BYTE_STRING(node_isolate,
+    message = FIXED_ONE_BYTE_STRING(args.GetIsolate(),
                                     "SSL_CTX_set_session_id_context error");
   } else {
     ERR_print_errors(bio);
     BIO_get_mem_ptr(bio, &mem);
-    message = OneByteString(node_isolate, mem->data, mem->length);
+    message = OneByteString(args.GetIsolate(), mem->data, mem->length);
     BIO_free_all(bio);
   }
 
@@ -707,7 +707,7 @@ void SecureContext::SetSessionIdContext(
 
 
 void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
 
@@ -721,7 +721,7 @@ void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::Close(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   SecureContext* sc = Unwrap<SecureContext>(args.This());
   sc->FreeCTXMem();
 }
@@ -729,7 +729,7 @@ void SecureContext::Close(const FunctionCallbackInfo<Value>& args) {
 
 // Takes .pfx or .p12 and password in string or buffer format
 void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   BIO* in = NULL;
   PKCS12* p12 = NULL;
@@ -820,7 +820,7 @@ void SecureContext::GetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::SetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 #if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_get_tlsext_ticket_keys)
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   if (args.Length() < 1 ||
       !Buffer::HasInstance(args[0]) ||
@@ -963,7 +963,7 @@ void SSLWrap<Base>::OnClientHello(void* arg,
 template <class Base>
 void SSLWrap<Base>::GetPeerCertificate(
     const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
   Environment* env = w->ssl_env();
@@ -979,7 +979,7 @@ void SSLWrap<Base>::GetPeerCertificate(
                            X509_NAME_FLAGS) > 0) {
       BIO_get_mem_ptr(bio, &mem);
       info->Set(env->subject_string(),
-                OneByteString(node_isolate, mem->data, mem->length));
+                OneByteString(args.GetIsolate(), mem->data, mem->length));
     }
     (void) BIO_reset(bio);
 
@@ -987,7 +987,7 @@ void SSLWrap<Base>::GetPeerCertificate(
     if (X509_NAME_print_ex(bio, issuer_name, 0, X509_NAME_FLAGS) > 0) {
       BIO_get_mem_ptr(bio, &mem);
       info->Set(env->issuer_string(),
-                OneByteString(node_isolate, mem->data, mem->length));
+                OneByteString(args.GetIsolate(), mem->data, mem->length));
     }
     (void) BIO_reset(bio);
 
@@ -1004,7 +1004,7 @@ void SSLWrap<Base>::GetPeerCertificate(
 
       BIO_get_mem_ptr(bio, &mem);
       info->Set(env->subjectaltname_string(),
-                OneByteString(node_isolate, mem->data, mem->length));
+                OneByteString(args.GetIsolate(), mem->data, mem->length));
 
       (void) BIO_reset(bio);
     }
@@ -1018,13 +1018,13 @@ void SSLWrap<Base>::GetPeerCertificate(
         BN_print(bio, rsa->n);
         BIO_get_mem_ptr(bio, &mem);
         info->Set(env->modulus_string(),
-                  OneByteString(node_isolate, mem->data, mem->length));
+                  OneByteString(args.GetIsolate(), mem->data, mem->length));
         (void) BIO_reset(bio);
 
         BN_print(bio, rsa->e);
         BIO_get_mem_ptr(bio, &mem);
         info->Set(env->exponent_string(),
-                  OneByteString(node_isolate, mem->data, mem->length));
+                  OneByteString(args.GetIsolate(), mem->data, mem->length));
         (void) BIO_reset(bio);
     }
 
@@ -1040,13 +1040,13 @@ void SSLWrap<Base>::GetPeerCertificate(
     ASN1_TIME_print(bio, X509_get_notBefore(peer_cert));
     BIO_get_mem_ptr(bio, &mem);
     info->Set(env->valid_from_string(),
-              OneByteString(node_isolate, mem->data, mem->length));
+              OneByteString(args.GetIsolate(), mem->data, mem->length));
     (void) BIO_reset(bio);
 
     ASN1_TIME_print(bio, X509_get_notAfter(peer_cert));
     BIO_get_mem_ptr(bio, &mem);
     info->Set(env->valid_to_string(),
-              OneByteString(node_isolate, mem->data, mem->length));
+              OneByteString(args.GetIsolate(), mem->data, mem->length));
     BIO_free_all(bio);
 
     unsigned int md_size, i;
@@ -1069,7 +1069,7 @@ void SSLWrap<Base>::GetPeerCertificate(
       }
 
       info->Set(env->fingerprint_string(),
-                OneByteString(node_isolate, fingerprint));
+                OneByteString(args.GetIsolate(), fingerprint));
     }
 
     STACK_OF(ASN1_OBJECT)* eku = static_cast<STACK_OF(ASN1_OBJECT)*>(
@@ -1081,7 +1081,7 @@ void SSLWrap<Base>::GetPeerCertificate(
       int j = 0;
       for (int i = 0; i < sk_ASN1_OBJECT_num(eku); i++) {
         if (OBJ_obj2txt(buf, sizeof(buf), sk_ASN1_OBJECT_value(eku, i), 1) >= 0)
-          ext_key_usage->Set(j++, OneByteString(node_isolate, buf));
+          ext_key_usage->Set(j++, OneByteString(args.GetIsolate(), buf));
       }
 
       sk_ASN1_OBJECT_pop_free(eku, ASN1_OBJECT_free);
@@ -1092,7 +1092,7 @@ void SSLWrap<Base>::GetPeerCertificate(
       if (BIGNUM* bn = ASN1_INTEGER_to_BN(serial_number, NULL)) {
         if (char* buf = BN_bn2hex(bn)) {
           info->Set(env->serial_number_string(),
-                    OneByteString(node_isolate, buf));
+                    OneByteString(args.GetIsolate(), buf));
           OPENSSL_free(buf);
         }
         BN_free(bn);
@@ -1108,7 +1108,7 @@ void SSLWrap<Base>::GetPeerCertificate(
 
 template <class Base>
 void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
@@ -1129,7 +1129,7 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::SetSession(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
@@ -1167,7 +1167,7 @@ void SSLWrap<Base>::SetSession(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::LoadSession(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
   Environment* env = w->ssl_env();
@@ -1187,10 +1187,10 @@ void SSLWrap<Base>::LoadSession(const FunctionCallbackInfo<Value>& args) {
     Local<Object> info = Object::New();
 #ifndef OPENSSL_NO_TLSEXT
     if (sess->tlsext_hostname == NULL) {
-      info->Set(env->servername_string(), False(node_isolate));
+      info->Set(env->servername_string(), False(args.GetIsolate()));
     } else {
       info->Set(env->servername_string(),
-                OneByteString(node_isolate, sess->tlsext_hostname));
+                OneByteString(args.GetIsolate(), sess->tlsext_hostname));
     }
 #endif
     args.GetReturnValue().Set(info);
@@ -1200,7 +1200,7 @@ void SSLWrap<Base>::LoadSession(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Base* w = Unwrap<Base>(args.This());
   bool yes = SSL_session_reused(w->ssl_);
   args.GetReturnValue().Set(yes);
@@ -1209,7 +1209,7 @@ void SSLWrap<Base>::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::EndParser(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Base* w = Unwrap<Base>(args.This());
   w->hello_parser_.End();
 }
@@ -1217,7 +1217,7 @@ void SSLWrap<Base>::EndParser(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::Renegotiate(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
@@ -1231,7 +1231,7 @@ void SSLWrap<Base>::Renegotiate(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::Shutdown(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
@@ -1242,7 +1242,7 @@ void SSLWrap<Base>::Shutdown(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::IsInitFinished(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Base* w = Unwrap<Base>(args.This());
   bool yes = SSL_is_init_finished(w->ssl_);
   args.GetReturnValue().Set(yes);
@@ -1251,7 +1251,7 @@ void SSLWrap<Base>::IsInitFinished(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::VerifyError(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
@@ -1316,7 +1316,7 @@ void SSLWrap<Base>::VerifyError(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::GetCurrentCipher(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
   Environment* env = w->ssl_env();
@@ -1327,9 +1327,10 @@ void SSLWrap<Base>::GetCurrentCipher(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> info = Object::New();
   const char* cipher_name = SSL_CIPHER_get_name(c);
-  info->Set(env->name_string(), OneByteString(node_isolate, cipher_name));
+  info->Set(env->name_string(), OneByteString(args.GetIsolate(), cipher_name));
   const char* cipher_version = SSL_CIPHER_get_version(c);
-  info->Set(env->version_string(), OneByteString(node_isolate, cipher_version));
+  info->Set(env->version_string(),
+            OneByteString(args.GetIsolate(), cipher_version));
   args.GetReturnValue().Set(info);
 }
 
@@ -1350,7 +1351,7 @@ int SSLWrap<Base>::AdvertiseNextProtoCallback(SSL* s,
     *data = reinterpret_cast<const unsigned char*>("");
     *len = 0;
   } else {
-    Local<Object> obj = PersistentToLocal(node_isolate, w->npn_protos_);
+    Local<Object> obj = PersistentToLocal(env->isolate(), w->npn_protos_);
     *data = reinterpret_cast<const unsigned char*>(Buffer::Data(obj));
     *len = Buffer::Length(obj);
   }
@@ -1381,12 +1382,12 @@ int SSLWrap<Base>::SelectNextProtoCallback(SSL* s,
     *outlen = 8;
 
     // set status: unsupported
-    w->selected_npn_proto_.Reset(node_isolate, False(node_isolate));
+    w->selected_npn_proto_.Reset(env->isolate(), False(env->isolate()));
 
     return SSL_TLSEXT_ERR_OK;
   }
 
-  Local<Object> obj = PersistentToLocal(node_isolate, w->npn_protos_);
+  Local<Object> obj = PersistentToLocal(env->isolate(), w->npn_protos_);
   const unsigned char* npn_protos =
       reinterpret_cast<const unsigned char*>(Buffer::Data(obj));
   size_t len = Buffer::Length(obj);
@@ -1395,20 +1396,20 @@ int SSLWrap<Base>::SelectNextProtoCallback(SSL* s,
   Handle<Value> result;
   switch (status) {
     case OPENSSL_NPN_UNSUPPORTED:
-      result = Null(node_isolate);
+      result = Null(env->isolate());
       break;
     case OPENSSL_NPN_NEGOTIATED:
-      result = OneByteString(node_isolate, *out, *outlen);
+      result = OneByteString(env->isolate(), *out, *outlen);
       break;
     case OPENSSL_NPN_NO_OVERLAP:
-      result = False(node_isolate);
+      result = False(env->isolate());
       break;
     default:
       break;
   }
 
   if (!result.IsEmpty())
-    w->selected_npn_proto_.Reset(node_isolate, result);
+    w->selected_npn_proto_.Reset(env->isolate(), result);
 
   return SSL_TLSEXT_ERR_OK;
 }
@@ -1417,7 +1418,7 @@ int SSLWrap<Base>::SelectNextProtoCallback(SSL* s,
 template <class Base>
 void SSLWrap<Base>::GetNegotiatedProto(
     const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
@@ -1437,20 +1438,20 @@ void SSLWrap<Base>::GetNegotiatedProto(
     return args.GetReturnValue().Set(false);
 
   args.GetReturnValue().Set(
-      OneByteString(node_isolate, npn_proto, npn_proto_len));
+      OneByteString(args.GetIsolate(), npn_proto, npn_proto_len));
 }
 
 
 template <class Base>
 void SSLWrap<Base>::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Base* w = Unwrap<Base>(args.This());
 
   if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
     return ThrowTypeError("Must give a Buffer as first argument");
 
-  w->npn_protos_.Reset(node_isolate, args[0].As<Object>());
+  w->npn_protos_.Reset(args.GetIsolate(), args[0].As<Object>());
 }
 #endif  // OPENSSL_NPN_NEGOTIATED
 
@@ -1611,7 +1612,7 @@ void Connection::SetShutdownFlags() {
 void Connection::Initialize(Environment* env, Handle<Object> target) {
   Local<FunctionTemplate> t = FunctionTemplate::New(Connection::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(node_isolate, "Connection"));
+  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Connection"));
 
   NODE_SET_PROTOTYPE_METHOD(t, "encIn", Connection::EncIn);
   NODE_SET_PROTOTYPE_METHOD(t, "clearOut", Connection::ClearOut);
@@ -1639,7 +1640,7 @@ void Connection::Initialize(Environment* env, Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "setSNICallback",  Connection::SetSNICallback);
 #endif
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Connection"),
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Connection"),
               t->GetFunction());
 }
 
@@ -1692,29 +1693,28 @@ int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx) {
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
-  HandleScope scope(node_isolate);
-
   Connection* conn = static_cast<Connection*>(SSL_get_app_data(s));
   Environment* env = conn->env();
+  HandleScope scope(env->isolate());
 
   const char* servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
 
   if (servername) {
-    conn->servername_.Reset(node_isolate,
-                            OneByteString(node_isolate, servername));
+    conn->servername_.Reset(env->isolate(),
+                            OneByteString(env->isolate(), servername));
 
     // Call the SNI callback and use its return value as context
     if (!conn->sniObject_.IsEmpty()) {
       conn->sniContext_.Dispose();
 
-      Local<Value> arg = PersistentToLocal(node_isolate, conn->servername_);
+      Local<Value> arg = PersistentToLocal(env->isolate(), conn->servername_);
       Local<Value> ret = conn->MakeCallback(env->onselect_string(), 1, &arg);
 
       // If ret is SecureContext
       Local<FunctionTemplate> secure_context_constructor_template =
           env->secure_context_constructor_template();
       if (secure_context_constructor_template->HasInstance(ret)) {
-        conn->sniContext_.Reset(node_isolate, ret);
+        conn->sniContext_.Reset(env->isolate(), ret);
         SecureContext* sc = Unwrap<SecureContext>(ret.As<Object>());
         InitNPN(sc, conn);
         SSL_set_SSL_CTX(s, sc->ctx_);
@@ -1729,7 +1729,7 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
 #endif
 
 void Connection::New(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   if (args.Length() < 1 || !args[0]->IsObject()) {
     return ThrowError("First argument must be a crypto module Credentials");
@@ -1823,7 +1823,7 @@ void Connection::SSLInfoCallback(const SSL *ssl_, int where, int ret) {
 
 
 void Connection::EncIn(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -1873,7 +1873,7 @@ void Connection::EncIn(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::ClearOut(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -1928,7 +1928,7 @@ void Connection::ClearOut(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::ClearPending(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Connection* conn = Unwrap<Connection>(args.This());
   int bytes_pending = BIO_pending(conn->bio_read_);
   args.GetReturnValue().Set(bytes_pending);
@@ -1936,7 +1936,7 @@ void Connection::ClearPending(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::EncPending(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Connection* conn = Unwrap<Connection>(args.This());
   int bytes_pending = BIO_pending(conn->bio_write_);
   args.GetReturnValue().Set(bytes_pending);
@@ -1944,7 +1944,7 @@ void Connection::EncPending(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::EncOut(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -1975,7 +1975,7 @@ void Connection::EncOut(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::ClearIn(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -2030,7 +2030,7 @@ void Connection::ClearIn(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::Start(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -2055,7 +2055,7 @@ void Connection::Start(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::Close(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -2068,7 +2068,7 @@ void Connection::Close(const FunctionCallbackInfo<Value>& args) {
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 void Connection::GetServername(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -2081,7 +2081,7 @@ void Connection::GetServername(const FunctionCallbackInfo<Value>& args) {
 
 
 void Connection::SetSNICallback(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Connection* conn = Unwrap<Connection>(args.This());
 
@@ -2090,8 +2090,8 @@ void Connection::SetSNICallback(const FunctionCallbackInfo<Value>& args) {
   }
 
   Local<Object> obj = Object::New();
-  obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "onselect"), args[0]);
-  conn->sniObject_.Reset(node_isolate, obj);
+  obj->Set(FIXED_ONE_BYTE_STRING(args.GetIsolate(), "onselect"), args[0]);
+  conn->sniObject_.Reset(args.GetIsolate(), obj);
 }
 #endif
 
@@ -2109,7 +2109,7 @@ void CipherBase::Initialize(Environment* env, Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "getAuthTag", GetAuthTag);
   NODE_SET_PROTOTYPE_METHOD(t, "setAuthTag", SetAuthTag);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "CipherBase"),
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "CipherBase"),
               t->GetFunction());
 }
 
@@ -2164,7 +2164,7 @@ void CipherBase::Init(const char* cipher_type,
 
 
 void CipherBase::Init(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   CipherBase* cipher = Unwrap<CipherBase>(args.This());
 
@@ -2216,7 +2216,7 @@ void CipherBase::InitIv(const char* cipher_type,
 
 
 void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   CipherBase* cipher = Unwrap<CipherBase>(args.This());
 
@@ -2375,7 +2375,7 @@ bool CipherBase::SetAutoPadding(bool auto_padding) {
 
 
 void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   CipherBase* cipher = Unwrap<CipherBase>(args.This());
   cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue());
 }
@@ -2443,7 +2443,7 @@ void Hmac::Initialize(Environment* env, v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "update", HmacUpdate);
   NODE_SET_PROTOTYPE_METHOD(t, "digest", HmacDigest);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Hmac"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Hmac"), t->GetFunction());
 }
 
 
@@ -2473,7 +2473,7 @@ void Hmac::HmacInit(const char* hash_type, const char* key, int key_len) {
 
 
 void Hmac::HmacInit(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Hmac* hmac = Unwrap<Hmac>(args.This());
 
@@ -2499,7 +2499,7 @@ bool Hmac::HmacUpdate(const char* data, int len) {
 
 
 void Hmac::HmacUpdate(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Hmac* hmac = Unwrap<Hmac>(args.This());
 
@@ -2541,7 +2541,7 @@ bool Hmac::HmacDigest(unsigned char** md_value, unsigned int* md_len) {
 
 
 void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Hmac* hmac = Unwrap<Hmac>(args.This());
 
@@ -2574,12 +2574,12 @@ void Hash::Initialize(Environment* env, v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "update", HashUpdate);
   NODE_SET_PROTOTYPE_METHOD(t, "digest", HashDigest);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Hash"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Hash"), t->GetFunction());
 }
 
 
 void Hash::New(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   if (args.Length() == 0 || !args[0]->IsString()) {
     return ThrowError("Must give hashtype string as argument");
@@ -2616,7 +2616,7 @@ bool Hash::HashUpdate(const char* data, int len) {
 
 
 void Hash::HashUpdate(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Hash* hash = Unwrap<Hash>(args.This());
 
@@ -2647,7 +2647,7 @@ void Hash::HashUpdate(const FunctionCallbackInfo<Value>& args) {
 
 
 void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Hash* hash = Unwrap<Hash>(args.This());
 
@@ -2682,7 +2682,7 @@ void Sign::Initialize(Environment* env, v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "update", SignUpdate);
   NODE_SET_PROTOTYPE_METHOD(t, "sign", SignFinal);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Sign"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Sign"), t->GetFunction());
 }
 
 
@@ -2708,7 +2708,7 @@ void Sign::SignInit(const char* sign_type) {
 
 
 void Sign::SignInit(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Sign* sign = Unwrap<Sign>(args.This());
 
@@ -2730,7 +2730,7 @@ bool Sign::SignUpdate(const char* data, int len) {
 
 
 void Sign::SignUpdate(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Sign* sign = Unwrap<Sign>(args.This());
 
@@ -2816,7 +2816,7 @@ bool Sign::SignFinal(const char* key_pem,
 
 
 void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Sign* sign = Unwrap<Sign>(args.This());
 
@@ -2865,7 +2865,8 @@ void Verify::Initialize(Environment* env, v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "update", VerifyUpdate);
   NODE_SET_PROTOTYPE_METHOD(t, "verify", VerifyFinal);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "Verify"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Verify"),
+              t->GetFunction());
 }
 
 
@@ -2892,7 +2893,7 @@ void Verify::VerifyInit(const char* verify_type) {
 
 
 void Verify::VerifyInit(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Verify* verify = Unwrap<Verify>(args.This());
 
@@ -2914,7 +2915,7 @@ bool Verify::VerifyUpdate(const char* data, int len) {
 
 
 void Verify::VerifyUpdate(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Verify* verify = Unwrap<Verify>(args.This());
 
@@ -3027,7 +3028,7 @@ bool Verify::VerifyFinal(const char* key_pem,
 
 
 void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Verify* verify = Unwrap<Verify>(args.This());
 
@@ -3076,7 +3077,7 @@ void DiffieHellman::Initialize(Environment* env, Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t, "setPublicKey", SetPublicKey);
   NODE_SET_PROTOTYPE_METHOD(t, "setPrivateKey", SetPrivateKey);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "DiffieHellman"),
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "DiffieHellman"),
               t->GetFunction());
 
   Local<FunctionTemplate> t2 = FunctionTemplate::New(DiffieHellmanGroup);
@@ -3089,7 +3090,7 @@ void DiffieHellman::Initialize(Environment* env, Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(t2, "getPublicKey", GetPublicKey);
   NODE_SET_PROTOTYPE_METHOD(t2, "getPrivateKey", GetPrivateKey);
 
-  target->Set(FIXED_ONE_BYTE_STRING(node_isolate, "DiffieHellmanGroup"),
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "DiffieHellmanGroup"),
               t2->GetFunction());
 }
 
@@ -3130,7 +3131,7 @@ bool DiffieHellman::Init(const char* p, int p_len, const char* g, int g_len) {
 
 void DiffieHellman::DiffieHellmanGroup(
     const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   DiffieHellman* diffieHellman = new DiffieHellman(env, args.This());
@@ -3158,7 +3159,7 @@ void DiffieHellman::DiffieHellmanGroup(
 
 
 void DiffieHellman::New(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   DiffieHellman* diffieHellman =
@@ -3181,7 +3182,7 @@ void DiffieHellman::New(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3204,7 +3205,7 @@ void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3222,7 +3223,7 @@ void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetGenerator(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3240,7 +3241,7 @@ void DiffieHellman::GetGenerator(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3263,7 +3264,7 @@ void DiffieHellman::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3286,7 +3287,7 @@ void DiffieHellman::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3357,7 +3358,7 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3377,7 +3378,7 @@ void DiffieHellman::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
 
@@ -3790,7 +3791,7 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   RandomBytesRequest* req = new RandomBytesRequest(env, obj, size);
 
   if (args[1]->IsFunction()) {
-    obj->Set(FIXED_ONE_BYTE_STRING(node_isolate, "ondone"), args[1]);
+    obj->Set(FIXED_ONE_BYTE_STRING(args.GetIsolate(), "ondone"), args[1]);
     // XXX(trevnorris): This will need to go with the rest of domains.
     if (env->in_domain())
       obj->Set(env->domain_string(), env->domain_array()->Get(0));
@@ -3814,7 +3815,7 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
 
 
 void GetSSLCiphers(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   SSL_CTX* ctx = SSL_CTX_new(TLSv1_server_method());
   if (ctx == NULL) {
@@ -3832,7 +3833,7 @@ void GetSSLCiphers(const FunctionCallbackInfo<Value>& args) {
 
   for (int i = 0; i < sk_SSL_CIPHER_num(ciphers); ++i) {
     SSL_CIPHER* cipher = sk_SSL_CIPHER_value(ciphers, i);
-    arr->Set(i, OneByteString(node_isolate, SSL_CIPHER_get_name(cipher)));
+    arr->Set(i, OneByteString(args.GetIsolate(), SSL_CIPHER_get_name(cipher)));
   }
 
   SSL_free(ssl);
@@ -3853,7 +3854,7 @@ static void array_push_back(const TypeName* md,
 
 
 void GetCiphers(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Local<Array> arr = Array::New();
   EVP_CIPHER_do_all_sorted(array_push_back<EVP_CIPHER>, &arr);
   args.GetReturnValue().Set(arr);
@@ -3861,7 +3862,7 @@ void GetCiphers(const FunctionCallbackInfo<Value>& args) {
 
 
 void GetHashes(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
   Local<Array> arr = Array::New();
   EVP_MD_do_all_sorted(array_push_back<EVP_MD>, &arr);
   args.GetReturnValue().Set(arr);
@@ -3918,7 +3919,7 @@ bool Certificate::VerifySpkac(const char* data, unsigned int len) {
 
 
 void Certificate::VerifySpkac(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Certificate* certificate = Unwrap<Certificate>(args.This());
   bool i = false;
@@ -3983,7 +3984,7 @@ const char* Certificate::ExportPublicKey(const char* data, int len) {
 
 
 void Certificate::ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Certificate* certificate = Unwrap<Certificate>(args.This());
 
@@ -4026,7 +4027,7 @@ const char* Certificate::ExportChallenge(const char* data, int len) {
 
 
 void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
-  HandleScope scope(node_isolate);
+  HandleScope scope(args.GetIsolate());
 
   Certificate* crt = Unwrap<Certificate>(args.This());
 


### PR DESCRIPTION
All C++ code should be using `args.GetIsolate()` or `env->isolate()`.
Using static `node_isolate` var limits possible future functionality
(like multi-isolate support).

see #6899
