### PR TITLE
crypto: add `honorCipherOrder` argument

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -74,6 +74,9 @@ dictionary with keys:
   Consult
   <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT>
   for details on the format.
+* `honorCipherOrder` : When choosing a cipher, use the server's preferences
+  instead of the client preferences. For further details see `tls` module
+  documentation.
 
 If no 'ca' details are given, then node.js will use the default
 publicly trusted list of CAs as given in

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -536,7 +536,8 @@ more information.
 
 Add secure context that will be used if client request's SNI hostname is
 matching passed `hostname` (wildcards can be used). `credentials` can contain
-`key`, `cert` and `ca`.
+`key`, `cert`, `ca` and/or any other properties from `crypto.createCredentials`
+`options` argument.
 
 ### server.maxConnections
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -539,6 +539,7 @@ function Server(/* [options], listener */) {
         tls.DEFAULT_ECDH_CURVE : self.ecdhCurve,
     secureProtocol: self.secureProtocol,
     secureOptions: self.secureOptions,
+    honorCipherOrder: self.honorCipherOrder,
     crl: self.crl,
     sessionIdContext: self.sessionIdContext
   });
@@ -657,9 +658,10 @@ Server.prototype.setOptions = function(options) {
   if (options.sessionTimeout) this.sessionTimeout = options.sessionTimeout;
   if (options.ticketKeys) this.ticketKeys = options.ticketKeys;
   var secureOptions = options.secureOptions || 0;
-  if (options.honorCipherOrder) {
-    secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
-  }
+  if (options.honorCipherOrder)
+    this.honorCipherOrder = true;
+  else
+    this.honorCipherOrder = false;
   if (secureOptions) this.secureOptions = secureOptions;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
   if (options.sessionIdContext) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -84,9 +84,11 @@ exports.Credentials = Credentials;
 exports.createCredentials = function(options, context) {
   if (!options) options = {};
 
-  var c = new Credentials(options.secureProtocol,
-                          options.secureOptions,
-                          context);
+  var secureOptions = options.secureOptions;
+  if (options.honorCipherOrder)
+    secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+
+  var c = new Credentials(options.secureProtocol, secureOptions, context);
 
   if (context) return c;
 


### PR DESCRIPTION
Add `honorCipherOrder` argument to `crypto.createCredentials`.

fix #7249
