### PR TITLE
net: make Socket destroy() re-entrance safe

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -461,8 +461,11 @@ Socket.prototype._destroy = function(exception, cb) {
     this._handle = null;
   }
 
-  fireErrorCallbacks();
+  // we set destroyed to true before firing error callbacks in order
+  // to make it re-entrance safe in case Socket.prototype.destroy()
+  // is called within callbacks
   this.destroyed = true;
+  fireErrorCallbacks();
 
   if (this.server) {
     COUNTER_NET_SERVER_CONNECTION_CLOSE(this);

--- a/test/simple/test-net-stream.js
+++ b/test/simple/test-net-stream.js
@@ -37,3 +37,42 @@ s.destroy();
 assert.equal(9, s.server.connections);
 s.destroy();
 assert.equal(9, s.server.connections);
+
+var SIZE = 2E6;
+var N = 10;
+var buf = new Buffer(SIZE);
+buf.fill(0x61); // 'a'
+
+var server = net.createServer(function(socket) {
+  socket.setNoDelay();
+
+  var lastError;
+  socket.on('error', function(err) {
+    socket.destroy();
+    if (lastError === err) {
+      assert.fail(err, undefined, 'error event emitted more than once for the same error');
+    } else {
+      lastError = err;
+    }
+  }).on('close', function() {
+    server.close();
+  })
+
+  for (var i = 0; i < N; ++i) {
+    socket.write(buf, function() { });
+  }
+  socket.end();
+
+}).listen(common.PORT, function() {
+    var conn = net.connect(common.PORT);
+    conn.on('data', function(buf) {
+      conn.pause();
+      setTimeout(function() {
+        conn.destroy();
+      }, 20);
+    });
+  });
+
+process.on('exit', function() {
+  assert.equal(server.connections, 0);
+});


### PR DESCRIPTION
So that we are free to call socket.destroy() in error event handler.
Otherwise, we'll get server.getConnections() == -1.
