### PR TITLE
node: remove asyncStack

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -475,7 +475,8 @@
       if (asyncQueue) {
         for (i = 0; i < asyncQueue.length; i++) {
           queueItem = asyncQueue[i];
-          if ((queueItem.flags & HAS_ERROR_AL) === 0)
+          if ((queueItem.flags & HAS_ERROR_AL) === 0 ||
+              (data && data[queueItem.uid] !== undefined))
             continue;
           try {
             threw = true;

--- a/test/simple/test-asynclistener-run-error-once.js
+++ b/test/simple/test-asynclistener-run-error-once.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var cntr = 0;
+var al = process.addAsyncListener({
+  error: function(stor, er) {
+    cntr++;
+    process._rawDebug('Handling error: ' + er.message);
+    return true;
+  }
+});
+
+process.on('exit', function(status) {
+  process.removeAsyncListener(al);
+
+  assert.equal(status, 0);
+  assert.equal(cntr, 1);
+  console.log('ok');
+});
+
+
+var server = net.createServer(function(c) {
+  throw new Error('net - error: server connection');
+});
+
+
+server.listen(common.PORT, function() {
+  net.connect(common.PORT, function() {
+    setImmediate(function() {
+      process.exit();
+    });
+  });
+});


### PR DESCRIPTION
Now that the context stores the active execution stack, and because
removeAsyncListener() always removed the AsyncListener from the queue
and the stack, there's no need to keep a stack around anymore. Instead
the active asyncQueue and the currentContext is able to handle it all.
