### PR TITLE
http: Improve HTTP Expect header handling

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -115,6 +115,17 @@ request body.
 Note that when this event is emitted and handled, the `request` event will
 not be emitted.
 
+### Event: 'checkExpectation'
+
+`function (request, response) { }`
+
+Emitted each time a request with an http Expect header is received, where the
+value is not 100-continue. If this event isn't listened for, the server will
+automatically respond with a 417 Expectation Failed as appropriate.
+
+Note that when this event is emitted and handled, the `request` event will
+not be emitted.
+
 ### Event: 'connect'
 
 `function (request, socket, head) { }`

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -492,14 +492,22 @@ function connectionListener(socket) {
     }
 
     if (!util.isUndefined(req.headers.expect) &&
-        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1) &&
-        continueExpression.test(req.headers['expect'])) {
-      res._expect_continue = true;
-      if (EventEmitter.listenerCount(self, 'checkContinue') > 0) {
-        self.emit('checkContinue', req, res);
+        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1)) {
+      if (continueExpression.test(req.headers['expect'])) {
+        res._expect_continue = true;
+        if (EventEmitter.listenerCount(self, 'checkContinue') > 0) {
+          self.emit('checkContinue', req, res);
+        } else {
+          res.writeContinue();
+          self.emit('request', req, res);
+        }
       } else {
-        res.writeContinue();
-        self.emit('request', req, res);
+        if (EventEmitter.listenerCount(self, 'checkExpectation') > 0) {
+          self.emit('checkExpectation', req, res);
+        } else {
+          res.writeHead(417);
+          res.end();
+        }
       }
     } else {
       self.emit('request', req, res);

--- a/test/simple/test-http-expect.js
+++ b/test/simple/test-http-expect.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var server = http.createServer(function (req, res) {
+    throw new Error('This shouldn\'t have been called');
+}).listen(common.PORT);
+
+server.on('listening', function() {
+  var options = {
+    port: common.PORT,
+    headers: { 'Expect': 'meoww' }
+  };
+  http.request(options).on('response', function(res) {
+    assert.equal(417, res.statusCode, 'Final status code was ' + res.statusCode + ', not 417.');
+    server.on('checkExpectation', common.mustCall(function checkExpectaionHandler(req, res) {
+      res.end();
+    }));
+    http.request(options).on('response', function(res) {
+      process.exit();
+    });
+  });
+});


### PR DESCRIPTION
Just following the spec:
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20

Fixes #4651

Note that, Now we have the following pattern 3 times in the _http_server.js:

```
if (EventEmitter.listenerCount(self, 'someEventName') > 0) {
    self.emit('someEventName');
} else {
     // Do something as default
}
```

I think maybe we should move it to a function, though didn't have any good idea for the name of the function. Something like this. If you guys give me a good name, I'll refactor it.

I also see this pattern in userland too. Maybe it should be a event emitter prototype method name `setDefaultListener` that will set the default action when there's no listeners but won't do anything when there are listeners to a particular event.
