### PR TITLE
timer: Continue processing on same tick if a domain caught an exception

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -113,9 +113,18 @@ function listOnTimeout() {
         threw = false;
       } finally {
         if (threw) {
-          process.nextTick(function() {
-            list.ontimeout();
-          });
+          // We need to continue processing after domain error handling
+          // is complete, but not by using whatever domain was left over
+          // when the timeout threw its exception.
+          var oldDomain = process.domain;
+          process.domain = undefined;
+          try {
+            process.nextTick(function() {
+              list.ontimeout();
+            });
+          } finally {
+            process.domain = oldDomain;
+          }
         }
       }
     }

--- a/test/simple/test-domain-exit-dispose-again.js
+++ b/test/simple/test-domain-exit-dispose-again.js
@@ -1,0 +1,76 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var assert = require('assert');
+var domain = require('domain');
+var disposalFailed = false;
+
+// no matter what happens, we should increment a 10 times.
+var a = 0;
+log();
+function log(){
+  console.log(a++, process.domain);
+  if (a < 10) setTimeout(log, 20);
+}
+
+var secondTimerRan = false;
+
+// in 50ms we'll throw an error.
+setTimeout(err, 50);
+setTimeout(secondTimer, 50);
+function err(){
+  var d = domain.create();
+  d.on('error', handle);
+  d.run(err2);
+
+  function err2() {
+    // this timeout should never be called, since the domain gets
+    // disposed when the error happens.
+    setTimeout(function() {
+      console.error('This should not happen.');
+      disposalFailed = true;
+      process.exit(1);
+    });
+
+    // this function doesn't exist, and throws an error as a result.
+    err3();
+  }
+
+  function handle(e) {
+    // this should clean up everything properly.
+    d.dispose();
+    console.error(e);
+    console.error('in handler', process.domain, process.domain === d);
+  }
+}
+
+function secondTimer() {
+  console.log('In second timer');
+  secondTimerRan = true;
+}
+
+process.on('exit', function() {
+  assert.equal(a, 10);
+  assert.equal(disposalFailed, false);
+  assert(secondTimerRan);
+  console.log('ok');
+});


### PR DESCRIPTION
If two timers run on the same tick, and the first timer uses a domain,
and then catches an exception and disposes of the domain, then the
second timer never runs. (And even if the first timer does not dispose
of the domain, the second timer could run under the wrong domain.)

This happens because timer.js uses "process.nextTick()" to schedule
continued processing of the timers for that tick. However, there was
an exception inside a domain, then "process.nextTick()" runs under
the domain of the first timer function, and will do nothing if
the domain has been disposed.

To avoid this, we temporarily save the value of "process.domain"
before calling nextTick so that it does not run inside any domain.
