### PR TITLE
http: invoke createConnection when no agent is passed

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1346,7 +1346,10 @@ function ClientRequest(options, cb) {
   var self = this;
   OutgoingMessage.call(self);
 
-  self.agent = options.agent === undefined ? globalAgent : options.agent;
+  self.agent = options.agent;
+  if (!options.agent && options.agent !== false && !options.createConnection) {
+    self.agent = globalAgent;
+  }
 
   var defaultPort = options.defaultPort || 80;
 

--- a/test/simple/test-http-createConnection.js
+++ b/test/simple/test-http-createConnection.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+
+var create = 0;
+var response = 0;
+process.on('exit', function() {
+  assert.equal(1, create, 'createConnection() http option was not called');
+  assert.equal(1, response, 'http server "request" callback was not called');
+});
+
+var server = http.createServer(function(req, res) {
+  res.end();
+  response++;
+}).listen(common.PORT, '127.0.0.1', function() {
+  http.get({ createConnection: createConnection }, function (res) {
+    res.resume();
+    server.close();
+  });
+});
+
+function createConnection() {
+  create++;
+  return net.createConnection(common.PORT, '127.0.0.1');
+}


### PR DESCRIPTION
This makes it so that the user may pass in a `createConnection()` option,
and they don't have to pass `agent: false` at the same time.

Also adding a test for the `createConnection` option, since none was
in place before.

See #7014.
