### PR TITLE
tls: Fix for requestCert: true

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1256,9 +1256,11 @@ Server.prototype.setOptions = function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else if (this.requestCert) {
-    this.sessionIdContext = crypto.createHash('md5')
-                                  .update(process.argv.join(' '))
-                                  .digest('hex');
+    var hash = crypto.createHash('md5');
+    hash.setEncoding('hex');
+    hash.write(process.argv.join(' '));
+    hash.end();
+    this.sessionIdContext = hash.read();
   }
   if (options.cleartext) this.cleartext = options.cleartext;
   if (options.encrypted) this.encrypted = options.encrypted;


### PR DESCRIPTION
When specifying the `requestCert: true` line [#1260](https://github.com/joyent/node/blob/v0.10.26-release/lib/tls.js#L1260) fails with the following error:

``` javascript
crypto.js:209
  this._binding.update(data, encoding);
                ^
TypeError: Bad input string
    at Hash.update (crypto.js:209:17)
    at Server.setOptions (tls.js:1260:36)
    at new Server (tls.js:1124:8)
    at Object.exports.createServer (tls.js:1220:10)
    at methods.server (/home/jas/projects/mine/Rejewski/lib/Rejewski.js:98:24)
    at new Rejewski (/home/jas/projects/mine/Rejewski/lib/Rejewski.js:615:28)
    at Object.<anonymous> (/home/jas/projects/mine/Rejewski/test/test-rejewski.js:22:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```

Steps to recreate:

``` javascript
var tls = require('tls')
    , fs = require('fs');

var opts = {
  host: 'localhost',
  port: 3000,
  key: fs.readFileSync('app.key'),
  cert: fs.readFileSync('app.crt'),
  requestCert: true
};

var server = tls.createServer(opts, function serv(stream){
  /* additional stream handlers */
});
```

The problem lies with [line #1260](https://github.com/joyent/node/blob/v0.10.26-release/lib/tls.js#L1260) and the outdated use of the `crypto.createHash(algo).update().end('hex')` functionality in the `v0.10.26-release` branch.

It should be updated as follows:

``` javascript
    hash = crypto.createHash('md5');
    hash.setEncoding('hex');
    hash.write(process.argv.join(' '));
    hash.end();
    this.sessionIdContext = hash.read();
```
