### PR TITLE
assert.deepEqual is not reflexive

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -203,9 +203,8 @@ function objEquiv(a, b) {
   //   Converting to array solves the problem.
   var aIsArgs = isArguments(a),
       bIsArgs = isArguments(b);
-  if (aIsArgs ^ bIsArgs) {
+  if (aIsArgs ^ bIsArgs)
     return false;
-  }
   if (aIsArgs) {
     a = pSlice.call(a);
     b = pSlice.call(b);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -201,10 +201,12 @@ function objEquiv(a, b) {
   if (a.prototype !== b.prototype) return false;
   //~~~I've managed to break Object.keys through screwy arguments passing.
   //   Converting to array solves the problem.
-  if (isArguments(a)) {
-    if (!isArguments(b)) {
-      return false;
-    }
+  var aIsArgs = isArguments(a),
+      bIsArgs = isArguments(b);
+  if (aIsArgs ^ bIsArgs) {
+    return false;
+  }
+  if (aIsArgs) {
     a = pSlice.call(a);
     b = pSlice.call(b);
     return _deepEqual(a, b);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -203,7 +203,7 @@ function objEquiv(a, b) {
   //   Converting to array solves the problem.
   var aIsArgs = isArguments(a),
       bIsArgs = isArguments(b);
-  if (aIsArgs ^ bIsArgs)
+  if ((aIsArgs && !bIsArgs) || (!aIsArgs && bIsArgs))
     return false;
   if (aIsArgs) {
     a = pSlice.call(a);

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -249,6 +249,11 @@ try {
   gotError = true;
 }
 
+// GH-7178. Ensure reflexivity of deepEqual with `arguments` objects.
+var args = (function() { return arguments; })();
+a.throws(makeBlock(a.deepEqual, [], args));
+a.throws(makeBlock(a.deepEqual, args, []));
+
 console.log('All OK');
 assert.ok(gotError);
 


### PR DESCRIPTION
The behavior of `assert.deepEqual` is dependent on the ordering of arguments. 

``` javascript
var assert = require('assert');
var args = (function() { return arguments; })();

assert.deepEqual([], args); // passes
assert.deepEqual(args, []); // throws
```

I recognize that this module's stability index is 5, but this non-reflexive behavior seems to be limited to the case of comparing an `arguments` object with an array and therefore inconsistent enough to warrant a patch.

In addition, [the in-line comment immediately preceding the branch](https://github.com/joyent/node/blob/dbae8b569fd1afa04cddac47b30379e4ebf3388a/lib/assert.js#L202-L203) suggests that using `Objects.keys` on an `arguments` object can cause unexpected results. This operation currently occurs any time only the second argument is an `arguments` object.

Relevant source: https://github.com/joyent/node/blob/dbae8b569fd1afa04cddac47b30379e4ebf3388a/lib/assert.js#L204-L211
