### PR TITLE
cluster: do not emit 'exit'/'disconnect' in worker

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -343,12 +343,14 @@ function Worker(customEnv) {
   this.process.once('exit', function(exitCode, signalCode) {
     prepareExit(self, 'dead');
     self.emit('exit', exitCode, signalCode);
-    cluster.emit('exit', self, exitCode, signalCode);
+    if (cluster.isMaster)
+      cluster.emit('exit', self, exitCode, signalCode);
   });
   this.process.once('disconnect', function() {
     prepareExit(self, 'disconnected');
     self.emit('disconnect');
-    cluster.emit('disconnect', self);
+    if (cluster.isMaster)
+      cluster.emit('disconnect', self);
   });
 
   // relay message and error


### PR DESCRIPTION
`cluster.on('exit')`/`cluster.on('disonnect')` should be emitted only in
master process, not a worker. (This behavior matches current v0.11
behavior).

fix #6915
