### PR TITLE
correct tls docs. server -> client

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -291,7 +291,7 @@ Creates a new client connection to the given `port` and `host` (old API) or
     are ignored.
 
   - `pfx`: A string or `Buffer` containing the private key, certificate and
-    CA certs of the server in PFX or PKCS12 format.
+    CA certs of the client in PFX or PKCS12 format.
 
   - `key`: A string or `Buffer` containing the private key of the client in
     PEM format.


### PR DESCRIPTION
when a pfx file is passed to tls.connection, it is the client private key, not the server's private key.
