### PR TITLE
dns: resolve: verify argument is function

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -185,9 +185,11 @@ exports.resolve = function(hostname, type_, callback_) {
   if (util.isString(type_)) {
     resolver = resolveMap[type_];
     callback = callback_;
-  } else {
+  } else if (util.isFunction(type_)) {
     resolver = exports.resolve4;
     callback = type_;
+  } else {
+    throw new Error('Type must be a string')
   }
 
   if (util.isFunction(resolver)) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -189,7 +189,7 @@ exports.resolve = function(hostname, type_, callback_) {
     resolver = exports.resolve4;
     callback = type_;
   } else {
-    throw new Error('Type must be a string')
+    throw new Error('Type must be a string');
   }
 
   if (util.isFunction(resolver)) {

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -60,3 +60,13 @@ assert.deepEqual(dns.getServers(), portsExpected);
 
 assert.doesNotThrow(function () { dns.setServers([]); });
 assert.deepEqual(dns.getServers(), []);
+
+assert.throws(
+  function() {
+    dns.resolve("test.com", [], new Function);
+  },
+  function(err) {
+    return !(err instanceof TypeError)
+  },
+  "Unexpected error"
+);


### PR DESCRIPTION
Don't use argument as callback if it's not a valid callback function. Throw a valid exception instead explaining the issue. Adds to #7070 ("DNS — Throw meaningful error(s)").
