### PR TITLE
lib: Remove unused variable + operations in util.inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -424,10 +424,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
 
 
 function reduceToSingleString(output, base, braces) {
-  var numLinesEst = 0;
   var length = output.reduce(function(prev, cur) {
-    numLinesEst++;
-    if (cur.indexOf('\n') >= 0) numLinesEst++;
     return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
   }, 0);
 


### PR DESCRIPTION
This was originally introduced in 6034701 to prevent the closing brace being pushed onto the next line if an object is longer than the max width, however the functionality was removed in d164989 but the supplementary variables (and operations) were left behind
