### PR TITLE
main: Handle SIGINT properly.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2800,9 +2800,13 @@ static void AtExit() {
 
 
 static void SignalExit(int signo) {
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_flags = SA_RESETHAND;
+  sigaction(signo, &sa, NULL);
+
   uv_tty_reset_mode();
-  signal(signo, SIG_DFL);
-  kill(getpid(), signo);
+  raise(signo);
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2799,9 +2799,10 @@ static void AtExit() {
 }
 
 
-static void SignalExit(int signal) {
+static void SignalExit(int signo) {
   uv_tty_reset_mode();
-  _exit(128 + signal);
+  signal(signo, SIG_DFL);
+  kill(getpid(), signo);
 }
 
 


### PR DESCRIPTION
As explained by http://www.cons.org/cracauer/sigint.html

TL;DR: If a process catches SIGINT in order to do some cleanup before exiting, it should kill itself with the default SIGINT handler once cleanup is done.
