### PR TITLE
module: eliminate double `getenv()`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -515,9 +515,10 @@ Module._initPaths = function() {
     paths.unshift(path.resolve(homeDir, '.node_modules'));
   }
 
-  if (process.env['NODE_PATH']) {
+  var nodePath = process.env['NODE_PATH'];
+  if (nodePath) {
     var splitter = isWindows ? ';' : ':';
-    paths = process.env['NODE_PATH'].split(splitter).concat(paths);
+    paths = nodePath.split(splitter).concat(paths);
   }
 
   modulePaths = paths;


### PR DESCRIPTION
`process.env` access results in a synchronous `getenv` call. Cache the
first result instead and save one syscall.
