### PR TITLE
node: invoke `beforeExit` again if loop was active

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3536,8 +3536,12 @@ int Start(int argc, char** argv) {
       more = uv_run(env->event_loop(), UV_RUN_ONCE);
       if (more == false) {
         EmitBeforeExit(env);
+
+        // Emit `beforeExit` if the loop became alive either after emitting
+        // event, or after running some callbacks.
         more = uv_loop_alive(env->event_loop());
-        uv_run(env->event_loop(), UV_RUN_NOWAIT);
+        if (uv_run(env->event_loop(), UV_RUN_NOWAIT) != 0)
+          more = true;
       }
     } while (more == true);
     code = EmitExit(env);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3536,7 +3536,8 @@ int Start(int argc, char** argv) {
       more = uv_run(env->event_loop(), UV_RUN_ONCE);
       if (more == false) {
         EmitBeforeExit(env);
-        more = uv_run(env->event_loop(), UV_RUN_NOWAIT);
+        more = uv_loop_alive(env->event_loop());
+        uv_run(env->event_loop(), UV_RUN_NOWAIT);
       }
     } while (more == true);
     code = EmitExit(env);


### PR DESCRIPTION
When `setImmediate(cb)` is called in `beforeExit` event handler the
consequent `uv_run(..., UV_RUN_NOWAIT)` may return `0`, even if there
was some active handles at start.

Fixes simple/test-beforeexit-event.js.

cc @saghul @bnoordhuis
