### PR TITLE
made util.isArray a direct alias for Array.isArray

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -167,6 +167,8 @@ formatted according to the returned Object. This is similar to how
 
 ## util.isArray(object)
 
+Internal alias for Array.isArray.
+
 Returns `true` if the given "object" is an `Array`. `false` otherwise.
 
     var util = require('util');

--- a/lib/util.js
+++ b/lib/util.js
@@ -505,10 +505,7 @@ function reduceToSingleString(output, base, braces) {
 
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
-function isArray(ar) {
-  return Array.isArray(ar);
-}
-exports.isArray = isArray;
+var isArray = exports.isArray = Array.isArray;
 
 function isBoolean(arg) {
   return typeof arg === 'boolean';


### PR DESCRIPTION
Previously we were wrapping Array.isArray. Now I just alias it over, and I noted in the docs that nothing is special about this.
