### PR TITLE
Revert "src: only define ssize_t on windows if undefined"

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -61,6 +61,14 @@
 #include "v8.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
 
+#ifdef _WIN32
+# include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+typedef SIZE_T size_t;
+#else  // !_WIN32
+# include <sys/types.h>  // size_t, ssize_t
+#endif  // _WIN32
+
 // Forward-declare these functions now to stop MSVS from becoming
 // terminally confused when it's done in node_internals.h
 namespace node {
@@ -183,17 +191,6 @@ void DisplayExceptionLine(v8::Handle<v8::Message> message);
 
 NODE_EXTERN v8::Local<v8::Value> Encode(const void *buf, size_t len,
                                         enum encoding encoding = BINARY);
-
-#ifdef _WIN32
-// TODO(tjfontaine) consider changing the usage of ssize_t to ptrdiff_t
-#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
-typedef intptr_t ssize_t;
-# define _SSIZE_T_
-# define _SSIZE_T_DEFINED
-#endif
-#else  // !_WIN32
-# include <sys/types.h>  // size_t, ssize_t
-#endif  // _WIN32
 
 // Returns -1 if the handle was not valid for decoding
 NODE_EXTERN ssize_t DecodeBytes(v8::Handle<v8::Value>,


### PR DESCRIPTION
Reverted for breaking building add-ons on Linux, OS X and probably
other UNIX platforms.  See rvagg/nan#66 for an example.

This reverts commit ab54e32bbd53ba920ac8e6cd06330fc8aa317de3.

/cc @tjfontaine @indutny
