### PR TITLE
tls: set _connecting before starting the flow

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -177,8 +177,8 @@ function TLSSocket(socket, options) {
   net.Socket.call(this, {
     handle: socket && socket._handle,
     allowHalfOpen: socket && socket.allowHalfOpen,
-    readable: true,
-    writable: true
+    readable: false,
+    writable: false
   });
 
   // To prevent assertion in afterConnect()
@@ -210,6 +210,12 @@ function TLSSocket(socket, options) {
   } else {
     this._init(socket);
   }
+
+  // Make sure to setup all required properties like: `_connecting` before
+  // starting the flow of the data
+  this.readable = true;
+  this.writable = true;
+  this.read(0);
 }
 util.inherits(TLSSocket, net.Socket);
 exports.TLSSocket = TLSSocket;


### PR DESCRIPTION
When creating a TLSSocket instance based on the existing connecting
socket, `_connecting` property is copied after the initialization of
`net.Socket`. However, since `net.Socket` constructor will call
`.read(0)` if the `readable` is true - error may happen at this code
chunk in net.js:

```
Socket.prototype._read = function(n) {
  debug('_read');

  if (this._connecting || !this._handle) {
    debug('_read wait for connection');
    this.once('connect', this._read.bind(this, n));
...
```

Leading to a test failures on windows:
- test/simple/test-tls-connect-given-socket.js

cc @orangemocha 
