### PR TITLE
crypto: remove duplicate `ERR_load_crypto_strings()`.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4139,7 +4139,6 @@ void InitCryptoOnce() {
   SSL_library_init();
   OpenSSL_add_all_algorithms();
   SSL_load_error_strings();
-  ERR_load_crypto_strings();
 
   crypto_lock_init();
   CRYPTO_set_locking_callback(crypto_lock_cb);


### PR DESCRIPTION
ERR_load_crypto_strings() registers the error strings for
all libcrypto functions, SSL_load_error_strings() does the
same, but also registers the libssl error strings.

refs: https://www.openssl.org/docs/crypto/ERR_load_crypto_strings.html
/cc @indutny
