### PR TITLE
tls: Provide default object for _tlsOptions when options are undefined

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -179,7 +179,7 @@ function TLSSocket(socket, options) {
   if (socket)
     this._connecting = socket._connecting;
 
-  this._tlsOptions = options;
+  this._tlsOptions = options || {};
   this._secureEstablished = false;
   this._securePending = false;
   this._newSessionPending = false;


### PR DESCRIPTION
Prevents this error when `options` is not set.

```
_tls_wrap.js:205
  var credentials = options.credentials || crypto.createCredentials();
                           ^
TypeError: Cannot read property 'credentials' of undefined
    at TLSSocket._init (_tls_wrap.js:205:28)
    at new TLSSocket (_tls_wrap.js:186:10)
```
