### PR TITLE
lib: Add "wrap" option to util.inspect to disable or set line length

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -143,6 +143,7 @@ function inspect(obj, opts) {
   if (isUndefined(ctx.depth)) ctx.depth = 2;
   if (isUndefined(ctx.colors)) ctx.colors = false;
   if (isUndefined(ctx.customInspect)) ctx.customInspect = true;
+  if (isUndefined(ctx.wrap) || ctx.wrap === true) ctx.wrap = 60;
   if (ctx.colors) ctx.stylize = stylizeWithColor;
   return formatValue(ctx, obj, ctx.depth);
 }
@@ -310,7 +311,7 @@ function formatValue(ctx, value, recurseTimes) {
 
   ctx.seen.pop();
 
-  return reduceToSingleString(output, base, braces);
+  return reduceToSingleString(output, base, braces, ctx.wrap);
 }
 
 
@@ -423,21 +424,21 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
 }
 
 
-function reduceToSingleString(output, base, braces) {
-  var length = output.reduce(function(prev, cur) {
-    return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
-  }, 0);
+function reduceToSingleString(output, base, braces, wrap) {
+  var join = ', ';
 
-  if (length > 60) {
-    return braces[0] +
-           (base === '' ? '' : base + '\n ') +
-           ' ' +
-           output.join(',\n  ') +
-           ' ' +
-           braces[1];
+  if (wrap) {
+    var length = output.reduce(function(prev, cur) {
+      return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
+    }, 0);
+    if (length > wrap) {
+      join = ',\n  ';
+      if (base !== '')
+        base += '\n ';
+    }
   }
 
-  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
+  return braces[0] + base + ' ' + output.join(join) + ' ' + braces[1];
 }
 
 


### PR DESCRIPTION
Previously inspect would always wrap if the string exceeded 60 chars.

Now the "wrap" option can either be set to false, to disable wrapping, to an explicit number to enable wrapping at that length, or true to revert to the previous default wrapping length of 60 (default behaviour).

Follows on from #6943
