### PR TITLE
Fix a buffer overrun in node_crypto_bio

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -80,18 +80,6 @@ function Credentials(secureProtocol, flags, context) {
 
 exports.Credentials = Credentials;
 
-function addNewline(buf) {
-  var last = buf[buf.length - 1];
-  var isBuf = Buffer.isBuffer(buf);
-
-  if (!isBuf && !util.isString(buf))
-    throw new Error('Certificate should be of type Buffer or string');
-
-  if (isBuf ? last !== 10 : last !== '\n')
-    return buf.toString().trim() + '\n';
-  else
-    return buf;
-}
 
 exports.createCredentials = function(options, context) {
   if (!options) options = {};
@@ -103,15 +91,14 @@ exports.createCredentials = function(options, context) {
   if (context) return c;
 
   if (options.key) {
-    var key = addNewline(options.key);
     if (options.passphrase) {
-      c.context.setKey(key, options.passphrase);
+      c.context.setKey(options.key, options.passphrase);
     } else {
-      c.context.setKey(key);
+      c.context.setKey(options.key);
     }
   }
 
-  if (options.cert) c.context.setCert(addNewline(options.cert));
+  if (options.cert) c.context.setCert(options.cert);
 
   if (options.ciphers) c.context.setCiphers(options.ciphers);
 

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -145,8 +145,8 @@ int NodeBIO::Gets(BIO* bio, char* out, int size) {
 
   int i = nbio->IndexOf('\n', size);
 
-  // Include '\n'
-  if (i < size)
+  // Include '\n', if it's there.  If not, don't read off the end.
+  if (i < size && i >= 0 && static_cast<size_t>(i) < nbio->Length())
     i++;
 
   // Shift `i` a bit to NULL-terminate string later


### PR DESCRIPTION
Fix a read off the end of a node BIO buffer that was calling a failure to read and parse X509 certificates, which was in turn causing the 'ca' option to `https.Agent` to be ignored.

This bug was introduced in a58f93ffc4a23aa7240808288acf8cf9f3022abea

A gist containing git bisection logs and a test case can be found here: https://gist.github.com/maxtaco/9211605
