### PR TITLE
buffer: allow toString to accept Infinity for end

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -208,7 +208,7 @@ Buffer.prototype.toString = function(encoding, start, end) {
   var loweredCase = false;
 
   start = start >>> 0;
-  end = util.isUndefined(end) ? this.length : end >>> 0;
+  end = util.isUndefined(end) || end === Infinity ? this.length : end >>> 0;
 
   if (!encoding) encoding = 'utf8';
   if (start < 0) start = 0;

--- a/test/simple/test-buffer-inspect.js
+++ b/test/simple/test-buffer-inspect.js
@@ -49,3 +49,10 @@ expected = '<Buffer 31 32>';
 
 assert.strictEqual(util.inspect(b), expected);
 assert.strictEqual(util.inspect(s), expected);
+
+buffer.INSPECT_MAX_BYTES = Infinity;
+
+assert.doesNotThrow(function() {
+  assert.strictEqual(util.inspect(b), expected);
+  assert.strictEqual(util.inspect(s), expected);
+});


### PR DESCRIPTION
The reason for this is that when sometimes when debugging, it's necessary to (easily) see the entirety of buffers. So what I've always done up through node v0.10 is set `require('buffer').INSPECT_MAX_BYTES = Infinity;` to accomplish this.

However since some time ago in v0.11, the inspect() implementation changed and now INSPECT_MAX_BYTES is passed directly to toString() which tries to do `Infinity >>> 0` which results in 0. This then causes inspect() to throw because the regexp used doesn't match an empty string.
