### PR TITLE
util: format as Error if instanceof Error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -452,7 +452,8 @@ exports.isDate = isDate;
 
 
 function isError(e) {
-  return typeof e === 'object' && objectToString(e) === '[object Error]';
+  return typeof e === 'object' &&
+      (objectToString(e) === '[object Error]' || e instanceof Error);
 }
 exports.isError = isError;
 

--- a/test/simple/test-util-format.js
+++ b/test/simple/test-util-format.js
@@ -60,3 +60,13 @@ assert.equal(util.format('%s:%s', 'foo', 'bar'), 'foo:bar');
 assert.equal(util.format('%s:%s', 'foo', 'bar', 'baz'), 'foo:bar baz');
 assert.equal(util.format('%%%s%%', 'hi'), '%hi%');
 assert.equal(util.format('%%%s%%%%', 'hi'), '%hi%%');
+
+// Errors
+assert.equal(util.format(new Error('foo')), '[Error: foo]');
+function CustomError(msg) {
+  Error.call(this);
+  Object.defineProperty(this, 'message', { value: msg, enumerable: false });
+  Object.defineProperty(this, 'name', { value: 'CustomError', enumerable: false });
+}
+util.inherits(CustomError, Error);
+assert.equal(util.format(new CustomError('bar')), '[CustomError: bar]');

--- a/test/simple/test-util.js
+++ b/test/simple/test-util.js
@@ -68,7 +68,7 @@ assert.equal(true, util.isError(new (context('SyntaxError'))));
 assert.equal(false, util.isError({}));
 assert.equal(false, util.isError({ name: 'Error', message: '' }));
 assert.equal(false, util.isError([]));
-assert.equal(false, util.isError(Object.create(Error.prototype)));
+assert.equal(true, util.isError(Object.create(Error.prototype)));
 
 // _extend
 assert.deepEqual(util._extend({a:1}),             {a:1});


### PR DESCRIPTION
Conflicts:
    lib/util.js
    test/simple/test-util-format.js

This is a backport to fix #7253

@tjfontaine : it seems to be pretty harmless, but I'm afraid to decide if it is a bug fix or a feature.
