### PR TITLE
buffer: fix typo in `SlowBuffer`

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -93,7 +93,7 @@ function Buffer(subject, encoding) {
 
 function SlowBuffer(length) {
   length = length >>> 0;
-  if (this.length > kMaxLength) {
+  if (length > kMaxLength) {
     throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
                          'size: 0x' + kMaxLength.toString(16) + ' bytes');
   }

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -24,6 +24,7 @@ var assert = require('assert');
 
 var Buffer = require('buffer').Buffer;
 var SlowBuffer = require('buffer').SlowBuffer;
+var smalloc = require('smalloc');
 
 // counter to ensure unique value is always copied
 var cntr = 0;
@@ -993,3 +994,12 @@ for (var i = 0; i < 5; i++)
 b.fill('ghijk');
 for (var i = 0; i < 5; i++)
   assert.notEqual(d[i], b[i]);
+
+
+assert.throws(function () {
+  new Buffer(smalloc.kMaxLength + 1);
+}, RangeError);
+
+assert.throws(function () {
+  new SlowBuffer(smalloc.kMaxLength + 1);
+}, RangeError);


### PR DESCRIPTION
Just a simple typo:

```
> new buffer.SlowBuffer(smalloc.kMaxLength +1)
Assertion failed: (length <= kMaxLength), function Alloc, file ../src/smalloc.cc, line 249.
Abort trap: 6
```
