### PR TITLE
streams: remove unused require('assert')

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -27,7 +27,6 @@ module.exports = Writable;
 Writable.WritableState = WritableState;
 
 var util = require('util');
-var assert = require('assert');
 var Stream = require('stream');
 
 util.inherits(Writable, Stream);


### PR DESCRIPTION
thanks to @calvinmetcalf for noticing this. [ref](https://github.com/isaacs/readable-stream/issues/88)

only in v0.10.
