### PR TITLE
stream: use `uv_write2` instead of `uv_write` use case

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -640,11 +640,7 @@ int StreamWrapCallbacks::DoWrite(WriteWrap* w,
                                  uv_stream_t* send_handle,
                                  uv_write_cb cb) {
   int r;
-  if (send_handle == NULL) {
-    r = uv_write(&w->req_, wrap()->stream(), bufs, count, cb);
-  } else {
-    r = uv_write2(&w->req_, wrap()->stream(), bufs, count, send_handle, cb);
-  }
+  r = uv_write2(&w->req_, wrap()->stream(), bufs, count, send_handle, cb);
 
   if (!r) {
     size_t bytes = 0;


### PR DESCRIPTION
I noticed that `uv_write` is just passing NULL to `send_handle` at https://github.com/joyent/libuv/blob/master/src/unix/stream.c#L1359-L1365, then here should we need use `uv_write2` all the way?
