### PR TITLE
Add path.common(path1/*, ...pathn*/);

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -84,6 +84,16 @@ if (isWindows) {
     return '\\\\' + device.replace(/^[\\\/]+/, '').replace(/[\\\/]+/g, '\\');
   };
 
+  var normalizeForCommon = function (path) {
+    if (!util.isString(path)) {
+      throw new TypeError('Arguments to path.common must be strings');
+    }
+    var isDir = (path[path.length - 1] === '\\');
+    path = exports.resolve(path);
+    if (isDir) return path;
+    return exports.dirname(path);
+  };
+
   // path.resolve([from ...], to)
   // windows version
   exports.resolve = function() {
@@ -300,6 +310,44 @@ if (isWindows) {
     return outputParts.join('\\');
   };
 
+  // path.common(path1/*, ...pathn*/)
+  // windows version
+  exports.common = function(path/*, ...pathn*/) {
+    path = normalizeForCommon(path);
+    var i = 1;
+    var l = arguments.length;
+    var pathLength = path.length;
+    for (; i < l; ++i) {
+      var other = normalizeForCommon(arguments[i]).toLowerCase();
+      var end = 0;
+      var j = 0;
+      var otherLength = other.length;
+      while (path[j].toLowerCase() === other[j]) {
+        if (path[j] === '\\') end = j;
+        ++j;
+        if (pathLength === j) {
+          if (otherLength === j) end = j;
+          else if (other[j] === '\\') end = j;
+          break;
+        }
+        if (otherLength === j) {
+          if (path[j] === '\\') end = j;
+          break;
+        }
+      }
+      if (!end) return null;
+      if (end !== pathLength) {
+        path = path.slice(0, end);
+        if (path[path.length - 1] === ':') {
+          path += '\\';
+          ++end;
+        }
+        pathLength = end;
+      }
+    }
+    return path;
+  };
+
   exports.sep = '\\';
   exports.delimiter = ';';
 
@@ -311,6 +359,15 @@ if (isWindows) {
       /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
   var splitPath = function(filename) {
     return splitPathRe.exec(filename).slice(1);
+  };
+  var normalizeForCommon = function (path) {
+    if (!util.isString(path)) {
+      throw new TypeError('Arguments to path.common must be strings');
+    }
+    var isDir = (path[path.length - 1] === '/');
+    path = exports.resolve(path);
+    if (isDir) return path;
+    return exports.dirname(path);
   };
 
   // path.resolve([from ...], to)
@@ -436,6 +493,41 @@ if (isWindows) {
     outputParts = outputParts.concat(toParts.slice(samePartsLength));
 
     return outputParts.join('/');
+  };
+
+  // path.common(path1/*, ...pathn*/)
+  // posix version
+  exports.common = function(path/*, ...pathn*/) {
+    path = normalizeForCommon(path);
+    if (path === '/') return '/';
+    var i = 1;
+    var l = arguments.length;
+    var pathLength = path.length;
+    for (; i < l; ++i) {
+      var other = normalizeForCommon(arguments[i]);
+      var end = 0;
+      var j = 0;
+      var otherLength = other.length;
+      while (path[j] === other[j]) {
+        if (path[j] === '/') end = j;
+        ++j;
+        if (pathLength === j) {
+          if (otherLength === j) end = j;
+          else if (other[j] === '/') end = j;
+          break;
+        }
+        if (otherLength === j) {
+          if (path[j] === '/') end = j;
+          break;
+        }
+      }
+      if (end <= 1) return '/';
+      if (end !== pathLength) {
+        path = path.slice(0, end);
+        pathLength = end;
+      }
+    }
+    return path;
   };
 
   exports.sep = '/';

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -405,6 +405,53 @@ relativeTests.forEach(function(test) {
 });
 assert.equal(failures.length, 0, failures.join(''));
 
+// path.common tests
+if (isWindows) {
+  // windows
+  var resolveTests =
+      // arguments  result
+      [[['C:\\'], 'C:\\'],
+       [['d:\\'], 'd:\\'],
+       [['c:\\', 'd:\\'], null],
+       [['c:\\raz\\dwa\\'], 'c:\\raz\\dwa'],
+       [['C:\\raZ\\dwa'], 'C:\\raZ'],
+       [['c:\\raz\\dwa', 'c:\\trzy\\cztery'], 'c:\\'],
+       [['c:\\raz\\dwa', 'c:\\raz\\trzy'], 'c:\\raz'],
+       [['c:\\raZ\\dwa', 'c:\\rAz\\trzy'], 'c:\\raZ'],
+       [['c:\\raz\\dwa', 'c:\\raz\\dwa\\trzy', 'c:\\raz\\cztery'], 'c:\\raz'],
+       [['C:\\raz\\dwa\\piec', 'c:\\raz\\dwa\\trzy', 'c:\\raz\\dwa\\cztery'],
+         'C:\\raz\\dwa'],
+       [['C:\\raz\\dwa\\piec', 'c:\\raz\\dwa\\trzy', 'c:\\raz\\dwa\\'],
+         'C:\\raz\\dwa'],
+       [['c:\\raz\\dwa\\piec', 'c:\\raz\\dwa\\trzy', 'c:\\raz\\dwa'],
+         'c:\\raz'],
+       [['c:\\raz\\dwa\\trzy', 'c:\\raz\\dwatrzy'], 'c:\\raz']];
+} else {
+  // Posix
+  var resolveTests =
+      // arguments      result
+      [[['/'], '/'],
+       [['/raz/dwa/'], '/raz/dwa'],
+       [['/raz/dwa'], '/raz'],
+       [['/raz/dwa', '/trzy/cztery'], '/'],
+       [['/raz/dwa', '/raz/trzy'], '/raz'],
+       [['/raz/dwa', '/raz/dwa/trzy', '/raz/cztery'], '/raz'],
+       [['/raz/dwa/piec', '/raz/dwa/trzy', '/raz/dwa/cztery'], '/raz/dwa'],
+       [['/raz/dwa/piec', '/raz/dwa/trzy', '/raz/dwa/'], '/raz/dwa'],
+       [['/raz/dwa/piec', '/raz/dwa/trzy', '/raz/dwa'], '/raz'],
+       [['/raz/dwa/trzy', '/raz/dwatrzy'], '/raz']];
+}
+var failures = [];
+resolveTests.forEach(function(test) {
+  var actual = path.common.apply(path, test[0]);
+  var expected = test[1];
+  var message = 'path.common(' + test[0].map(JSON.stringify).join(',') + ')' +
+                '\n  expect=' + JSON.stringify(expected) +
+                '\n  actual=' + JSON.stringify(actual);
+  if (actual !== expected) failures.push('\n' + message);
+});
+assert.equal(failures.length, 0, failures.join(''));
+
 // path.sep tests
 if (isWindows) {
   // windows


### PR DESCRIPTION
``` javascript
var path = require('path');

path.common('/lorem/ipsum/foo/bar', '/lorem/ipsum/raz/dwa', '/lorem/elo/foo/bar'); //  => '/lorem'

path.common('/foo/bar', '/raz/dwa'); // => '/'

path.common('C:\\\\foo\\bar', 'D:\\\\foo\\bar'); // => null
```

I have use case for it in few of my modules (using counterparts for now), and I wonder why it's not part of `path` API.

I'll be happy to provide a pull request, but before that I'd like to be sure that you're open for such add on.
