### PR TITLE
smalloc: remove `env.h` include

### DIFF
--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -24,9 +24,11 @@
 
 #include "node.h"
 #include "v8.h"
-#include "env.h"
 
 namespace node {
+
+// Forward declaration
+class Environment;
 
 /**
  * Simple memory allocator.


### PR DESCRIPTION
Since `smalloc.h` is included in a `node_buffer.h`, including private
headers in it is strictly prohibited.

fix #7206
