### PR TITLE
doc: add an example about multiple extensions

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -151,6 +151,10 @@ an empty string.  Examples:
     path.extname('index.html')
     // returns
     '.html'
+    
+    path.extname('index.coffee.md')
+    // returns
+    '.md'
 
     path.extname('index.')
     // returns


### PR DESCRIPTION
`path.extname` returns only the last extension
