### PR TITLE
test: fix test-timers-first-fire.js

### DIFF
--- a/test/simple/test-timers-first-fire.js
+++ b/test/simple/test-timers-first-fire.js
@@ -29,5 +29,6 @@ setTimeout(function() {
   var ms = (hr[0] * 1e3) + (hr[1] / 1e6);
   var delta = ms - TIMEOUT;
   console.log('timer fired in', delta);
-  assert.ok(delta > 0, 'Timer fired early');
+  // Timer rounding to milliseconds can cause up to 1.5ms error 
+  assert.ok(delta > -1.5, 'Timer fired early');
 }, TIMEOUT);


### PR DESCRIPTION
Making the test tolerant to rounding errors.
