### PR TITLE
Add signature to SET_PROTOTYPE_METHOD and use args.Holder() in methods.

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -401,7 +401,7 @@ prototype:
       Isolate* isolate = Isolate::GetCurrent();
       HandleScope scope(isolate);
 
-      MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
+      MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.Holder());
       obj->value_ += 1;
 
       args.GetReturnValue().Set(Number::New(isolate, obj->value_));
@@ -539,7 +539,7 @@ The implementation is similar to the above in `myobject.cc`:
       Isolate* isolate = Isolate::GetCurrent();
       HandleScope scope(isolate);
 
-      MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
+      MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.Holder());
       obj->value_ += 1;
 
       args.GetReturnValue().Set(Number::New(isolate, obj->value_));

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -106,7 +106,7 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
+  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
 
   if (args.Length() < 1 || !args[0]->IsString()) {
     return env->ThrowTypeError("Bad arguments");
@@ -189,7 +189,7 @@ void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
+  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
 
   if (wrap == NULL || wrap->initialized_ == false)
     return;

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -47,7 +47,7 @@ void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  HandleWrap* wrap = Unwrap<HandleWrap>(args.This());
+  HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 
   if (wrap != NULL && wrap->handle__ != NULL) {
     uv_ref(wrap->handle__);
@@ -60,7 +60,7 @@ void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  HandleWrap* wrap = Unwrap<HandleWrap>(args.This());
+  HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 
   if (wrap != NULL && wrap->handle__ != NULL) {
     uv_unref(wrap->handle__);
@@ -73,7 +73,7 @@ void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  HandleWrap* wrap = Unwrap<HandleWrap>(args.This());
+  HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 
   // guard against uninitialized handle or double close
   if (wrap == NULL || wrap->handle__ == NULL)

--- a/src/node.h
+++ b/src/node.h
@@ -212,8 +212,9 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
                                       v8::FunctionCallback callback) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);
-  v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate,
-                                                                callback);
+  v8::Handle<v8::Signature> s = v8::Signature::New(isolate, recv);
+  v8::Local<v8::FunctionTemplate> t =
+      v8::FunctionTemplate::New(isolate, callback, v8::Handle<v8::Value>(), s);
   recv->PrototypeTemplate()->Set(v8::String::NewFromUtf8(isolate, name),
                                  t->GetFunction());
 }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -634,7 +634,7 @@ class ContextifyScript : public BaseObject {
     }
 
     ContextifyScript* wrapped_script =
-        Unwrap<ContextifyScript>(args.This());
+        Unwrap<ContextifyScript>(args.Holder());
     Local<Script> script = PersistentToLocal(env->isolate(),
                                              wrapped_script->script_);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -264,7 +264,7 @@ void SecureContext::New(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
   Environment* env = sc->env();
 
   OPENSSL_CONST SSL_METHOD *method = SSLv23_method();
@@ -392,7 +392,7 @@ void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   unsigned int len = args.Length();
   if (len != 1 && len != 2) {
@@ -499,7 +499,7 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1) {
     return env->ThrowTypeError("Bad parameter");
@@ -528,7 +528,7 @@ void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1) {
     return env->ThrowTypeError("Bad parameter");
@@ -558,7 +558,7 @@ void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1) {
     return env->ThrowTypeError("Bad parameter");
@@ -590,7 +590,7 @@ void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   assert(sc->ca_store_ == NULL);
 
@@ -627,7 +627,7 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1 || !args[0]->IsString()) {
     return sc->env()->ThrowTypeError("Bad parameter");
@@ -641,7 +641,7 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetECDHCurve(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
   Environment* env = sc->env();
 
   if (args.Length() != 1 || !args[0]->IsString())
@@ -669,7 +669,7 @@ void SecureContext::SetECDHCurve(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1 || !args[0]->IntegerValue()) {
     return sc->env()->ThrowTypeError("Bad parameter");
@@ -683,7 +683,7 @@ void SecureContext::SetSessionIdContext(
     const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1 || !args[0]->IsString()) {
     return sc->env()->ThrowTypeError("Bad parameter");
@@ -720,7 +720,7 @@ void SecureContext::SetSessionIdContext(
 void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() != 1 || !args[0]->IsInt32()) {
     return sc->env()->ThrowTypeError("Bad parameter");
@@ -733,7 +733,7 @@ void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::Close(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
   sc->FreeCTXMem();
 }
 
@@ -751,7 +751,7 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
   char* pass = NULL;
   bool ret = false;
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() < 1) {
     return env->ThrowTypeError("Bad parameter");
@@ -809,7 +809,7 @@ void SecureContext::GetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 #if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_get_tlsext_ticket_keys)
   HandleScope handle_scope(args.GetIsolate());
 
-  SecureContext* wrap = Unwrap<SecureContext>(args.This());
+  SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
 
   Local<Object> buff = Buffer::New(wrap->env(), 48);
   if (SSL_CTX_get_tlsext_ticket_keys(wrap->ctx_,
@@ -826,7 +826,7 @@ void SecureContext::GetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 #if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_get_tlsext_ticket_keys)
   HandleScope scope(args.GetIsolate());
-  SecureContext* wrap = Unwrap<SecureContext>(args.This());
+  SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
 
   if (args.Length() < 1 ||
       !Buffer::HasInstance(args[0]) ||
@@ -977,7 +977,7 @@ void SSLWrap<Base>::GetPeerCertificate(
     const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   Environment* env = w->ssl_env();
 
   ClearErrorOnReturn clear_error_on_return;
@@ -1126,7 +1126,7 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   SSL_SESSION* sess = SSL_get_session(w->ssl_);
   if (sess == NULL)
@@ -1148,7 +1148,7 @@ void SSLWrap<Base>::SetSession(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   if (args.Length() < 1 ||
       (!args[0]->IsString() && !Buffer::HasInstance(args[0]))) {
@@ -1180,7 +1180,7 @@ template <class Base>
 void SSLWrap<Base>::LoadSession(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   Environment* env = w->ssl_env();
 
   if (args.Length() >= 1 && Buffer::HasInstance(args[0])) {
@@ -1212,7 +1212,7 @@ void SSLWrap<Base>::LoadSession(const FunctionCallbackInfo<Value>& args) {
 template <class Base>
 void SSLWrap<Base>::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   bool yes = SSL_session_reused(w->ssl_);
   args.GetReturnValue().Set(yes);
 }
@@ -1221,7 +1221,7 @@ void SSLWrap<Base>::IsSessionReused(const FunctionCallbackInfo<Value>& args) {
 template <class Base>
 void SSLWrap<Base>::EndParser(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   w->hello_parser_.End();
 }
 
@@ -1230,7 +1230,7 @@ template <class Base>
 void SSLWrap<Base>::Renegotiate(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   ClearErrorOnReturn clear_error_on_return;
   (void) &clear_error_on_return;  // Silence unused variable warning.
@@ -1244,7 +1244,7 @@ template <class Base>
 void SSLWrap<Base>::Shutdown(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   int rv = SSL_shutdown(w->ssl_);
   args.GetReturnValue().Set(rv);
@@ -1255,7 +1255,7 @@ template <class Base>
 void SSLWrap<Base>::GetTLSTicket(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   Environment* env = w->ssl_env();
 
   SSL_SESSION* sess = SSL_get_session(w->ssl_);
@@ -1274,7 +1274,7 @@ template <class Base>
 void SSLWrap<Base>::NewSessionDone(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   w->new_session_wait_ = false;
   w->NewSessionDoneCb();
 }
@@ -1287,7 +1287,7 @@ void SSLWrap<Base>::SetMaxSendFragment(
   HandleScope scope(args.GetIsolate());
   CHECK(args.Length() >= 1 && args[0]->IsNumber());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   int rv = SSL_set_max_send_fragment(w->ssl_, args[0]->Int32Value());
   args.GetReturnValue().Set(rv);
@@ -1298,7 +1298,7 @@ void SSLWrap<Base>::SetMaxSendFragment(
 template <class Base>
 void SSLWrap<Base>::IsInitFinished(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   bool yes = SSL_is_init_finished(w->ssl_);
   args.GetReturnValue().Set(yes);
 }
@@ -1308,7 +1308,7 @@ template <class Base>
 void SSLWrap<Base>::VerifyError(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   // XXX(bnoordhuis) The UNABLE_TO_GET_ISSUER_CERT error when there is no
   // peer certificate is questionable but it's compatible with what was
@@ -1373,7 +1373,7 @@ template <class Base>
 void SSLWrap<Base>::GetCurrentCipher(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
   Environment* env = w->ssl_env();
 
   OPENSSL_CONST SSL_CIPHER* c = SSL_get_current_cipher(w->ssl_);
@@ -1475,7 +1475,7 @@ void SSLWrap<Base>::GetNegotiatedProto(
     const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   if (w->is_client()) {
     if (w->selected_npn_proto_.IsEmpty() == false) {
@@ -1501,7 +1501,7 @@ template <class Base>
 void SSLWrap<Base>::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Base* w = Unwrap<Base>(args.This());
+  Base* w = Unwrap<Base>(args.Holder());
 
   if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
     return w->env()->ThrowTypeError("Must give a Buffer as first argument");
@@ -1891,7 +1891,7 @@ void Connection::SSLInfoCallback(const SSL *ssl_, int where, int ret) {
 void Connection::EncIn(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   Environment* env = conn->env();
 
   if (args.Length() < 3) {
@@ -1942,7 +1942,7 @@ void Connection::EncIn(const FunctionCallbackInfo<Value>& args) {
 void Connection::ClearOut(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   Environment* env = conn->env();
 
   if (args.Length() < 3) {
@@ -1997,7 +1997,7 @@ void Connection::ClearOut(const FunctionCallbackInfo<Value>& args) {
 
 void Connection::ClearPending(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   int bytes_pending = BIO_pending(conn->bio_read_);
   args.GetReturnValue().Set(bytes_pending);
 }
@@ -2005,7 +2005,7 @@ void Connection::ClearPending(const FunctionCallbackInfo<Value>& args) {
 
 void Connection::EncPending(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   int bytes_pending = BIO_pending(conn->bio_write_);
   args.GetReturnValue().Set(bytes_pending);
 }
@@ -2014,7 +2014,7 @@ void Connection::EncPending(const FunctionCallbackInfo<Value>& args) {
 void Connection::EncOut(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   Environment* env = conn->env();
 
   if (args.Length() < 3) {
@@ -2046,7 +2046,7 @@ void Connection::EncOut(const FunctionCallbackInfo<Value>& args) {
 void Connection::ClearIn(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   Environment* env = conn->env();
 
   if (args.Length() < 3) {
@@ -2102,7 +2102,7 @@ void Connection::ClearIn(const FunctionCallbackInfo<Value>& args) {
 void Connection::Start(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
 
   int rv = 0;
   if (!SSL_is_init_finished(conn->ssl_)) {
@@ -2127,7 +2127,7 @@ void Connection::Start(const FunctionCallbackInfo<Value>& args) {
 void Connection::Close(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
 
   if (conn->ssl_ != NULL) {
     SSL_free(conn->ssl_);
@@ -2140,7 +2140,7 @@ void Connection::Close(const FunctionCallbackInfo<Value>& args) {
 void Connection::GetServername(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
 
   if (conn->is_server() && !conn->servername_.IsEmpty()) {
     args.GetReturnValue().Set(conn->servername_);
@@ -2153,7 +2153,7 @@ void Connection::GetServername(const FunctionCallbackInfo<Value>& args) {
 void Connection::SetSNICallback(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Connection* conn = Unwrap<Connection>(args.This());
+  Connection* conn = Unwrap<Connection>(args.Holder());
   Environment* env = conn->env();
 
   if (args.Length() < 1 || !args[0]->IsFunction()) {
@@ -2238,7 +2238,7 @@ void CipherBase::Init(const char* cipher_type,
 void CipherBase::Init(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   if (args.Length() < 2 ||
       !(args[0]->IsString() && Buffer::HasInstance(args[1]))) {
@@ -2290,7 +2290,7 @@ void CipherBase::InitIv(const char* cipher_type,
 void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
   Environment* env = cipher->env();
 
   if (args.Length() < 3 || !args[0]->IsString()) {
@@ -2332,7 +2332,7 @@ bool CipherBase::GetAuthTag(char** out, unsigned int* out_len) const {
 void CipherBase::GetAuthTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope handle_scope(args.GetIsolate());
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   char* out = NULL;
   unsigned int out_len = 0;
@@ -2365,7 +2365,7 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   if (!buf->IsObject() || !Buffer::HasInstance(buf))
     return env->ThrowTypeError("Argument must be a Buffer");
 
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   if (!cipher->SetAuthTag(Buffer::Data(buf), Buffer::Length(buf)))
     env->ThrowError("Attempting to set auth tag in unsupported state");
@@ -2394,7 +2394,7 @@ void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
 
   ASSERT_IS_BUFFER(args[0]);
 
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   if (!cipher->SetAAD(Buffer::Data(args[0]), Buffer::Length(args[0])))
     env->ThrowError("Attempting to set AAD in unsupported state");
@@ -2432,7 +2432,7 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   ASSERT_IS_STRING_OR_BUFFER(args[0]);
 
@@ -2483,7 +2483,7 @@ bool CipherBase::SetAutoPadding(bool auto_padding) {
 
 void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
   cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue());
 }
 
@@ -2520,7 +2520,7 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  CipherBase* cipher = Unwrap<CipherBase>(args.This());
+  CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   unsigned char* out_value = NULL;
   int out_len = -1;
@@ -2582,7 +2582,7 @@ void Hmac::HmacInit(const char* hash_type, const char* key, int key_len) {
 void Hmac::HmacInit(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Hmac* hmac = Unwrap<Hmac>(args.This());
+  Hmac* hmac = Unwrap<Hmac>(args.Holder());
   Environment* env = hmac->env();
 
   if (args.Length() < 2 || !args[0]->IsString()) {
@@ -2610,7 +2610,7 @@ void Hmac::HmacUpdate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Hmac* hmac = Unwrap<Hmac>(args.This());
+  Hmac* hmac = Unwrap<Hmac>(args.Holder());
 
   ASSERT_IS_STRING_OR_BUFFER(args[0]);
 
@@ -2657,7 +2657,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Hmac* hmac = Unwrap<Hmac>(args.This());
+  Hmac* hmac = Unwrap<Hmac>(args.Holder());
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {
@@ -2735,7 +2735,7 @@ void Hash::HashUpdate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Hash* hash = Unwrap<Hash>(args.This());
+  Hash* hash = Unwrap<Hash>(args.Holder());
 
   ASSERT_IS_STRING_OR_BUFFER(args[0]);
 
@@ -2771,7 +2771,7 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Hash* hash = Unwrap<Hash>(args.This());
+  Hash* hash = Unwrap<Hash>(args.Holder());
 
   if (!hash->initialised_) {
     return env->ThrowError("Not initialized");
@@ -2875,7 +2875,7 @@ SignBase::Error Sign::SignInit(const char* sign_type) {
 void Sign::SignInit(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Sign* sign = Unwrap<Sign>(args.This());
+  Sign* sign = Unwrap<Sign>(args.Holder());
 
   if (args.Length() == 0 || !args[0]->IsString()) {
     return sign->env()->ThrowError("Must give signtype string as argument");
@@ -2899,7 +2899,7 @@ void Sign::SignUpdate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Sign* sign = Unwrap<Sign>(args.This());
+  Sign* sign = Unwrap<Sign>(args.Holder());
 
   ASSERT_IS_STRING_OR_BUFFER(args[0]);
 
@@ -2979,7 +2979,7 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Sign* sign = Unwrap<Sign>(args.This());
+  Sign* sign = Unwrap<Sign>(args.Holder());
 
   unsigned char* md_value;
   unsigned int md_len;
@@ -3060,7 +3060,7 @@ SignBase::Error Verify::VerifyInit(const char* verify_type) {
 void Verify::VerifyInit(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Verify* verify = Unwrap<Verify>(args.This());
+  Verify* verify = Unwrap<Verify>(args.Holder());
 
   if (args.Length() == 0 || !args[0]->IsString()) {
     return verify->env()->ThrowError("Must give verifytype string as argument");
@@ -3086,7 +3086,7 @@ void Verify::VerifyUpdate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Verify* verify = Unwrap<Verify>(args.This());
+  Verify* verify = Unwrap<Verify>(args.Holder());
 
   ASSERT_IS_STRING_OR_BUFFER(args[0]);
 
@@ -3197,7 +3197,7 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Verify* verify = Unwrap<Verify>(args.This());
+  Verify* verify = Unwrap<Verify>(args.Holder());
 
   ASSERT_IS_BUFFER(args[0]);
   char* kbuf = Buffer::Data(args[0]);
@@ -3394,7 +3394,7 @@ void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_) {
     return env->ThrowError("Not initialized");
@@ -3418,7 +3418,7 @@ void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_) {
     return env->ThrowError("Not initialized");
@@ -3437,7 +3437,7 @@ void DiffieHellman::GetGenerator(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_) {
     return env->ThrowError("Not initialized");
@@ -3456,7 +3456,7 @@ void DiffieHellman::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_) {
     return env->ThrowError("Not initialized");
@@ -3480,7 +3480,7 @@ void DiffieHellman::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_) {
     return env->ThrowError("Not initialized");
@@ -3504,7 +3504,7 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_) {
     return env->ThrowError("Not initialized");
@@ -3575,7 +3575,7 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
 void DiffieHellman::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
   Environment* env = diffieHellman->env();
 
   if (!diffieHellman->initialised_) {
@@ -3596,7 +3596,7 @@ void DiffieHellman::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
 void DiffieHellman::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
   Environment* env = diffieHellman->env();
 
   if (!diffieHellman->initialised_) {
@@ -3619,7 +3619,7 @@ void DiffieHellman::VerifyErrorGetter(Local<String> property,
                                       const PropertyCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.This());
+  DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
   if (!diffieHellman->initialised_)
     return diffieHellman->env()->ThrowError("Not initialized");
@@ -4188,7 +4188,7 @@ bool Certificate::VerifySpkac(const char* data, unsigned int len) {
 void Certificate::VerifySpkac(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
 
-  Certificate* certificate = Unwrap<Certificate>(args.This());
+  Certificate* certificate = Unwrap<Certificate>(args.Holder());
   Environment* env = certificate->env();
   bool i = false;
 
@@ -4255,7 +4255,7 @@ void Certificate::ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Certificate* certificate = Unwrap<Certificate>(args.This());
+  Certificate* certificate = Unwrap<Certificate>(args.Holder());
 
   if (args.Length() < 1)
     return env->ThrowTypeError("Missing argument");
@@ -4299,7 +4299,7 @@ void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  Certificate* crt = Unwrap<Certificate>(args.This());
+  Certificate* crt = Unwrap<Certificate>(args.Holder());
 
   if (args.Length() < 1)
     return env->ThrowTypeError("Missing argument");

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -376,7 +376,7 @@ class Parser : public BaseObject {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
 
-    Parser* parser = Unwrap<Parser>(args.This());
+    Parser* parser = Unwrap<Parser>(args.Holder());
     assert(parser->current_buffer_.IsEmpty());
     assert(parser->current_buffer_len_ == 0);
     assert(parser->current_buffer_data_ == NULL);
@@ -431,7 +431,7 @@ class Parser : public BaseObject {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
 
-    Parser* parser = Unwrap<Parser>(args.This());
+    Parser* parser = Unwrap<Parser>(args.Holder());
 
     assert(parser->current_buffer_.IsEmpty());
     parser->got_exception_ = false;
@@ -463,7 +463,7 @@ class Parser : public BaseObject {
         static_cast<http_parser_type>(args[0]->Int32Value());
 
     assert(type == HTTP_REQUEST || type == HTTP_RESPONSE);
-    Parser* parser = Unwrap<Parser>(args.This());
+    Parser* parser = Unwrap<Parser>(args.Holder());
     // Should always be called from the same context.
     assert(env == parser->env());
     parser->Init(type);
@@ -474,7 +474,7 @@ class Parser : public BaseObject {
   static void Pause(const FunctionCallbackInfo<Value>& args) {
     HandleScope handle_scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    Parser* parser = Unwrap<Parser>(args.This());
+    Parser* parser = Unwrap<Parser>(args.Holder());
     // Should always be called from the same context.
     assert(env == parser->env());
     http_parser_pause(&parser->parser_, should_pause);

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -112,7 +112,7 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  StatWatcher* wrap = Unwrap<StatWatcher>(args.This());
+  StatWatcher* wrap = Unwrap<StatWatcher>(args.Holder());
   String::Utf8Value path(args[0]);
   const bool persistent = args[1]->BooleanValue();
   const uint32_t interval = args[2]->Uint32Value();
@@ -125,7 +125,7 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
 
 
 void StatWatcher::Stop(const FunctionCallbackInfo<Value>& args) {
-  StatWatcher* wrap = Unwrap<StatWatcher>(args.This());
+  StatWatcher* wrap = Unwrap<StatWatcher>(args.Holder());
   Environment* env = wrap->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -130,7 +130,7 @@ class ZCtx : public AsyncWrap {
   static void Close(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    ZCtx* ctx = Unwrap<ZCtx>(args.This());
+    ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
     ctx->Close();
   }
 
@@ -142,7 +142,7 @@ class ZCtx : public AsyncWrap {
     HandleScope scope(env->isolate());
     assert(args.Length() == 7);
 
-    ZCtx* ctx = Unwrap<ZCtx>(args.This());
+    ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
     assert(ctx->init_done_ && "write before init");
     assert(ctx->mode_ != NONE && "already finalized");
 
@@ -393,7 +393,7 @@ class ZCtx : public AsyncWrap {
     assert((args.Length() == 4 || args.Length() == 5) &&
            "init(windowBits, level, memLevel, strategy, [dictionary])");
 
-    ZCtx* ctx = Unwrap<ZCtx>(args.This());
+    ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
 
     int windowBits = args[0]->Uint32Value();
     assert((windowBits >= 8 && windowBits <= 15) && "invalid windowBits");
@@ -433,7 +433,7 @@ class ZCtx : public AsyncWrap {
 
     assert(args.Length() == 2 && "params(level, strategy)");
 
-    ZCtx* ctx = Unwrap<ZCtx>(args.This());
+    ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
 
     Params(ctx, args[0]->Int32Value(), args[1]->Int32Value());
   }
@@ -442,7 +442,7 @@ class ZCtx : public AsyncWrap {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
 
-    ZCtx* ctx = Unwrap<ZCtx>(args.This());
+    ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
 
     Reset(ctx);
     SetDictionary(ctx);

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -146,7 +146,7 @@ void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  PipeWrap* wrap = Unwrap<PipeWrap>(args.This());
+  PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
   String::Utf8Value name(args[0]);
   int err = uv_pipe_bind(&wrap->handle_, *name);
@@ -159,7 +159,7 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  PipeWrap* wrap = Unwrap<PipeWrap>(args.This());
+  PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
   int instances = args[0]->Int32Value();
 
@@ -172,7 +172,7 @@ void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  PipeWrap* wrap = Unwrap<PipeWrap>(args.This());
+  PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
   int backlog = args[0]->Int32Value();
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
@@ -262,7 +262,7 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  PipeWrap* wrap = Unwrap<PipeWrap>(args.This());
+  PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
   int fd = args[0]->Int32Value();
 
@@ -277,7 +277,7 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  PipeWrap* wrap = Unwrap<PipeWrap>(args.This());
+  PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -134,7 +134,7 @@ class ProcessWrap : public HandleWrap {
     HandleScope handle_scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-    ProcessWrap* wrap = Unwrap<ProcessWrap>(args.This());
+    ProcessWrap* wrap = Unwrap<ProcessWrap>(args.Holder());
 
     Local<Object> js_options = args[0]->ToObject();
 
@@ -256,7 +256,7 @@ class ProcessWrap : public HandleWrap {
   static void Kill(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    ProcessWrap* wrap = Unwrap<ProcessWrap>(args.This());
+    ProcessWrap* wrap = Unwrap<ProcessWrap>(args.Holder());
 
     int signal = args[0]->Int32Value();
     int err = uv_process_kill(&wrap->process_, signal);

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -88,7 +88,7 @@ class SignalWrap : public HandleWrap {
   static void Start(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    SignalWrap* wrap = Unwrap<SignalWrap>(args.This());
+    SignalWrap* wrap = Unwrap<SignalWrap>(args.Holder());
 
     int signum = args[0]->Int32Value();
     int err = uv_signal_start(&wrap->handle_, OnSignal, signum);
@@ -98,7 +98,7 @@ class SignalWrap : public HandleWrap {
   static void Stop(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    SignalWrap* wrap = Unwrap<SignalWrap>(args.This());
+    SignalWrap* wrap = Unwrap<SignalWrap>(args.Holder());
 
     int err = uv_signal_stop(&wrap->handle_);
     args.GetReturnValue().Set(err);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -71,7 +71,7 @@ void StreamWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 #if !defined(_WIN32)
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
   int fd = -1;
   if (wrap != NULL && wrap->stream() != NULL) {
     fd = wrap->stream()->io_watcher.fd;
@@ -92,7 +92,7 @@ void StreamWrap::ReadStart(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   int err = uv_read_start(wrap->stream(), OnAlloc, OnRead);
 
@@ -104,7 +104,7 @@ void StreamWrap::ReadStop(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   int err = uv_read_stop(wrap->stream());
   args.GetReturnValue().Set(err);
@@ -192,7 +192,7 @@ void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   assert(Buffer::HasInstance(args[1]));
@@ -250,7 +250,7 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   int err;
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
@@ -378,7 +378,7 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   assert(args[1]->IsArray());
@@ -501,7 +501,7 @@ void StreamWrap::SetBlocking(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   assert(args.Length() > 0);
   int err = uv_stream_set_blocking(wrap->stream(), args[0]->IsTrue());
@@ -548,7 +548,7 @@ void StreamWrap::Shutdown(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  StreamWrap* wrap = Unwrap<StreamWrap>(args.This());
+  StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   Local<Object> req_wrap_obj = args[0].As<Object>();

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -161,7 +161,7 @@ void TCPWrap::GetSockName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   struct sockaddr_storage address;
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   Local<Object> out = args[0].As<Object>();
@@ -184,7 +184,7 @@ void TCPWrap::GetPeerName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   struct sockaddr_storage address;
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   Local<Object> out = args[0].As<Object>();
@@ -206,7 +206,7 @@ void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   int enable = static_cast<int>(args[0]->BooleanValue());
   int err = uv_tcp_nodelay(&wrap->handle_, enable);
@@ -218,7 +218,7 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   int enable = args[0]->Int32Value();
   unsigned int delay = args[1]->Uint32Value();
@@ -233,7 +233,7 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   bool enable = args[0]->BooleanValue();
   int err = uv_tcp_simultaneous_accepts(&wrap->handle_, enable);
@@ -245,7 +245,7 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
 void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
   int fd = args[0]->IntegerValue();
   uv_tcp_open(&wrap->handle_, fd);
 }
@@ -255,7 +255,7 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   String::Utf8Value ip_address(args[0]);
   int port = args[1]->Int32Value();
@@ -276,7 +276,7 @@ void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   String::Utf8Value ip6_address(args[0]);
   int port = args[1]->Int32Value();
@@ -297,7 +297,7 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   int backlog = args[0]->Int32Value();
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
@@ -374,7 +374,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
@@ -408,7 +408,7 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  TCPWrap* wrap = Unwrap<TCPWrap>(args.This());
+  TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -99,7 +99,7 @@ class TimerWrap : public HandleWrap {
   static void Start(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.This());
+    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int64_t timeout = args[0]->IntegerValue();
     int64_t repeat = args[1]->IntegerValue();
@@ -110,7 +110,7 @@ class TimerWrap : public HandleWrap {
   static void Stop(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.This());
+    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int err = uv_timer_stop(&wrap->handle_);
     args.GetReturnValue().Set(err);
@@ -119,7 +119,7 @@ class TimerWrap : public HandleWrap {
   static void Again(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.This());
+    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int err = uv_timer_again(&wrap->handle_);
     args.GetReturnValue().Set(err);
@@ -128,7 +128,7 @@ class TimerWrap : public HandleWrap {
   static void SetRepeat(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.This());
+    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int64_t repeat = args[0]->IntegerValue();
     uv_timer_set_repeat(&wrap->handle_, repeat);
@@ -138,7 +138,7 @@ class TimerWrap : public HandleWrap {
   static void GetRepeat(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args.GetIsolate());
     HandleScope scope(env->isolate());
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.This());
+    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int64_t repeat = uv_timer_get_repeat(&wrap->handle_);
     args.GetReturnValue().Set(static_cast<double>(repeat));

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -243,7 +243,7 @@ void TLSCallbacks::Wrap(const FunctionCallbackInfo<Value>& args) {
 void TLSCallbacks::Receive(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   CHECK(Buffer::HasInstance(args[0]));
   char* data = Buffer::Data(args[0]);
@@ -269,7 +269,7 @@ void TLSCallbacks::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   if (wrap->started_)
     return env->ThrowError("Already started.");
@@ -673,7 +673,7 @@ void TLSCallbacks::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   if (args.Length() < 2 || !args[0]->IsBoolean() || !args[1]->IsBoolean())
     return env->ThrowTypeError("Bad arguments, expected two booleans");
@@ -705,7 +705,7 @@ void TLSCallbacks::EnableSessionCallbacks(
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   wrap->enable_session_callbacks();
   EnableHelloParser(args);
@@ -716,7 +716,7 @@ void TLSCallbacks::EnableHelloParser(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   wrap->hello_parser_.Start(SSLWrap<TLSCallbacks>::OnClientHello,
                             OnClientHelloParseEnd,
@@ -735,7 +735,7 @@ void TLSCallbacks::GetServername(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   const char* servername = SSL_get_servername(wrap->ssl_,
                                               TLSEXT_NAMETYPE_host_name);
@@ -751,7 +751,7 @@ void TLSCallbacks::SetServername(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.This());
+  TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   if (args.Length() < 1 || !args[0]->IsString())
     return env->ThrowTypeError("First argument should be a string");

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -133,7 +133,7 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TTYWrap* wrap = Unwrap<TTYWrap>(args.This());
+  TTYWrap* wrap = Unwrap<TTYWrap>(args.Holder());
   assert(args[0]->IsArray());
 
   int width, height;
@@ -153,7 +153,7 @@ void TTYWrap::SetRawMode(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  TTYWrap* wrap = Unwrap<TTYWrap>(args.This());
+  TTYWrap* wrap = Unwrap<TTYWrap>(args.Holder());
 
   int err = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());
   args.GetReturnValue().Set(err);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -139,7 +139,7 @@ void UDPWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 #if !defined(_WIN32)
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
   int fd = (wrap == NULL) ? -1 : wrap->handle_.io_watcher.fd;
   args.GetReturnValue().Set(fd);
 #endif
@@ -150,7 +150,7 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
 
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   // bind(ip, port, flags)
   assert(args.Length() == 3);
@@ -196,7 +196,7 @@ void UDPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
 #define X(name, fn)                                                           \
   void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {               \
     HandleScope scope(args.GetIsolate());                                     \
-    UDPWrap* wrap = Unwrap<UDPWrap>(args.This());                             \
+    UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                           \
     assert(args.Length() == 1);                                               \
     int flag = args[0]->Int32Value();                                         \
     int err = fn(&wrap->handle_, flag);                                       \
@@ -215,7 +215,7 @@ void UDPWrap::SetMembership(const FunctionCallbackInfo<Value>& args,
                             uv_membership membership) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   assert(args.Length() == 2);
 
@@ -249,7 +249,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   // send(req, buffer, offset, length, port, address)
   assert(args[0]->IsObject());
@@ -320,7 +320,7 @@ void UDPWrap::Send6(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   int err = uv_udp_recv_start(&wrap->handle_, OnAlloc, OnRecv);
   // UV_EALREADY means that the socket is already bound but that's okay
@@ -333,7 +333,7 @@ void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::RecvStop(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   int r = uv_udp_recv_stop(&wrap->handle_);
   args.GetReturnValue().Set(r);
@@ -345,7 +345,7 @@ void UDPWrap::GetSockName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
   struct sockaddr_storage address;
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   assert(args[0]->IsObject());
   Local<Object> obj = args[0].As<Object>();

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -68,6 +68,16 @@ try {
   process.exit();
 }
 
+// 'this' safety
+// https://github.com/joyent/node/issues/6690
+assert.throws(function() {
+  var options = {key: keyPem, cert: certPem, ca: caPem};
+  var credentials = crypto.createCredentials(options);
+  var context = credentials.context;
+  var notcontext = { setOptions: context.setOptions, setKey: context.setKey };
+  crypto.createCredentials({ secureOptions: 1 }, notcontext);
+}, TypeError);
+
 // PFX tests
 assert.doesNotThrow(function() {
   crypto.createCredentials({pfx:certPfx, passphrase:'sample'});

--- a/test/simple/test-fs-watch.js
+++ b/test/simple/test-fs-watch.js
@@ -131,3 +131,22 @@ setTimeout(function() {
 fs.watch(__filename, {persistent: false}, function() {
   assert(0);
 });
+
+// whitebox test to ensure that wrapped FSEvent is safe
+// https://github.com/joyent/node/issues/6690
+var oldhandle;
+assert.throws(function() {
+  var w = fs.watch(__filename, function(event, filename) { });
+  oldhandle = w._handle;
+  w._handle = { close: w._handle.close };
+  w.close();
+}, TypeError);
+oldhandle.close(); // clean up
+
+assert.throws(function() {
+  var w = fs.watchFile(__filename, {persistent:false}, function(){});
+  oldhandle = w._handle;
+  w._handle = { stop: w._handle.stop };
+  w.stop();
+}, TypeError);
+oldhandle.stop(); // clean up

--- a/test/simple/test-http-parser.js
+++ b/test/simple/test-http-parser.js
@@ -556,3 +556,15 @@ function expectBody(expected) {
   parser[kOnHeadersComplete] = onHeadersComplete2;
   parser.execute(req2, 0, req2.length);
 })();
+
+// Test parser 'this' safety
+// https://github.com/joyent/node/issues/6690
+assert.throws(function() {
+  var request = Buffer(
+      'GET /hello HTTP/1.1' + CRLF +
+      CRLF);
+
+  var parser = newParser(REQUEST);
+  var notparser = { execute: parser.execute };
+  notparser.execute(request, 0, request.length);
+}, TypeError);

--- a/test/simple/test-process-wrap.js
+++ b/test/simple/test-process-wrap.js
@@ -65,6 +65,20 @@ p.spawn({
   ]
 });
 
+// 'this' safety
+// https://github.com/joyent/node/issues/6690
+assert.throws(function() {
+  var notp = { spawn: p.spawn };
+  notp.spawn({
+    file: process.execPath,
+    args: [process.execPath, '-v'],
+    stdio: [
+      { type: 'ignore' },
+      { type: 'pipe', handle: pipe },
+      { type: 'ignore' }
+    ]
+  });
+}, TypeError);
 
 process.on('exit', function() {
   assert.ok(processExited);

--- a/test/simple/test-signal-safety.js
+++ b/test/simple/test-signal-safety.js
@@ -1,0 +1,11 @@
+var common = require('../common.js');
+var assert = require('assert');
+var Signal = process.binding('signal_wrap').Signal;
+
+// Test Signal `this` safety
+// https://github.com/joyent/node/issues/6690
+assert.throws(function() {
+  var s = new Signal();
+  var nots = { start: s.start };
+  nots.start(9);
+}, TypeError);


### PR DESCRIPTION
This prevents segfaults when a native method is reassigned to a different
object to corrupt `args.This()`.

Closes #6690.
