### PR TITLE
stream: emit pipe and unpipe on readable

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -209,6 +209,43 @@ descriptor) has been closed. Not all streams will emit this.
 
 Emitted if there was an error receiving data.
 
+#### Event: 'pipe'
+
+* `src` {[Writable][] Stream} destination stream to where this readable is
+piping.
+
+This is emitted whenever the `pipe()` method is called on the readable
+stream, adding the writable to its set of destinations.
+
+```javascript
+var writer = getWritableStreamSomehow();
+var reader = getReadableStreamSomehow();
+reader.on('pipe', function(dest) {
+  console.error('something is piping into the writer');
+  assert.equal(dest, writer);
+});
+reader.pipe(writer);
+```
+
+#### Event: 'unpipe'
+
+* `src` {[Writable][] Stream} The source stream that [unpiped][] this readable
+* `err` {Error} The error (if any) that triggered this unpipe event
+
+This is emitted whenever the [`unpipe()`][] method is called on a
+readable stream, removing the given writable from its set of destinations.
+
+```javascript
+var writer = getWritableStreamSomehow();
+var reader = getReadableStreamSomehow();
+reader.on('unpipe', function(dest, err) {
+  console.error('something has stopped piping into the writer');
+  assert.equal(dest, writer);
+});
+reader.pipe(writer);
+reader.unpipe(writer);
+```
+
 #### readable.read([size])
 
 * `size` {Number} Optional argument to specify how much data to read.
@@ -600,6 +637,7 @@ reader.pipe(writer);
 #### Event: 'unpipe'
 
 * `src` {[Readable][] Stream} The source stream that [unpiped][] this writable
+* `err` {Error} The error (if any) that triggered this unpipe event
 
 This is emitted whenever the [`unpipe()`][] method is called on a
 readable stream, removing this writable from its set of destinations.
@@ -607,7 +645,7 @@ readable stream, removing this writable from its set of destinations.
 ```javascript
 var writer = getWritableStreamSomehow();
 var reader = getReadableStreamSomehow();
-writer.on('unpipe', function(src) {
+writer.on('unpipe', function(src, err) {
   console.error('something has stopped piping into the writer');
   assert.equal(src, reader);
 });

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -543,7 +543,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // however, don't suppress the throwing behavior for this.
   function onerror(er) {
     debug('onerror', er);
-    unpipe();
+    unpipe(er);
     dest.removeListener('error', onerror);
     if (EE.listenerCount(dest, 'error') === 0)
       dest.emit('error', er);
@@ -572,13 +572,14 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   }
   dest.once('finish', onfinish);
 
-  function unpipe() {
+  function unpipe(er) {
     debug('unpipe');
-    src.unpipe(dest);
+    src.unpipe(dest, er);
   }
 
   // tell the dest that it's being piped to
   dest.emit('pipe', src);
+  src.emit('pipe', dest);
 
   // start the flow if it hasn't been started already.
   if (!state.flowing) {
@@ -603,7 +604,13 @@ function pipeOnDrain(src) {
 }
 
 
-Readable.prototype.unpipe = function(dest) {
+Readable.prototype._emitUnpipe = function(dest, err) {
+  dest.emit('unpipe', this, err);
+  this.emit('unpipe', dest, err);
+};
+
+
+Readable.prototype.unpipe = function(dest, err) {
   var state = this._readableState;
 
   // if we're not piping anywhere, then do nothing.
@@ -624,7 +631,7 @@ Readable.prototype.unpipe = function(dest) {
     state.pipesCount = 0;
     state.flowing = false;
     if (dest)
-      dest.emit('unpipe', this);
+      this._emitUnpipe(dest, err);
     return this;
   }
 
@@ -639,7 +646,7 @@ Readable.prototype.unpipe = function(dest) {
     state.flowing = false;
 
     for (var i = 0; i < len; i++)
-      dests[i].emit('unpipe', this);
+      this._emitUnpipe(dests[i], err);
     return this;
   }
 
@@ -653,7 +660,7 @@ Readable.prototype.unpipe = function(dest) {
   if (state.pipesCount === 1)
     state.pipes = state.pipes[0];
 
-  dest.emit('unpipe', this);
+  this._emitUnpipe(dest, err);
 
   return this;
 };

--- a/test/simple/test-stream-readable-pipe-event.js
+++ b/test/simple/test-stream-readable-pipe-event.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var stream = require('stream');
+
+var reader = new stream.Readable();
+reader._read = function() {}
+
+var writer = new stream.Writable();
+writer._write = function() {}
+
+reader.on('pipe', common.mustCall(function(dest) {
+  assert.strictEqual(dest, writer);
+}));
+
+writer.on('pipe', common.mustCall(function(src) {
+  assert.strictEqual(src, reader);
+}));
+
+var originalError = new Error('we have an error');
+
+reader.on('unpipe', common.mustCall(function(dest, err) {
+  assert.strictEqual(dest, writer);
+  assert.strictEqual(err, originalError);
+}));
+
+writer.on('unpipe', common.mustCall(function(src, err) {
+  assert.strictEqual(src, reader);
+  assert.strictEqual(err, originalError);
+}));
+
+// listen here to avoid the EE throw on no listeners
+writer.on('error', function(err) {
+  assert.strictEqual(err, originalError);
+});
+
+reader.pipe(writer);
+writer.emit('error', originalError);


### PR DESCRIPTION
Prior to this commit, 'pipe' and 'unpipe' events would only be emitted
on the writable, i.e. the destination to where the readable was being
piped. Now 'pipe' and 'unpipe' will be emitted on both sides of a
pipeline.

Relatedly, if the unpipe was triggered by an error in the writable that
error is now passed to the unpipe event.
