### PR TITLE
stream: split `objectMode` for Duplex

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -68,6 +68,9 @@ function ReadableState(options, stream) {
   // make all the buffer merging and length checks go away
   this.objectMode = !!options.objectMode;
 
+  if (stream instanceof Stream.Duplex)
+    this.objectMode = this.objectMode || !!options.readableObjectMode;
+
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -51,6 +51,9 @@ function WritableState(options, stream) {
   // contains buffers or objects.
   this.objectMode = !!options.objectMode;
 
+  if (stream instanceof Stream.Duplex)
+    this.objectMode = this.objectMode || !!options.writableObjectMode;
+
   // cast to ints.
   this.highWaterMark = ~~this.highWaterMark;
 

--- a/test/simple/test-stream-duplex.js
+++ b/test/simple/test-stream-duplex.js
@@ -26,6 +26,9 @@ var Duplex = require('stream').Transform;
 
 var stream = new Duplex({ objectMode: true });
 
+assert(stream._readableState.objectMode);
+assert(stream._writableState.objectMode);
+
 var written;
 var read;
 

--- a/test/simple/test-stream-duplex.js
+++ b/test/simple/test-stream-duplex.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var Duplex = require('stream').Transform;
+
+var stream = new Duplex({ objectMode: true });
+
+var written;
+var read;
+
+stream._write = function (obj, _, cb) {
+  written = obj;
+  cb();
+};
+
+stream._read = function () {};
+
+stream.on('data', function (obj) {
+  read = obj;
+});
+
+stream.push({ val: 1 });
+stream.end({ val: 2 });
+
+process.on('exit', function () {
+  assert(read.val === 1);
+  assert(written.val === 2);
+});

--- a/test/simple/test-stream-transform-split-objectmode.js
+++ b/test/simple/test-stream-transform-split-objectmode.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var Transform = require('stream').Transform;
+
+var parser = new Transform({ readableObjectMode : true });
+
+parser._transform = function (chunk, enc, callback) {
+  callback(null, { val : chunk[0] });
+};
+
+var parsed;
+
+parser.on('data', function (obj) {
+  parsed = obj;
+});
+
+parser.end(new Buffer([42]));
+
+process.on('exit', function () {
+  assert(parsed.val === 42);
+});
+
+
+var serializer = new Transform({ writableObjectMode : true });
+
+serializer._transform = function (obj, _, callback) {
+  callback(null, new Buffer([obj.val]));
+}
+
+var serialized;
+
+serializer.on('data', function (chunk) {
+  serialized = chunk;
+});
+
+serializer.write({ val : 42 });
+
+process.on('exit', function () {
+  assert(serialized[0] === 42);
+});

--- a/test/simple/test-stream-transform-split-objectmode.js
+++ b/test/simple/test-stream-transform-split-objectmode.js
@@ -26,6 +26,9 @@ var Transform = require('stream').Transform;
 
 var parser = new Transform({ readableObjectMode : true });
 
+assert(parser._readableState.objectMode);
+assert(!parser._writableState.objectMode);
+
 parser._transform = function (chunk, enc, callback) {
   callback(null, { val : chunk[0] });
 };
@@ -44,6 +47,9 @@ process.on('exit', function () {
 
 
 var serializer = new Transform({ writableObjectMode : true });
+
+assert(!serializer._readableState.objectMode);
+assert(serializer._writableState.objectMode);
 
 serializer._transform = function (obj, _, callback) {
   callback(null, new Buffer([obj.val]));


### PR DESCRIPTION
This PR introduces `readableObjectMode` and `writableObjectMode` options for Duplex streams.

This can be used mostly to make parsers and serializers with Transform streams.

Also the docs section about stream state objects is removed, because it is not relevant anymore.

fixes #6284
