### PR TITLE
vm: don't copy Proxy object from parent context

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -149,6 +149,7 @@ class ContextifyContext {
         if (clone_property_method.IsEmpty()) {
           Local<String> code = FIXED_ONE_BYTE_STRING(node_isolate,
               "(function cloneProperty(source, key, target) {\n"
+              "  if (key === 'Proxy') return;\n"
               "  try {\n"
               "    var desc = Object.getOwnPropertyDescriptor(source, key);\n"
               "    if (desc.value === source) desc.value = target;\n"

--- a/test/common.js
+++ b/test/common.js
@@ -89,75 +89,76 @@ exports.spawnPwd = function(options) {
   }
 };
 
+var knownGlobals = [setTimeout,
+                    setInterval,
+                    setImmediate,
+                    clearTimeout,
+                    clearInterval,
+                    clearImmediate,
+                    console,
+                    constructor, // Enumerable in V8 3.21.
+                    Buffer,
+                    process,
+                    global];
+
+if (global.gc) {
+  knownGlobals.push(gc);
+}
+
+if (global.DTRACE_HTTP_SERVER_RESPONSE) {
+  knownGlobals.push(DTRACE_HTTP_SERVER_RESPONSE);
+  knownGlobals.push(DTRACE_HTTP_SERVER_REQUEST);
+  knownGlobals.push(DTRACE_HTTP_CLIENT_RESPONSE);
+  knownGlobals.push(DTRACE_HTTP_CLIENT_REQUEST);
+  knownGlobals.push(DTRACE_NET_STREAM_END);
+  knownGlobals.push(DTRACE_NET_SERVER_CONNECTION);
+  knownGlobals.push(DTRACE_NET_SOCKET_READ);
+  knownGlobals.push(DTRACE_NET_SOCKET_WRITE);
+}
+
+if (global.COUNTER_NET_SERVER_CONNECTION) {
+  knownGlobals.push(COUNTER_NET_SERVER_CONNECTION);
+  knownGlobals.push(COUNTER_NET_SERVER_CONNECTION_CLOSE);
+  knownGlobals.push(COUNTER_HTTP_SERVER_REQUEST);
+  knownGlobals.push(COUNTER_HTTP_SERVER_RESPONSE);
+  knownGlobals.push(COUNTER_HTTP_CLIENT_REQUEST);
+  knownGlobals.push(COUNTER_HTTP_CLIENT_RESPONSE);
+}
+
+if (global.ArrayBuffer) {
+  knownGlobals.push(ArrayBuffer);
+  knownGlobals.push(Int8Array);
+  knownGlobals.push(Uint8Array);
+  knownGlobals.push(Uint8ClampedArray);
+  knownGlobals.push(Int16Array);
+  knownGlobals.push(Uint16Array);
+  knownGlobals.push(Int32Array);
+  knownGlobals.push(Uint32Array);
+  knownGlobals.push(Float32Array);
+  knownGlobals.push(Float64Array);
+  knownGlobals.push(DataView);
+}
+
+function leakedGlobals() {
+  var leaked = [];
+
+  for (var val in global)
+    if (-1 === knownGlobals.indexOf(global[val]))
+      leaked.push(val);
+
+  return leaked;
+};
+exports.leakedGlobals = leakedGlobals;
 
 // Turn this off if the test should not check for global leaks.
 exports.globalCheck = true;
 
 process.on('exit', function() {
   if (!exports.globalCheck) return;
-  var knownGlobals = [setTimeout,
-                      setInterval,
-                      setImmediate,
-                      clearTimeout,
-                      clearInterval,
-                      clearImmediate,
-                      console,
-                      constructor, // Enumerable in V8 3.21.
-                      Buffer,
-                      process,
-                      global];
-
-  if (global.gc) {
-    knownGlobals.push(gc);
-  }
-
-  if (global.DTRACE_HTTP_SERVER_RESPONSE) {
-    knownGlobals.push(DTRACE_HTTP_SERVER_RESPONSE);
-    knownGlobals.push(DTRACE_HTTP_SERVER_REQUEST);
-    knownGlobals.push(DTRACE_HTTP_CLIENT_RESPONSE);
-    knownGlobals.push(DTRACE_HTTP_CLIENT_REQUEST);
-    knownGlobals.push(DTRACE_NET_STREAM_END);
-    knownGlobals.push(DTRACE_NET_SERVER_CONNECTION);
-    knownGlobals.push(DTRACE_NET_SOCKET_READ);
-    knownGlobals.push(DTRACE_NET_SOCKET_WRITE);
-  }
-  if (global.COUNTER_NET_SERVER_CONNECTION) {
-    knownGlobals.push(COUNTER_NET_SERVER_CONNECTION);
-    knownGlobals.push(COUNTER_NET_SERVER_CONNECTION_CLOSE);
-    knownGlobals.push(COUNTER_HTTP_SERVER_REQUEST);
-    knownGlobals.push(COUNTER_HTTP_SERVER_RESPONSE);
-    knownGlobals.push(COUNTER_HTTP_CLIENT_REQUEST);
-    knownGlobals.push(COUNTER_HTTP_CLIENT_RESPONSE);
-  }
-
-  if (global.ArrayBuffer) {
-    knownGlobals.push(ArrayBuffer);
-    knownGlobals.push(Int8Array);
-    knownGlobals.push(Uint8Array);
-    knownGlobals.push(Uint8ClampedArray);
-    knownGlobals.push(Int16Array);
-    knownGlobals.push(Uint16Array);
-    knownGlobals.push(Int32Array);
-    knownGlobals.push(Uint32Array);
-    knownGlobals.push(Float32Array);
-    knownGlobals.push(Float64Array);
-    knownGlobals.push(DataView);
-  }
-
-  for (var x in global) {
-    var found = false;
-
-    for (var y in knownGlobals) {
-      if (global[x] === knownGlobals[y]) {
-        found = true;
-        break;
-      }
-    }
-
-    if (!found) {
-      console.error('Unknown global: %s', x);
-      assert.ok(false, 'Unknown global found');
-    }
+  var leaked = leakedGlobals();
+  if (leaked.length > 0) {
+    console.error('Unknown globals: %s', leaked);
+    assert.ok(false, 'Unknown global found');
   }
 });
 

--- a/test/common.js
+++ b/test/common.js
@@ -139,6 +139,15 @@ if (global.ArrayBuffer) {
   knownGlobals.push(DataView);
 }
 
+// Harmony features.
+if (global.Proxy) {
+  knownGlobals.push(Proxy);
+}
+
+if (global.Symbol) {
+  knownGlobals.push(Symbol);
+}
+
 function leakedGlobals() {
   var leaked = [];
 

--- a/test/simple/test-common.js
+++ b/test/simple/test-common.js
@@ -1,0 +1,27 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+common.globalCheck = false;
+global.gc = 42;  // Not a valid global unless --expose_gc is set.
+assert.deepEqual(common.leakedGlobals(), ['gc']);

--- a/test/simple/test-vm-harmony-proxies.js
+++ b/test/simple/test-vm-harmony-proxies.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Flags: --harmony_proxies
+
+var common = require('../common');
+var assert = require('assert');
+var vm = require('vm');
+
+// src/node_contextify.cc filters out the Proxy object from the parent
+// context.  Make sure that the new context has a Proxy object of its own.
+var sandbox = {};
+var result = vm.runInNewContext('this.Proxy = Proxy', sandbox);
+assert(typeof sandbox.Proxy === 'object');
+assert(sandbox.Proxy !== Proxy);
+
+// Unless we copy the Proxy object explicitly, of course.
+var sandbox = { Proxy: Proxy };
+var result = vm.runInNewContext('this.Proxy = Proxy', sandbox);
+assert(typeof sandbox.Proxy === 'object');
+assert(sandbox.Proxy === Proxy);

--- a/test/simple/test-vm-harmony-symbols.js
+++ b/test/simple/test-vm-harmony-symbols.js
@@ -1,0 +1,38 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Flags: --harmony_symbols
+
+var common = require('../common');
+var assert = require('assert');
+var vm = require('vm');
+
+// The sandbox should have its own Symbol constructor.
+var sandbox = {};
+var result = vm.runInNewContext('this.Symbol = Symbol', sandbox);
+assert(typeof sandbox.Symbol === 'function');
+assert(sandbox.Symbol !== Symbol);
+
+// Unless we copy the Symbol constructor explicitly, of course.
+var sandbox = { Symbol: Symbol };
+var result = vm.runInNewContext('this.Symbol = Symbol', sandbox);
+assert(typeof sandbox.Symbol === 'function');
+assert(sandbox.Symbol === Symbol);


### PR DESCRIPTION
Make vm.runInContext() and vm.runInNewContext() stop copying the Proxy
object from the parent context into the new context when --harmony or
--harmony_proxies is in effect because it overwrites the new context's
native Proxy object.

This commit also adds a regression test for Harmony symbols.  They work
okay in the current implementation and the test should ensure it stays
that way.

These are the bug fixes from #6999.  Suggested reviewer: @tjfontaine
