### PR TITLE
Buffer: concat multi buffers

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -163,13 +163,8 @@ Buffer.concat = function(list, length) {
 
   var buffer = new Buffer(length);
   var pos = 0;
-  for (var i = 0; i < list.length; i++) {
-
-    if (pos > length) break;
-
-    var buf = list[i];
-    buf.copy(buffer, pos);
-    pos += buf.length;
+  for (var i = 0; i < list.length && pos < length; i++) {
+    pos += list[i].copy(buffer, pos);
   }
 
   return buffer;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -164,6 +164,9 @@ Buffer.concat = function(list, length) {
   var buffer = new Buffer(length);
   var pos = 0;
   for (var i = 0; i < list.length; i++) {
+
+    if (pos > length) break;
+
     var buf = list[i];
     buf.copy(buffer, pos);
     pos += buf.length;

--- a/test/simple/test-buffer-concat.js
+++ b/test/simple/test-buffer-concat.js
@@ -32,6 +32,15 @@ var flatOne = Buffer.concat(one);
 var flatLong = Buffer.concat(long);
 var flatLongLen = Buffer.concat(long, 40);
 
+var buf1 = new Buffer('abcdefg');
+var buf2 = new Buffer('hijklmn');
+var buf3 = new Buffer('opq');
+
+var buf = Buffer.concat([buf1, buf2, buf3], buf1.length);
+assert(buf.length === buf1.length);
+buf = Buffer.concat([buf1, buf2, buf3], 10);
+assert(buf.length === 10);
+
 assert(flatZero.length === 0);
 assert(flatOne.toString() === 'asdf');
 assert(flatOne === one[0]);


### PR DESCRIPTION
When use `Buffer.concat` like below:

``` js
  var buf1 = new Buffer('hello');
  var buf2 = new Buffer('world');
  var buf = Buffer.concat([buf1, buf2], 6);
  console.log(buf.toString() + '  :  ' + buf.length);      // hellow : 6
```

 It's ok. 
But, if **totalLength** less than `listBuffers.length - lastBuffer.length` , it will throw a **RangeError**.

``` js
  var buf1 = new Buffer('hello');
  var buf2 = new Buffer('world');
  var buf = Buffer.concat([buf1, buf2], 4);   // throw new RangeError
```

I think, if someone specified **totalLength**, maybe they just want a buffer has that length.
So, return a buffer with that length may be better than throw an error.
