### PR TITLE
url: parse, replace % not part of urlencoded character

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -176,6 +176,11 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     if (atSign !== -1) {
       auth = rest.slice(0, atSign);
       rest = rest.slice(atSign + 1);
+
+      // Before decoding find % that are not part of encoded characters,
+      // and replace these with encoded %25 otherwise decodeURIComponent
+      // might throw a malformed URI error.
+      auth = auth.replace(/%(?![0-9a-f]{2})/ig, '%25');
       this.auth = decodeURIComponent(auth);
     }
 


### PR DESCRIPTION
Check if % characters are part of an urlencoded char if not replace to prevent malformed uri errors from being thrown, fixes https://github.com/joyent/node/issues/7234

Will add tests in subsequent commit.
