### PR TITLE
doc: stdout blocking or non-blocking behaviour

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -125,9 +125,13 @@ Example: the definition of `console.log`
     };
 
 `process.stderr` and `process.stdout` are unlike other streams in Node in
-that writes to them are usually blocking.  They are blocking in the case
-that they refer to regular files or TTY file descriptors. In the case they
-refer to pipes, they are non-blocking like other streams.
+that writes to them are usually blocking.
+
+- They are blocking in the case that they refer to regular files or TTY file
+  descriptors.
+- In the case they refer to pipes:
+  - They are blocking in Linux/Unix.
+  - They are non-blocking like other streams in Windows.
 
 To check if Node is being run in a TTY context, read the `isTTY` property
 on `process.stderr`, `process.stdout`, or `process.stdin`:
@@ -149,9 +153,13 @@ See [the tty docs](tty.html#tty_tty) for more information.
 A writable stream to stderr.
 
 `process.stderr` and `process.stdout` are unlike other streams in Node in
-that writes to them are usually blocking.  They are blocking in the case
-that they refer to regular files or TTY file descriptors. In the case they
-refer to pipes, they are non-blocking like other streams.
+that writes to them are usually blocking.
+
+- They are blocking in the case that they refer to regular files or TTY file
+  descriptors.
+- In the case they refer to pipes:
+  - They are blocking in Linux/Unix.
+  - They are non-blocking like other streams in Windows.
 
 
 ## process.stdin


### PR DESCRIPTION
Makes clear that the behaviour of stdout is blocking in Linux/Unix even when they refer to pipes.

The current documentation can lead to misunderstandings telling that stdout is always non-blocking (when it refers to a pipe). This is not the behaviour in linux/unix, because of the current working of uv_pipe_open in libuv.

There is a working in progress right now to change that behaviour, but it is not clear yet the direction of those changes. Meanwhile I propose to update the current documentation to tell the actual and current behaviour.

I commented details of that issue #3584 (https://github.com/joyent/node/issues/3584#issuecomment-34908285), in a old commit of libuv joyent/libuv@8c9cbee1b1fb19786405bdd92af5edfdab4cdbbe and in the node group https://groups.google.com/d/msg/nodejs/Ua4nmiNPZXY/Vq3pepnM9Q8J
