### PR TITLE
license: update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Node's license follows:
 
 ====
 
-Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Copyright 2014 Joyent, Inc. and other Node contributors. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
 deal in the Software without restriction, including without limitation the


### PR DESCRIPTION
license: update copyright year

I added a the year of copyright to the license. Copyright 
notices should reflect the current year, so this commit updates 
the listed year to 2014. 
See http://www.copyright.gov/circs/circ01.pdf for more info.
