### PR TITLE
contextify: handle infinite recursion errors

### DIFF
--- a/test/simple/test-vm-infinite-recursion.js
+++ b/test/simple/test-vm-infinite-recursion.js
@@ -1,0 +1,30 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Flags: --stack-size=128
+
+var assert = require('assert');
+var vm = require('vm');
+var s = 'vm.runInNewContext(s, { vm: vm, s: s })';
+
+assert.throws(function() {
+  eval(s);
+}, /Maximum call stack/);


### PR DESCRIPTION
Try to be consistent with v0.10 and emit "Maximum call stack size
reached", even if it happens when allocating context or doing other
stuff.

fix #7045
