### PR TITLE
Inherit EventEmitter handlers instead of share them

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -49,7 +49,7 @@ EventEmitter.init = function() {
       this.domain = domain.active;
     }
   }
-  this._events = this._events || {};
+  this._events = util._extend({}, this._events || {});
   this._maxListeners = this._maxListeners || undefined;
 };
 

--- a/test/simple/test-event-emitter-prototype.js
+++ b/test/simple/test-event-emitter-prototype.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+// EventEmitter subclassing without util.inherits()
+function P() {
+  events.EventEmitter.call(this);
+}
+
+P.prototype = new events.EventEmitter();
+
+var a = new P();
+var b = new P();
+
+var received = [];
+function record(on) {
+  return function() {
+    received.push(on);
+  }
+}
+
+a.on('B', record('a'));
+b.on('B', record('b'));
+
+b.emit('B');
+
+assert.deepEqual(received, ['b'], 'Instances have their own event handlers');


### PR DESCRIPTION
Using simple assignment in the constructor, `this._events` is lifted from the prototype and shared among all instances.

Rather than rely on `util.inherits()` to copy the prototype properties to the subclass instance, we can copy the properties that matter in the constructor, that way inheritance can be done without `util.inherits()`.

This fixes #7157, if I understand it correctly.
