### PR TITLE
async_wrap: initialize after constructor

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -722,7 +722,7 @@ Explanation of function parameters:
 
 `callbacksObj`: An `Object` which may contain three optional fields:
 
-* `create(userData)`: A `Function` called when an asynchronous
+* `create(context, userData)`: A `Function` called when an asynchronous
 event is instantiated. If a `Value` is returned then it will be attached
 to the event and overwrite any value that had been passed to
 `process.createAsyncListener()`'s `userData` argument. If an initial
@@ -739,7 +739,7 @@ either occurred).
 the asynchronous event's callback has run. Note this will not be called
 if the callback throws and the error is not handled.
 
-* `error(userData, error)`: A `Function` called if the event's
+* `error(context, userData, error)`: A `Function` called if the event's
 callback threw. If this registered callback returns `true` then Node will
 assume the error has been properly handled and resume execution normally.
 When multiple `error()` callbacks have been registered only **one** of
@@ -753,7 +753,7 @@ is returned by `create()`.
 Here is an example of overwriting the `userData`:
 
     process.createAsyncListener({
-      create: function listener(value) {
+      create: function listener(context, value) {
         // value === true
         return false;
     }, {
@@ -784,7 +784,7 @@ Example usage for capturing errors:
 
     var cntr = 0;
     var key = process.addAsyncListener({
-      create: function onCreate() {
+      create: function onCreate(context) {
         return { uid: cntr++ };
       },
       before: function onBefore(context, storage) {
@@ -794,7 +794,7 @@ Example usage for capturing errors:
       after: function onAfter(context, storage) {
         fs.writeSync(1, 'uid: ' + storage.uid + ' is about to run\n');
       },
-      error: function onError(storage, err) {
+      error: function onError(context, storage, err) {
         // Handle known errors
         if (err.message === 'everything is fine') {
           fs.writeSync(1, 'handled error just threw:\n');

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -37,23 +37,32 @@ namespace node {
 
 inline AsyncWrap::AsyncWrap(Environment* env, v8::Handle<v8::Object> object)
     : BaseObject(env, object),
+      initialized_(false),
       async_flags_(NO_OPTIONS) {
-  if (!env->has_async_listener())
+}
+
+
+inline AsyncWrap::~AsyncWrap() {
+  assert(initialized_ != false);
+}
+
+
+inline void AsyncWrap::Init() {
+  assert(initialized_ == false);
+  initialized_ = true;
+
+  if (!env()->has_async_listener())
     return;
 
   // TODO(trevnorris): Do we really need to TryCatch this call?
   v8::TryCatch try_catch;
   try_catch.SetVerbose(true);
 
-  v8::Local<v8::Value> val = object.As<v8::Value>();
-  env->async_listener_run_function()->Call(env->process_object(), 1, &val);
+  v8::Local<v8::Value> val = object().As<v8::Value>();
+  env()->async_listener_run_function()->Call(env()->process_object(), 1, &val);
 
   if (!try_catch.HasCaught())
     async_flags_ |= HAS_ASYNC_LISTENER;
-}
-
-
-inline AsyncWrap::~AsyncWrap() {
 }
 
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -39,6 +39,8 @@ class AsyncWrap : public BaseObject {
 
   inline ~AsyncWrap();
 
+  inline void Init();
+
   inline uint32_t async_flags() const;
 
   inline bool has_async_listener();
@@ -64,6 +66,7 @@ class AsyncWrap : public BaseObject {
       int argc,
       v8::Handle<v8::Value>* argv);
 
+  bool initialized_;
   uint32_t async_flags_;
 };
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -225,6 +225,7 @@ class QueryWrap : public AsyncWrap {
  public:
   QueryWrap(Environment* env, Local<Object> req_wrap_obj)
       : AsyncWrap(env, req_wrap_obj) {
+    AsyncWrap::Init();
   }
 
   virtual ~QueryWrap() {

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -98,6 +98,7 @@ HandleWrap::HandleWrap(Environment* env,
   HandleScope scope(node_isolate);
   Wrap<HandleWrap>(object, this);
   QUEUE_INSERT_TAIL(&handle_wrap_queue, &handle_wrap_queue_);
+  AsyncWrap::Init();
 }
 
 

--- a/src/node.js
+++ b/src/node.js
@@ -351,7 +351,7 @@
         for (i = 0; i < ccQueue.length; i++) {
           queueItem = ccQueue[i];
           queue[queue.length] = queueItem;
-          if ((queueItem.flags & HAS_CREATE_AL) === 0) {
+          if ((queueItem.callback_flags & HAS_CREATE_AL) === 0) {
             data[queueItem.uid] = queueItem.data;
             continue;
           }
@@ -369,8 +369,8 @@
           if (data[queueItem.uid] !== undefined)
             continue;
           queue[queue.length] = queueItem;
-          context._asyncFlags |= queueItem.flags;
-          if ((queueItem.flags & HAS_CREATE_AL) === 0) {
+          context._asyncFlags |= queueItem.callback_flags;
+          if ((queueItem.callback_flags & HAS_CREATE_AL) === 0) {
             data[queueItem.uid] = queueItem.data;
             continue;
           }
@@ -397,7 +397,7 @@
       inAsyncTick = true;
       for (i = 0; i < queue.length; i++) {
         queueItem = queue[i];
-        if ((queueItem.flags & HAS_BEFORE_AL) > 0)
+        if ((queueItem.callback_flags & HAS_BEFORE_AL) > 0)
           queueItem.before(context, data[queueItem.uid]);
       }
       inAsyncTick = false;
@@ -418,7 +418,7 @@
       inAsyncTick = true;
       for (i = 0; i < queue.length; i++) {
         queueItem = queue[i];
-        if ((queueItem.flags & HAS_AFTER_AL) > 0)
+        if ((queueItem.callback_flags & HAS_AFTER_AL) > 0)
           queueItem.after(context, data[queueItem.uid]);
       }
       inAsyncTick = false;
@@ -445,7 +445,7 @@
         var data = currentContext._asyncData;
         for (i = 0; i < queue.length; i++) {
           queueItem = queue[i];
-          if ((queueItem.flags & HAS_ERROR_AL) === 0)
+          if ((queueItem.callback_flags & HAS_ERROR_AL) === 0)
             continue;
           try {
             threw = true;
@@ -469,7 +469,7 @@
       if (asyncQueue) {
         for (i = 0; i < asyncQueue.length; i++) {
           queueItem = asyncQueue[i];
-          if ((queueItem.flags & HAS_ERROR_AL) === 0 ||
+          if ((queueItem.callback_flags & HAS_ERROR_AL) === 0 ||
               (data && data[queueItem.uid] !== undefined))
             continue;
           try {
@@ -501,19 +501,19 @@
     function AsyncListenerInst(callbacks, data) {
       if (typeof callbacks.create === 'function') {
         this.create = callbacks.create;
-        this.flags |= HAS_CREATE_AL;
+        this.callback_flags |= HAS_CREATE_AL;
       }
       if (typeof callbacks.before === 'function') {
         this.before = callbacks.before;
-        this.flags |= HAS_BEFORE_AL;
+        this.callback_flags |= HAS_BEFORE_AL;
       }
       if (typeof callbacks.after === 'function') {
         this.after = callbacks.after;
-        this.flags |= HAS_AFTER_AL;
+        this.callback_flags |= HAS_AFTER_AL;
       }
       if (typeof callbacks.error === 'function') {
         this.error = callbacks.error;
-        this.flags |= HAS_ERROR_AL;
+        this.callback_flags |= HAS_ERROR_AL;
       }
 
       this.uid = ++alUid;
@@ -525,7 +525,7 @@
     AsyncListenerInst.prototype.error = undefined;
     AsyncListenerInst.prototype.data = undefined;
     AsyncListenerInst.prototype.uid = 0;
-    AsyncListenerInst.prototype.flags = 0;
+    AsyncListenerInst.prototype.callback_flags = 0;
 
     // Create new async listener object. Useful when instantiating a new
     // object and want the listener instance, but not add it to the stack.

--- a/src/node.js
+++ b/src/node.js
@@ -355,7 +355,7 @@
             data[queueItem.uid] = queueItem.data;
             continue;
           }
-          value = queueItem.create(queueItem.data);
+          value = queueItem.create(context, queueItem.data);
           data[queueItem.uid] = (value === undefined) ? queueItem.data : value;
         }
       }
@@ -374,7 +374,7 @@
             data[queueItem.uid] = queueItem.data;
             continue;
           }
-          value = queueItem.create(queueItem.data);
+          value = queueItem.create(context, queueItem.data);
           data[queueItem.uid] = (value === undefined) ? queueItem.data : value;
         }
       }
@@ -449,10 +449,9 @@
             continue;
           try {
             threw = true;
-            // While it would be possible to pass in currentContext, if
-            // the error is thrown from the "create" callback then there's
-            // a chance the object hasn't been fully constructed.
-            handled = queueItem.error(data[queueItem.uid], er) || handled;
+            handled = queueItem.error(currentContext,
+                                      data[queueItem.uid],
+                                      er) || handled;
             threw = false;
           } finally {
             // If the error callback thew then die quickly. Only allow the
@@ -474,7 +473,9 @@
             continue;
           try {
             threw = true;
-            handled = queueItem.error(queueItem.data, er) || handled;
+            handled = queueItem.error(currentContext || global,
+                                      queueItem.data,
+                                      er) || handled;
             threw = false;
           } finally {
             // If the error callback thew then die quickly. Only allow the

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3490,6 +3490,7 @@ class PBKDF2Request : public AsyncWrap {
         iter_(iter) {
     if (key() == NULL)
       FatalError("node::PBKDF2Request()", "Out of Memory");
+    AsyncWrap::Init();
   }
 
   ~PBKDF2Request() {
@@ -3746,6 +3747,7 @@ class RandomBytesRequest : public AsyncWrap {
         data_(static_cast<char*>(malloc(size))) {
     if (data() == NULL)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
+    AsyncWrap::Init();
   }
 
   ~RandomBytesRequest() {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -305,6 +305,7 @@ class Connection : public SSLWrap<Connection>, public AsyncWrap {
                         OnClientHelloParseEnd,
                         this);
     enable_session_callbacks();
+    AsyncWrap::Init();
   }
 
  private:
@@ -584,6 +585,7 @@ class Certificate : public AsyncWrap {
   Certificate(Environment* env, v8::Local<v8::Object> wrap)
       : AsyncWrap(env, wrap) {
     MakeWeak<Certificate>(this);
+    AsyncWrap::Init();
   }
 };
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -71,6 +71,7 @@ StatWatcher::StatWatcher(Environment* env, Local<Object> wrap)
   MakeWeak<StatWatcher>(this);
   uv_fs_poll_init(env->event_loop(), watcher_);
   watcher_->data = static_cast<void*>(this);
+  AsyncWrap::Init();
 }
 
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -89,6 +89,7 @@ class ZCtx : public AsyncWrap {
         write_in_progress_(false),
         refs_(0) {
     MakeWeak<ZCtx>(this);
+    AsyncWrap::Init();
   }
 
 

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -43,6 +43,8 @@ class ReqWrap : public AsyncWrap {
       object->Set(env->domain_string(), env->domain_array()->Get(0));
 
     QUEUE_INSERT_TAIL(&req_wrap_queue, &req_wrap_queue_);
+
+    AsyncWrap::Init();
   }
 
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -91,6 +91,7 @@ TLSCallbacks::TLSCallbacks(Environment* env,
   SSL_CTX_sess_set_new_cb(sc_->ctx_, SSLWrap<TLSCallbacks>::NewSessionCallback);
 
   InitSSL();
+  AsyncWrap::Init();
 }
 
 

--- a/test/simple/test-asynclistener-error-multiple-handled.js
+++ b/test/simple/test-asynclistener-error-multiple-handled.js
@@ -33,7 +33,7 @@ function onAsync1() {
   return 1;
 }
 
-function onError(stor) {
+function onError(ctx, stor) {
   results.push(stor);
   return true;
 }

--- a/test/simple/test-asynclistener-error-multiple-mix.js
+++ b/test/simple/test-asynclistener-error-multiple-mix.js
@@ -24,13 +24,13 @@ var assert = require('assert');
 
 var results = [];
 var asyncNoHandleError = {
-  error: function(stor) {
+  error: function(ctx, stor) {
     results.push(1);
   }
 };
 
 var asyncHandleError = {
-  error: function(stor) {
+  error: function(ctx, stor) {
     results.push(0);
     return true;
   }

--- a/test/simple/test-asynclistener-error-multiple-unhandled.js
+++ b/test/simple/test-asynclistener-error-multiple-unhandled.js
@@ -30,7 +30,7 @@ function onAsync1() {
   return 1;
 }
 
-function onError(stor) {
+function onError(ctx, stor) {
   results.push(stor);
 }
 

--- a/test/simple/test-asynclistener-error-net.js
+++ b/test/simple/test-asynclistener-error-net.js
@@ -30,7 +30,7 @@ var caught = 0;
 var expectCaught = 0;
 
 var callbacksObj = {
-  error: function(value, er) {
+  error: function(ctx, stor, er) {
     var idx = errorMsgs.indexOf(er.message);
     caught++;
 

--- a/test/simple/test-asynclistener-error-throw-in-after.js
+++ b/test/simple/test-asynclistener-error-throw-in-after.js
@@ -29,7 +29,7 @@ var handlers = {
   after: function() {
     throw 1;
   },
-  error: function(stor, err) {
+  error: function(ctx, stor, err) {
     // Error handler must be called exactly *once*.
     once++;
     assert.equal(err, 1);

--- a/test/simple/test-asynclistener-error-throw-in-before.js
+++ b/test/simple/test-asynclistener-error-throw-in-before.js
@@ -29,7 +29,7 @@ var handlers = {
   before: function() {
     throw 1;
   },
-  error: function(stor, err) {
+  error: function(ctx, stor, err) {
     // Error handler must be called exactly *once*.
     once++;
     assert.equal(err, 1);

--- a/test/simple/test-asynclistener-error.js
+++ b/test/simple/test-asynclistener-error.js
@@ -34,7 +34,7 @@ var expectCaught = 0;
 var exitCbRan = false;
 
 var callbacksObj = {
-  error: function(value, er) {
+  error: function(ctx, value, er) {
     var idx = errorMsgs.indexOf(er.message);
 
     caught++;

--- a/test/simple/test-asynclistener-multi-timeout.js
+++ b/test/simple/test-asynclistener-multi-timeout.js
@@ -28,7 +28,7 @@ var caught = [];
 var expect = [];
 
 var callbacksObj = {
-  error: function(value, er) {
+  error: function(ctx, value, er) {
     process._rawDebug('caught', er.message);
     caught.push(er.message);
     return (expect.indexOf(er.message) !== -1);

--- a/test/simple/test-asynclistener-run-error-once.js
+++ b/test/simple/test-asynclistener-run-error-once.js
@@ -25,7 +25,7 @@ var net = require('net');
 
 var cntr = 0;
 var al = process.addAsyncListener({
-  error: function(stor, er) {
+  error: function(ctx, stor, er) {
     cntr++;
     process._rawDebug('Handling error: ' + er.message);
     return true;


### PR DESCRIPTION
I don't like needing to run `AsyncWrap::Init()` outside of the constructor, but currently is the only way with how `ReqWrap` is setup.

This is an pre-commit helper to simplify future tasks.
