### PR TITLE
cleanup: unused definition currentSource

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -165,7 +165,6 @@ function Client() {
 
   this.currentFrame = NO_FRAME;
   this.currentSourceLine = -1;
-  this.currentSource = null;
   this.handles = {};
   this.scripts = {};
   this.breakpoints = [];


### PR DESCRIPTION
Client's member currentSource has no use throughout the project.
