### PR TITLE
url: url.parse requires URL encoded strings

### DIFF
--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -63,7 +63,8 @@ The following methods are provided by the URL module:
 
 ## url.parse(urlStr, [parseQueryString], [slashesDenoteHost])
 
-Take a URL string, and return an object.
+Take a URL string, and return an object. The provided string should be
+URL encoded.
 
 Pass `true` as the second argument to also parse
 the query string using the `querystring` module.


### PR DESCRIPTION
Related to https://github.com/joyent/node/pull/7236 and https://github.com/joyent/node/pull/7234
