### PR TITLE
debugger: Fix breakpoint not showing after restart

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1115,8 +1115,9 @@ Interface.prototype.list = function(delta) {
 
       var current = lineno == 1 + client.currentSourceLine,
           breakpoint = client.breakpoints.some(function(bp) {
-            return bp.script === client.currentScript &&
-                   bp.line == lineno;
+            return (bp.scriptReq === client.currentScript ||
+                    bp.script === client.currentScript) &&
+                    bp.line == lineno;
           });
 
       if (lineno == 1) {

--- a/test/debugger/test-debugger-repl-restart.js
+++ b/test/debugger/test-debugger-repl-restart.js
@@ -22,10 +22,19 @@
 var repl = require('./helper-debugger-repl.js');
 
 repl.startDebugger('breakpoints.js');
+var linesWithBreakpoint = [
+    /> 1/, /2/, /3/, /4/, /5/, /\* 6/
+];
+// We slice here, because addTest will change the given array.
+repl.addTest('sb(6)', linesWithBreakpoint.slice());
+
+var initialLines = repl.initialLines.slice()
+initialLines.splice(2, 0, /Restoring/, /Warning/);
 
 // Restart the debugged script
 repl.addTest('restart', [
   /terminated/,
-].concat(repl.initialLines));
+].concat(initialLines));
 
+repl.addTest('list(5)', linesWithBreakpoint);
 repl.addTest('quit', []);


### PR DESCRIPTION
The reason this wasn't working was because after restart, when restoring
breakpoints the scripts wasn't loaded, so the breakpoint.script was
undefined. As a fix I added another check to use breakpoint.scriptReq
instead of breakpoint.script, which is the same except when the
breakpoint is a function.

fixes #7027
