### PR TITLE
crypto: do not lowercase cipher/hash names

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -701,8 +701,13 @@ function filterDuplicates(names) {
   // for example, 'sha1' instead of 'SHA1'.
   var ctx = {};
   names.forEach(function(name) {
-    if (/^[0-9A-Z\-]+$/.test(name)) name = name.toLowerCase();
-    ctx[name] = true;
+    var key = name;
+    if (/^[0-9A-Z\-]+$/.test(key)) key = key.toLowerCase();
+    if (!ctx.hasOwnProperty(key) || ctx[key] < name)
+      ctx[key] = name;
   });
-  return Object.getOwnPropertyNames(ctx).sort();
+
+  return Object.getOwnPropertyNames(ctx).map(function(key) {
+    return ctx[key];
+  }).sort();
 }

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -1008,6 +1008,8 @@ assert.notEqual(-1, crypto.getHashes().indexOf('sha1'));
 assert.notEqual(-1, crypto.getHashes().indexOf('sha'));
 assert.equal(-1, crypto.getHashes().indexOf('SHA1'));
 assert.equal(-1, crypto.getHashes().indexOf('SHA'));
+assert.notEqual(-1, crypto.getHashes().indexOf('RSA-SHA1'));
+assert.equal(-1, crypto.getHashes().indexOf('rsa-sha1'));
 assertSorted(crypto.getHashes());
 
 // Base64 padding regression test, see #4837.


### PR DESCRIPTION
`crypto.getCiphers()` and `crypto.getHashes()` should prefer lower-case
variants of names, but should not introduce them.

fix #7282
