### PR TITLE
configure: make --v8-options switch more robust

### DIFF
--- a/configure
+++ b/configure
@@ -207,8 +207,7 @@ parser.add_option('--tag',
 parser.add_option('--v8-options',
     action='store',
     dest='v8_options',
-    help='v8 options to pass, see `node --v8-options` for examples. '
-         'The flags should be separated by a comma')
+    help='v8 options to pass, see `node --v8-options` for examples.')
 
 parser.add_option('--with-arm-float-abi',
     action='store',
@@ -520,10 +519,7 @@ def configure_node(o):
     o['variables']['node_tag'] = ''
 
   if options.v8_options:
-    opts = options.v8_options.split(',')
-    o['variables']['node_v8_options'] = '"' + '","'.join(opts) + '"'
-  else:
-    o['variables']['node_v8_options'] = ''
+    o['variables']['node_v8_options'] = options.v8_options.replace('"', '\\"')
 
 
 def configure_libz(o):

--- a/node.gyp
+++ b/node.gyp
@@ -160,7 +160,7 @@
         'ARCH="<(target_arch)"',
         'PLATFORM="<(OS)"',
         'NODE_TAG="<(node_tag)"',
-        'NODE_V8_OPTIONS=<(node_v8_options)',
+        'NODE_V8_OPTIONS="<(node_v8_options)"',
       ],
 
       'conditions': [

--- a/src/node.cc
+++ b/src/node.cc
@@ -3062,26 +3062,6 @@ static void ParseArgs(int* argc,
 }
 
 
-static void SetCompileTimeV8Options(const char** argv) {
-#ifdef NODE_V8_OPTIONS
-  int v8_argc;
-  static const char* v8_argv[] = { NULL, NODE_V8_OPTIONS };
-  if (ARRAY_SIZE(v8_argv) == 1)
-    return;
-
-  v8_argv[0] = argv[0];
-  v8_argc = ARRAY_SIZE(v8_argv);
-  V8::SetFlagsFromCommandLine(&v8_argc, const_cast<char**>(v8_argv), true);
-
-  // Anything that's still in v8_argv is not a V8 or a node option.
-  for (int i = 1; i < v8_argc; i++)
-    fprintf(stderr, "%s: bad option: %s\n", argv[0], v8_argv[i]);
-  if (v8_argc > 1)
-    exit(9);
-#endif  // NODE_V8_OPTIONS
-}
-
-
 // Called from V8 Debug Agent TCP thread.
 static void DispatchMessagesDebugAgentCallback() {
   uv_async_send(&dispatch_debug_messages_async);
@@ -3375,7 +3355,12 @@ void Init(int* argc,
                 DispatchDebugMessagesAsyncCallback);
   uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
-  SetCompileTimeV8Options(argv);
+#if defined(NODE_V8_OPTIONS)
+  // Should come before the call to V8::SetFlagsFromCommandLine()
+  // so the user can disable a flag --foo at run-time by passing
+  // --no_foo from the command line.
+  V8::SetFlagsFromString(NODE_V8_OPTIONS, sizeof(NODE_V8_OPTIONS) - 1);
+#endif
 
   // Parse a few arguments which are specific to Node.
   int v8_argc;


### PR DESCRIPTION
Improve on commit b55c9d6 by not requiring that switches are comma
separated.  This commit makes `./configure --v8-options="--foo --bar"`
work and takes special care to properly escape quotes in the options
string.

R=@indutny
