### PR TITLE
src, test: fix up ObjectWrap, `make test-addons`

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -160,8 +160,8 @@ function calls and return a result. This is the main and only needed source
         return;
       }
 
-      Local<Number> num = Number::New(args[0]->NumberValue() +
-          args[1]->NumberValue());
+      double value = args[0]->NumberValue() + args[1]->NumberValue();
+      Local<Number> num = Number::New(isolate, value);
 
       args.GetReturnValue().Set(num);
     }
@@ -197,7 +197,7 @@ there. Here's `addon.cc`:
       Local<Function> cb = Local<Function>::Cast(args[0]);
       const unsigned argc = 1;
       Local<Value> argv[argc] = { String::NewFromUtf8(isolate, "hello world") };
-      cb->Call(Context::GetCurrent()->Global(), argc, argv);
+      cb->Call(isolate->GetCurrentContext()->Global(), argc, argv);
     }
 
     void Init(Handle<Object> exports, Handle<Object> module) {
@@ -236,7 +236,7 @@ the string passed to `createObject()`:
       Isolate* isolate = Isolate::GetCurrent();
       HandleScope scope(isolate);
 
-      Local<Object> obj = Object::New();
+      Local<Object> obj = Object::New(isolate);
       obj->Set(String::NewFromUtf8(isolate, "msg"), args[0]->ToString());
 
       args.GetReturnValue().Set(obj);
@@ -278,7 +278,7 @@ wraps a C++ function:
       Isolate* isolate = Isolate::GetCurrent();
       HandleScope scope(isolate);
 
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(MyFunction);
+      Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, MyFunction);
       Local<Function> fn = tpl->GetFunction();
 
       // omit this to make it anonymous
@@ -366,7 +366,7 @@ prototype:
       Isolate* isolate = Isolate::GetCurrent();
 
       // Prepare constructor template
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
+      Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
       tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
       tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
@@ -404,7 +404,7 @@ prototype:
       MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
       obj->value_ += 1;
 
-      args.GetReturnValue().Set(Number::New(obj->value_));
+      args.GetReturnValue().Set(Number::New(isolate, obj->value_));
     }
 
 Test it with:
@@ -494,7 +494,7 @@ The implementation is similar to the above in `myobject.cc`:
     void MyObject::Init() {
       Isolate* isolate = Isolate::GetCurrent();
       // Prepare constructor template
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
+      Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
       tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
       tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
@@ -542,7 +542,7 @@ The implementation is similar to the above in `myobject.cc`:
       MyObject* obj = ObjectWrap::Unwrap<MyObject>(args.This());
       obj->value_ += 1;
 
-      args.GetReturnValue().Set(Number::New(obj->value_));
+      args.GetReturnValue().Set(Number::New(isolate, obj->value_));
     }
 
 Test it with:
@@ -591,7 +591,7 @@ In the following `addon.cc` we introduce a function `add()` that can take on two
           args[1]->ToObject());
 
       double sum = obj1->value() + obj2->value();
-      args.GetReturnValue().Set(Number::New(sum));
+      args.GetReturnValue().Set(Number::New(isolate, sum));
     }
 
     void InitAll(Handle<Object> exports) {
@@ -650,7 +650,7 @@ The implementation of `myobject.cc` is similar as before:
       Isolate* isolate = Isolate::GetCurrent();
 
       // Prepare constructor template
-      Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
+      Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
       tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
       tpl->InstanceTemplate()->SetInternalFieldCount(1);
 

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -82,7 +82,7 @@ class ObjectWrap {
 
 
   inline void MakeWeak(void) {
-    persistent().MakeWeak(this, WeakCallback);
+    persistent().SetWeak(this, WeakCallback);
     persistent().MarkIndependent();
   }
 
@@ -116,13 +116,16 @@ class ObjectWrap {
   int refs_;  // ro
 
  private:
-  static void WeakCallback(v8::Isolate* isolate,
-                           v8::Persistent<v8::Object>* pobj,
-                           ObjectWrap* wrap) {
+  static void WeakCallback(
+      const v8::WeakCallbackData<v8::Object, ObjectWrap>& data) {
+    v8::Isolate* isolate = data.GetIsolate();
     v8::HandleScope scope(isolate);
+    ObjectWrap* wrap = data.GetParameter();
     assert(wrap->refs_ == 0);
-    assert(*pobj == wrap->persistent());
-    assert((*pobj).IsNearDeath());
+    assert(wrap->handle_.IsNearDeath());
+    assert(
+        data.GetValue() == v8::Local<v8::Object>::New(isolate, wrap->handle_));
+    wrap->handle_.Reset();
     delete wrap;
   }
 

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -24,15 +24,18 @@ void AfterAsync(uv_work_t* r) {
   HandleScope scope(isolate);
   async_req* req = reinterpret_cast<async_req*>(r->data);
 
-  Handle<Value> argv[2] = { Null(), Integer::New(req->output) };
+  Handle<Value> argv[2] = {
+    Null(isolate),
+    Integer::New(isolate, req->output)
+  };
 
   TryCatch try_catch;
 
   Local<Function> callback = Local<Function>::New(isolate, req->callback);
-  callback->Call(Context::GetCurrent()->Global(), 2, argv);
+  callback->Call(isolate->GetCurrentContext()->Global(), 2, argv);
 
   // cleanup
-  req->callback.Dispose();
+  req->callback.Reset();
   delete req;
 
   if (try_catch.HasCaught()) {

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -16,9 +16,11 @@ static int at_exit_cb1_called = 0;
 static int at_exit_cb2_called = 0;
 
 static void at_exit_cb1(void* arg) {
-  HandleScope scope(Isolate::GetCurrent());
+  // FIXME(bnoordhuis) Isolate::GetCurrent() is on its way out.
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope handle_scope(isolate);
   assert(arg == 0);
-  Local<Object> obj = Object::New();
+  Local<Object> obj = Object::New(isolate);
   assert(!obj.IsEmpty()); // assert VM is still alive
   assert(obj->IsObject());
   at_exit_cb1_called++;


### PR DESCRIPTION
V8 was upgraded from 3.22 to 3.24 in commit 1c7bf24.  Upgrade source
files in test/addons/ and automatically generated tests from
doc/api/addons.markdown to the new V8 API.

This coincidentally fixes a bug in src/node_object_wrap.h where it was
still using the old V8 weak persistent handle interface, which is gone
in 3.24.

Suggested reviewer: @indutny
