### PR TITLE
domain: fix parents tracking

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -54,6 +54,7 @@ inherits(Domain, EventEmitter);
 function Domain() {
   EventEmitter.call(this);
 
+  this.parent = process.domain;
   this.members = [];
 }
 

--- a/src/node.js
+++ b/src/node.js
@@ -256,13 +256,11 @@
           domainModule.active = process.domain = null;
         } catch (er2) {
           // The domain error handler threw!  oh no!
-          // See if another domain can catch THIS error,
+          // See if parent domain can catch THIS error,
           // or else crash on the original one.
           // If the user already exited it, then don't double-exit.
-          if (domain === domainModule.active)
-            domainStack.pop();
-          if (domainStack.length) {
-            var parentDomain = domainStack[domainStack.length - 1];
+          if (domain.parent) {
+            var parentDomain = domain.parent;
             process.domain = domainModule.active = parentDomain;
             caught = process._fatalException(er2);
           } else

--- a/test/simple/test-domain-nested-throw-async.js
+++ b/test/simple/test-domain-nested-throw-async.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+
+var outerDomainError = false;
+var innerDomainError = false;
+
+function inner() {
+  var innerDomain = domain.createDomain();
+
+  innerDomain.on('error', function (err) {
+    innerDomainError = err;
+    throw err;
+  });
+
+  innerDomain.run(function () {
+    process.nextTick(function () {
+      throw new Error("D'oh!");
+    });
+  });
+}
+
+function outer() {
+  var outerDomain = domain.createDomain();
+
+  outerDomain.on('error', function (err) {
+    outerDomainError = err;
+  });
+
+  outerDomain.run(function () {
+    inner();
+  });
+}
+
+process.on('exit', function() {
+  assert(outerDomainError);
+  assert(innerDomainError);
+  assert.strictEqual(innerDomainError, outerDomainError);
+});
+
+outer();


### PR DESCRIPTION
We cannot use current stack to keep track of domains chain and their
parents for exceptions handling, we need an additional property to do
so. The reason behind it is an asynchronous code that throws an
exception and so when domain is handling that exception, the stack is
empty and there is no way to get the parent.
