### PR TITLE
fs: Improve performance of fs.stat, fs.statSync.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -147,39 +147,8 @@ fs.Stats = function(
   this.birthtime = birthtime;
 };
 
-// Create and return a new Stats object.
-fs.Stats.createStatsObject = function(
-    dev,
-    mode,
-    nlink,
-    uid,
-    gid,
-    rdev,
-    ino,
-    size,
-    blocks,
-    atime,
-    mtime,
-    ctime,
-    birthtime) {
-  return new fs.Stats(
-      dev,
-      mode,
-      nlink,
-      uid,
-      gid,
-      rdev,
-      ino,
-      size,
-      blocks,
-      atime,
-      mtime,
-      ctime,
-      birthtime);
-};
-
 // Create a C++ binding to the function which creates a Stats object.
-binding.setCreateStatsObjectFunction(fs.Stats.createStatsObject);
+binding.FSInitialize(fs.Stats);
 
 fs.Stats.prototype._checkModeProperty = function(property) {
   return ((this.mode & constants.S_IFMT) === property);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -117,11 +117,8 @@ function nullCheck(path, callback) {
   return true;
 }
 
-fs.Stats = binding.Stats;
-
 // Static method to set the stats properties on a Stats object.
-fs.Stats.buildStatsObject = function(
-    obj,
+fs.Stats = function(
     dev,
     mode,
     nlink,
@@ -135,23 +132,54 @@ fs.Stats.buildStatsObject = function(
     mtime,
     ctime,
     birthtime) {
-  obj.dev = dev;
-  obj.mode = mode;
-  obj.nlink = nlink;
-  obj.uid = uid;
-  obj.gid = gid;
-  obj.rdev = rdev;
-  obj.ino = ino;
-  obj.size = size;
-  obj.blocks = blocks;
-  obj.atime = atime;
-  obj.mtime = mtime;
-  obj.ctime = ctime;
-  obj.birthtime = birthtime;
+  this.dev = dev;
+  this.mode = mode;
+  this.nlink = nlink;
+  this.uid = uid;
+  this.gid = gid;
+  this.rdev = rdev;
+  this.ino = ino;
+  this.size = size;
+  this.blocks = blocks;
+  this.atime = atime;
+  this.mtime = mtime;
+  this.ctime = ctime;
+  this.birthtime = birthtime;
 };
 
-// Create a binding in C++.
-binding.bindBuildStatsObject(fs.Stats.buildStatsObject);
+// Create and return a new Stats object.
+fs.Stats.createStatsObject = function(
+    dev,
+    mode,
+    nlink,
+    uid,
+    gid,
+    rdev,
+    ino,
+    size,
+    blocks,
+    atime,
+    mtime,
+    ctime,
+    birthtime) {
+  return new fs.Stats(
+      dev,
+      mode,
+      nlink,
+      uid,
+      gid,
+      rdev,
+      ino,
+      size,
+      blocks,
+      atime,
+      mtime,
+      ctime,
+      birthtime);
+};
+
+// Create a C++ binding to the function which creates a Stats object.
+binding.setCreateStatsObjectFunction(fs.Stats.createStatsObject);
 
 fs.Stats.prototype._checkModeProperty = function(property) {
   return ((this.mode & constants.S_IFMT) === property);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -128,10 +128,10 @@ fs.Stats = function(
     ino,
     size,
     blocks,
-    atime,
-    mtime,
-    ctime,
-    birthtime) {
+    atim_msec,
+    mtim_msec,
+    ctim_msec,
+    birthtim_msec) {
   this.dev = dev;
   this.mode = mode;
   this.nlink = nlink;
@@ -141,10 +141,10 @@ fs.Stats = function(
   this.ino = ino;
   this.size = size;
   this.blocks = blocks;
-  this.atime = atime;
-  this.mtime = mtime;
-  this.ctime = ctime;
-  this.birthtime = birthtime;
+  this.atime = new Date(atim_msec);
+  this.mtime = new Date(mtim_msec);
+  this.ctime = new Date(ctim_msec);
+  this.birthtime = new Date(birthtim_msec);
 };
 
 // Create a C++ binding to the function which creates a Stats object.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -119,7 +119,9 @@ function nullCheck(path, callback) {
 
 fs.Stats = binding.Stats;
 
-fs.Stats.prototype.buildStatsObject = function(
+// Static method to set the stats properties on a Stats object.
+fs.Stats.buildStatsObject = function(
+    obj,
     dev,
     mode,
     nlink,
@@ -133,20 +135,23 @@ fs.Stats.prototype.buildStatsObject = function(
     mtime,
     ctime,
     birthtime) {
-  this.dev = dev;
-  this.mode = mode;
-  this.nlink = nlink;
-  this.uid = uid;
-  this.gid = gid;
-  this.rdev = rdev;
-  this.ino = ino;
-  this.size = size;
-  this.blocks = blocks;
-  this.atime = atime;
-  this.mtime = mtime;
-  this.ctime = ctime;
-  this.birthtime = birthtime;
+  obj.dev = dev;
+  obj.mode = mode;
+  obj.nlink = nlink;
+  obj.uid = uid;
+  obj.gid = gid;
+  obj.rdev = rdev;
+  obj.ino = ino;
+  obj.size = size;
+  obj.blocks = blocks;
+  obj.atime = atime;
+  obj.mtime = mtime;
+  obj.ctime = ctime;
+  obj.birthtime = birthtime;
 };
+
+// Create a binding in C++.
+binding.bindBuildStatsObject(fs.Stats.buildStatsObject);
 
 fs.Stats.prototype._checkModeProperty = function(property) {
   return ((this.mode & constants.S_IFMT) === property);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -119,6 +119,35 @@ function nullCheck(path, callback) {
 
 fs.Stats = binding.Stats;
 
+fs.Stats.prototype.buildStatsObject = function(
+    dev,
+    mode,
+    nlink,
+    uid,
+    gid,
+    rdev,
+    ino,
+    size,
+    blocks,
+    atime,
+    mtime,
+    ctime,
+    birthtime) {
+  this.dev = dev;
+  this.mode = mode;
+  this.nlink = nlink;
+  this.uid = uid;
+  this.gid = gid;
+  this.rdev = rdev;
+  this.ino = ino;
+  this.size = size;
+  this.blocks = blocks;
+  this.atime = atime;
+  this.mtime = mtime;
+  this.ctime = ctime;
+  this.birthtime = birthtime;
+};
+
 fs.Stats.prototype._checkModeProperty = function(property) {
   return ((this.mode & constants.S_IFMT) === property);
 };

--- a/src/env.h
+++ b/src/env.h
@@ -62,7 +62,6 @@ namespace node {
   V(blksize_string, "blksize")                                                \
   V(blocks_string, "blocks")                                                  \
   V(buffer_string, "buffer")                                                  \
-  V(build_stats_object_string, "buildStatsObject")                            \
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
   V(byte_length_string, "byteLength")                                         \
@@ -242,8 +241,8 @@ namespace node {
   V(async_listener_unload_function, v8::Function)                             \
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
-  V(build_stats_object_function, v8::Function)                                \
   V(context, v8::Context)                                                     \
+  V(create_stats_object_function, v8::Function)                               \
   V(domain_array, v8::Array)                                                  \
   V(gc_info_callback_function, v8::Function)                                  \
   V(module_load_list_array, v8::Array)                                        \
@@ -252,7 +251,6 @@ namespace node {
   V(script_context_constructor_template, v8::FunctionTemplate)                \
   V(script_data_constructor_function, v8::Function)                           \
   V(secure_context_constructor_template, v8::FunctionTemplate)                \
-  V(stats_constructor_function, v8::Function)                                 \
   V(tcp_constructor_template, v8::FunctionTemplate)                           \
   V(tick_callback_function, v8::Function)                                     \
   V(tls_wrap_constructor_function, v8::Function)                              \

--- a/src/env.h
+++ b/src/env.h
@@ -62,6 +62,7 @@ namespace node {
   V(blksize_string, "blksize")                                                \
   V(blocks_string, "blocks")                                                  \
   V(buffer_string, "buffer")                                                  \
+  V(build_stats_object_string, "buildStatsObject")                            \
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
   V(byte_length_string, "byteLength")                                         \

--- a/src/env.h
+++ b/src/env.h
@@ -242,6 +242,7 @@ namespace node {
   V(async_listener_unload_function, v8::Function)                             \
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
+  V(build_stats_object_function, v8::Function)                                \
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(gc_info_callback_function, v8::Function)                                  \

--- a/src/env.h
+++ b/src/env.h
@@ -242,8 +242,8 @@ namespace node {
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
   V(context, v8::Context)                                                     \
-  V(create_stats_object_function, v8::Function)                               \
   V(domain_array, v8::Array)                                                  \
+  V(fs_stats_constructor_function, v8::Function)                              \
   V(gc_info_callback_function, v8::Function)                                  \
   V(module_load_list_array, v8::Array)                                        \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -377,17 +377,19 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
 #undef X
 
   // Dates.
-#define X(name, rec)                                                        \
-  double msecs_##name = static_cast<double>(s->st_##rec.tv_sec) * 1000;     \
-  msecs_##name += static_cast<double>(s->st_##rec.tv_nsec / 1000000);       \
-  Local<Value> name = v8::Date::New(env->isolate(), msecs_##name);          \
-  if (name.IsEmpty())                                                       \
+#define X(name)                                                             \
+  Local<Value> name##_msec =                                                \
+    Number::New(env->isolate(),                                             \
+        (static_cast<double>(s->st_##name.tv_sec) * 1000) +                 \
+        (static_cast<double>(s->st_##name.tv_nsec) * 1000000));             \
+                                                                            \
+  if (name##_msec.IsEmpty())                                                \
     return handle_scope.Escape(Local<Object>());                            \
 
-  X(atime, atim)
-  X(mtime, mtim)
-  X(ctime, ctim)
-  X(birthtime, birthtim)
+  X(atim)
+  X(mtim)
+  X(ctim)
+  X(birthtim)
 #undef X
 
   // Pass stats as the first argument, this is the object we are modifying.
@@ -401,10 +403,10 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
     ino,
     size,
     blocks,
-    atime,
-    mtime,
-    ctime,
-    birthtime
+    atim_msec,
+    mtim_msec,
+    ctim_msec,
+    birthtim_msec
   };
 
   // Call out to JavaScript to create the stats object.

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -395,7 +395,7 @@ Local<Object> BuildStatsObject(Environment* env, const uv_stat_t* s) {
   X(birthtime, birthtim)
 #undef X
 
-  Local<Value> argv[13] = {
+  Local<Value> argv[] = {
     dev,
     mode,
     nlink,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -381,7 +381,7 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
   Local<Value> name##_msec =                                                \
     Number::New(env->isolate(),                                             \
         (static_cast<double>(s->st_##name.tv_sec) * 1000) +                 \
-        (static_cast<double>(s->st_##name.tv_nsec) * 1000000));             \
+        (static_cast<double>(s->st_##name.tv_nsec / 1000000)));             \
                                                                             \
   if (name##_msec.IsEmpty())                                                \
     return handle_scope.Escape(Local<Object>());                            \

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -414,7 +414,7 @@ Local<Object> BuildStatsObject(Environment* env, const uv_stat_t* s) {
   // Call out to JavaScript to build the object.
   Local<Value> fnVal = stats->Get(env->build_stats_object_string());
   Local<Function> fn = fnVal.As<Function>();
-  fn->Call(stats, 13, argv);
+  fn->Call(stats, ARRAY_SIZE(argv), argv);
 
   return handle_scope.Escape(stats);
 }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -361,7 +361,7 @@ Local<Object> BuildStatsObject(Environment* env, const uv_stat_t* s) {
 # if defined(__POSIX__)
   X(blksize)
 # else
-  Local<Value> blksize = Undefined(node_isolate);
+  Local<Value> blksize = Undefined(env->isolate());
 # endif
 #undef X
 
@@ -377,7 +377,7 @@ Local<Object> BuildStatsObject(Environment* env, const uv_stat_t* s) {
 # if defined(__POSIX__)
   X(blocks)
 # else
-  Local<Value> blocks = Undefined(node_isolate);
+  Local<Value> blocks = Undefined(env->isolate());
 # endif
 #undef X
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1122,7 +1122,7 @@ void InitFs(Handle<Object> target,
   // Function which creates a new Stats object.
   target->Set(
       FIXED_ONE_BYTE_STRING(env->isolate(), "FSInitialize"),
-      FunctionTemplate::New(FSInitialize)->GetFunction());
+      FunctionTemplate::New(env->isolate(), FSInitialize)->GetFunction());
 
   NODE_SET_METHOD(target, "close", Close);
   NODE_SET_METHOD(target, "open", Open);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -126,7 +126,7 @@ void AppendExceptionLine(Environment* env,
 
 NO_RETURN void FatalError(const char* location, const char* message);
 
-v8::Local<v8::Object> BuildStatsObject(Environment* env, const uv_stat_t* s);
+v8::Local<v8::Value> BuildStatsObject(Environment* env, const uv_stat_t* s);
 
 enum Endianness {
   kLittleEndian,  // _Not_ LITTLE_ENDIAN, clashes with endian.h.


### PR DESCRIPTION
As suggested by @trevnorris in joyent/node#6662 moved the setting of
object properties from C++ to JavaScript. Specifically, remove calls to
stats->Set and instead set properties of the stats object in JavaScript
with a call to a new function fs.Stats.prototype.buildStatsObject.

Note that the returned value from fs.stat changes slightly for non-POSIX
systems. Whereas before the stats object would be missing blocks and
blksize keys, it now has these keys with undefined as the value.
