### PR TITLE
module: fix addition of filetypes, if require ends with ..

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -167,20 +167,21 @@ Module._findPath = function(request, paths) {
   // For each path
   for (var i = 0, PL = paths.length; i < PL; i++) {
     var basePath = path.resolve(paths[i], request);
+    var stats = statPath(basePath);
     var filename;
 
     if (!trailingSlash) {
       // try to join the request to the path
       filename = tryFile(basePath);
 
-      if (!filename && !trailingSlash) {
+      if (!filename && stats && stats.isDirectory()) {
+        filename = tryPackage(basePath, exts);
+      }
+
+      if (!filename) {
         // try it with each of the extensions
         filename = tryExtensions(basePath, exts);
       }
-    }
-
-    if (!filename) {
-      filename = tryPackage(basePath, exts);
     }
 
     if (!filename) {

--- a/test/fixtures/json-with-directory-name-module/module-stub.json
+++ b/test/fixtures/json-with-directory-name-module/module-stub.json
@@ -1,0 +1,1 @@
+{"rocko": "artischocko"}

--- a/test/fixtures/json-with-directory-name-module/module-stub/index.js
+++ b/test/fixtures/json-with-directory-name-module/module-stub/index.js
@@ -1,0 +1,1 @@
+module.exports = "hello from module-stub!"

--- a/test/fixtures/json-with-directory-name-module/module-stub/package.json
+++ b/test/fixtures/json-with-directory-name-module/module-stub/package.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.1.12",
+  "name": "module-stub",
+  "main": "./index.js",
+  "description": "A stub for node tests",
+  "author": "Robert Kowalski <rok@kowalski.gd>"
+}

--- a/test/fixtures/json-with-directory-name-module/module-stub/test/tap/test.js
+++ b/test/fixtures/json-with-directory-name-module/module-stub/test/tap/test.js
@@ -1,0 +1,1 @@
+module.exports = require('../..');

--- a/test/simple/test-require-extensions-same-filename-as-dir.js
+++ b/test/simple/test-require-extensions-same-filename-as-dir.js
@@ -1,0 +1,29 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var content = require(common.fixturesDir +
+  '/json-with-directory-name-module/module-stub/test/tap/test.js');
+
+assert.ok(content.rocko !== 'artischocko');
+assert.equal(content, 'hello from module-stub!');


### PR DESCRIPTION
Given my home-directory is `/Users/rocko` - and I have a file named
`npm.json` in it and also a repository with name `npm`, which is a
node-module.

When try to require the `/Users/rocko/npm/index.js` two direcotry
levels down in the npm folder (e.g. `/Users/rocko/npm/test/tap`)
with `require("../../")` node will load `/Users/rocko/npm/index.js`.

When I use `require("../..")` node will load `/Users/rocko/npm.json`
which is fixed by this commit.
