### PR TITLE
debugger: Improve clearBreakpoint

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1443,6 +1443,17 @@ Interface.prototype.clearBreakpoint = function(script, line) {
       breakpoint,
       index;
 
+  if (util.isUndefined(script)) {
+    script = this.client.currentScript;
+    line = this.client.currentSourceLine + 1;
+  }
+
+  // clearBreakpoint(line-number) should clear breakpoint in current script
+  if (util.isUndefined(line) && util.isNumber(script)) {
+    line = script;
+    script = this.client.currentScript;
+  }
+
   this.client.breakpoints.some(function(bp, i) {
     if (bp.scriptId === script ||
         bp.scriptReq === script ||
@@ -1450,11 +1461,14 @@ Interface.prototype.clearBreakpoint = function(script, line) {
       if (!util.isUndefined(index)) {
         ambiguous = true;
       }
-      if (bp.line === line) {
-        index = i;
-        breakpoint = bp.id;
-        return true;
+      if (!util.isUndefined(line)) {
+        if (bp.line !== line) {
+          return;
+        }
       }
+      index = i;
+      breakpoint = bp.id;
+      return true;
     }
   });
 

--- a/test/debugger/test-debugger-repl-break-in-loop.js
+++ b/test/debugger/test-debugger-repl-break-in-loop.js
@@ -1,0 +1,95 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var repl = require('./helper-debugger-repl.js');
+
+repl.startDebugger('breakpoints-loop.js');
+
+repl.addTest('n', [
+  /break/,
+  /1/, /2/, /3/, /4/, /5/
+]);
+
+// -- SET BREAKPOINT --
+
+// Set breakpoint on current line(3rd)
+repl.addTest('sb()', [
+  /1/, /2/, /3/, /4/, /5/, /6/, /7/, /8/
+]);
+
+// CHeck if it shows the breakpoint marker
+repl.addTest('n', [
+  /break/,
+  /2/, /\* 3/, /> 4/, /5/, /6/
+]);
+
+// Check if breakpoint is working
+repl.addTest('c', [
+  /break/,
+  /1/, /2/, /> 3/, /4/, /5/
+]);
+
+// Set breakpoint on 2nd line
+repl.addTest('sb(2)', [
+  /1/, /\* 2/, /> 3/, /4/, /5/, /6/, /7/, /8/
+]);
+
+// Check if it stops on 2nd line
+repl.addTest('c', [
+  /break/, /1/, /> 2/, /\* 3/, /4/
+]);
+
+// Clear current line breakpoint
+repl.addTest('cb()', [
+  /1/, /> 2/, /\* 3/, /4/, /5/, /6/, /7/
+]);
+
+// Clear 3rd breakpoint
+repl.addTest('cb(3)', [
+  /1/, /> 2/, /  3/, /4/, /5/, /6/, /7/
+]);
+
+repl.addTest('sb(8)', [
+  /1/, /> 2/, /3/, /4/, /5/, /6/, /7/
+]);
+
+repl.addTest('c', [
+  /break/, /6/, /7/, /> 8/, /9/, /10/
+]);
+
+repl.addTest('sb("someFn()")', [
+  /3/, /4/, /5/, /6/, /7/, /> 8/, /9/, /\*10/, /11/, /12/, /13/
+]);
+
+// Check if the function break point works
+repl.addTest('c', [
+  /break/, /9/, /10/, />11/, /12/, /13/
+]);
+
+repl.addTest('cb("someFn()")', [
+  /6/, /7/, /8/, /9/, /10/, />11/, /12/, /13/, /14/
+]);
+
+repl.addTest('c', [
+  /program terminated/
+]);
+
+repl.addTest('quit', []);

--- a/test/fixtures/breakpoints-loop.js
+++ b/test/fixtures/breakpoints-loop.js
@@ -1,0 +1,12 @@
+var i = 0;
+while (i < 5) {
+  i++;
+  someFn();
+}
+
+global.someFn = someFn;
+someFn();
+someFn()
+function someFn() {
+  return 'I need food!';
+}


### PR DESCRIPTION
This will make clearBreakpoint() to clear breakpoint on current line(no
arguments) and clearBreakpoint(number) to clear breakpoint on the line
number.

For #7026

Right now, I'm working on getting setBreakpoint('functionname()') working. I get this error:

```
debug> sb('someFn()')
Error: "ReferenceError: someFn is not defined" evaluating "someFn"
```
