### PR TITLE
http: use defaultAgent.protocol in protocol check

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -58,6 +58,11 @@ function ClientRequest(options, cb) {
   }
   self.agent = agent;
 
+  var protocol = options.protocol || defaultAgent.protocol;
+  var expectedProtocol = defaultAgent.protocol;
+  if (self.agent && self.agent.protocol)
+    expectedProtocol = self.agent.protocol;
+
   if (options.path && / /.test(options.path)) {
     // The actual regex is more like /[^A-Za-z0-9\-._~!$&'()*+,;=/:@]/
     // with an additional rule for ignoring percentage-escaped characters
@@ -66,8 +71,8 @@ function ClientRequest(options, cb) {
     // why it only scans for spaces because those are guaranteed to create
     // an invalid request.
     throw new TypeError('Request path contains unescaped characters.');
-  } else if (options.protocol && options.protocol !== self.agent.protocol) {
-    throw new Error('Protocol:' + options.protocol + ' not supported.');
+  } else if (protocol !== expectedProtocol) {
+    throw new Error('Protocol:' + protocol + ' not supported.');
   }
 
   var defaultPort = options.defaultPort || self.agent && self.agent.defaultPort;

--- a/test/simple/test-http-agent-no-protocol.js
+++ b/test/simple/test-http-agent-no-protocol.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var url = require('url');
+
+var request = 0;
+var response = 0;
+process.on('exit', function() {
+  assert.equal(1, request, 'http server "request" callback was not called');
+  assert.equal(1, response, 'http client "response" callback was not called');
+});
+
+var server = http.createServer(function(req, res) {
+  res.end();
+  request++;
+}).listen(common.PORT, '127.0.0.1', function() {
+  var opts = url.parse('http://127.0.0.1:' + common.PORT + '/');
+
+  // remove the `protocol` field… the `http` module should fall back
+  // to "http:", as defined by the global, default `http.Agent` instance.
+  opts.agent = new http.Agent();
+  opts.agent.protocol = null;
+
+  http.get(opts, function (res) {
+    response++;
+    res.resume();
+    server.close();
+  });
+});


### PR DESCRIPTION
Default to the `defaultAgent.protocol` when comparing the
user-specified `options.protocol` string. This is so that
`http.Agent` instances do not need to specify their own
`protocol` field, since we have the relevant information
already from the `defaultAgent`.

Note that the test case could be separately cherry-picked
to the `v0.10` branch, since it already passes correctly.

Fixes #7349.
Fixes the regression described in: http://git.io/2ds-WQ
