### PR TITLE
stream_wrap: use `uv_try_write` where possible

### DIFF
--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -51,7 +51,7 @@ function server() {
       if (nread < 0)
         fail(nread, 'read');
 
-      var writeReq = {};
+      var writeReq = { async: false };
       err = clientHandle.writeBuffer(writeReq, buffer);
 
       if (err)

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -68,7 +68,7 @@ function server() {
       write();
 
     function write() {
-      var writeReq = { oncomplete: afterWrite };
+      var writeReq = { async: false, oncomplete: afterWrite };
       var err;
       switch (type) {
         case 'buf':
@@ -82,8 +82,13 @@ function server() {
           break;
       }
 
-      if (err)
+      if (err) {
         fail(err, 'write');
+      } else if (!writeReq.async) {
+        setImmediate(function() {
+          afterWrite(null, clientHandle, writeReq);
+        });
+      }
     }
 
     function afterWrite(err, handle, req) {

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -85,7 +85,7 @@ function server() {
       if (err) {
         fail(err, 'write');
       } else if (!writeReq.async) {
-        setImmediate(function() {
+        process.nextTick(function() {
           afterWrite(null, clientHandle, writeReq);
         });
       }

--- a/deps/uv/src/unix/core.c
+++ b/deps/uv/src/unix/core.c
@@ -419,7 +419,6 @@ int uv__close(int fd) {
   int rc;
 
   assert(fd > -1);  /* Catch uninitialized io_watcher.fd bugs. */
-  assert(fd > STDERR_FILENO);  /* Catch stdio close bugs. */
 
   saved_errno = errno;
   rc = close(fd);

--- a/deps/uv/src/unix/core.c
+++ b/deps/uv/src/unix/core.c
@@ -419,6 +419,7 @@ int uv__close(int fd) {
   int rc;
 
   assert(fd > -1);  /* Catch uninitialized io_watcher.fd bugs. */
+  assert(fd > STDERR_FILENO);  /* Catch stdio close bugs. */
 
   saved_errno = errno;
   rc = close(fd);

--- a/lib/net.js
+++ b/lib/net.js
@@ -624,7 +624,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     return false;
   }
 
-  var req = { oncomplete: afterWrite };
+  var req = { oncomplete: afterWrite, async: false };
   var err;
 
   if (writev) {
@@ -658,10 +658,13 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
 
   // If it was entirely flushed, we can write some more right now.
   // However, if more is left in the queue, then wait until that clears.
-  if (this._handle.writeQueueSize === 0)
-    cb();
-  else
+  if (req.async && this._handle.writeQueueSize != 0) {
     req.cb = cb;
+  } else {
+    if (!req.async)
+      timers._unrefActive(this);
+    cb();
+  }
 };
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -53,6 +53,7 @@ namespace node {
 #define PER_ISOLATE_STRING_PROPERTIES(V)                                      \
   V(address_string, "address")                                                \
   V(atime_string, "atime")                                                    \
+  V(async, "async")                                                           \
   V(async_queue_string, "_asyncQueue")                                        \
   V(birthtime_string, "birthtime")                                            \
   V(blksize_string, "blksize")                                                \

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -206,7 +206,6 @@ void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   char* storage;
   WriteWrap* req_wrap;
   uv_buf_t buf;
-
   WriteBuffer(buf_obj, &buf);
 
   // Try writing immediately without allocation
@@ -273,7 +272,7 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
   char* storage;
   WriteWrap* req_wrap;
   char* data;
-  char stack_storage[16384];
+  char stack_storage[16384];  // 16kb
   size_t data_size;
   uv_buf_t buf;
 
@@ -560,7 +559,7 @@ int StreamWrapCallbacks::TryWrite(uv_buf_t** bufs, size_t* count) {
   if (err < 0)
     return err;
 
-  // Slice of the buffers
+  // Slice off the buffers
   written = err;
   for (; written != 0 && vcount > 0; vbufs++, vcount--) {
     // Slice

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -33,6 +33,7 @@
 #include "util-inl.h"
 
 #include <stdlib.h>  // abort()
+#include <string.h>  // memcpy()
 #include <limits.h>  // INT_MAX
 
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -73,6 +73,8 @@ class StreamWrapCallbacks {
   virtual ~StreamWrapCallbacks() {
   }
 
+  virtual int TryWrite(uv_buf_t** bufs, size_t* count);
+
   virtual int DoWrite(WriteWrap* w,
                       uv_buf_t* bufs,
                       size_t count,

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -429,6 +429,12 @@ bool TLSCallbacks::ClearIn() {
 }
 
 
+int TLSCallbacks::TryWrite(uv_buf_t** bufs, size_t* count) {
+  // TODO(indutny): Support it
+  return -1;
+}
+
+
 int TLSCallbacks::DoWrite(WriteWrap* w,
                           uv_buf_t* bufs,
                           size_t count,

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -50,6 +50,7 @@ class TLSCallbacks : public crypto::SSLWrap<TLSCallbacks>,
                          v8::Handle<v8::Value> unused,
                          v8::Handle<v8::Context> context);
 
+  int TryWrite(uv_buf_t** bufs, size_t* count);
   int DoWrite(WriteWrap* w,
               uv_buf_t* bufs,
               size_t count,

--- a/test/simple/test-tcp-wrap-listen.js
+++ b/test/simple/test-tcp-wrap-listen.js
@@ -55,7 +55,7 @@ server.onconnection = function(err, client) {
 
       assert.equal(0, client.writeQueueSize);
 
-      var req = {};
+      var req = { async: false };
       var err = client.writeBuffer(req, buffer);
       assert.equal(err, 0);
       client.pendingWrites.push(req);
@@ -64,7 +64,12 @@ server.onconnection = function(err, client) {
       // 11 bytes should flush
       assert.equal(0, client.writeQueueSize);
 
-      req.oncomplete = function(status, client_, req_) {
+      if (req.async && client.writeQueueSize != 0)
+        req.oncomplete = done;
+      else
+        process.nextTick(done.bind(null, 0, client, req));
+
+      function done(status, client_, req_) {
         assert.equal(req, client.pendingWrites.shift());
 
         // Check parameters.


### PR DESCRIPTION
Use `uv_try_write` for string and buffer writes, thus avoiding to do
allocations and copying in some of the cases.

/cc @tjfontaine @trevnorris
