### PR TITLE
repl: add `repl.setPrompt` for dynamic repl server.

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -32,8 +32,9 @@ For example, you could add this to your bashrc file:
 
 ## repl.start(options)
 
-Returns and starts a `REPLServer` instance. Accepts an "options" Object that
-takes the following values:
+Returns and starts a `REPLServer` instance, that inherits from 
+[Readline Interface][]. Accepts an "options" Object that takes 
+the following values:
 
  - `prompt` - the prompt and `stream` for all I/O. Defaults to `> `.
 
@@ -68,10 +69,6 @@ You can use your own `eval` function if it has following signature:
     function eval(cmd, context, filename, callback) {
       callback(null, result);
     }
-
-## repl.setPrompt(prompt)
-
-Sets `prompt` of the existing instance of `REPLServer` of node.
 
 Multiple REPLs may be started against the same running instance of node.  Each
 will share the same global object but will have unique I/O.

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -69,6 +69,10 @@ You can use your own `eval` function if it has following signature:
       callback(null, result);
     }
 
+## repl.setPrompt(prompt)
+
+Sets `prompt` of the existing instance of `REPLServer` of node.
+
 Multiple REPLs may be started against the same running instance of node.  Each
 will share the same global object but will have unique I/O.
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -48,7 +48,6 @@ var path = require('path');
 var fs = require('fs');
 var rl = require('readline');
 var Console = require('console').Console;
-var EventEmitter = require('events').EventEmitter;
 var domain = require('domain');
 var debug = util.debuglog('repl');
 
@@ -245,7 +244,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
     if (cmd && cmd.charAt(0) === '.' && isNaN(parseFloat(cmd))) {
-      var matches = cmd.match(/^(\.[^\s]+)\s*(.*)$/);
+      var matches = cmd.match(/^\.([^\s]+)\s*(.*)$/);
       var keyword = matches && matches[1];
       var rest = matches && matches[2];
       if (self.parseREPLKeyword(keyword, rest) === true) {
@@ -705,7 +704,7 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   } else if (!util.isFunction(cmd.action)) {
     throw new Error('bad argument, action must be a function');
   }
-  this.commands['.' + keyword] = cmd;
+  this.commands[keyword] = cmd;
 };
 
 REPLServer.prototype.memory = function memory(cmd) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -82,8 +82,6 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     return new REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined);
   }
 
-  EventEmitter.call(this);
-
   var options, input, output, dom;
   if (util.isObject(prompt)) {
     // an options object was given
@@ -179,19 +177,18 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.bufferedCommand = '';
   self.lines.level = [];
 
-  self.prompt = !util.isUndefined(prompt) ? prompt : '> ';
-
   function complete(text, callback) {
     self.complete(text, callback);
   }
 
-  var rli = rl.createInterface({
-    input: self.inputStream,
-    output: self.outputStream,
-    completer: complete,
-    terminal: options.terminal
-  });
-  self.rli = rli;
+  rl.Interface.apply(this, [
+    self.inputStream,
+    self.outputStream,
+    complete,
+    options.terminal
+  ])
+
+  self.setPrompt(!util.isUndefined(prompt) ? prompt : '> ');
 
   this.commands = {};
   defineDefaultCommands(this);
@@ -200,7 +197,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.writer = options.writer || exports.writer;
 
   if (util.isUndefined(options.useColors)) {
-    options.useColors = rli.terminal;
+    options.useColors = self.terminal;
   }
   self.useColors = !!options.useColors;
 
@@ -211,24 +208,24 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     };
   }
 
-  rli.setPrompt(self.prompt);
+  self.setPrompt(self._prompt);
 
-  rli.on('close', function() {
+  self.on('close', function() {
     self.emit('exit');
   });
 
   var sawSIGINT = false;
-  rli.on('SIGINT', function() {
-    var empty = rli.line.length === 0;
-    rli.clearLine();
+  self.on('SIGINT', function() {
+    var empty = self.line.length === 0;
+    self.clearLine();
 
     if (!(self.bufferedCommand && self.bufferedCommand.length > 0) && empty) {
       if (sawSIGINT) {
-        rli.close();
+        self.close();
         sawSIGINT = false;
         return;
       }
-      rli.output.write('(^C again to quit)\n');
+      self.output.write('(^C again to quit)\n');
       sawSIGINT = true;
     } else {
       sawSIGINT = false;
@@ -239,7 +236,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     self.displayPrompt();
   });
 
-  rli.on('line', function(cmd) {
+  self.on('line', function(cmd) {
     debug('line %j', cmd);
     sawSIGINT = false;
     var skipCatchall = false;
@@ -322,13 +319,13 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     };
   });
 
-  rli.on('SIGCONT', function() {
+  self.on('SIGCONT', function() {
     self.displayPrompt(true);
   });
 
   self.displayPrompt();
 }
-inherits(REPLServer, EventEmitter);
+inherits(REPLServer, rl.Interface);
 exports.REPLServer = REPLServer;
 
 
@@ -339,7 +336,6 @@ exports.start = function(prompt, source, eval_, useGlobal, ignoreUndefined) {
   if (!exports.repl) exports.repl = repl;
   return repl;
 };
-
 
 REPLServer.prototype.createContext = function() {
   var context;
@@ -388,16 +384,16 @@ REPLServer.prototype.resetContext = function() {
 };
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
-  var prompt = this.prompt;
+  var prompt = this._prompt;
   if (this.bufferedCommand.length) {
     prompt = '...';
     var levelInd = new Array(this.lines.level.length).join('..');
     prompt += levelInd + ' ';
+  } else {
+    this.setPrompt(prompt);
   }
-  this.rli.setPrompt(prompt);
-  this.rli.prompt(preserveCursor);
+  this.prompt(preserveCursor);
 };
-
 
 // A stream to push an array into a REPL
 // used in REPLServer.complete
@@ -838,7 +834,7 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('exit', {
     help: 'Exit the repl',
     action: function() {
-      this.rli.close();
+      this.close();
     }
   });
 
@@ -879,7 +875,7 @@ function defineDefaultCommands(repl) {
           this.displayPrompt();
           lines.forEach(function(line) {
             if (line) {
-              self.rli.write(line + '\n');
+              self.write(line + '\n');
             }
           });
         }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -106,6 +106,9 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.useGlobal = !!useGlobal;
   self.ignoreUndefined = !!ignoreUndefined;
 
+  // just for backwards compat, see github.com/joyent/node/pull/7127
+  self.rli = this;
+
   eval_ = eval_ || defaultEval;
 
   function defaultEval(code, context, file, cb) {

--- a/test/simple/test-repl-options.js
+++ b/test/simple/test-repl-options.js
@@ -37,6 +37,7 @@ var r1 = repl.start({
   output: stream,
   terminal: true
 });
+
 assert.equal(r1.input, stream);
 assert.equal(r1.output, stream);
 assert.equal(r1.input, r1.inputStream);
@@ -45,6 +46,14 @@ assert.equal(r1.terminal, true);
 assert.equal(r1.useColors, r1.terminal);
 assert.equal(r1.useGlobal, false);
 assert.equal(r1.ignoreUndefined, false);
+
+// test r1 for backwards compact
+assert.equal(r1.rli.input, stream);
+assert.equal(r1.rli.output, stream);
+assert.equal(r1.rli.input, r1.inputStream);
+assert.equal(r1.rli.output, r1.outputStream);
+assert.equal(r1.rli.terminal, true);
+assert.equal(r1.useColors, r1.rli.terminal);
 
 // 2
 function writer() {}
@@ -68,3 +77,11 @@ assert.equal(r2.useColors, true);
 assert.equal(r2.useGlobal, true);
 assert.equal(r2.ignoreUndefined, true);
 assert.equal(r2.writer, writer);
+
+// test r2 for backwards compact
+assert.equal(r2.rli.input, stream);
+assert.equal(r2.rli.output, stream);
+assert.equal(r2.rli.input, r2.inputStream);
+assert.equal(r2.rli.output, r2.outputStream);
+assert.equal(r2.rli.terminal, false);
+

--- a/test/simple/test-repl-options.js
+++ b/test/simple/test-repl-options.js
@@ -37,12 +37,12 @@ var r1 = repl.start({
   output: stream,
   terminal: true
 });
-assert.equal(r1.rli.input, stream);
-assert.equal(r1.rli.output, stream);
-assert.equal(r1.rli.input, r1.inputStream);
-assert.equal(r1.rli.output, r1.outputStream);
-assert.equal(r1.rli.terminal, true);
-assert.equal(r1.useColors, r1.rli.terminal);
+assert.equal(r1.input, stream);
+assert.equal(r1.output, stream);
+assert.equal(r1.input, r1.inputStream);
+assert.equal(r1.output, r1.outputStream);
+assert.equal(r1.terminal, true);
+assert.equal(r1.useColors, r1.terminal);
 assert.equal(r1.useGlobal, false);
 assert.equal(r1.ignoreUndefined, false);
 
@@ -59,11 +59,11 @@ var r2 = repl.start({
   eval: evaler,
   writer: writer
 });
-assert.equal(r2.rli.input, stream);
-assert.equal(r2.rli.output, stream);
-assert.equal(r2.rli.input, r2.inputStream);
-assert.equal(r2.rli.output, r2.outputStream);
-assert.equal(r2.rli.terminal, false);
+assert.equal(r2.input, stream);
+assert.equal(r2.output, stream);
+assert.equal(r2.input, r2.inputStream);
+assert.equal(r2.output, r2.outputStream);
+assert.equal(r2.terminal, false);
 assert.equal(r2.useColors, true);
 assert.equal(r2.useGlobal, true);
 assert.equal(r2.ignoreUndefined, true);

--- a/test/simple/test-repl-require-cache.js
+++ b/test/simple/test-repl-require-cache.js
@@ -28,6 +28,6 @@ var common = require('../common'),
 require.cache.something = 1;
 assert.equal(require.cache.something, 1);
 
-repl.start({ useGlobal: false }).rli.close();
+repl.start({ useGlobal: false }).close();
 
 assert.equal(require.cache.something, 1);


### PR DESCRIPTION
Recently I'm using `repl` to implement a simple cli based on REPL.
I found `repl` module has not a specified way to change the prompt when server is running, but like `npm init` do a better experience of CLI by changing `prompt` to show tips for user, hence that, I think node's official module `repl` should export a function `.setPrompt(prompt)`, that perfects REPL and CLI apps.

demo:

``` js
var repl = require('repl');
repl.start({
  prompt: 'node > ',
  eval: function(cmd, context, filename, callback) {
    repl.setPrompt('name > (yorkie) ');
    callback(null, null);
  }
});
```
