### PR TITLE
deps: fix v8 valgrind warning

### DIFF
--- a/deps/v8/src/global-handles.cc
+++ b/deps/v8/src/global-handles.cc
@@ -610,7 +610,7 @@ void GlobalHandles::IterateAllRoots(ObjectVisitor* v) {
 
 void GlobalHandles::IterateAllRootsWithClassIds(ObjectVisitor* v) {
   for (NodeIterator it(this); !it.done(); it.Advance()) {
-    if (it.node()->has_wrapper_class_id() && it.node()->IsRetainer()) {
+    if (it.node()->IsRetainer() && it.node()->has_wrapper_class_id()) {
       v->VisitEmbedderReference(it.node()->location(),
                                 it.node()->wrapper_class_id());
     }


### PR DESCRIPTION
Fix the following valgrind warning:

```
Conditional jump or move depends on uninitialised value(s)
    at 0x7D64E7: v8::internal::GlobalHandles::IterateAllRootsWithClassIds(v8::internal::ObjectVisitor*) (global-handles.cc:613)
    by 0x94DCDC: v8::internal::NativeObjectsExplorer::FillRetainedObjects() (profile-generator.cc:2849)
    # etc.
```

This was fixed upstream in r12903 and released in 3.15.2 but that commit
was never back-ported to the 3.14 branch that node.js v0.10 uses.

The code itself works okay; this commit simply shuffles the clauses in
an `if` statement to check that the node is in use before checking its
class id (which is uninitialized if the node is not in use.)

Suggested reviewer: @tjfontaine
