### PR TITLE
Revamp docs with JSDocs (incomplete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ deps/zlib/zlib.target.mk
 /SHASUMS*.txt*
 
 /tools/wrk/wrk
+/tools/jsdoc/node_modules

--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,10 @@ test-npm-publish: node
 test-addons: test-build
 	$(PYTHON) tools/test.py --mode=release addons
 
-apidoc_sources = $(wildcard doc/api/*.markdown)
-apidocs = $(addprefix out/,$(apidoc_sources:.markdown=.html)) \
-          $(addprefix out/,$(apidoc_sources:.markdown=.json))
+apidoc_sources = $(filter-out lib/_%, $(wildcard lib/*.js))
+apidocs = $(subst lib/,out/doc/api/,$(apidoc_sources:.js=.html)) \
+          $(subst lib/,out/doc/api/,$(apidoc_sources:.js=.json))
+
 
 apidoc_dirs = out/doc out/doc/api/ out/doc/api/assets out/doc/about out/doc/community out/doc/download out/doc/logos out/doc/images
 
@@ -205,11 +206,11 @@ out/doc/%.html: doc/%.html node
 out/doc/%: doc/%
 	cp -r $< $@
 
-out/doc/api/%.json: doc/api/%.markdown node
-	out/Release/node tools/doc/generate.js --format=json $< > $@
+out/doc/api/%.json: lib/%.js tools/jsdoc/ tools/jsdoc/template/ node
+	out/Release/node tools/jsdoc/node_modules/jsdoc/jsdoc.js --configure tools/jsdoc/jsdoc.json --query format=json $< > $@
 
-out/doc/api/%.html: doc/api/%.markdown node
-	out/Release/node tools/doc/generate.js --format=html --template=doc/template.html $< > $@
+out/doc/api/%.html: lib/%.js tools/jsdoc/ tools/jsdoc/template/ node
+	out/Release/node tools/jsdoc/node_modules/jsdoc/jsdoc.js --configure tools/jsdoc/jsdoc.json --query format=html $< > $@
 
 email.md: ChangeLog tools/email-footer.md
 	bash tools/changelog-head.sh | sed 's|^\* #|* \\#|g' > $@
@@ -236,6 +237,9 @@ docopen: out/doc/api/all.html
 
 docclean:
 	-rm -rf out/doc
+
+docwatch:
+	nodemon --watch tools/jsdoc/ --exec "make" doc
 
 RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)
 VERSION=v$(RAWVER)

--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -8,7 +8,7 @@ The file system is not consulted to check whether paths are valid.
 
 Use `require('path')` to use this module.  The following methods are provided:
 
-## path.normalize(p)
+## path.normalize(path)
 
 Normalize a string path, taking care of `'..'` and `'.'` parts.
 
@@ -22,7 +22,7 @@ Example:
     // returns
     '/foo/bar/baz/asdf'
 
-## path.join([path1], [path2], [...])
+## path.join([path ...])
 
 Join all arguments together and normalize the resulting path.
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -23,10 +23,6 @@
 /**
  * @module path
  * @stability 3
- * @description
- * This module contains utilities for handling and transforming file
- * paths. Almost all these methods perform only string transformations.
- * The file system is not consulted to check whether paths are valid.
  */
 
 var isWindows = process.platform === 'win32';
@@ -94,48 +90,10 @@ if (isWindows) {
   };
 
   /**
-   * Resolves `to` to an absolute path.
-
-   * If `to` isn't already absolute `from` arguments are prepended in right to left
-   * order, until an absolute path is found. If after using all `from` paths still
-   * no absolute path is found, the current working directory is used as well. The
-   * resulting path is normalized, and trailing slashes are removed unless the path
-   * gets resolved to the root directory. Non-string arguments are ignored.
-   *
-   * Another way to think of it is as a sequence of `cd` commands in a shell.
-   *
-   *     path.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile')
-   *
-   * Is similar to:
-   *
-   *     cd foo/bar
-   *     cd /tmp/file/
-   *     cd ..
-   *     cd a/../subfile
-   *     pwd
-   *
-   * The difference is that the different paths don't need to exist and may also be
-   * files.
-   *
-   * Examples:
-   *
-   *     path.resolve('/foo/bar', './baz')
-   *     // returns
-   *     '/foo/bar/baz'
-   *
-   *     path.resolve('/foo/bar', '/tmp/file/')
-   *     // returns
-   *     '/tmp/file'
-   *
-   *     path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
-   *     // if currently in /home/myself/node, it returns
-   *     '/home/myself/node/wwwroot/static_files/gif/image.gif'
-   *
    * @param {...string} [from] from
    * @param {string} to to
    * @returns {string} absoute path
    */
-  // path.resolve([from ...], to)
   // windows version
   exports.resolve = function() {
     var resolvedDevice = '',
@@ -219,18 +177,6 @@ if (isWindows) {
   };
 
   /**
-   * Normalize a string path, taking care of `'..'` and `'.'` parts.
-   *
-   * When multiple slashes are found, they're replaced by a single one;
-   * when the path contains a trailing slash, it is preserved.
-   * On Windows backslashes are used.
-   *
-   * Example:
-   *
-   *     path.normalize('/foo/bar//baz/asdf/quux/..')
-   *     // returns
-   *     '/foo/bar/baz/asdf'
-   *
    * @param  {string} path path
    * @return {string} normalized path
    */
@@ -270,23 +216,6 @@ if (isWindows) {
   };
 
   /**
-   * Determines whether `path` is an absolute path. An absolute path will always
-   * resolve to the same location, regardless of the working directory.
-   *
-   * Posix examples:
-   *
-   *     path.isAbsolute('/foo/bar') // true
-   *     path.isAbsolute('/baz/..')  // true
-   *     path.isAbsolute('qux/')     // false
-   *     path.isAbsolute('.')        // false
-   *
-   * Windows examples:
-   *
-   *     path.isAbsolute('//server')  // true
-   *     path.isAbsolute('C:/foo/..') // true
-   *     path.isAbsolute('bar\\baz')   // false
-   *     path.isAbsolute('.')         // false
-   *
    * @param  {string}  path path
    * @return {Boolean}      whether path is an absolute path
    */
@@ -300,21 +229,6 @@ if (isWindows) {
   };
 
   /**
-   * Join all arguments together and normalize the resulting path.
-   *
-   * Arguments must be strings.  In v0.8, non-string arguments were
-   * silently ignored.  In v0.10 and up, an exception is thrown.
-   *
-   * Example:
-   *
-   *     path.join('/foo', 'bar', 'baz/asdf', 'quux', '..')
-   *     // returns
-   *     '/foo/bar/baz/asdf'
-   *
-   *     path.join('foo', {}, 'bar')
-   *     // throws exception
-   *     TypeError: Arguments to path.join must be strings
-   *
    * @param  {...string} [path]
    * @return {string} joined path
    */
@@ -351,23 +265,6 @@ if (isWindows) {
   };
 
   /**
-   * Solve the relative path from `from` to `to`.
-   * At times we have two absolute paths, and we need to derive the relative
-   * path from one to the other.  This is actually the reverse transform of
-   * `path.resolve`, which means we see that:
-   *
-   *     path.resolve(from, path.relative(from, to)) == path.resolve(to)
-   *
-   * Examples:
-   *
-   *     path.relative('C:\\orandea\\test\\aaa', 'C:\\orandea\\impl\\bbb')
-   *     // returns
-   *     '..\\..\\impl\\bbb'
-   *
-   *     path.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb')
-   *     // returns
-   *     '../../impl/bbb'
-
    * @param  {string} from from
    * @param  {string} to   to
    * @return {string}      relative path from `from` to `to`
@@ -425,45 +322,11 @@ if (isWindows) {
   };
 
   /**
-   * The platform-specific file separator. `'\\'` or `'/'`.
-   *
-   * An example on *nix:
-   *
-   *     'foo/bar/baz'.split(path.sep)
-   *     // returns
-   *     ['foo', 'bar', 'baz']
-   *
-   * An example on Windows:
-   *
-   *     'foo\\bar\\baz'.split(path.sep)
-   *     // returns
-   *     ['foo', 'bar', 'baz']
-   *
    * @type {String}
    */
   exports.sep = '\\';
 
   /**
-   * The platform-specific path delimiter, `;` or `':'`.
-   *
-   * An example on *nix:
-   *
-   *     console.log(process.env.PATH)
-   *     // '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
-   *
-   *     process.env.PATH.split(path.delimiter)
-   *     // returns
-   *     ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
-   *
-   * An example on Windows:
-   *
-   *     console.log(process.env.PATH)
-   *     // 'C:\Windows\system32;C:\Windows;C:\Program Files\nodejs\'
-   *
-   *     process.env.PATH.split(path.delimiter)
-   *     // returns
-   *     ['C:\Windows\system32', 'C:\Windows', 'C:\Program Files\nodejs\']
-   *
    * @type {String}
    */
   exports.delimiter = ';';

--- a/lib/path.js
+++ b/lib/path.js
@@ -20,6 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+/**
+ * @module path
+ * @stability 3
+ * @description
+ * This module contains utilities for handling and transforming file
+ * paths. Almost all these methods perform only string transformations.
+ * The file system is not consulted to check whether paths are valid.
+ */
+
 var isWindows = process.platform === 'win32';
 var util = require('util');
 
@@ -84,6 +93,48 @@ if (isWindows) {
     return '\\\\' + device.replace(/^[\\\/]+/, '').replace(/[\\\/]+/g, '\\');
   };
 
+  /**
+   * Resolves `to` to an absolute path.
+
+   * If `to` isn't already absolute `from` arguments are prepended in right to left
+   * order, until an absolute path is found. If after using all `from` paths still
+   * no absolute path is found, the current working directory is used as well. The
+   * resulting path is normalized, and trailing slashes are removed unless the path
+   * gets resolved to the root directory. Non-string arguments are ignored.
+   *
+   * Another way to think of it is as a sequence of `cd` commands in a shell.
+   *
+   *     path.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile')
+   *
+   * Is similar to:
+   *
+   *     cd foo/bar
+   *     cd /tmp/file/
+   *     cd ..
+   *     cd a/../subfile
+   *     pwd
+   *
+   * The difference is that the different paths don't need to exist and may also be
+   * files.
+   *
+   * Examples:
+   *
+   *     path.resolve('/foo/bar', './baz')
+   *     // returns
+   *     '/foo/bar/baz'
+   *
+   *     path.resolve('/foo/bar', '/tmp/file/')
+   *     // returns
+   *     '/tmp/file'
+   *
+   *     path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
+   *     // if currently in /home/myself/node, it returns
+   *     '/home/myself/node/wwwroot/static_files/gif/image.gif'
+   *
+   * @param {...string} [from] from
+   * @param {string} to to
+   * @returns {string} absoute path
+   */
   // path.resolve([from ...], to)
   // windows version
   exports.resolve = function() {
@@ -167,6 +218,22 @@ if (isWindows) {
            '.';
   };
 
+  /**
+   * Normalize a string path, taking care of `'..'` and `'.'` parts.
+   *
+   * When multiple slashes are found, they're replaced by a single one;
+   * when the path contains a trailing slash, it is preserved.
+   * On Windows backslashes are used.
+   *
+   * Example:
+   *
+   *     path.normalize('/foo/bar//baz/asdf/quux/..')
+   *     // returns
+   *     '/foo/bar/baz/asdf'
+   *
+   * @param  {string} path path
+   * @return {string} normalized path
+   */
   // windows version
   exports.normalize = function(path) {
     var result = splitDeviceRe.exec(path),
@@ -202,6 +269,27 @@ if (isWindows) {
     return device + (isAbsolute ? '\\' : '') + tail;
   };
 
+  /**
+   * Determines whether `path` is an absolute path. An absolute path will always
+   * resolve to the same location, regardless of the working directory.
+   *
+   * Posix examples:
+   *
+   *     path.isAbsolute('/foo/bar') // true
+   *     path.isAbsolute('/baz/..')  // true
+   *     path.isAbsolute('qux/')     // false
+   *     path.isAbsolute('.')        // false
+   *
+   * Windows examples:
+   *
+   *     path.isAbsolute('//server')  // true
+   *     path.isAbsolute('C:/foo/..') // true
+   *     path.isAbsolute('bar\\baz')   // false
+   *     path.isAbsolute('.')         // false
+   *
+   * @param  {string}  path path
+   * @return {Boolean}      whether path is an absolute path
+   */
   // windows version
   exports.isAbsolute = function(path) {
     var result = splitDeviceRe.exec(path),
@@ -211,6 +299,25 @@ if (isWindows) {
     return !!result[2] || isUnc;
   };
 
+  /**
+   * Join all arguments together and normalize the resulting path.
+   *
+   * Arguments must be strings.  In v0.8, non-string arguments were
+   * silently ignored.  In v0.10 and up, an exception is thrown.
+   *
+   * Example:
+   *
+   *     path.join('/foo', 'bar', 'baz/asdf', 'quux', '..')
+   *     // returns
+   *     '/foo/bar/baz/asdf'
+   *
+   *     path.join('foo', {}, 'bar')
+   *     // throws exception
+   *     TypeError: Arguments to path.join must be strings
+   *
+   * @param  {...string} [path]
+   * @return {string} joined path
+   */
   // windows version
   exports.join = function() {
     function f(p) {
@@ -243,11 +350,28 @@ if (isWindows) {
     return exports.normalize(joined);
   };
 
-  // path.relative(from, to)
-  // it will solve the relative path from 'from' to 'to', for instance:
-  // from = 'C:\\orandea\\test\\aaa'
-  // to = 'C:\\orandea\\impl\\bbb'
-  // The output of the function should be: '..\\..\\impl\\bbb'
+  /**
+   * Solve the relative path from `from` to `to`.
+   * At times we have two absolute paths, and we need to derive the relative
+   * path from one to the other.  This is actually the reverse transform of
+   * `path.resolve`, which means we see that:
+   *
+   *     path.resolve(from, path.relative(from, to)) == path.resolve(to)
+   *
+   * Examples:
+   *
+   *     path.relative('C:\\orandea\\test\\aaa', 'C:\\orandea\\impl\\bbb')
+   *     // returns
+   *     '..\\..\\impl\\bbb'
+   *
+   *     path.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb')
+   *     // returns
+   *     '../../impl/bbb'
+
+   * @param  {string} from from
+   * @param  {string} to   to
+   * @return {string}      relative path from `from` to `to`
+   */
   // windows version
   exports.relative = function(from, to) {
     from = exports.resolve(from);
@@ -300,7 +424,48 @@ if (isWindows) {
     return outputParts.join('\\');
   };
 
+  /**
+   * The platform-specific file separator. `'\\'` or `'/'`.
+   *
+   * An example on *nix:
+   *
+   *     'foo/bar/baz'.split(path.sep)
+   *     // returns
+   *     ['foo', 'bar', 'baz']
+   *
+   * An example on Windows:
+   *
+   *     'foo\\bar\\baz'.split(path.sep)
+   *     // returns
+   *     ['foo', 'bar', 'baz']
+   *
+   * @type {String}
+   */
   exports.sep = '\\';
+
+  /**
+   * The platform-specific path delimiter, `;` or `':'`.
+   *
+   * An example on *nix:
+   *
+   *     console.log(process.env.PATH)
+   *     // '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
+   *
+   *     process.env.PATH.split(path.delimiter)
+   *     // returns
+   *     ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
+   *
+   * An example on Windows:
+   *
+   *     console.log(process.env.PATH)
+   *     // 'C:\Windows\system32;C:\Windows;C:\Program Files\nodejs\'
+   *
+   *     process.env.PATH.split(path.delimiter)
+   *     // returns
+   *     ['C:\Windows\system32', 'C:\Windows', 'C:\Program Files\nodejs\']
+   *
+   * @type {String}
+   */
   exports.delimiter = ';';
 
 } else /* posix */ {
@@ -442,6 +607,18 @@ if (isWindows) {
   exports.delimiter = ':';
 }
 
+/**
+ * Return the directory name of a path.  Similar to the Unix `dirname` command.
+ *
+ * Example:
+ *
+ *     path.dirname('/foo/bar/baz/asdf/quux')
+ *     // returns
+ *     '/foo/bar/baz/asdf'
+ *
+ * @param  {string} path path
+ * @return {string}      directory name of path
+ */
 exports.dirname = function(path) {
   var result = splitPath(path),
       root = result[0],
@@ -461,6 +638,23 @@ exports.dirname = function(path) {
 };
 
 
+/**
+ * Return the last portion of a path.  Similar to the Unix `basename` command.
+ *
+ * Example:
+ *
+ *     path.basename('/foo/bar/baz/asdf/quux.html')
+ *     // returns
+ *     'quux.html'
+ *
+ *     path.basename('/foo/bar/baz/asdf/quux.html', '.html')
+ *     // returns
+ *     'quux'
+ *
+ * @param  {string} path path
+ * @param  {string} ext  extension
+ * @return {string}      last portion of path
+ */
 exports.basename = function(path, ext) {
   var f = splitPath(path)[2];
   // TODO: make this comparison case-insensitive on windows?
@@ -471,6 +665,27 @@ exports.basename = function(path, ext) {
 };
 
 
+/**
+ * Return the extension of the path, from the last '.' to end of string
+ * in the last portion of the path.  If there is no '.' in the last portion
+ * of the path or the first character of it is '.', then it returns
+ * an empty string.  Examples:
+ *
+ *     path.extname('index.html')
+ *     // returns
+ *     '.html'
+ *
+ *     path.extname('index.')
+ *     // returns
+ *     '.'
+ *
+ *     path.extname('index')
+ *     // returns
+ *     ''
+ *
+ * @param  {string} path path
+ * @return {string}      extension
+ */
 exports.extname = function(path) {
   return splitPath(path)[3];
 };

--- a/tools/jsdoc/jsdoc.json
+++ b/tools/jsdoc/jsdoc.json
@@ -1,0 +1,9 @@
+{
+	"opts": {
+		"template": "tools/jsdoc/template/",
+		"destination": "out/jsdoc/"
+	},
+	"plugins": [
+		"plugins/markdown"
+	]
+}

--- a/tools/jsdoc/package.json
+++ b/tools/jsdoc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nodejs-doc-generator",
+  "version": "0.0.0",
+  "description": "Internal tool for generating Node.js API docs",
+  "author": "https://github.com/joyent/node/blob/master/AUTHORS",
+  "license": "MIT",
+  "dependencies": {
+    "jsdoc": "~3.3.0-alpha4",
+    "handlebars": "~1.3.0"
+  }
+}

--- a/tools/jsdoc/template/api.html
+++ b/tools/jsdoc/template/api.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{module.title}} Node.js {{version}} Manual &amp; Documentation</title>
+  <link rel="stylesheet" href="assets/style.css">
+  <link rel="stylesheet" href="assets/sh.css">
+  <link rel="canonical" href="http://nodejs.org/api/{{module.name}}.html">
+</head>
+<body class="alt apidoc" id="api-section-{{module.name}}">
+    <div id="intro" class="interior">
+        <a href="/" title="Go back to the home page">
+            <img id="logo" src="http://nodejs.org/images/logo-light.png" alt="node.js">
+        </a>
+    </div>
+    <div id="content" class="clearfix">
+        <div id="column2" class="interior">
+            <ul>
+                <li><a href="/" class="home">Home</a></li>
+                <li><a href="/download/" class="download">Download</a></li>
+                <li><a href="/about/" class="about">About</a></li>
+                <li><a href="http://npmjs.org/" class="npm">npm Registry</a></li>
+                <li><a href="http://nodejs.org/api/" class="docs current">Docs</a></li>
+                <li><a href="http://blog.nodejs.org" class="blog">Blog</a></li>
+                <li><a href="/community/" class="community">Community</a></li>
+                <li><a href="/logos/" class="logos">Logos</a></li>
+                <li><a href="http://jobs.nodejs.org/" class="jobs">Jobs</a></li>
+            </ul>
+            <p class="twitter"><a href="http://twitter.com/nodejs">@nodejs</a></p>
+        </div>
+
+        <div id="column1" class="interior">
+          <header>
+            <h1>Node.js {{version}} Manual &amp; Documentation</h1>
+            <div id="gtoc">
+              <p>
+                <a href="index.html" name="toc">Index</a> |
+                <a href="all.html">View on single page</a> |
+                <a href="{{module.name}}.json">View as JSON</a>
+              </p>
+            </div>
+            <hr>
+          </header>
+
+          <div id="toc">
+            <h2>Table of Contents</h2>
+            <ul>
+              <li>
+                <a href="#{{module.anchor}}">{{module.title}}</a>
+                <ul>
+                {{#each members}}
+                  <li>
+                    <a href="#{{anchor}}">{{signature}}</a>
+                  </li>
+                {{/each}}
+                </ul>
+              </li>
+            </ul>
+          </div>
+
+          <div id="apicontent">
+            <h1>{{module.title}}<span><a class="mark" href="#{{module.anchor}}" id="{{module.anchor}}">#</a></span></h1>
+            <pre class="api_stability_{{stability.index}}">Stability: {{stability.index}} - {{stability.title}}</pre>
+            <p>{{{module.description}}}</p>
+            <p>Use <code>require('{{module.name}}')</code> to use this module.  The following methods are provided:</p>
+
+            {{#each members}}
+              <h2>{{signature}}<span><a id="{{anchor}}" href="#{{anchor}}">#</a></span></h2>
+              {{{description}}}
+            {{/each}}
+          </div>
+        </div>
+    </div>
+    <div id="footer">
+        <a href="http://joyent.com" class="joyent-logo">Joyent</a>
+        <ul class="clearfix">
+            <li><a href="/">Node.js</a></li>
+            <li><a href="/download/">Download</a></li>
+            <li><a href="/about/">About</a></li>
+            <li><a href="http://npmjs.org/">npm Registry</a></li>
+            <li><a href="http://nodejs.org/api/">Docs</a></li>
+            <li><a href="http://blog.nodejs.org">Blog</a></li>
+            <li><a href="/community/">Community</a></li>
+            <li><a href="/logos/">Logos</a></li>
+            <li><a href="http://jobs.nodejs.org/">Jobs</a></li>
+            <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
+        </ul>
+
+        <p>Copyright <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/{{version}}/LICENSE">license</a>.</p>
+    </div>
+
+  <script src="../sh_main.js"></script>
+  <script src="../sh_javascript.min.js"></script>
+  <script>highlight(undefined, undefined, 'pre');</script>
+  <script>
+    window._gaq = [['_setAccount', 'UA-10874194-2'], ['_trackPageview']];
+    (function(d, t) {
+      var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+      g.src = '//www.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g, s);
+    }(document, 'script'));
+  </script>
+</body>
+</html>

--- a/tools/jsdoc/template/publish.js
+++ b/tools/jsdoc/template/publish.js
@@ -1,0 +1,87 @@
+
+var fs = require('fs');
+var handlebars = require('handlebars');
+
+var formatMember = function (member) {
+  var module = member.memberof.substr(7);
+  var path = member.longname.substr(7);
+  var anchor = [module, module, member.name];
+
+  if (member.kind === 'function') {
+    var params = member.params.map(function (param) {
+      var signature = param.name + (param.variable ? ' ...' : '');
+      if (param.optional)
+        signature = '[' + signature + ']';
+      return signature;
+    });
+    member.signature = path + '(' + params.join(', ') + ')';
+
+    var params = member.params.map(function (param) {
+      return param.name;
+    });
+    anchor = anchor.concat(params);
+  } else {
+    member.signature = path;
+  }
+
+  member.anchor = anchor.join('_');
+
+  return member;
+};
+
+exports.publish = function(data, opts) {
+  var format = opts.query.format || 'html';
+
+  data({ undocumented: true }).remove();
+
+  // Get module list
+  var modules = data({ kind: 'module' }).get();
+
+  if (format === 'html') {
+    // Get templates
+    var templateFile = fs.readFileSync(__dirname + '/api.html');
+    var template = handlebars.compile(templateFile.toString());
+  }
+
+  modules.forEach(function (module) {
+    // Format
+    module.title = module.name.replace(/^[a-z]/, function (match) {
+      return match.toUpperCase();
+    });
+    module.anchor = [module.name, module.name].join('_');
+
+    var members = data({ memberof: 'module:' + module.name }).get();
+
+    var stability = 0;
+    (module.tags || []).some(function (tag) {
+      if (tag.title === 'stability') {
+        stability = tag.value;
+        return true;
+      }
+    });
+
+    switch (format) {
+      case 'html':
+        var output = template({
+          version: process.version,
+          stability: {
+            index: stability,
+            title: ['Deprecated', 'Experimental', 'Unstable', 'Stable',
+            'API Frozen', 'Locked'][stability]
+          },
+          module: module,
+          members: members.map(formatMember)
+        });
+        break;
+
+      case 'json':
+        var output = { todo: true };
+        break;
+
+      default:
+        throw new Error('Invalid format: ' + format);
+    }
+
+    console.log(output);
+  });
+}


### PR DESCRIPTION
Following on from the brief discussion in #6980 I've build a proof of concept of migrating the core documentation to jsdoc.

You will need to run `npm install` in tools/jsdoc to get the jsdoc library, you can then run `make doc` as usual. I've only added the inline comments to lib/path.js so far and various other pages are broken (all.html) etc. but an example of the output can be seen here: http://node.thomseddon.co.uk/api/path.html

I think there would be incredible value in more tightly coupling the api docs and the actual api code, it is quite common to have cases where the api is updated and the docs get left behind.

Additionally, one angle I really like the idea of is creating a generic node documentation tool (essentially jsdoc + template + simple to use) that others could use to documentation (similar to python's sphinx or java's javadoc). This could help give a very uniform feel to 3rd party library documentation (good and bad).

Again, this is only a proof of concept, if you like the idea then I'm ready to document the entire api + improve the generator.

Also, happy to move this onto the mailing list if that is preferred :)
