### PR TITLE
tls: do not call SNICallback unless present

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -104,7 +104,9 @@ function onclienthello(hello) {
     //   session.
     //
     // Therefore we should account session loading when dealing with servername
-    if (ret && ret.servername) {
+    if (!self._SNICallback) {
+      self.ssl.endParser();
+    } else if (ret && ret.servername) {
       self._SNICallback(ret.servername, onSNIResult);
     } else if (hello.servername && self._SNICallback) {
       self._SNICallback(hello.servername, onSNIResult);

--- a/test/simple/test-tls-session-cache.js
+++ b/test/simple/test-tls-session-cache.js
@@ -90,6 +90,7 @@ function doTest(testOptions, callback) {
       's_client',
       '-tls1',
       '-connect', 'localhost:' + common.PORT,
+      '-servername', 'ohgod',
       '-key', join(common.fixturesDir, 'agent.key'),
       '-cert', join(common.fixturesDir, 'agent.crt'),
       '-reconnect'


### PR DESCRIPTION
When asynchronously parsing ClientHello for session resumption -
SNICallback may not be set. Check if it is present before invoking
it.

fix #7010
