### PR TITLE
vm: share security token between contexts

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -224,7 +224,11 @@ class ContextifyContext {
                                              CreateDataWrapper(env));
     object_template->SetAccessCheckCallbacks(GlobalPropertyNamedAccessCheck,
                                              GlobalPropertyIndexedAccessCheck);
-    return scope.Escape(Context::New(env->isolate(), NULL, object_template));
+
+    Local<Context> ctx = Context::New(env->isolate(), NULL, object_template);
+    if (!ctx.IsEmpty())
+      ctx->SetSecurityToken(env->context()->GetSecurityToken());
+    return scope.Escape(ctx);
   }
 
 

--- a/test/simple/test-vm-cross-context.js
+++ b/test/simple/test-vm-cross-context.js
@@ -1,0 +1,30 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var vm = require('vm');
+var ctx = vm.createContext(global);
+
+assert.doesNotThrow(function() {
+  vm.runInContext("!function() { var x = console.log; }()", ctx);
+});


### PR DESCRIPTION
By default, each `v8::Context` has a different Security Token, which
prevents access to one context from another.

fix #7140
