### PR TITLE
http: remove path from Request options

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -193,6 +193,7 @@ Agent.prototype.createSocket = function(req, options) {
 
   debug('createConnection', name, options);
   options.encoding = null;
+  options.path = null;
   var s = self.createConnection(options);
   if (!self.sockets[name]) {
     self.sockets[name] = [];


### PR DESCRIPTION
Some 3rd request modules uses path property.  For instance:
https://github.com/mikeal/request/blob/master/request.js#L254

It did not matter in the Node 0.10. But in Node 0.11 it leads
to malfunction of the net core module. This is because the path
is considered as a pipe (v0.11.11-release/lib/net.js#L844).

It is not a bug. Although it is an eco-friendly way to get rid of
a problem.
