### PR TITLE
Fix querystring.stringify( {array: []} ). Now it returns "array="

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -138,7 +138,7 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq) {
       if (util.isArray(obj[k])) {
         return obj[k].map(function(v) {
           return ks + QueryString.escape(stringifyPrimitive(v));
-        }).join(sep);
+        }).join(sep) || ks;
       } else {
         return ks + QueryString.escape(stringifyPrimitive(obj[k]));
       }

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -87,7 +87,8 @@ var qsWeirdObjects = [
   [{f: false, t: true}, 'f=false&t=true', {'f': 'false', 't': 'true'}],
   [{n: null}, 'n=', {'n': ''}],
   [{nan: NaN}, 'nan=', {'nan': ''}],
-  [{inf: Infinity}, 'inf=', {'inf': ''}]
+  [{inf: Infinity}, 'inf=', {'inf': ''}],
+  [{array: []}, 'array=', {'array': ''}]
 ];
 // }}}
 


### PR DESCRIPTION
I found strange behavior of `QueryString.stringify( {array: []} ) === ""`
Other strange cases usually returns something like `"key="`
For example:

``` javascript
QueryString.stringify( {a: [], b: undefined, c: null, d: NaN, e: ""} ); 
// "&b=&c=&d=&e="
```

So for conveniece it should be:

``` javascript
QueryString.stringify( {array: []} )
// "array="
```
