### PR TITLE
path: Improve POSIX path.join performance

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -348,12 +348,17 @@ if (isWindows) {
   // posix version
   exports.normalize = function(path) {
     var isAbsolute = exports.isAbsolute(path),
-        trailingSlash = path.substr(-1) === '/';
+        trailingSlash = path[path.length - 1] === '/',
+        segments = path.split('/'),
+        nonEmptySegments = [];
 
     // Normalize the path
-    path = normalizeArray(path.split('/').filter(function(p) {
-      return !!p;
-    }), !isAbsolute).join('/');
+    for (var i = 0; i < segments.length; i++) {
+      if (segments[i]) {
+        nonEmptySegments.push(segments[i]);
+      }
+    }
+    path = normalizeArray(nonEmptySegments, !isAbsolute).join('/');
 
     if (!path && !isAbsolute) {
       path = '.';
@@ -372,13 +377,21 @@ if (isWindows) {
 
   // posix version
   exports.join = function() {
-    var paths = Array.prototype.slice.call(arguments, 0);
-    return exports.normalize(paths.filter(function(p, index) {
-      if (!util.isString(p)) {
+    var path = '';
+    for (var i = 0; i < arguments.length; i++) {
+      var segment = arguments[i];
+      if (!util.isString(segment)) {
         throw new TypeError('Arguments to path.join must be strings');
       }
-      return p;
-    }).join('/'));
+      if (segment) {
+        if (!path) {
+          path += segment;
+        } else {
+          path += '/' + segment;
+        }
+      }
+    }
+    return exports.normalize(path);
   };
 
 


### PR DESCRIPTION
Here is a simple benchmark:

``` js
var path = require('path');
var foo = 'foo', bar = 'bar';

var n = 1000000
global.x = new Array(n)
global.y = new Array(n)

console.time('path.join');
for (var i = 0; i < n; i++) {
  x[i] = path.join(foo, bar);
}
console.timeEnd('path.join');


function myJoin (foo, bar) {
  // Naive implementation for comparison
  return foo + '/' + bar;
}

console.time('myJoin')
for (i = 0; i < n; i++) {
  y[i] = myJoin(foo, bar);
}
console.timeEnd('myJoin')
```

This commit reduces the time for path.join in the above benchmark from
2 us to .45 us. It is still much slower than the naive myJoin
implementation (.2 us), but it's progress at least.

There seems to be some duplicate work between join, normalize, and
normalizeArray, if people want to optimize it further.

Note that this only improves the POSIX implementation. The Windows
implementation uses .filter closures as well (and also regexes), so
there is much room for improvement, but I'm not trying to fix it here.

Thanks to @isaacs and @othiym23 for helping with this optimization.
