### PR TITLE
net: fix listening on FDs on Windows

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1060,8 +1060,7 @@ var createServerHandle = exports._createServerHandle =
     handle.open(fd);
     handle.readable = true;
     handle.writable = true;
-    return handle;
-
+    assert(!address && !port);
   } else if (port === -1 && addressType === -1) {
     handle = createPipe();
     if (process.platform === 'win32') {


### PR DESCRIPTION
With 3da36fe00e5d85414031ae812e473f16629d8645, I had intended to make
createServerHandle always listen to the handle on Windows.
Unfortunately, I had missed the code path we take when a file
descriptor is passed in.

This fixes test-net-listen-fd0.js on Windows.
