### PR TITLE
events: check, if `_events` is an own property

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -49,7 +49,10 @@ EventEmitter.init = function() {
       this.domain = domain.active;
     }
   }
-  this._events = this._events || {};
+
+  if (!this._events || this._events === Object.getPrototypeOf(this)._events)
+    this._events = {};
+
   this._maxListeners = this._maxListeners || undefined;
 };
 

--- a/test/simple/test-event-emitter-subclass.js
+++ b/test/simple/test-event-emitter-subclass.js
@@ -53,3 +53,17 @@ process.on('exit', function() {
   assert.deepEqual(myee._events, {});
   console.log('ok');
 });
+
+
+function MyEE2() {
+  EventEmitter.call(this);
+}
+
+MyEE2.prototype = new EventEmitter();
+
+var ee1 = new MyEE2();
+var ee2 = new MyEE2();
+
+ee1.on('x', function () {});
+
+assert.equal(EventEmitter.listenerCount(ee2, 'x'), 0);


### PR DESCRIPTION
Rework of #7158. Differences:
- instead of extending existing `_events`, just check if they are an own property;
- no performance impact in general case.

In case `_events` exists instead of `!this.hasOwnProperty('_events')` `this._events === this.__proto__._events` is used, which is slightly faster.
