### PR TITLE
lib/readline.js: Fix backspace for multi-line(\n)

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -228,7 +228,7 @@ Interface.prototype._refreshLine = function() {
   }
 
   // Cursor to left edge.
-  exports.cursorTo(this.output, 0);
+  exports.cursorTo(this.output, 0,0);
   // erase data
   exports.clearScreenDown(this.output);
 
@@ -580,7 +580,8 @@ Interface.prototype._getDisplayPos = function(str) {
 // Returns current cursor's position and line
 Interface.prototype._getCursorPos = function() {
   var columns = this.columns;
-  var strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
+  var linesOfPrompt=this._prompt.split("\n");
+  var strBeforeCursor = linesOfPrompt[linesOfPrompt.length-1] + this.line.substring(0, this.cursor);
   var dispPos = this._getDisplayPos(stripVTControlCharacters(strBeforeCursor));
   var cols = dispPos.cols;
   var rows = dispPos.rows;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -228,7 +228,7 @@ Interface.prototype._refreshLine = function() {
   }
 
   // Cursor to left edge.
-  exports.cursorTo(this.output, 0,0);
+  exports.cursorTo(this.output, 0, 0);
   // erase data
   exports.clearScreenDown(this.output);
 
@@ -580,8 +580,9 @@ Interface.prototype._getDisplayPos = function(str) {
 // Returns current cursor's position and line
 Interface.prototype._getCursorPos = function() {
   var columns = this.columns;
-  var linesOfPrompt=this._prompt.split("\n");
-  var strBeforeCursor = linesOfPrompt[linesOfPrompt.length-1] + this.line.substring(0, this.cursor);
+  var linesOfPrompt = this._prompt.split('\n');
+  var strBeforeCursor = linesOfPrompt[linesOfPrompt.length - 1];
+  strBeforeCursor += this.line.substring(0, this.cursor);
   var dispPos = this._getDisplayPos(stripVTControlCharacters(strBeforeCursor));
   var cols = dispPos.cols;
   var rows = dispPos.rows;


### PR DESCRIPTION
Add additional parameter to cursorTo in _refreshLine to ensure that
the cursor moves to the top left row as well as the far left column
This prevents multi-line output from repeating previous lines.

Calculate the cursor position relative to the last line by splitting
the prompt text on newline characters.

Fixes joyent/node#6415
