### PR TITLE
child_process: fix deadlock when sending handles

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -451,7 +451,8 @@ function setupChannel(target, channel) {
       if (obj.simultaneousAccepts) {
         net._setSimultaneousAccepts(handle);
       }
-    } else if (this._handleQueue) {
+    } else if (this._handleQueue &&
+               !(message && message.cmd === 'NODE_HANDLE_ACK')) {
       // Queue request anyway to avoid out-of-order messages.
       this._handleQueue.push({ message: message, handle: null });
       return;

--- a/test/simple/test-cluster-send-deadlock.js
+++ b/test/simple/test-cluster-send-deadlock.js
@@ -1,0 +1,65 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Testing mutual send of handles: from master to worker, and from worker to
+// master.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  var worker = cluster.fork();
+  worker.on('exit', function(code, signal) {
+    assert.equal(code, 0, 'Worker exited with an error code');
+    assert(!signal, 'Worker exited by a signal');
+    server.close();
+  });
+
+  var server = net.createServer(function(socket) {
+    worker.send('handle', socket);
+  });
+
+  server.listen(common.PORT, function() {
+    worker.send('listen');
+  });
+} else {
+  process.on('message', function(msg, handle) {
+    if (msg === 'listen') {
+      var client1 = net.connect({ host: 'localhost', port: common.PORT });
+      var client2 = net.connect({ host: 'localhost', port: common.PORT });
+      var waiting = 2;
+      client1.on('close', onclose);
+      client2.on('close', onclose);
+      function onclose() {
+        if (--waiting === 0)
+          cluster.worker.disconnect();
+      }
+      setTimeout(function() {
+        client1.end();
+        client2.end();
+      }, 50);
+    } else {
+      process.send('reply', handle);
+    }
+  });
+}


### PR DESCRIPTION
Fix possible deadlock, when handles are sent in both direction
simultaneously. In such rare cases, both sides may queue their
`NODE_HANDLE_ACK` replies and wait for them.

fix #7465
