### PR TITLE
doc: nextTick is replaced when domains are in use

### DIFF
--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -9,6 +9,15 @@ will be notified, rather than losing the context of the error in the
 `process.on('uncaughtException')` handler, or causing the program to
 exit immediately with an error code.
 
+## Warning: Don't cache `process.nextTick`!
+
+Do not cache `process.nextTick` as it will be replaced with a different
+reference (implementation) to provide domains support as soon as you do
+`require('domain')` in your code.
+
+It also means that you better to `require('domain')` in your code as
+soon as possible if you are planning to use domains in your application.
+
 ## Warning: Don't Ignore Errors!
 
 <!-- type=misc -->


### PR DESCRIPTION
Probably it also makes sense to document this behavior not only for `domain` module, but for `nextTick` function as well. It's very tricky and people, especially library authors, should be warned about such side effect. My further propose would be to to make a wrapper for `nextTick` inside `node.js` and make sure the actual reference is always the same so people don't get caught when they cache it. All `node.js` versions are affected so it would be good to have a solution for 0.10.xx as well.
