### PR TITLE
buffer: truncate buffer after string decode

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,6 +23,7 @@ var buffer = process.binding('buffer');
 var smalloc = process.binding('smalloc');
 var util = require('util');
 var alloc = smalloc.alloc;
+var truncate = smalloc.truncate;
 var sliceOnto = smalloc.sliceOnto;
 var kMaxLength = smalloc.kMaxLength;
 var internal = {};
@@ -79,7 +80,13 @@ function Buffer(subject, encoding) {
       // In the case of base64 it's possible that the size of the buffer
       // allocated was slightly too large. In this case we need to rewrite
       // the length to the actual length written.
-      this.length = this.write(subject, encoding);
+      var len = this.write(subject, encoding);
+
+      // Buffer was truncated after decode, realloc internal ExternalArray
+      if (len !== this.length) {
+        this.length = len;
+        truncate(this, this.length);
+      }
     } else {
       if (util.isBuffer(subject))
         subject.copy(this, 0, 0, this.length);

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -1003,3 +1003,14 @@ assert.throws(function () {
 assert.throws(function () {
   new SlowBuffer(smalloc.kMaxLength + 1);
 }, RangeError);
+
+// Test truncation after decode
+var crypto = require('crypto');
+
+var b1 = new Buffer('YW55=======', 'base64');
+var b2 = new Buffer('YW55', 'base64');
+
+assert.equal(
+  crypto.createHash('sha1').update(b1).digest('hex'),
+  crypto.createHash('sha1').update(b2).digest('hex')
+);


### PR DESCRIPTION
When our estimates for a storage size are higher than the actual length
of decoded data, the destination buffer should be truncated. Otherwise
`Buffer::Length` will give misleading information to C++ layer.

fix #7365
