### PR TITLE
Buffer helper performance

### DIFF
--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -20,9 +20,12 @@ function main(conf) {
   var fn = 'read' + conf.type;
 
   buff.writeDoubleLE(0, 0, noAssert);
+  var testFunction = new Function('buff', [
+    "for (var i = 0; i !== " + len + "; i++) {",
+    "  buff." + fn + "(0, " + JSON.stringify(noAssert) + ");",
+    "}"
+  ].join("\n"));
   bench.start();
-  for (var i = 0; i < len; i++) {
-    buff[fn](0, noAssert);
-  }
+  testFunction(buff);
   bench.end(len / 1e6);
 }

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -15,9 +15,9 @@ var bench = common.createBenchmark(main, {
 const INT8   = 0x7f;
 const INT16  = 0x7fff;
 const INT32  = 0x7fffffff;
-const UINT8  = INT8 * 2;
-const UINT16 = INT16 * 2;
-const UINT32 = INT32 * 2;
+const UINT8  = (INT8 * 2) + 1;
+const UINT16 = (INT16 * 2) + 1;
+const UINT32 = INT32;
 
 var mod = {
   writeInt8: INT8,
@@ -47,17 +47,23 @@ function main(conf) {
 
 function benchInt(buff, fn, len, noAssert) {
   var m = mod[fn];
+  var testFunction = new Function('buff', [
+    "for (var i = 0; i !== " + len + "; i++) {",
+    "  buff." + fn + "(i & " + m + ", 0, " + JSON.stringify(noAssert) + ");",
+    "}"
+  ].join("\n"));
   bench.start();
-  for (var i = 0; i < len; i++) {
-    buff[fn](i % m, 0, noAssert);
-  }
+  testFunction(buff);
   bench.end(len / 1e6);
 }
 
 function benchFloat(buff, fn, len, noAssert) {
+  var testFunction = new Function('buff', [
+    "for (var i = 0; i !== " + len + "; i++) {",
+    "  buff." + fn + "(i, 0, " + JSON.stringify(noAssert) + ");",
+    "}"
+  ].join("\n"));
   bench.start();
-  for (var i = 0; i < len; i++) {
-    buff[fn](i * 0.1, 0, noAssert);
-  }
+  testFunction(buff);
   bench.end(len / 1e6);
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -590,165 +590,87 @@ Buffer.prototype.readUInt8 = function(offset, noAssert) {
 };
 
 
-function readUInt16(buffer, offset, isBigEndian) {
-  var val = 0;
-  if (isBigEndian) {
-    val = buffer[offset] << 8;
-    val |= buffer[offset + 1];
-  } else {
-    val = buffer[offset];
-    val |= buffer[offset + 1] << 8;
-  }
-
-  return val;
-}
-
-
 Buffer.prototype.readUInt16LE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 2, this.length);
-  return readUInt16(this, offset, false, noAssert);
+  return this[offset] | (this[offset + 1] << 8);
 };
 
 
 Buffer.prototype.readUInt16BE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 2, this.length);
-  return readUInt16(this, offset, true, noAssert);
+  return (this[offset] << 8) | this[offset + 1];
 };
-
-
-function readUInt32(buffer, offset, isBigEndian, noAssert) {
-  var val = 0;
-
-  if (isBigEndian) {
-    val = buffer[offset + 1] << 16;
-    val |= buffer[offset + 2] << 8;
-    val |= buffer[offset + 3];
-    val = val + (buffer[offset] << 24 >>> 0);
-  } else {
-    val = buffer[offset + 2] << 16;
-    val |= buffer[offset + 1] << 8;
-    val |= buffer[offset];
-    val = val + (buffer[offset + 3] << 24 >>> 0);
-  }
-
-  return val;
-}
 
 
 Buffer.prototype.readUInt32LE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return readUInt32(this, offset, false, noAssert);
+
+  return ((this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16)) +
+      (this[offset + 3] * 0x1000000);
 };
 
 
 Buffer.prototype.readUInt32BE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return readUInt32(this, offset, true, noAssert);
+
+  return (this[offset] * 0x1000000) +
+      ((this[offset + 1] << 16) |
+      (this[offset + 2] << 8)) |
+      (this[offset + 3]);
 };
-
-
-/*
- * Signed integer types, yay team! A reminder on how two's complement actually
- * works. The first bit is the signed bit, i.e. tells us whether or not the
- * number should be positive or negative. If the two's complement value is
- * positive, then we're done, as it's equivalent to the unsigned representation.
- *
- * Now if the number is positive, you're pretty much done, you can just leverage
- * the unsigned translations and return those. Unfortunately, negative numbers
- * aren't quite that straightforward.
- *
- * At first glance, one might be inclined to use the traditional formula to
- * translate binary numbers between the positive and negative values in two's
- * complement. (Though it doesn't quite work for the most negative value)
- * Mainly:
- *  - invert all the bits
- *  - add one to the result
- *
- * Of course, this doesn't quite work in Javascript. Take for example the value
- * of -128. This could be represented in 16 bits (big-endian) as 0xff80. But of
- * course, Javascript will do the following:
- *
- * > ~0xff80
- * -65409
- *
- * Whoh there, Javascript, that's not quite right. But wait, according to
- * Javascript that's perfectly correct. When Javascript ends up seeing the
- * constant 0xff80, it has no notion that it is actually a signed number. It
- * assumes that we've input the unsigned value 0xff80. Thus, when it does the
- * binary negation, it casts it into a signed value, (positive 0xff80). Then
- * when you perform binary negation on that, it turns it into a negative number.
- *
- * Instead, we're going to have to use the following general formula, that works
- * in a rather Javascript friendly way. I'm glad we don't support this kind of
- * weird numbering scheme in the kernel.
- *
- * (BIT-MAX - (unsigned)val + 1) * -1
- *
- * The astute observer, may think that this doesn't make sense for 8-bit numbers
- * (really it isn't necessary for them). However, when you get 16-bit numbers,
- * you do. Let's go back to our prior example and see how this will look:
- *
- * (0xffff - 0xff80 + 1) * -1
- * (0x007f + 1) * -1
- * (0x0080) * -1
- */
 
 Buffer.prototype.readInt8 = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 1, this.length);
-  if (!(this[offset] & 0x80))
-    return (this[offset]);
-  return ((0xff - this[offset] + 1) * -1);
+  var val = this[offset];
+  if (val & 0x80) return val | 0xFFFFFF00;
+  else return val;
 };
-
-
-function readInt16(buffer, offset, isBigEndian) {
-  var val = readUInt16(buffer, offset, isBigEndian);
-
-  if (!(val & 0x8000))
-    return val;
-  return (0xffff - val + 1) * -1;
-}
 
 
 Buffer.prototype.readInt16LE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 2, this.length);
-  return readInt16(this, offset, false);
+  var val = this[offset] | (this[offset + 1] << 8);
+  if (val & 0x8000) return val | 0xFFFF0000;
+  else return val;
 };
 
 
 Buffer.prototype.readInt16BE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 2, this.length);
-  return readInt16(this, offset, true);
+  var val = this[offset + 1] | (this[offset] << 8);
+  if (val & 0x8000) return val | 0xFFFF0000;
+  else return val;
 };
-
-
-function readInt32(buffer, offset, isBigEndian) {
-  var val = readUInt32(buffer, offset, isBigEndian);
-
-  if (!(val & 0x80000000))
-    return (val);
-  return (0xffffffff - val + 1) * -1;
-}
 
 
 Buffer.prototype.readInt32LE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return readInt32(this, offset, false);
+
+  return (this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16) |
+      (this[offset + 3] << 24);
 };
 
 
 Buffer.prototype.readInt32BE = function(offset, noAssert) {
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return readInt32(this, offset, true);
+
+  return (this[offset] << 24) |
+      (this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      (this[offset + 3]);
 };
 
 Buffer.prototype.readFloatLE = function(offset, noAssert) {
@@ -830,44 +752,6 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   this[offset + 2] = (value >>> 8);
   this[offset + 3] = value;
 };
-
-
-/*
- * We now move onto our friends in the signed number category. Unlike unsigned
- * numbers, we're going to have to worry a bit more about how we put values into
- * arrays. Since we are only worrying about signed 32-bit values, we're in
- * slightly better shape. Unfortunately, we really can't do our favorite binary
- * & in this system. It really seems to do the wrong thing. For example:
- *
- * > -32 & 0xff
- * 224
- *
- * What's happening above is really: 0xe0 & 0xff = 0xe0. However, the results of
- * this aren't treated as a signed number. Ultimately a bad thing.
- *
- * What we're going to want to do is basically create the unsigned equivalent of
- * our representation and pass that off to the wuint* functions. To do that
- * we're going to do the following:
- *
- *  - if the value is positive
- *      we can pass it directly off to the equivalent wuint
- *  - if the value is negative
- *      we do the following computation:
- *         mb + val + 1, where
- *         mb   is the maximum unsigned value in that byte size
- *         val  is the Javascript negative integer
- *
- *
- * As a concrete value, take -128. In signed 16 bits this would be 0xff80. If
- * you do out the computations:
- *
- * 0xffff - 128 + 1
- * 0xffff - 127
- * 0xff80
- *
- * You can then encode this value as the signed version. This is really rather
- * hacky, but it should work and get the job done which is our goal here.
- */
 
 Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
   if (!noAssert)

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -796,57 +796,39 @@ Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
 };
 
 
-function writeUInt16(buffer, value, offset, isBigEndian) {
-  if (isBigEndian) {
-    buffer[offset] = (value & 0xff00) >>> 8;
-    buffer[offset + 1] = value & 0x00ff;
-  } else {
-    buffer[offset + 1] = (value & 0xff00) >>> 8;
-    buffer[offset] = value & 0x00ff;
-  }
-}
-
-
 Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
-  writeUInt16(this, value, offset, false);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
 };
 
 
 Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0xffff, 0);
-  writeUInt16(this, value, offset, true);
+  this[offset] = (value >>> 8);
+  this[offset + 1] = value;
 };
-
-
-function writeUInt32(buffer, value, offset, isBigEndian) {
-  if (isBigEndian) {
-    buffer[offset] = (value >>> 24) & 0xff;
-    buffer[offset + 1] = (value >>> 16) & 0xff;
-    buffer[offset + 2] = (value >>> 8) & 0xff;
-    buffer[offset + 3] = value & 0xff;
-  } else {
-    buffer[offset + 3] = (value >>> 24) & 0xff;
-    buffer[offset + 2] = (value >>> 16) & 0xff;
-    buffer[offset + 1] = (value >>> 8) & 0xff;
-    buffer[offset] = value & 0xff;
-  }
-}
 
 
 Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
-  writeUInt32(this, value, offset, false);
+  this[offset + 3] = (value >>> 24);
+  this[offset + 2] = (value >>> 16);
+  this[offset + 1] = (value >>> 8);
+  this[offset] = value & 0xff;
 };
 
 
 Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0xffffffff, 0);
-  writeUInt32(this, value, offset, true);
+  this[offset] = (value >>> 24);
+  this[offset + 1] = (value >>> 16);
+  this[offset + 2] = (value >>> 8);
+  this[offset + 3] = value;
 };
 
 
@@ -898,32 +880,36 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
 Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
-  if (value < 0) value = 0xffff + value + 1;
-  writeUInt16(this, value, offset, false);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
 };
 
 
 Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 2, 0x7fff, -0x8000);
-  if (value < 0) value = 0xffff + value + 1;
-  writeUInt16(this, value, offset, true);
+  this[offset] = (value >>> 8);
+  this[offset + 1] = value;
 };
 
 
 Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
-  if (value < 0) value = 0xffffffff + value + 1;
-  writeUInt32(this, value, offset, false);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
+  this[offset + 2] = (value >>> 16);
+  this[offset + 3] = (value >>> 24);
 };
 
 
 Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
   if (!noAssert)
     checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
-  if (value < 0) value = 0xffffffff + value + 1;
-  writeUInt32(this, value, offset, true);
+  this[offset] = (value >>> 24);
+  this[offset + 1] = (value >>> 16);
+  this[offset + 2] = (value >>> 8);
+  this[offset + 3] = value;
 };
 
 


### PR DESCRIPTION
The API of Buffer.read\* and Buffer.write\* functions is clearly unable to be optimized well, but this pull request does increase the performance of the integer reading and writing performance by around 10-30%. Everything should behave exactly the same other than just running faster.

Additionally, the benchmarks for these functions were not really measuring the functions they set our to measure. More than 90% of the run-time was consumed by running the benchmark code itself. This pull request also fixes that. Of particular note, this pull request did NOT cause a 20x performance gain. To evaluate its performance gain, cherry pick the benchmark changes and run benchmarks against the unaltered read\* and write\* functions then apply the rest of this pull request.
