### PR TITLE
Patch test to be endian aware

### DIFF
--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -21,6 +21,7 @@
 
 var common = require('../common');
 var assert = require('assert');
+var os = require('os');
 
 // first grab js api's
 var smalloc = require('smalloc');
@@ -150,8 +151,13 @@ for (var i = 0; i < 6; i++) {
 
 var b = alloc(1, Types.Double);
 var c = alloc(2, Types.Uint32);
-c[0] = 2576980378;
-c[1] = 1069128089;
+if (os.endianness() === 'LE') {
+  c[0] = 2576980378;
+  c[1] = 1069128089;
+} else {
+  c[0] = 1069128089;
+  c[1] = 2576980378;
+}
 copyOnto(c, 0, b, 0, 2);
 assert.equal(b[0], 0.1);
 

--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -33,6 +33,7 @@ var Types = smalloc.Types;
 // sliceOnto is volatile and cannot be exposed to users.
 var sliceOnto = process.binding('smalloc').sliceOnto;
 
+
 // verify allocation
 
 var b = alloc(5, {});
@@ -150,7 +151,7 @@ for (var i = 0; i < 6; i++) {
 
 var b = alloc(1, Types.Double);
 var c = alloc(2, Types.Uint32);
-if(os.endianness() == 'LE') {
+if (os.endianness() === 'LE') {
   c[0] = 2576980378;
   c[1] = 1069128089;
 } else {

--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -21,6 +21,7 @@
 
 var common = require('../common');
 var assert = require('assert');
+var os = require('os');
 
 // first grab js api's
 var smalloc = require('smalloc');
@@ -31,12 +32,6 @@ var kMaxLength = smalloc.kMaxLength;
 var Types = smalloc.Types;
 // sliceOnto is volatile and cannot be exposed to users.
 var sliceOnto = process.binding('smalloc').sliceOnto;
-
-// Helper to determine endian - returns true on little endian platforms
-function isLittleEndian() {
-  return ((new Uint32Array((new Uint8Array([4,3,2,1])).buffer))[0])
-           == 0x01020304;
-}
 
 // verify allocation
 
@@ -155,7 +150,7 @@ for (var i = 0; i < 6; i++) {
 
 var b = alloc(1, Types.Double);
 var c = alloc(2, Types.Uint32);
-if(isLittleEndian()) {
+if(os.endianness() == 'LE') {
   c[0] = 2576980378;
   c[1] = 1069128089;
 } else {

--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -32,6 +32,11 @@ var Types = smalloc.Types;
 // sliceOnto is volatile and cannot be exposed to users.
 var sliceOnto = process.binding('smalloc').sliceOnto;
 
+// Helper to determine endian - returns true on little endian platforms
+function isLittleEndian() {
+  return ((new Uint32Array((new Uint8Array([4,3,2,1])).buffer))[0])
+           == 0x01020304;
+}
 
 // verify allocation
 
@@ -150,8 +155,13 @@ for (var i = 0; i < 6; i++) {
 
 var b = alloc(1, Types.Double);
 var c = alloc(2, Types.Uint32);
-c[0] = 2576980378;
-c[1] = 1069128089;
+if(isLittleEndian()) {
+  c[0] = 2576980378;
+  c[1] = 1069128089;
+} else {
+  c[0] = 1069128089;
+  c[1] = 2576980378;
+}
 copyOnto(c, 0, b, 0, 2);
 assert.equal(b[0], 0.1);
 


### PR DESCRIPTION
The test/simple/test-smalloc.js has an implicit assumption
of the byte order of the data stored for Double and Uint32
values. On a big endian platform this test fails without
these patches.

An isLittleEndian() helper is introduced, and it is used
to gate the static value used for comparison.
