### PR TITLE
debugger: don't set the `repl.prompt` string

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1558,7 +1558,6 @@ Interface.prototype.repl = function() {
   this.history.control = this.repl.rli.history;
   this.repl.rli.history = this.history.debug;
 
-  this.repl.prompt = '> ';
   this.repl.rli.setPrompt('> ');
   this.repl.displayPrompt();
 };
@@ -1574,7 +1573,6 @@ Interface.prototype.exitRepl = function() {
   this.repl.rli.history = this.history.control;
 
   this.repl.context = this.context;
-  this.repl.prompt = 'debug> ';
   this.repl.rli.setPrompt('debug> ');
   this.repl.displayPrompt();
 };


### PR DESCRIPTION
It wasn't doing anything, and actually due to
3ae0b17c76f693dd2e68a46f78c7dc7f595b33c6, it was causing
the readline `prompt()` function to be overwritten
which throws an error in the REPL shortly after.

See: https://github.com/joyent/node/commit/3ae0b17c76f693dd2e68a46f78c7dc7f595b33c6#commitcomment-5445121
