### PR TITLE
contributing: clarify CONTRIBUTING.md to reflect actual branch names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Okay, so you have decided on the proper branch.  Create a feature branch
 and start hacking:
 
 ```
-$ git checkout -b my-feature-branch -t origin/v0.10
+$ git checkout -b my-feature-branch -t origin/v0.10-release
 ```
 
 (Where v0.10 is the latest stable branch as of this writing.)


### PR DESCRIPTION
While following the CONTRIBUTING.md document, the instructions provided caused me to get the following git error:

```
fatal: git checkout: updating paths is incompatible with switching branches.
```

By appending "-release" to the instructions, a person following CONTRIBUTING.md will be better assisted when running the command.

Thank you
