### PR TITLE
Out of memory when inspect large sparse array

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var MAX_SPARSE_ARRAY_GAP = 10;
 var formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (!isString(f)) {
@@ -404,28 +405,62 @@ function formatError(value) {
   return '[' + Error.prototype.toString.call(value) + ']';
 }
 
+function formatArrayItem(ctx, index, item, sparse) {
+  return sparse ? ctx.stylize(index, 'special') + ': ' + item : item;
+}
 
+/*
+  If a gap in array longer than MAX_SPARSE_ARRAY_GAP was detected then
+  all gap will entirely skipped from an output. First defined item after
+  gap will prefixed with it index and ':'. If such item not present (gap up to
+  the array end) then just output the last index in the array and ':'
+*/
 function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
-  for (var i = 0, l = value.length; i < l; ++i) {
-    if (hasOwnProperty(value, String(i))) {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-          String(i), true));
-    } else {
-      output.push('');
+
+  var skipped = 0, j,
+      l = value.length;
+
+  if (keys.length === 0) { // empty sparsed array?
+    skipped = l;
+  } else {
+    for (var i = 0; i < l; ++i) {
+      var key = String(i);
+      if (hasOwnProperty(value, key)) {
+        if (skipped <= MAX_SPARSE_ARRAY_GAP) {
+          for (j = 0; j < skipped; ++j) output.push('');
+        }
+        output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+            key, true, (skipped > MAX_SPARSE_ARRAY_GAP)));
+        skipped = 0;
+      } else {
+        ++skipped;
+      }
     }
   }
+
+  if (skipped) {
+    if (skipped <= MAX_SPARSE_ARRAY_GAP) {
+      for (j = 0; j < skipped; ++j) output.push('');
+    } else
+    {
+      output.push(formatArrayItem(ctx, l - 1, '', true));
+    }
+  }
+
   keys.forEach(function(key) {
     if (!key.match(/^\d+$/)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
           key, true));
     }
   });
+
   return output;
 }
 
 
-function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
+function formatProperty(ctx, value, recurseTimes, visibleKeys, key, 
+                        array, sparse) {
   var name, str, desc;
   desc = Object.getOwnPropertyDescriptor(value, key) || { value: value[key] };
   if (desc.get) {
@@ -466,7 +501,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
   }
   if (isUndefined(name)) {
     if (array && key.match(/^\d+$/)) {
-      return str;
+      return formatArrayItem(ctx, key, str, sparse);
     }
     name = JSON.stringify('' + key);
     if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -46,6 +46,12 @@ assert.equal(util.inspect(a), '[ \'foo\', , \'baz\' ]');
 assert.equal(util.inspect(a, true), '[ \'foo\', , \'baz\', [length]: 3 ]');
 assert.equal(util.inspect(new Array(5)), '[ , , , ,  ]');
 
+// test for large sparse array
+assert.equal(util.inspect(new Array(0xFFFFFFFF)), '[ 4294967294:  ]');
+a = new Array(50001);
+a[10000] = 1; a[20000] = 2; a[20001] = 3; a[20003] = 4;
+assert.equal(util.inspect(a), '[ 10000: 1, 20000: 2, 3, , 4, 50000:  ]');
+
 // test for property descriptors
 var getter = Object.create(null, {
   a: {


### PR DESCRIPTION
util.inspect crashes Node when I  inspect large sparse array (even empty!)

Try in Node's REPL:

```
> new Array(0xffffffff)
```

Output:

```
FATAL ERROR: JS Allocation failed - process out of memory
```

But this work:

```
var a = new Array(0xFFFFFFFF)
a[0xFFFFFFFF]=1
console.log(a[0xFFFFFFFF],a.length);
```

It is possible to detect large arrays in util.inspect and not output them at whole or replace them with some stub like this:

```
[ 1, 20, 6,
... 2000000 elements skipped ...
34, 68, 30]
```

?
