### PR TITLE
zlib: add adler32 and crc32

### DIFF
--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -6,9 +6,9 @@ You can access this module with:
 
     var zlib = require('zlib');
 
-This provides bindings to Gzip/Gunzip, Deflate/Inflate, and
-DeflateRaw/InflateRaw classes.  Each class takes the same options, and
-is a readable/writable Stream.
+This provides bindings to Gzip/Gunzip, Deflate/Inflate, DeflateRaw/InflateRaw,
+as well as Adler32 and CRC32 classes. Each class is a readable/writable Stream,
+and each compressor/decompressor class takes the same options.
 
 ## Examples
 
@@ -240,7 +240,8 @@ Decompress a raw Buffer with Unzip.
 
 <!--type=misc-->
 
-Each class takes an options object.  All options are optional.
+Each compressor/decompressor class takes an options object.  All options
+are optional.
 
 Note that some options are only relevant when compressing, and are
 ignored by the decompression classes.
@@ -361,3 +362,39 @@ The deflate compression method (the only one supported in this version).
 For initializing zalloc, zfree, opaque.
 
 * `zlib.Z_NULL`
+
+
+## Checksum functions
+
+Adler-32 and CRC-32 are provided in two ways. The functions accept a string or
+buffer and return its checksum as an unsigned integer. The streams compute the
+checksum using the written data – once the writable side of the stream is
+ended, use the `read()` method to get the computed checksum as an unsigned
+integer.
+
+
+## zlib.createAdler32()
+
+Returns a new [Adler32](#zlib_class_zlib_adler32) object.
+
+## zlib.createCRC32()
+
+Returns a new [CRC32](#zlib_class_zlib_crc32) object.
+
+
+## Class: zlib.Adler32
+
+Calculate Adler-32 checksum.
+
+## Class: zlib.CRC32
+
+Calculate CRC-32 checksum.
+
+
+## zlib.adler32(buffer)
+
+Calculate Adler-32 checksum of `buffer`.
+
+## zlib.crc32(buffer)
+
+Calculate CRC-32 checksum of `buffer`.

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -68,6 +68,9 @@ Object.keys(exports.codes).forEach(function(k) {
   exports.codes[exports.codes[k]] = k;
 });
 
+exports.adler32 = binding.adler32;
+exports.crc32 = binding.crc32;
+
 exports.Deflate = Deflate;
 exports.Inflate = Inflate;
 exports.Gzip = Gzip;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -628,19 +628,19 @@ exports.createCRC32 = exports.CRC32 = CRC32;
 function CRC32() {
   if (!(this instanceof CRC32))
     return new CRC32();
-  this._binding = new binding.CRC32();
+  this._handle = new binding.CRC32();
   Transform.call(this, { readableObjectMode : true });
 }
 
 util.inherits(CRC32, Transform);
 
 CRC32.prototype._transform = function(chunk, encoding, callback) {
-  this._binding.update(chunk);
+  this._handle.update(chunk);
   callback();
 };
 
 CRC32.prototype._flush = function(callback) {
-  this.push(this._binding.digest());
+  this.push(this._handle.digest());
   callback();
 };
 
@@ -649,18 +649,18 @@ exports.createAdler32 = exports.Adler32 = Adler32;
 function Adler32() {
   if (!(this instanceof Adler32))
     return new Adler32();
-  this._binding = new binding.Adler32();
+  this._handle = new binding.Adler32();
   Transform.call(this, { readableObjectMode : true });
 }
 
 util.inherits(Adler32, Transform);
 
 Adler32.prototype._transform = function(chunk, encoding, callback) {
-  this._binding.update(chunk);
+  this._handle.update(chunk);
   callback();
 };
 
 Adler32.prototype._flush = function(callback) {
-  this.push(this._binding.digest());
+  this.push(this._handle.digest());
   callback();
 };

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -68,9 +68,6 @@ Object.keys(exports.codes).forEach(function(k) {
   exports.codes[exports.codes[k]] = k;
 });
 
-exports.adler32 = binding.adler32;
-exports.crc32 = binding.crc32;
-
 exports.Deflate = Deflate;
 exports.Inflate = Inflate;
 exports.Gzip = Gzip;
@@ -614,12 +611,27 @@ util.inherits(Unzip, Zlib);
 
 
 
+exports.adler32 = function(buffer) {
+  var engine = new Adler32();
+  engine.end(buffer);
+  return engine.read();
+};
+
+exports.crc32 = function(buffer) {
+  var engine = new CRC32();
+  engine.end(buffer);
+  return engine.read();
+};
+
+
 exports.createCRC32 = exports.CRC32 = CRC32;
 function CRC32() {
   if (!(this instanceof CRC32))
     return new CRC32();
   this._binding = new binding.CRC32();
   Transform.call(this);
+  this._writableState.objectMode = false;
+  this._readableState.objectMode = true;
 }
 
 util.inherits(CRC32, Transform);
@@ -630,9 +642,7 @@ CRC32.prototype._transform = function(chunk, encoding, callback) {
 };
 
 CRC32.prototype._flush = function(callback) {
-  var buffer = new Buffer(4);
-  buffer.writeUInt32LE(this._binding.digest());
-  this.push(buffer);
+  this.push(this._binding.digest());
   callback();
 };
 
@@ -643,6 +653,8 @@ function Adler32() {
     return new Adler32();
   this._binding = new binding.Adler32();
   Transform.call(this);
+  this._writableState.objectMode = false;
+  this._readableState.objectMode = true;
 }
 
 util.inherits(Adler32, Transform);
@@ -653,8 +665,6 @@ Adler32.prototype._transform = function(chunk, encoding, callback) {
 };
 
 Adler32.prototype._flush = function(callback) {
-  var buffer = new Buffer(4);
-  buffer.writeUInt32LE(this._binding.digest());
-  this.push(buffer);
+  this.push(this._binding.digest());
   callback();
 };

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -629,9 +629,7 @@ function CRC32() {
   if (!(this instanceof CRC32))
     return new CRC32();
   this._binding = new binding.CRC32();
-  Transform.call(this);
-  this._writableState.objectMode = false;
-  this._readableState.objectMode = true;
+  Transform.call(this, { readableObjectMode : true });
 }
 
 util.inherits(CRC32, Transform);
@@ -652,9 +650,7 @@ function Adler32() {
   if (!(this instanceof Adler32))
     return new Adler32();
   this._binding = new binding.Adler32();
-  Transform.call(this);
-  this._writableState.objectMode = false;
-  this._readableState.objectMode = true;
+  Transform.call(this, { readableObjectMode : true });
 }
 
 util.inherits(Adler32, Transform);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -611,3 +611,50 @@ util.inherits(Gunzip, Zlib);
 util.inherits(DeflateRaw, Zlib);
 util.inherits(InflateRaw, Zlib);
 util.inherits(Unzip, Zlib);
+
+
+
+exports.createCRC32 = exports.CRC32 = CRC32;
+function CRC32() {
+  if (!(this instanceof CRC32))
+    return new CRC32();
+  this._binding = new binding.CRC32();
+  Transform.call(this);
+}
+
+util.inherits(CRC32, Transform);
+
+CRC32.prototype._transform = function(chunk, encoding, callback) {
+  this._binding.update(chunk);
+  callback();
+};
+
+CRC32.prototype._flush = function(callback) {
+  var buffer = new Buffer(4);
+  buffer.writeUInt32LE(this._binding.digest());
+  this.push(buffer);
+  callback();
+};
+
+
+exports.createAdler32 = exports.Adler32 = Adler32;
+function Adler32() {
+  if (!(this instanceof Adler32))
+    return new Adler32();
+  this._binding = new binding.Adler32();
+  Transform.call(this);
+}
+
+util.inherits(Adler32, Transform);
+
+Adler32.prototype._transform = function(chunk, encoding, callback) {
+  this._binding.update(chunk);
+  callback();
+};
+
+Adler32.prototype._flush = function(callback) {
+  var buffer = new Buffer(4);
+  buffer.writeUInt32LE(this._binding.digest());
+  this.push(buffer);
+  callback();
+};

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -608,6 +608,56 @@ class ZCtx : public AsyncWrap {
 };
 
 
+void Adler32(const FunctionCallbackInfo<Value>& args) {
+  HandleScope handle_scope(args.GetIsolate());
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+
+  if (!Buffer::HasInstance(args[0])) {
+    return env->ThrowTypeError("Must give a Buffer as first argument");
+  }
+
+  uLong adler;
+
+  if (args.Length() == 1) {
+    // get initial value
+    adler = adler32(0L, Z_NULL, 0);
+  } else {
+    adler = args[1]->Uint32Value();
+  }
+
+  Local<Object> buf = args[0]->ToObject();
+
+  adler = adler32(adler, reinterpret_cast<Bytef *>(Buffer::Data(buf)), Buffer::Length(buf));
+
+  args.GetReturnValue().Set(Number::New(env->isolate(), adler));
+}
+
+
+void CRC32(const FunctionCallbackInfo<Value>& args) {
+  HandleScope handle_scope(args.GetIsolate());
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+
+  if (!Buffer::HasInstance(args[0])) {
+    return env->ThrowTypeError("Must give a Buffer as first argument");
+  }
+
+  uLong crc;
+
+  if (args.Length() == 1) {
+    // get initial value
+    crc = crc32(0L, Z_NULL, 0);
+  } else {
+    crc = args[1]->Uint32Value();
+  }
+
+  Local<Object> buf = args[0]->ToObject();
+
+  crc = crc32(crc, reinterpret_cast<Bytef *>(Buffer::Data(buf)), Buffer::Length(buf));
+
+  args.GetReturnValue().Set(Number::New(env->isolate(), crc));
+}
+
+
 void InitZlib(Handle<Object> target,
               Handle<Value> unused,
               Handle<Context> context,
@@ -626,6 +676,9 @@ void InitZlib(Handle<Object> target,
 
   z->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib"));
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib"), z->GetFunction());
+
+  NODE_SET_METHOD(target, "adler32", Adler32);
+  NODE_SET_METHOD(target, "crc32", CRC32);
 
   // valid flush values.
   NODE_DEFINE_CONSTANT(target, Z_NO_FLUSH);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -608,6 +608,61 @@ class ZCtx : public AsyncWrap {
 };
 
 
+template <uLong (*update)(uLong checksum, const Bytef *buf, uInt len)>
+class Checksum : public BaseObject {
+public:
+  static void Initialize(Environment* env, v8::Handle<v8::Object> target, v8::Handle<v8::String> name) {
+    Local<FunctionTemplate> t = FunctionTemplate::New(env->isolate(), New);
+
+    t->InstanceTemplate()->SetInternalFieldCount(1);
+
+    NODE_SET_PROTOTYPE_METHOD(t, "update", ChecksumUpdate);
+    NODE_SET_PROTOTYPE_METHOD(t, "digest", ChecksumDigest);
+
+    target->Set(name, t->GetFunction());
+  }
+
+protected:
+  static void New(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    HandleScope scope(env->isolate());
+
+    Checksum* checksum = new Checksum(env, args.This());
+  }
+
+  static void ChecksumUpdate(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    HandleScope scope(env->isolate());
+
+    Checksum* checksum = Unwrap<Checksum>(args.This());
+
+    assert(Buffer::HasInstance(args[0]));
+
+    char* buf = Buffer::Data(args[0]);
+    size_t buflen = Buffer::Length(args[0]);
+    checksum->checksum_ = update(checksum->checksum_, reinterpret_cast<Bytef *>(buf), buflen);
+  }
+
+  static void ChecksumDigest(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    HandleScope scope(env->isolate());
+
+    Checksum* checksum = Unwrap<Checksum>(args.This());
+
+    args.GetReturnValue().Set(Number::New(env->isolate(), checksum->checksum_));
+  }
+
+  Checksum(Environment* env, v8::Local<v8::Object> wrap)
+      : BaseObject(env, wrap),
+        checksum_(update(0L, Z_NULL, 0)) {
+    MakeWeak<Checksum>(this);
+  }
+
+private:
+  uLong checksum_;
+};
+
+
 void Adler32(const FunctionCallbackInfo<Value>& args) {
   HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
@@ -676,6 +731,9 @@ void InitZlib(Handle<Object> target,
 
   z->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib"));
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib"), z->GetFunction());
+
+  Checksum<adler32>::Initialize(env, target, FIXED_ONE_BYTE_STRING(env->isolate(), "Adler32"));
+  Checksum<crc32>::Initialize(env, target, FIXED_ONE_BYTE_STRING(env->isolate(), "CRC32"));
 
   NODE_SET_METHOD(target, "adler32", Adler32);
   NODE_SET_METHOD(target, "crc32", CRC32);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -663,56 +663,6 @@ private:
 };
 
 
-void Adler32(const FunctionCallbackInfo<Value>& args) {
-  HandleScope handle_scope(args.GetIsolate());
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-
-  if (!Buffer::HasInstance(args[0])) {
-    return env->ThrowTypeError("Must give a Buffer as first argument");
-  }
-
-  uLong adler;
-
-  if (args.Length() == 1) {
-    // get initial value
-    adler = adler32(0L, Z_NULL, 0);
-  } else {
-    adler = args[1]->Uint32Value();
-  }
-
-  Local<Object> buf = args[0]->ToObject();
-
-  adler = adler32(adler, reinterpret_cast<Bytef *>(Buffer::Data(buf)), Buffer::Length(buf));
-
-  args.GetReturnValue().Set(Number::New(env->isolate(), adler));
-}
-
-
-void CRC32(const FunctionCallbackInfo<Value>& args) {
-  HandleScope handle_scope(args.GetIsolate());
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-
-  if (!Buffer::HasInstance(args[0])) {
-    return env->ThrowTypeError("Must give a Buffer as first argument");
-  }
-
-  uLong crc;
-
-  if (args.Length() == 1) {
-    // get initial value
-    crc = crc32(0L, Z_NULL, 0);
-  } else {
-    crc = args[1]->Uint32Value();
-  }
-
-  Local<Object> buf = args[0]->ToObject();
-
-  crc = crc32(crc, reinterpret_cast<Bytef *>(Buffer::Data(buf)), Buffer::Length(buf));
-
-  args.GetReturnValue().Set(Number::New(env->isolate(), crc));
-}
-
-
 void InitZlib(Handle<Object> target,
               Handle<Value> unused,
               Handle<Context> context,
@@ -734,9 +684,6 @@ void InitZlib(Handle<Object> target,
 
   Checksum<adler32>::Initialize(env, target, FIXED_ONE_BYTE_STRING(env->isolate(), "Adler32"));
   Checksum<crc32>::Initialize(env, target, FIXED_ONE_BYTE_STRING(env->isolate(), "CRC32"));
-
-  NODE_SET_METHOD(target, "adler32", Adler32);
-  NODE_SET_METHOD(target, "crc32", CRC32);
 
   // valid flush values.
   NODE_DEFINE_CONSTANT(target, Z_NO_FLUSH);

--- a/test/simple/test-zlib-checksums.js
+++ b/test/simple/test-zlib-checksums.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var assert = require('assert');
+var zlib = require('zlib');
+
+// checksum functions
+
+assert.equal(zlib.crc32('Test123'), 1072274215);
+assert.equal(zlib.adler32('Test123'), 166330935);
+
+assert.equal(zlib.crc32(new Buffer('Test123')), 1072274215);
+assert.equal(zlib.adler32(new Buffer('Test123')), 166330935);
+
+// stream interface should produce the same result.
+
+var crc = zlib.createCRC32();
+crc.write('Te');
+crc.write('st');
+crc.write('123');
+crc.end();
+assert.equal(crc.read(), 1072274215);
+
+var adler = zlib.createAdler32();
+adler.write('Te');
+adler.write('st');
+adler.write('123');
+adler.end();
+assert.equal(adler.read(), 166330935);


### PR DESCRIPTION
Continuing from #7213.

I couldn't think of a way to make a streaming interface without over-complicating the API, and it seems like something that could be easily implemented by a user-land library. But if someone can do some benchmarking and show that marshaling the running checksum between JS and C++ causes a significant performance loss, it will be a good reason to reconsider.

The proposed API is pretty straightforward. If it LGTY, I'll add docs and tests.
