### PR TITLE
openssl: fix keypress requirement in apps on win32

### DIFF
--- a/deps/openssl/openssl/apps/s_client.c
+++ b/deps/openssl/openssl/apps/s_client.c
@@ -178,6 +178,13 @@ typedef unsigned int u_int;
 #include <fcntl.h>
 #endif
 
+/* Use Windows API with STD_INPUT_HANDLE when checking for input?
+   Don't look at OPENSSL_SYS_MSDOS for this, since it is always defined if
+   OPENSSL_SYS_WINDOWS is defined */
+#if defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_WINCE) && defined(STD_INPUT_HANDLE)
+#define OPENSSL_USE_STD_INPUT_HANDLE
+#endif
+
 #undef PROG
 #define PROG	s_client_main
 
@@ -1604,10 +1611,10 @@ SSL_set_tlsext_status_ids(con, ids);
 					tv.tv_usec = 0;
 					i=select(width,(void *)&readfds,(void *)&writefds,
 						 NULL,&tv);
-#if defined(OPENSSL_SYS_WINCE) || defined(OPENSSL_SYS_MSDOS)
-					if(!i && (!_kbhit() || !read_tty) ) continue;
-#else
+#if defined(OPENSSL_USE_STD_INPUT_HANDLE)
 					if(!i && (!((_kbhit()) || (WAIT_OBJECT_0 == WaitForSingleObject(GetStdHandle(STD_INPUT_HANDLE), 0))) || !read_tty) ) continue;
+#else
+					if(!i && (!_kbhit() || !read_tty) ) continue;
 #endif
 				} else 	i=select(width,(void *)&readfds,(void *)&writefds,
 					 NULL,timeoutp);
@@ -1812,10 +1819,10 @@ printf("read=%d pending=%d peek=%d\n",k,SSL_pending(con),SSL_peek(con,zbuf,10240
 			}
 
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
-#if defined(OPENSSL_SYS_WINCE) || defined(OPENSSL_SYS_MSDOS)
-		else if (_kbhit())
-#else
+#if defined(OPENSSL_USE_STD_INPUT_HANDLE)
 		else if ((_kbhit()) || (WAIT_OBJECT_0 == WaitForSingleObject(GetStdHandle(STD_INPUT_HANDLE), 0)))
+#else
+		else if (_kbhit())
 #endif
 #elif defined (OPENSSL_SYS_NETWARE)
 		else if (_kbhit())


### PR DESCRIPTION
Re-applying commit 153784b3489e2feb9d93a3a5eee5a4aa34f74e39, which
was overwritten by the update to openssl 1.0.1f.

Original source:

http://openssl.6102.n7.nabble.com/PATCH-s-client-Fix-keypress-requirement-with-redirected-input-on-Windows-td46787.html
