### PR TITLE
http: correct fencepost error when freeing sockets

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -84,7 +84,7 @@ function Agent(options) {
         if (self.sockets[name])
           count += self.sockets[name].length;
 
-        if (count >= self.maxSockets || freeLen >= self.maxFreeSockets) {
+        if (count > self.maxSockets || freeLen >= self.maxFreeSockets) {
           self.removeSocket(socket, options);
           socket.destroy();
         } else {


### PR DESCRIPTION
This only becomes apparent when using a small maxSockets for pipelining requests on a keep-alive connection. Bug introduced in 65f6f06a.

This change doesn't break `make test jslint`, which indicates that there need to be some more tests written around this stuff. Will get to that when I get a chance.

This only affects master, as the keep-alive behavior is very different in 0.10 and earlier.
