### PR TITLE
deps: provide TXT chunk info in c-ares

### DIFF
--- a/deps/cares/include/ares.h
+++ b/deps/cares/include/ares.h
@@ -512,6 +512,8 @@ struct ares_txt_reply {
   struct ares_txt_reply  *next;
   unsigned char          *txt;
   size_t                  length;  /* length excludes null termination */
+  unsigned char           record_start;  /* 1 - if start of new record
+                                          * 0 - if a chunk in the same record */
 };
 
 struct ares_naptr_reply {

--- a/deps/cares/src/ares_parse_txt_reply.c
+++ b/deps/cares/src/ares_parse_txt_reply.c
@@ -134,8 +134,6 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
                   break;
                 }
 
-              ++strptr;
-
               /* Allocate storage for this TXT answer appending it to the list */
               txt_curr = ares_malloc_data(ARES_DATATYPE_TXT_REPLY);
               if (!txt_curr)
@@ -153,6 +151,7 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
                 }
               txt_last = txt_curr;
 
+              txt_curr->record_start = strptr == aptr;
               txt_curr->length = substr_len;
               txt_curr->txt = malloc (substr_len + 1/* Including null byte */);
               if (txt_curr->txt == NULL)
@@ -160,6 +159,8 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
                   status = ARES_ENOMEM;
                   break;
                 }
+
+              ++strptr;
               memcpy ((char *) txt_curr->txt, strptr, substr_len);
 
               /* Make sure we NULL-terminate */

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -144,6 +144,11 @@ function resolver(bindingName) {
   return function query(name, callback) {
     function onanswer(status, result) {
       if (!status) {
+        // XXX Hack to preserve API in v0.10, remove in v0.11
+        if (bindingName === 'queryTxt') {
+          for (var i = 0; i < result.length; i++)
+            result[i] = result[i].join('\0');
+        }
         callback(null, result);
       } else {
         callback(errnoException(process._errno, bindingName));

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -546,17 +546,20 @@ class QueryTxtWrap: public QueryWrap {
     }
 
     Local<Array> txt_records = Array::New();
+    Local<Array> txt_record = Array::New();
 
     struct ares_txt_reply *current = txt_out;
-    for (int i = -1; current; current = current->next) {
+    for (int i = -1, j = 0; current; current = current->next, j++) {
       Local<String> txt = String::New(reinterpret_cast<char*>(current->txt));
       if (current->record_start) {
         i++;
-        txt_records->Set(i, txt);
-      } else {
-        txt_records->Set(i, String::Concat(txt_records->Get(i).As<String>(),
-                                           txt));
+        j = 0;
+        if (i != 0)
+          txt_record = Array::New();
+        txt_records->Set(i, txt_record);
       }
+
+      txt_record->Set(j, txt);
     }
 
     ares_free_data(txt_out);

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -548,9 +548,15 @@ class QueryTxtWrap: public QueryWrap {
     Local<Array> txt_records = Array::New();
 
     struct ares_txt_reply *current = txt_out;
-    for (int i = 0; current; ++i, current = current->next) {
+    for (int i = -1; current; current = current->next) {
       Local<String> txt = String::New(reinterpret_cast<char*>(current->txt));
-      txt_records->Set(Integer::New(i), txt);
+      if (current->record_start) {
+        i++;
+        txt_records->Set(i, txt);
+      } else {
+        txt_records->Set(i, String::Concat(txt_records->Get(i).As<String>(),
+                                           txt));
+      }
     }
 
     ares_free_data(txt_out);


### PR DESCRIPTION
Provide more information in `ares_txt_reply` to coalesce chunks from the
same record into one string.

fix #7367
