### PR TITLE
test: fix tls-honorcipherorder slowness

### DIFF
--- a/test/simple/test-tls-honorcipherorder.js
+++ b/test/simple/test-tls-honorcipherorder.js
@@ -44,6 +44,10 @@ function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
 
   var server = tls.createServer(soptions, function(cleartextStream) {
     nconns++;
+
+    // End socket to send CLOSE_NOTIFY and TCP FIN packet, otherwise
+    // it may hang for ~30 seconds in FIN_WAIT_1 state (at least on OSX).
+    cleartextStream.end();
   });
   server.listen(common.PORT, localhost, function() {
     var coptions = {


### PR DESCRIPTION
End accepted stream to prevent client fd from hanging in FIN_WAIT_1
state. The 30 second delay was caused by default non-zero SO_LINGER.
