### PR TITLE
test: close server grafefully in http test

### DIFF
--- a/test/simple/test-http-many-ended-pipelines.js
+++ b/test/simple/test-http-many-ended-pipelines.js
@@ -32,23 +32,25 @@ console.trace = function() {
 var http = require('http');
 var net = require('net');
 
+var numRequests = 20;
+var done = 0;
+
 var server = http.createServer(function(req, res) {
   res.end('ok');
 
   // Oh no!  The connection died!
   req.socket.destroy();
+  if (++done == numRequests)
+    server.close();
 });
 
 server.listen(common.PORT);
 
 var client = net.connect({ port: common.PORT, allowHalfOpen: true });
-for (var i = 0; i < 20; i++) {
+for (var i = 0; i < numRequests; i++) {
   client.write('GET / HTTP/1.1\r\n' +
                'Host: some.host.name\r\n'+
                '\r\n\r\n');
 }
 client.end();
-client.on('connect', function() {
-  server.close();
-});
 client.pipe(process.stdout);


### PR DESCRIPTION
The test was calling server.close() without waiting for the server
to have received all the requests. This would cause an ECONNRESET.
