### PR TITLE
http: do not emit EOF non-readable socket

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -98,9 +98,7 @@ IncomingMessage.prototype._read = function(n) {
   // We actually do almost nothing here, because the parserOnBody
   // function fills up our internal buffer directly.  However, we
   // do need to unpause the underlying socket so that it flows.
-  if (!this.socket.readable)
-    this.push(null);
-  else
+  if (this.socket.readable)
     readStart(this.socket);
 };
 

--- a/test/simple/test-http-client-readable.js
+++ b/test/simple/test-http-client-readable.js
@@ -1,0 +1,80 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var util = require('util');
+
+var Duplex = require('stream').Duplex;
+
+function FakeAgent() {
+  http.Agent.call(this);
+}
+util.inherits(FakeAgent, http.Agent);
+
+FakeAgent.prototype.createConnection = function createConnection() {
+  var s = new Duplex();
+  var once = false;
+
+  s._read = function read() {
+    if (once)
+      return this.push(null);
+    once = true;
+
+    this.push('HTTP/1.1 200 Ok\r\nTransfer-Encoding: chunked\r\n\r\n');
+    this.push('b\r\nhello world\r\n');
+    this.readable = false;
+    this.push('0\r\n\r\n');
+  };
+
+  // Blackhole
+  s._write = function write(data, enc, cb) {
+    cb();
+  };
+
+  s.destroy = s.destroySoon = function destroy() {
+    this.writable = false;
+  };
+
+  return s;
+};
+
+var received = '';
+var ended = 0;
+
+var req = http.request({
+  agent: new FakeAgent()
+}, function(res) {
+  res.on('data', function(chunk) {
+    received += chunk;
+  });
+
+  res.on('end', function() {
+    ended++;
+  });
+});
+req.end();
+
+process.on('exit', function() {
+  assert.equal(received, 'hello world');
+  assert.equal(ended, 1);
+});


### PR DESCRIPTION
Socket may become not `readable`, but http should not rely on this
property and should not think that it means that no data will ever
arrive from it. In fact, it may arrive in a next tick and, since
`this.push(null)` was already called, it will result in a error like
this:

```
Error: stream.push() after EOF
    at readableAddChunk (_stream_readable.js:143:15)
    at IncomingMessage.Readable.push (_stream_readable.js:123:10)
    at HTTPParser.parserOnBody (_http_common.js:132:22)
    at Socket.socketOnData (_http_client.js:277:20)
    at Socket.EventEmitter.emit (events.js:101:17)
    at Socket.Readable.read (_stream_readable.js:367:10)
    at Socket.socketCloseListener (_http_client.js:196:10)
    at Socket.EventEmitter.emit (events.js:123:20)
    at TCP.close (net.js:479:12)
```

fix #6784
