### PR TITLE
The docs for readLine.pause are misleading.

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -119,6 +119,8 @@ Example usage:
 
 Pauses the readline `input` stream, allowing it to be resumed later if needed.
 
+Note that this doesn't immediately pause the stream of events. Several events may be emitted after calling `pause`, including `line`.
+
 ### rl.resume()
 
 Resumes the readline `input` stream.


### PR DESCRIPTION
I seriously spent hours on this. If it isn't a bug, at least it should be well documented.

Someone else stumbled on this too: http://stackoverflow.com/questions/21341050/pausing-readline-in-node-js
