### PR TITLE
dns: resolver: validate arguments

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -152,6 +152,12 @@ function resolver(bindingName) {
   var binding = cares[bindingName];
 
   return function query(name, callback) {
+    if (!util.isString(name)) {
+      throw new Error('Name must be a string');
+    } else if (!util.isFunction(callback)) {
+      throw new Error('Callback must be a function');
+    }
+
     callback = makeAsync(callback);
     var req = {
       bindingName: bindingName,

--- a/test/simple/test-dns-regress-7070.js
+++ b/test/simple/test-dns-regress-7070.js
@@ -1,0 +1,28 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var dns = require('dns');
+
+// Should not raise assertion error. Issue #7070
+assert.throws(function () { dns.resolveNs([]) }); // bad name
+assert.throws(function () { dns.resolveNs("") }); // bad callback


### PR DESCRIPTION
Mitigates C++-land assertion error when unchecked arguments are delegated; adds tests accordingly. Closes #7070 ("DNS — Throw meaningful error(s)").
