### PR TITLE
Fix for UInt32 returning signed int

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -469,8 +469,8 @@ Buffer.prototype.readUInt32BE = function(offset, noAssert) {
 
   return (this[offset] * 0x1000000) +
       ((this[offset + 1] << 16) |
-      (this[offset + 2] << 8)) |
-      (this[offset + 3]);
+      (this[offset + 2] << 8) |
+      (this[offset + 3]) >>> 0);
 };
 
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -914,6 +914,13 @@ var buf = new Buffer(0);
 assert.throws(function() { buf.readUInt8(0); }, RangeError);
 assert.throws(function() { buf.readInt8(0); }, RangeError);
 
+var buf = new Buffer([0xFF]);
+
+assert.equal(buf.readUInt8(0), 255);
+assert.equal(buf.readInt8(0), -1);
+
+
+
 [16, 32].forEach(function(bits) {
   var buf = new Buffer(bits / 8 - 1);
 
@@ -932,6 +939,22 @@ assert.throws(function() { buf.readInt8(0); }, RangeError);
   assert.throws(function() { buf['readInt' + bits + 'LE'](0); },
                 RangeError,
                 'readInt' + bits + 'LE()');
+});
+
+[16, 32].forEach(function(bits) {
+  var buf = new Buffer([0xFF, 0xFF, 0xFF, 0xFF]);
+
+  assert.equal(buf['readUInt' + bits + 'BE'](0),
+                (0xFFFFFFFF >>> (32 - bits)));
+
+  assert.equal(buf['readUInt' + bits + 'LE'](0),
+                (0xFFFFFFFF >>> (32 - bits)));
+
+  assert.equal(buf['readInt' + bits + 'BE'](0),
+                (0xFFFFFFFF >> (32 - bits)));
+
+  assert.equal(buf['readInt' + bits + 'LE'](0),
+                (0xFFFFFFFF >> (32 - bits)));
 });
 
 // test Buffer slice


### PR DESCRIPTION
Read UInt32 on v0.11.13-pre returns a signed integer if the MSB of the the 3rd byte is 1:

example:
-- UInt32.js
var b = new Buffer([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
var firstHalf = b.readUInt32BE(0);
console.log("ReadUIntBE32 (4294967295)" + firstHalf);

firstHalf = b.readUInt32LE(0);
console.log("ReadUIntLE32 (4294967295)" + firstHalf);

var firstHalf = b.readUInt16BE(0);
console.log("ReadUIntBE16 (4294967295)" + firstHalf);

firstHalf = b.readUInt16LE(0);
console.log("ReadUIntLE16 (4294967295)" + firstHalf); 
## 

 ./node --version  
v0.11.13-pre

./node UInt32.js 
ReadUIntBE32 (4294967295)-1
ReadUIntLE32 (4294967295)4294967295
ReadUIntBE16 (4294967295)65535
ReadUIntLE16 (4294967295)65535

 ./node --version  
v0.10.15

./node UInt32.js 
ReadUIntBE32 (4294967295)4294967295
ReadUIntLE32 (4294967295)4294967295
ReadUIntBE16 (4294967295)65535
ReadUIntLE16 (4294967295)65535
