### PR TITLE
util: format add %t placeholder for calling inspect to serialize

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var formatRegExp = /%[sdj%]/g;
+var formatRegExp = /%[sdjt%]/g;
 exports.format = function(f) {
   if (!isString(f)) {
     var objects = [];
@@ -38,6 +38,7 @@ exports.format = function(f) {
     switch (x) {
       case '%s': return String(args[i++]);
       case '%d': return Number(args[i++]);
+      case '%t': return inspect(args[i++]);
       case '%j':
         try {
           return JSON.stringify(args[i++]);

--- a/test/simple/test-util-format.js
+++ b/test/simple/test-util-format.js
@@ -42,11 +42,13 @@ assert.equal(util.format('%d', 42.0), '42');
 assert.equal(util.format('%d', 42), '42');
 assert.equal(util.format('%s', 42), '42');
 assert.equal(util.format('%j', 42), '42');
+assert.equal(util.format('%t', 42), '42');
 
 assert.equal(util.format('%d', '42.0'), '42');
 assert.equal(util.format('%d', '42'), '42');
 assert.equal(util.format('%s', '42'), '42');
 assert.equal(util.format('%j', '42'), '"42"');
+assert.equal(util.format('%t', '42'), '\'42\'');
 
 assert.equal(util.format('%%s%s', 'foo'), '%sfoo');
 
@@ -65,6 +67,18 @@ assert.equal(util.format('%%%s%%%%', 'hi'), '%hi%%');
   var o = {};
   o.o = o;
   assert.equal(util.format('%j', o), '[Circular]');
+})();
+
+// customInspect
+(function() {
+  var o = {
+    name: 'name',
+    inspect: function()
+    {
+      return 'custom';
+    }
+  };
+  assert.equal(util.format('%t', o), 'custom');
 })();
 
 // Errors


### PR DESCRIPTION
`util.format` add `%t` placeholder for calling `inspect` to serialize object
- This is very convenient for calling `util.inspect` method in `util.format`.
- Compared with json(`%j`), it can be serialized width `customInspect` opt. It is useful for serializing other Object (eg: `Data`) in format.
