### PR TITLE
src: add default visibility to NODE_MODULE

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -217,7 +217,7 @@ node_module_struct* get_builtin_module(const char *name);
 #ifdef _WIN32
 # define NODE_MODULE_EXPORT __declspec(dllexport)
 #else
-# define NODE_MODULE_EXPORT /* empty */
+# define NODE_MODULE_EXPORT __attribute__((visibility("default")))
 #endif
 
 #define NODE_MODULE(modname, regfunc)                                 \


### PR DESCRIPTION
It's currently not really possible to compile native add-ons with
-fvisibility=hidden because that also hides the struct containing
the module definition.

The NODE_MODULE() and NODE_MODULE_DECL() macros are structured in
a way that makes it impossible to add a visibility attribute manually
so there is no escape hatch there.

That's why this commit adds an explicit visibility attribute to
the module definition.  It doesn't help with node.js releases that
are already out there but at least it improves the situation going
forward.

Suggested reviewer: I don't know, @indutny?
