### PR TITLE
build: fix g++ 4.8 build, disable -Werror

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -1,5 +1,6 @@
 {
   'variables': {
+    'werror': '',                    # Turn off -Werror in V8 build.
     'visibility%': 'hidden',         # V8's visibility setting
     'target_arch%': 'ia32',          # set v8's target architecture
     'host_arch%': 'ia32',            # set v8's host architecture

--- a/node.gyp
+++ b/node.gyp
@@ -1,9 +1,6 @@
 {
   'variables': {
     'v8_use_snapshot%': 'true',
-    # Turn off -Werror in V8
-    # See http://codereview.chromium.org/8159015
-    'werror': '',
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',


### PR DESCRIPTION
Turn off -Werror when building V8, it hits -Werror=unused-local-typedefs
with g++ 4.8.  The warning itself is harmless so don't abort the build.

This was originally implemented in commit d2ab314e back in 2011 but the
build process has gone through a few iterations since then, that change
no longer works.

Suggested reviewer: @tjfontaine for no particular reason.
