### PR TITLE
Typo in Net createConnection's parameter name

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -50,8 +50,8 @@ Use `nc` to connect to a UNIX domain socket server:
 
     nc -U /tmp/echo.sock
 
-## net.connect(options, [connectionListener])
-## net.createConnection(options, [connectionListener])
+## net.connect(options, [connectListener])
+## net.createConnection(options, [connectListener])
 
 Constructs a new socket object and opens the socket to the given location.
 When the socket is established, the ['connect'][] event will be emitted.


### PR DESCRIPTION
Hello,

There were a typo in documentation, the listener of "createConnection" is listening to "connect" event. "connectionListener" name is so, a bad name because "connectionListener" for createServer() is listening to "connection" event ;)

Regards,
Peekmo
