### PR TITLE
test: fix test-tcp-wrap-listen

### DIFF
--- a/test/simple/test-tcp-wrap-listen.js
+++ b/test/simple/test-tcp-wrap-listen.js
@@ -64,7 +64,7 @@ server.onconnection = function(err, client) {
       // 11 bytes should flush
       assert.equal(0, client.writeQueueSize);
 
-      if (req.async && client.writeQueueSize != 0)
+      if (req.async)
         req.oncomplete = done;
       else
         process.nextTick(done.bind(null, 0, client, req));


### PR DESCRIPTION
If the call to writeBuffer completes asynchronously, we need to have
an oncomplete callback on the request object no matter what. The
writeQueueSize seems irrelvant to that regard.

Note that on Windows writeBuffer always completes asynchronously.

See related commit 9836a4eeda1e2d43aad0923f1f72b364792629bc
