### PR TITLE
doc: remove an unnecessary argument in process.stdin's readable event.

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -226,7 +226,7 @@ Example of opening standard input and listening for both events:
 
     process.stdin.setEncoding('utf8');
 
-    process.stdin.on('readable', function(chunk) {
+    process.stdin.on('readable', function() {
       var chunk = process.stdin.read();
       if (chunk !== null) {
         process.stdout.write('data: ' + chunk);


### PR DESCRIPTION
`readable` event handler does not need any argument. It might have been `data` event handler's argument.
