### PR TITLE
http: better client "protocol not supported" error

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -72,7 +72,8 @@ function ClientRequest(options, cb) {
     // an invalid request.
     throw new TypeError('Request path contains unescaped characters.');
   } else if (protocol !== expectedProtocol) {
-    throw new Error('Protocol:' + protocol + ' not supported.');
+    throw new Error('Protocol "' + protocol + '" not supported. ' +
+                    'Expected "' + expectedProtocol + '".');
   }
 
   var defaultPort = options.defaultPort || self.agent && self.agent.defaultPort;

--- a/test/simple/test-http-url.parse-only-support-http-https-protocol.js
+++ b/test/simple/test-http-url.parse-only-support-http-https-protocol.js
@@ -29,7 +29,7 @@ assert.throws(function() {
   http.request(url.parse('file:///whatever'));
 }, function(err) {
   if (err instanceof Error) {
-    assert.strictEqual(err.message, 'Protocol:file: not supported.');
+    assert.strictEqual(err.message, 'Protocol "file:" not supported. Expected "http:".');
     return true;
   }
 });
@@ -38,7 +38,7 @@ assert.throws(function() {
   http.request(url.parse('mailto:asdf@asdf.com'));
 }, function(err) {
   if (err instanceof Error) {
-    assert.strictEqual(err.message, 'Protocol:mailto: not supported.');
+    assert.strictEqual(err.message, 'Protocol "mailto:" not supported. Expected "http:".');
     return true;
   }
 });
@@ -47,7 +47,7 @@ assert.throws(function() {
   http.request(url.parse('ftp://www.example.com'));
 }, function(err) {
   if (err instanceof Error) {
-    assert.strictEqual(err.message, 'Protocol:ftp: not supported.');
+    assert.strictEqual(err.message, 'Protocol "ftp:" not supported. Expected "http:".');
     return true;
   }
 });
@@ -56,7 +56,7 @@ assert.throws(function() {
   http.request(url.parse('javascript:alert(\'hello\');'));
 }, function(err) {
   if (err instanceof Error) {
-    assert.strictEqual(err.message, 'Protocol:javascript: not supported.');
+    assert.strictEqual(err.message, 'Protocol "javascript:" not supported. Expected "http:".');
     return true;
   }
 });
@@ -65,7 +65,7 @@ assert.throws(function() {
   http.request(url.parse('xmpp:isaacschlueter@jabber.org'));
 }, function(err) {
   if (err instanceof Error) {
-    assert.strictEqual(err.message, 'Protocol:xmpp: not supported.');
+    assert.strictEqual(err.message, 'Protocol "xmpp:" not supported. Expected "http:".');
     return true;
   }
 });
@@ -74,7 +74,7 @@ assert.throws(function() {
   http.request(url.parse('f://some.host/path'));
 }, function(err) {
   if (err instanceof Error) {
-    assert.strictEqual(err.message, 'Protocol:f: not supported.');
+    assert.strictEqual(err.message, 'Protocol "f:" not supported. Expected "http:".');
     return true;
   }
 });


### PR DESCRIPTION
Just a nice-to-have really. Would be good to land before v0.12 though if we want it.

Include the "expected protocol" in the Error message string, which evaluates to "http:" for the `http` core module, and "https:" for the `https` module.
