### PR TITLE
readline: fix `line` event, if input emit 'end'

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -91,6 +91,9 @@ function Interface(input, output, completer, terminal) {
   }
 
   function onend() {
+    if (self._line_buffer && self._line_buffer.length > 0) {
+       self.emit('line', self._line_buffer);
+    }
     self.close();
   }
 
@@ -118,6 +121,10 @@ function Interface(input, output, completer, terminal) {
 
     // input usually refers to stdin
     input.on('keypress', onkeypress);
+    input.on('end', function() {
+      if (!self.line || self.line.length === 0) return;
+      self.emit('line', self.line);
+    });
 
     // Current line
     this.line = '';

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -91,8 +91,8 @@ function Interface(input, output, completer, terminal) {
   }
 
   function onend() {
-    if (typeof self._line_buffer === 'string') {
-       self.emit('line', self._line_buffer);
+    if (util.isString(self._line_buffer) && self._line_buffer.length > 0) {
+      self.emit('line', self._line_buffer);
     }
     self.close();
   }
@@ -121,10 +121,10 @@ function Interface(input, output, completer, terminal) {
 
     // input usually refers to stdin
     input.on('keypress', onkeypress);
-    input.on('end', function() {
-      if (typeof self.line === 'string') {
+    input.on('end', function inputEnd() {
+      if (util.isString(self.line) && self.line.length > 0)
         self.emit('line', self.line);
-      }
+      self.close();
     });
 
     // Current line

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -91,7 +91,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   function onend() {
-    if (self._line_buffer && self._line_buffer.length > 0) {
+    if (typeof self._line_buffer === 'string') {
        self.emit('line', self._line_buffer);
     }
     self.close();
@@ -122,8 +122,9 @@ function Interface(input, output, completer, terminal) {
     // input usually refers to stdin
     input.on('keypress', onkeypress);
     input.on('end', function() {
-      if (!self.line || self.line.length === 0) return;
-      self.emit('line', self.line);
+      if (typeof self.line === 'string') {
+        self.emit('line', self.line);
+      }
     });
 
     // Current line

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -113,11 +113,11 @@ FakeInput.prototype.end = function() {};
   assert.equal(callCount, expectedLines.length - 1);
   rli.close();
 
-  // sending multiple newlines at once that does not end with a new line
-  // and a `end` event
+  // sending multiple newlines at once that does not end with a new(empty) 
+  // line and a `end` event
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  expectedLines = ['foo', 'bar', 'baz', 'bat'];
+  expectedLines = ['foo', 'bar', 'baz', ''];
   callCount = 0;
   rli.on('line', function(line) {
     assert.equal(line, expectedLines[callCount]);
@@ -127,6 +127,9 @@ FakeInput.prototype.end = function() {};
   fi.emit('end');
   assert.equal(callCount, expectedLines.length);
   rli.close();
+
+  // sending multiple newlines at once that does not end with a new line
+  // and a `end` event(last line is)
 
   // \r\n should emit one line event, not two
   fi = new FakeInput();

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -113,6 +113,21 @@ FakeInput.prototype.end = function() {};
   assert.equal(callCount, expectedLines.length - 1);
   rli.close();
 
+  // sending multiple newlines at once that does not end with a new line
+  // and a `end` event
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
+  expectedLines = ['foo', 'bar', 'baz', 'bat'];
+  callCount = 0;
+  rli.on('line', function(line) {
+    assert.equal(line, expectedLines[callCount]);
+    callCount++;
+  });
+  fi.emit('data', expectedLines.join('\n'));
+  fi.emit('end');
+  assert.equal(callCount, expectedLines.length);
+  rli.close();
+
   // \r\n should emit one line event, not two
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
@@ -214,6 +229,5 @@ FakeInput.prototype.end = function() {};
   assert.equal(readline.getStringWidth('\u001b[31m\u001b[39m'), 0);
   assert.equal(readline.getStringWidth('> '), 2);
 
-  assert.deepEqual(fi.listeners('end'), []);
   assert.deepEqual(fi.listeners(terminal ? 'keypress' : 'data'), []);
 });

--- a/test/simple/test-readline-interface.js
+++ b/test/simple/test-readline-interface.js
@@ -123,6 +123,9 @@ FakeInput.prototype.end = function() {};
     assert.equal(line, expectedLines[callCount]);
     callCount++;
   });
+  rli.on('close', function() {
+    callCount++;
+  })
   fi.emit('data', expectedLines.join('\n'));
   fi.emit('end');
   assert.equal(callCount, expectedLines.length);

--- a/test/simple/test-readline-set-raw-mode.js
+++ b/test/simple/test-readline-set-raw-mode.js
@@ -49,7 +49,7 @@ var rli = readline.createInterface({
   output: stream,
   terminal: true
 });
-assert(rli.terminal)
+assert(rli.terminal);
 assert(rawModeCalled);
 assert(resumeCalled);
 assert(!pauseCalled);
@@ -85,7 +85,6 @@ assert(rawModeCalled);
 assert(!resumeCalled);
 assert(pauseCalled);
 
-assert.deepEqual(stream.listeners('end'), []);
 assert.deepEqual(stream.listeners('keypress'), []);
 // one data listener for the keypress events.
 assert.equal(stream.listeners('data').length, 1);


### PR DESCRIPTION
If an input stream would emit `end` event, like `fs.createReadStream`, then readline need to get the last line correctly even though that line isnt ended with `\n`.
