### PR TITLE
npm 1.4.7

### DIFF
--- a/deps/npm/.travis.yml
+++ b/deps/npm/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+script: "npm run-script tap"
+node_js:
+  - "0.11"
+  - "0.10"

--- a/deps/npm/Makefile
+++ b/deps/npm/Makefile
@@ -169,7 +169,6 @@ publish: link doc
 	git push origin &&\
 	git push origin --tags &&\
 	npm publish &&\
-	npm tag npm@$(shell npm -v) $(shell npm -v | awk -F. '{print $$1 "." $$2}') &&\
 	make doc-publish &&\
 	make zip-publish
 

--- a/deps/npm/README.md
+++ b/deps/npm/README.md
@@ -1,6 +1,6 @@
 npm(1) -- node package manager
 ==============================
-
+[![Build Status](https://img.shields.io/travis/npm/npm/master.svg)](https://travis-ci.org/npm/npm)
 ## SYNOPSIS
 
 This is just enough info to get you up and running.

--- a/deps/npm/doc/files/package.json.md
+++ b/deps/npm/doc/files/package.json.md
@@ -404,6 +404,40 @@ can consume the functionality without requiring them to compile it
 themselves.  In dev mode (ie, locally running `npm install`), it'll
 run this script as well, so that you can test it easily.
 
+## peerDependencies
+
+In some cases, you want to express the compatibility of your package with an
+host tool or library, while not necessarily doing a `require` of this host.
+This is usually refered to as a *plugin*. Notably, your module may be exposing
+a specific interface, expected and specified by the host documentation.
+
+For example:
+
+    {
+      "name": "tea-latte",
+      "version": "1.3.5"
+      "peerDependencies": {
+        "tea": "2.x"
+      }
+    }
+
+This ensures your package `tea-latte` can be installed *along* with the second
+major version of the host package `tea` only. The host package is automatically
+installed if needed. `npm install tea-latte` could possibly yield the following
+dependency graph:
+
+    ├── tea-latte@1.3.5
+    └── tea@2.2.0
+
+Trying to install another plugin with a conflicting requirement will cause an
+error. For this reason, make sure your plugin requirement is as broad as
+possible, and not to lock it down to specific patch versions.
+
+Assuming the host complies with [semver](http://semver.org/), only changes in
+the host package's major version will break your plugin. Thus, if you've worked
+with every 1.x version of the host package, use `"^1.0"` or `"1.x"` to express
+this. If you depend on features introduced in 1.5.2, use `">= 1.5.2 < 2"`.
+
 ## bundledDependencies
 
 Array of package names that will be bundled when publishing the package.

--- a/deps/npm/doc/misc/npm-config.md
+++ b/deps/npm/doc/misc/npm-config.md
@@ -648,6 +648,19 @@ devDependencies hash.
 
 Only works if there is already a package.json file present.
 
+### save-prefix
+
+* Default: '^'
+* Type: String
+
+Configure how versions of packages installed to a package.json file via 
+`--save` or `--save-dev` get prefixed.
+
+For example if a package has version `1.2.3`, by default it's version is
+set to `^1.2.3` which allows minor upgrades for that package, but after  
+`npm config set save-prefix='~'` it would be set to `~1.2.3` which only allows
+patch upgrades.
+
 ### searchopts
 
 * Default: ""

--- a/deps/npm/doc/misc/npm-faq.md
+++ b/deps/npm/doc/misc/npm-faq.md
@@ -77,7 +77,7 @@ npm will not help you do something that is known to be a bad idea.
 
 Mikeal Rogers answered this question very well:
 
-<http://www.mikealrogers.com/posts/nodemodules-in-git.html>
+<http://www.futurealoof.com/posts/nodemodules-in-git.html>
 
 tl;dr
 

--- a/deps/npm/html/doc/README.html
+++ b/deps/npm/html/doc/README.html
@@ -3,6 +3,7 @@
   <title>README</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/<a href="../doc/README.html">README</a>.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -10,7 +11,8 @@
 
 <h1><a href="cli/npm.html">npm</a></h1> <p>node package manager</p>
 
-<h2 id="SYNOPSIS">SYNOPSIS</h2>
+<p><a href="https://img.shields.io/travis/npm/npm/master.svg)](https://travis-ci.org/npm/npm">![Build Status</a>
+## SYNOPSIS</p>
 
 <p>This is just enough info to get you up and running.</p>
 
@@ -254,5 +256,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@1.4.6</p>
+<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-bin.html
+++ b/deps/npm/html/doc/api/npm-bin.html
@@ -3,6 +3,7 @@
   <title>npm-bin</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-bin.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -31,5 +32,5 @@ to the <code>npm.bin</code> member.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@1.4.6</p>
+<p id="footer">npm-bin &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-bugs.html
+++ b/deps/npm/html/doc/api/npm-bugs.html
@@ -3,6 +3,7 @@
   <title>npm-bugs</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-bugs.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@1.4.6</p>
+<p id="footer">npm-bugs &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-commands.html
+++ b/deps/npm/html/doc/api/npm-commands.html
@@ -3,6 +3,7 @@
   <title>npm-commands</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-commands.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -40,5 +41,5 @@ usage, or <code>man 3 npm-&lt;command&gt;</code> for programmatic usage.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-commands &mdash; npm@1.4.6</p>
+<p id="footer">npm-commands &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-config.html
+++ b/deps/npm/html/doc/api/npm-config.html
@@ -3,6 +3,7 @@
   <title>npm-config</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-config.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -45,5 +46,5 @@ functions instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@1.4.6</p>
+<p id="footer">npm-config &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-deprecate.html
+++ b/deps/npm/html/doc/api/npm-deprecate.html
@@ -3,6 +3,7 @@
   <title>npm-deprecate</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-deprecate.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -44,5 +45,5 @@ install the package.</p></li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@1.4.6</p>
+<p id="footer">npm-deprecate &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-docs.html
+++ b/deps/npm/html/doc/api/npm-docs.html
@@ -3,6 +3,7 @@
   <title>npm-docs</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-docs.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@1.4.6</p>
+<p id="footer">npm-docs &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-edit.html
+++ b/deps/npm/html/doc/api/npm-edit.html
@@ -3,6 +3,7 @@
   <title>npm-edit</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-edit.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -42,5 +43,5 @@ and how this is used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@1.4.6</p>
+<p id="footer">npm-edit &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-explore.html
+++ b/deps/npm/html/doc/api/npm-explore.html
@@ -3,6 +3,7 @@
   <title>npm-explore</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-explore.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -36,5 +37,5 @@ sure to use <code>npm rebuild &lt;pkg&gt;</code> if you make any changes.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@1.4.6</p>
+<p id="footer">npm-explore &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-help-search.html
+++ b/deps/npm/html/doc/api/npm-help-search.html
@@ -3,6 +3,7 @@
   <title>npm-help-search</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-help-search.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -44,5 +45,5 @@ Name of the file that matched</li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@1.4.6</p>
+<p id="footer">npm-help-search &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-init.html
+++ b/deps/npm/html/doc/api/npm-init.html
@@ -3,6 +3,7 @@
   <title>npm-init</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-init.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -47,5 +48,5 @@ then go ahead and use this programmatically.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@1.4.6</p>
+<p id="footer">npm-init &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-install.html
+++ b/deps/npm/html/doc/api/npm-install.html
@@ -3,6 +3,7 @@
   <title>npm-install</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-install.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ installed or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@1.4.6</p>
+<p id="footer">npm-install &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-link.html
+++ b/deps/npm/html/doc/api/npm-link.html
@@ -3,6 +3,7 @@
   <title>npm-link</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-link.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -51,5 +52,5 @@ the package in the current working directory</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@1.4.6</p>
+<p id="footer">npm-link &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-load.html
+++ b/deps/npm/html/doc/api/npm-load.html
@@ -3,6 +3,7 @@
   <title>npm-load</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-load.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -44,5 +45,5 @@ config object.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-load &mdash; npm@1.4.6</p>
+<p id="footer">npm-load &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-ls.html
+++ b/deps/npm/html/doc/api/npm-ls.html
@@ -3,6 +3,7 @@
   <title>npm-ls</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-ls.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -71,5 +72,5 @@ dependency will only be output once.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@1.4.6</p>
+<p id="footer">npm-ls &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-outdated.html
+++ b/deps/npm/html/doc/api/npm-outdated.html
@@ -3,6 +3,7 @@
   <title>npm-outdated</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-outdated.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -31,5 +32,5 @@ currently outdated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@1.4.6</p>
+<p id="footer">npm-outdated &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-owner.html
+++ b/deps/npm/html/doc/api/npm-owner.html
@@ -3,6 +3,7 @@
   <title>npm-owner</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-owner.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -46,5 +47,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@1.4.6</p>
+<p id="footer">npm-owner &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-pack.html
+++ b/deps/npm/html/doc/api/npm-pack.html
@@ -3,6 +3,7 @@
   <title>npm-pack</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-pack.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@1.4.6</p>
+<p id="footer">npm-pack &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-prefix.html
+++ b/deps/npm/html/doc/api/npm-prefix.html
@@ -3,6 +3,7 @@
   <title>npm-prefix</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-prefix.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -33,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@1.4.6</p>
+<p id="footer">npm-prefix &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-prune.html
+++ b/deps/npm/html/doc/api/npm-prune.html
@@ -3,6 +3,7 @@
   <title>npm-prune</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-prune.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -35,5 +36,5 @@ package&#39;s dependencies list.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@1.4.6</p>
+<p id="footer">npm-prune &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-publish.html
+++ b/deps/npm/html/doc/api/npm-publish.html
@@ -3,6 +3,7 @@
   <title>npm-publish</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-publish.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -44,5 +45,5 @@ the registry.  Overwrites when the &quot;force&quot; environment variable is set
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@1.4.6</p>
+<p id="footer">npm-publish &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-rebuild.html
+++ b/deps/npm/html/doc/api/npm-rebuild.html
@@ -3,6 +3,7 @@
   <title>npm-rebuild</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-rebuild.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -34,5 +35,5 @@ the new binary. If no &#39;packages&#39; parameter is specify, every package wil
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@1.4.6</p>
+<p id="footer">npm-rebuild &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-repo.html
+++ b/deps/npm/html/doc/api/npm-repo.html
@@ -3,6 +3,7 @@
   <title>npm-repo</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-repo.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@1.4.6</p>
+<p id="footer">npm-repo &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-restart.html
+++ b/deps/npm/html/doc/api/npm-restart.html
@@ -3,6 +3,7 @@
   <title>npm-restart</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-restart.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -39,5 +40,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@1.4.6</p>
+<p id="footer">npm-restart &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-root.html
+++ b/deps/npm/html/doc/api/npm-root.html
@@ -3,6 +3,7 @@
   <title>npm-root</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-root.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -33,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@1.4.6</p>
+<p id="footer">npm-root &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-run-script.html
+++ b/deps/npm/html/doc/api/npm-run-script.html
@@ -3,6 +3,7 @@
   <title>npm-run-script</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-run-script.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -41,5 +42,5 @@ assumed to be the command to run. All other elements are ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@1.4.6</p>
+<p id="footer">npm-run-script &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-search.html
+++ b/deps/npm/html/doc/api/npm-search.html
@@ -3,6 +3,7 @@
   <title>npm-search</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-search.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -44,5 +45,5 @@ like).</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@1.4.6</p>
+<p id="footer">npm-search &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/api/npm-shrinkwrap.html
@@ -3,6 +3,7 @@
   <title>npm-shrinkwrap</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-shrinkwrap.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -38,5 +39,5 @@ been saved.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@1.4.6</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-start.html
+++ b/deps/npm/html/doc/api/npm-start.html
@@ -3,6 +3,7 @@
   <title>npm-start</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-start.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -31,5 +32,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@1.4.6</p>
+<p id="footer">npm-start &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-stop.html
+++ b/deps/npm/html/doc/api/npm-stop.html
@@ -3,6 +3,7 @@
   <title>npm-stop</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-stop.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -31,5 +32,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@1.4.6</p>
+<p id="footer">npm-stop &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-submodule.html
+++ b/deps/npm/html/doc/api/npm-submodule.html
@@ -3,6 +3,7 @@
   <title>npm-submodule</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-submodule.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -45,5 +46,5 @@ dependencies into the submodule folder.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-submodule &mdash; npm@1.4.6</p>
+<p id="footer">npm-submodule &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-tag.html
+++ b/deps/npm/html/doc/api/npm-tag.html
@@ -3,6 +3,7 @@
   <title>npm-tag</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-tag.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -41,5 +42,5 @@ used. For more information about how to set this config, check
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@1.4.6</p>
+<p id="footer">npm-tag &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-test.html
+++ b/deps/npm/html/doc/api/npm-test.html
@@ -3,6 +3,7 @@
   <title>npm-test</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-test.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -34,5 +35,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@1.4.6</p>
+<p id="footer">npm-test &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-uninstall.html
+++ b/deps/npm/html/doc/api/npm-uninstall.html
@@ -3,6 +3,7 @@
   <title>npm-uninstall</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-uninstall.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -34,5 +35,5 @@ uninstalled or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@1.4.6</p>
+<p id="footer">npm-uninstall &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-unpublish.html
+++ b/deps/npm/html/doc/api/npm-unpublish.html
@@ -3,6 +3,7 @@
   <title>npm-unpublish</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-unpublish.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -38,5 +39,5 @@ the root package entry is removed from the registry entirely.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@1.4.6</p>
+<p id="footer">npm-unpublish &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-update.html
+++ b/deps/npm/html/doc/api/npm-update.html
@@ -3,6 +3,7 @@
   <title>npm-update</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-update.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -30,5 +31,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@1.4.6</p>
+<p id="footer">npm-update &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-version.html
+++ b/deps/npm/html/doc/api/npm-version.html
@@ -3,6 +3,7 @@
   <title>npm-version</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-version.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -36,5 +37,5 @@ not have exactly one element. The only element should be a version number.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@1.4.6</p>
+<p id="footer">npm-version &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-view.html
+++ b/deps/npm/html/doc/api/npm-view.html
@@ -3,6 +3,7 @@
   <title>npm-view</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-view.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -111,5 +112,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@1.4.6</p>
+<p id="footer">npm-view &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm-whoami.html
+++ b/deps/npm/html/doc/api/npm-whoami.html
@@ -3,6 +3,7 @@
   <title>npm-whoami</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm-whoami.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -33,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@1.4.6</p>
+<p id="footer">npm-whoami &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/api/npm.html
+++ b/deps/npm/html/doc/api/npm.html
@@ -3,6 +3,7 @@
   <title>npm</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/api/npm.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -26,7 +27,7 @@ npm.load([configObject], function (er, npm) {
 
 <h2 id="VERSION">VERSION</h2>
 
-<p>1.4.6</p>
+<p>1.4.7</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -104,5 +105,5 @@ method names.  Use the <code>npm.deref</code> method to find the real name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@1.4.6</p>
+<p id="footer">npm &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-adduser.html
+++ b/deps/npm/html/doc/cli/npm-adduser.html
@@ -3,6 +3,7 @@
   <title>npm-adduser</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-adduser.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -51,5 +52,5 @@ authorize on a new machine.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-adduser &mdash; npm@1.4.6</p>
+<p id="footer">npm-adduser &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-bin.html
+++ b/deps/npm/html/doc/cli/npm-bin.html
@@ -3,6 +3,7 @@
   <title>npm-bin</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-bin.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@1.4.6</p>
+<p id="footer">npm-bin &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-bugs.html
+++ b/deps/npm/html/doc/cli/npm-bugs.html
@@ -3,6 +3,7 @@
   <title>npm-bugs</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-bugs.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -50,5 +51,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@1.4.6</p>
+<p id="footer">npm-bugs &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-build.html
+++ b/deps/npm/html/doc/cli/npm-build.html
@@ -3,6 +3,7 @@
   <title>npm-build</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-build.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ A folder containing a <code>package.json</code> file in its root.</li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-build &mdash; npm@1.4.6</p>
+<p id="footer">npm-build &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-bundle.html
+++ b/deps/npm/html/doc/cli/npm-bundle.html
@@ -3,6 +3,7 @@
   <title>npm-bundle</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-bundle.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@ install packages into the local space.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bundle &mdash; npm@1.4.6</p>
+<p id="footer">npm-bundle &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-cache.html
+++ b/deps/npm/html/doc/cli/npm-cache.html
@@ -3,6 +3,7 @@
   <title>npm-cache</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-cache.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -78,5 +79,5 @@ they do not make an HTTP request to the registry.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@1.4.6</p>
+<p id="footer">npm-cache &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-completion.html
+++ b/deps/npm/html/doc/cli/npm-completion.html
@@ -3,6 +3,7 @@
   <title>npm-completion</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-completion.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -45,5 +46,5 @@ completions based on the arguments.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-completion &mdash; npm@1.4.6</p>
+<p id="footer">npm-completion &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-config.html
+++ b/deps/npm/html/doc/cli/npm-config.html
@@ -3,6 +3,7 @@
   <title>npm-config</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-config.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -85,5 +86,5 @@ global config.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@1.4.6</p>
+<p id="footer">npm-config &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-dedupe.html
+++ b/deps/npm/html/doc/cli/npm-dedupe.html
@@ -3,6 +3,7 @@
   <title>npm-dedupe</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-dedupe.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -74,5 +75,5 @@ versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dedupe &mdash; npm@1.4.6</p>
+<p id="footer">npm-dedupe &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-deprecate.html
+++ b/deps/npm/html/doc/cli/npm-deprecate.html
@@ -3,6 +3,7 @@
   <title>npm-deprecate</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-deprecate.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -43,5 +44,5 @@ something like this:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@1.4.6</p>
+<p id="footer">npm-deprecate &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-docs.html
+++ b/deps/npm/html/doc/cli/npm-docs.html
@@ -3,6 +3,7 @@
   <title>npm-docs</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-docs.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -53,5 +54,5 @@ the current folder and use the <code>name</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@1.4.6</p>
+<p id="footer">npm-docs &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-edit.html
+++ b/deps/npm/html/doc/cli/npm-edit.html
@@ -3,6 +3,7 @@
   <title>npm-edit</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-edit.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -49,5 +50,5 @@ or <code>&quot;notepad&quot;</code> on Windows.</li><li>Type: path</li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@1.4.6</p>
+<p id="footer">npm-edit &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-explore.html
+++ b/deps/npm/html/doc/cli/npm-explore.html
@@ -3,6 +3,7 @@
   <title>npm-explore</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-explore.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -52,5 +53,5 @@ Windows</li><li>Type: path</li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@1.4.6</p>
+<p id="footer">npm-explore &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-help-search.html
+++ b/deps/npm/html/doc/cli/npm-help-search.html
@@ -3,6 +3,7 @@
   <title>npm-help-search</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-help-search.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -50,5 +51,5 @@ where the terms were found in the documentation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@1.4.6</p>
+<p id="footer">npm-help-search &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-help.html
+++ b/deps/npm/html/doc/cli/npm-help.html
@@ -3,6 +3,7 @@
   <title>npm-help</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-help.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -48,5 +49,5 @@ matches are equivalent to specifying a topic name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help &mdash; npm@1.4.6</p>
+<p id="footer">npm-help &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-init.html
+++ b/deps/npm/html/doc/cli/npm-init.html
@@ -3,6 +3,7 @@
   <title>npm-init</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-init.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -41,5 +42,5 @@ without a really good reason to do so.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@1.4.6</p>
+<p id="footer">npm-init &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-install.html
+++ b/deps/npm/html/doc/cli/npm-install.html
@@ -3,6 +3,7 @@
   <title>npm-install</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-install.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -165,5 +166,5 @@ affects a real use-case, it will be investigated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@1.4.6</p>
+<p id="footer">npm-install &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-link.html
+++ b/deps/npm/html/doc/cli/npm-link.html
@@ -3,6 +3,7 @@
   <title>npm-link</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-link.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -74,5 +75,5 @@ installation target into your project&#39;s <code>node_modules</code> folder.</p
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@1.4.6</p>
+<p id="footer">npm-link &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-ls.html
+++ b/deps/npm/html/doc/cli/npm-ls.html
@@ -3,6 +3,7 @@
   <title>npm-ls</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-ls.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -27,7 +28,7 @@ limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
 
-<pre><code>npm@1.4.6 /path/to/npm
+<pre><code>npm@1.4.7 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5</code></pre>
 
@@ -86,5 +87,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@1.4.6</p>
+<p id="footer">npm-ls &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-outdated.html
+++ b/deps/npm/html/doc/cli/npm-outdated.html
@@ -3,6 +3,7 @@
   <title>npm-outdated</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-outdated.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -70,5 +71,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@1.4.6</p>
+<p id="footer">npm-outdated &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-owner.html
+++ b/deps/npm/html/doc/cli/npm-owner.html
@@ -3,6 +3,7 @@
   <title>npm-owner</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-owner.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -46,5 +47,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@1.4.6</p>
+<p id="footer">npm-owner &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-pack.html
+++ b/deps/npm/html/doc/cli/npm-pack.html
@@ -3,6 +3,7 @@
   <title>npm-pack</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-pack.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -41,5 +42,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@1.4.6</p>
+<p id="footer">npm-pack &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-prefix.html
+++ b/deps/npm/html/doc/cli/npm-prefix.html
@@ -3,6 +3,7 @@
   <title>npm-prefix</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-prefix.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@1.4.6</p>
+<p id="footer">npm-prefix &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-prune.html
+++ b/deps/npm/html/doc/cli/npm-prune.html
@@ -3,6 +3,7 @@
   <title>npm-prune</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-prune.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -41,5 +42,5 @@ packages specified in your <code>devDependencies</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@1.4.6</p>
+<p id="footer">npm-prune &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-publish.html
+++ b/deps/npm/html/doc/cli/npm-publish.html
@@ -3,6 +3,7 @@
   <title>npm-publish</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-publish.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -48,5 +49,5 @@ it is removed with <a href="../cli/npm-unpublish.html">npm-unpublish(1)</a>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@1.4.6</p>
+<p id="footer">npm-publish &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-rebuild.html
+++ b/deps/npm/html/doc/cli/npm-rebuild.html
@@ -3,6 +3,7 @@
   <title>npm-rebuild</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-rebuild.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -38,5 +39,5 @@ the new binary.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@1.4.6</p>
+<p id="footer">npm-rebuild &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-repo.html
+++ b/deps/npm/html/doc/cli/npm-repo.html
@@ -3,6 +3,7 @@
   <title>npm-repo</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-repo.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -44,5 +45,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@1.4.6</p>
+<p id="footer">npm-repo &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-restart.html
+++ b/deps/npm/html/doc/cli/npm-restart.html
@@ -3,6 +3,7 @@
   <title>npm-restart</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-restart.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -36,5 +37,5 @@ the &quot;start&quot; script.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@1.4.6</p>
+<p id="footer">npm-restart &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-rm.html
+++ b/deps/npm/html/doc/cli/npm-rm.html
@@ -3,6 +3,7 @@
   <title>npm-rm</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-rm.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -36,5 +37,5 @@ on its behalf.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rm &mdash; npm@1.4.6</p>
+<p id="footer">npm-rm &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-root.html
+++ b/deps/npm/html/doc/cli/npm-root.html
@@ -3,6 +3,7 @@
   <title>npm-root</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-root.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@1.4.6</p>
+<p id="footer">npm-root &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-run-script.html
+++ b/deps/npm/html/doc/cli/npm-run-script.html
@@ -3,6 +3,7 @@
   <title>npm-run-script</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-run-script.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -35,5 +36,5 @@ called directly, as well.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@1.4.6</p>
+<p id="footer">npm-run-script &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-search.html
+++ b/deps/npm/html/doc/cli/npm-search.html
@@ -3,6 +3,7 @@
   <title>npm-search</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-search.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -49,5 +50,5 @@ fall on multiple lines.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@1.4.6</p>
+<p id="footer">npm-search &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/cli/npm-shrinkwrap.html
@@ -3,6 +3,7 @@
   <title>npm-shrinkwrap</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-shrinkwrap.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -195,5 +196,5 @@ contents rather than versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@1.4.6</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-star.html
+++ b/deps/npm/html/doc/cli/npm-star.html
@@ -3,6 +3,7 @@
   <title>npm-star</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-star.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -38,5 +39,5 @@ a vaguely positive way to show that you care.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-star &mdash; npm@1.4.6</p>
+<p id="footer">npm-star &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-stars.html
+++ b/deps/npm/html/doc/cli/npm-stars.html
@@ -3,6 +3,7 @@
   <title>npm-stars</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-stars.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -37,5 +38,5 @@ you will most certainly enjoy this command.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stars &mdash; npm@1.4.6</p>
+<p id="footer">npm-stars &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-start.html
+++ b/deps/npm/html/doc/cli/npm-start.html
@@ -3,6 +3,7 @@
   <title>npm-start</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-start.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@1.4.6</p>
+<p id="footer">npm-start &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-stop.html
+++ b/deps/npm/html/doc/cli/npm-stop.html
@@ -3,6 +3,7 @@
   <title>npm-stop</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-stop.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@1.4.6</p>
+<p id="footer">npm-stop &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-submodule.html
+++ b/deps/npm/html/doc/cli/npm-submodule.html
@@ -3,6 +3,7 @@
   <title>npm-submodule</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-submodule.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -45,5 +46,5 @@ dependencies into the submodule folder.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-submodule &mdash; npm@1.4.6</p>
+<p id="footer">npm-submodule &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-tag.html
+++ b/deps/npm/html/doc/cli/npm-tag.html
@@ -3,6 +3,7 @@
   <title>npm-tag</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-tag.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -46,5 +47,5 @@ of using a specific version number:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@1.4.6</p>
+<p id="footer">npm-tag &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-test.html
+++ b/deps/npm/html/doc/cli/npm-test.html
@@ -3,6 +3,7 @@
   <title>npm-test</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-test.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -36,5 +37,5 @@ true.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@1.4.6</p>
+<p id="footer">npm-test &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-uninstall.html
+++ b/deps/npm/html/doc/cli/npm-uninstall.html
@@ -3,6 +3,7 @@
   <title>npm-uninstall</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-uninstall.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -52,5 +53,5 @@ npm uninstall dtrace-provider --save-optional</code></pre>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@1.4.6</p>
+<p id="footer">npm-uninstall &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-unpublish.html
+++ b/deps/npm/html/doc/cli/npm-unpublish.html
@@ -3,6 +3,7 @@
   <title>npm-unpublish</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-unpublish.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -50,5 +51,5 @@ package again, a new version number must be used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@1.4.6</p>
+<p id="footer">npm-unpublish &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-update.html
+++ b/deps/npm/html/doc/cli/npm-update.html
@@ -3,6 +3,7 @@
   <title>npm-update</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-update.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -38,5 +39,5 @@ If no package name is specified, all packages in the specified location (global 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@1.4.6</p>
+<p id="footer">npm-update &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-version.html
+++ b/deps/npm/html/doc/cli/npm-version.html
@@ -3,6 +3,7 @@
   <title>npm-version</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-version.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -61,5 +62,5 @@ Enter passphrase:</code></pre>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@1.4.6</p>
+<p id="footer">npm-version &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-view.html
+++ b/deps/npm/html/doc/cli/npm-view.html
@@ -3,6 +3,7 @@
   <title>npm-view</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-view.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -103,5 +104,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@1.4.6</p>
+<p id="footer">npm-view &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm-whoami.html
+++ b/deps/npm/html/doc/cli/npm-whoami.html
@@ -3,6 +3,7 @@
   <title>npm-whoami</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm-whoami.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -32,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@1.4.6</p>
+<p id="footer">npm-whoami &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/cli/npm.html
+++ b/deps/npm/html/doc/cli/npm.html
@@ -3,6 +3,7 @@
   <title>npm</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/cli/npm.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -16,7 +17,7 @@
 
 <h2 id="VERSION">VERSION</h2>
 
-<p>1.4.6</p>
+<p>1.4.7</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -143,5 +144,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@1.4.6</p>
+<p id="footer">npm &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/files/npm-folders.html
+++ b/deps/npm/html/doc/files/npm-folders.html
@@ -3,6 +3,7 @@
   <title>npm-folders</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/files/npm-folders.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -217,5 +218,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@1.4.6</p>
+<p id="footer">npm-folders &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/files/npm-global.html
+++ b/deps/npm/html/doc/files/npm-global.html
@@ -3,6 +3,7 @@
   <title>npm-folders</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/files/npm-folders.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -217,5 +218,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@1.4.6</p>
+<p id="footer">npm-folders &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/files/npm-json.html
+++ b/deps/npm/html/doc/files/npm-json.html
@@ -3,6 +3,7 @@
   <title>package.json</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/files/package.json.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -396,6 +397,40 @@ can consume the functionality without requiring them to compile it
 themselves.  In dev mode (ie, locally running <code>npm install</code>), it&#39;ll
 run this script as well, so that you can test it easily.</p>
 
+<h2 id="peerDependencies">peerDependencies</h2>
+
+<p>In some cases, you want to express the compatibility of your package with an
+host tool or library, while not necessarily doing a <code>require</code> of this host.
+This is usually refered to as a <em>plugin</em>. Notably, your module may be exposing
+a specific interface, expected and specified by the host documentation.</p>
+
+<p>For example:</p>
+
+<pre><code>{
+  &quot;name&quot;: &quot;tea-latte&quot;,
+  &quot;version&quot;: &quot;1.3.5&quot;
+  &quot;peerDependencies&quot;: {
+    &quot;tea&quot;: &quot;2.x&quot;
+  }
+}</code></pre>
+
+<p>This ensures your package <code>tea-latte</code> can be installed <em>along</em> with the second
+major version of the host package <code>tea</code> only. The host package is automatically
+installed if needed. <code>npm install tea-latte</code> could possibly yield the following
+dependency graph:</p>
+
+<pre><code>├── tea-latte@1.3.5
+└── tea@2.2.0</code></pre>
+
+<p>Trying to install another plugin with a conflicting requirement will cause an
+error. For this reason, make sure your plugin requirement is as broad as
+possible, and not to lock it down to specific patch versions.</p>
+
+<p>Assuming the host complies with <a href="http://semver.org/">semver</a>, only changes in
+the host package&#39;s major version will break your plugin. Thus, if you&#39;ve worked
+with every 1.x version of the host package, use <code>&quot;^1.0&quot;</code> or <code>&quot;1.x&quot;</code> to express
+this. If you depend on features introduced in 1.5.2, use <code>&quot;&gt;= 1.5.2 &lt; 2&quot;</code>.</p>
+
 <h2 id="bundledDependencies">bundledDependencies</h2>
 
 <p>Array of package names that will be bundled when publishing the package.</p>
@@ -554,5 +589,5 @@ ignored.</p></li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@1.4.6</p>
+<p id="footer">package.json &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/files/npmrc.html
+++ b/deps/npm/html/doc/files/npmrc.html
@@ -3,6 +3,7 @@
   <title>npmrc</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/files/npmrc.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -71,5 +72,5 @@ manner.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npmrc &mdash; npm@1.4.6</p>
+<p id="footer">npmrc &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/files/package.json.html
+++ b/deps/npm/html/doc/files/package.json.html
@@ -3,6 +3,7 @@
   <title>package.json</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/files/package.json.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -396,6 +397,40 @@ can consume the functionality without requiring them to compile it
 themselves.  In dev mode (ie, locally running <code>npm install</code>), it&#39;ll
 run this script as well, so that you can test it easily.</p>
 
+<h2 id="peerDependencies">peerDependencies</h2>
+
+<p>In some cases, you want to express the compatibility of your package with an
+host tool or library, while not necessarily doing a <code>require</code> of this host.
+This is usually refered to as a <em>plugin</em>. Notably, your module may be exposing
+a specific interface, expected and specified by the host documentation.</p>
+
+<p>For example:</p>
+
+<pre><code>{
+  &quot;name&quot;: &quot;tea-latte&quot;,
+  &quot;version&quot;: &quot;1.3.5&quot;
+  &quot;peerDependencies&quot;: {
+    &quot;tea&quot;: &quot;2.x&quot;
+  }
+}</code></pre>
+
+<p>This ensures your package <code>tea-latte</code> can be installed <em>along</em> with the second
+major version of the host package <code>tea</code> only. The host package is automatically
+installed if needed. <code>npm install tea-latte</code> could possibly yield the following
+dependency graph:</p>
+
+<pre><code>├── tea-latte@1.3.5
+└── tea@2.2.0</code></pre>
+
+<p>Trying to install another plugin with a conflicting requirement will cause an
+error. For this reason, make sure your plugin requirement is as broad as
+possible, and not to lock it down to specific patch versions.</p>
+
+<p>Assuming the host complies with <a href="http://semver.org/">semver</a>, only changes in
+the host package&#39;s major version will break your plugin. Thus, if you&#39;ve worked
+with every 1.x version of the host package, use <code>&quot;^1.0&quot;</code> or <code>&quot;1.x&quot;</code> to express
+this. If you depend on features introduced in 1.5.2, use <code>&quot;&gt;= 1.5.2 &lt; 2&quot;</code>.</p>
+
 <h2 id="bundledDependencies">bundledDependencies</h2>
 
 <p>Array of package names that will be bundled when publishing the package.</p>
@@ -554,5 +589,5 @@ ignored.</p></li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@1.4.6</p>
+<p id="footer">package.json &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/index.html
+++ b/deps/npm/html/doc/index.html
@@ -3,6 +3,7 @@
   <title>npm-index</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/index.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -428,5 +429,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@1.4.6</p>
+<p id="footer">npm-index &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-coding-style.html
+++ b/deps/npm/html/doc/misc/npm-coding-style.html
@@ -3,6 +3,7 @@
   <title>npm-coding-style</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-coding-style.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -194,5 +195,5 @@ set to anything.&quot;</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-coding-style &mdash; npm@1.4.6</p>
+<p id="footer">npm-coding-style &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-config.html
+++ b/deps/npm/html/doc/misc/npm-config.html
@@ -3,6 +3,7 @@
   <title>npm-config</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-config.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -565,6 +566,17 @@ devDependencies hash.</p>
 
 <p>Only works if there is already a package.json file present.</p>
 
+<h3 id="save-prefix">save-prefix</h3>
+
+<ul><li>Default: &#39;^&#39;</li><li>Type: String</li></ul>
+
+<p>Configure how versions of packages installed to a package.json file via 
+<code>--save</code> or <code>--save-dev</code> get prefixed.</p>
+
+<p>For example if a package has version <code>1.2.3</code>, by default it&#39;s version is
+set to <code>^1.2.3</code> which allows minor upgrades for that package, but after<br /><code>npm config set save-prefix=&#39;~&#39;</code> it would be set to <code>~1.2.3</code> which only allows
+patch upgrades.</p>
+
 <h3 id="searchopts">searchopts</h3>
 
 <ul><li>Default: &quot;&quot;</li><li>Type: String</li></ul>
@@ -731,5 +743,5 @@ hash, and exit successfully.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@1.4.6</p>
+<p id="footer">npm-config &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-developers.html
+++ b/deps/npm/html/doc/misc/npm-developers.html
@@ -3,6 +3,7 @@
   <title>npm-developers</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-developers.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -186,5 +187,5 @@ from a fresh checkout.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-developers &mdash; npm@1.4.6</p>
+<p id="footer">npm-developers &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-disputes.html
+++ b/deps/npm/html/doc/misc/npm-disputes.html
@@ -3,6 +3,7 @@
   <title>npm-disputes</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-disputes.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -104,5 +105,5 @@ things into it.</li></ol>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-disputes &mdash; npm@1.4.6</p>
+<p id="footer">npm-disputes &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-faq.html
+++ b/deps/npm/html/doc/misc/npm-faq.html
@@ -3,6 +3,7 @@
   <title>npm-faq</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-faq.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -85,7 +86,7 @@ in a shell script if you really wanted to.</p>
 
 <p>Mikeal Rogers answered this question very well:</p>
 
-<p><a href="http://www.mikealrogers.com/posts/nodemodules-in-git.html">http://www.mikealrogers.com/posts/nodemodules-in-git.html</a></p>
+<p><a href="http://www.futurealoof.com/posts/nodemodules-in-git.html">http://www.futurealoof.com/posts/nodemodules-in-git.html</a></p>
 
 <p>tl;dr</p>
 
@@ -360,5 +361,5 @@ good folks at <a href="https://www.npmjs.com">npm, Inc.</a></p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-faq &mdash; npm@1.4.6</p>
+<p id="footer">npm-faq &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-index.html
+++ b/deps/npm/html/doc/misc/npm-index.html
@@ -3,6 +3,7 @@
   <title>npm-index</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-index.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -428,5 +429,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@1.4.6</p>
+<p id="footer">npm-index &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-registry.html
+++ b/deps/npm/html/doc/misc/npm-registry.html
@@ -3,6 +3,7 @@
   <title>npm-registry</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-registry.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -83,5 +84,5 @@ effectively implement the entire CouchDB API anyway.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-registry &mdash; npm@1.4.6</p>
+<p id="footer">npm-registry &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/npm-scripts.html
+++ b/deps/npm/html/doc/misc/npm-scripts.html
@@ -3,6 +3,7 @@
   <title>npm-scripts</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-scripts.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -235,5 +236,5 @@ the user will sudo the npm command in question.</li></ul>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scripts &mdash; npm@1.4.6</p>
+<p id="footer">npm-scripts &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/removing-npm.html
+++ b/deps/npm/html/doc/misc/removing-npm.html
@@ -3,6 +3,7 @@
   <title>removing-npm</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/removing-npm.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -70,5 +71,5 @@ modules.  To track those down, you can do the following:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">removing-npm &mdash; npm@1.4.6</p>
+<p id="footer">removing-npm &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/doc/misc/semver.html
+++ b/deps/npm/html/doc/misc/semver.html
@@ -3,6 +3,7 @@
   <title>semver</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/semver.html">
   <script async=true src="../../static/toc.js"></script>
 
   <body>
@@ -129,5 +130,5 @@ range, use the <code>satisfies(version, range)</code> function.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">semver &mdash; npm@1.4.6</p>
+<p id="footer">semver &mdash; npm@1.4.7</p>
 

--- a/deps/npm/html/dochead.html
+++ b/deps/npm/html/dochead.html
@@ -3,6 +3,7 @@
   <title>@NAME@</title>
   <meta http-equiv="content-type" value="text/html;utf-8">
   <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/@URL@">
   <script async=true src="../../static/toc.js"></script>
 
   <body>

--- a/deps/npm/lib/cache.js
+++ b/deps/npm/lib/cache.js
@@ -241,8 +241,9 @@ function add (args, cb) {
 
   log.verbose("cache add", "name=%j spec=%j args=%j", name, spec, args)
 
-
   if (!name && !spec) return cb(usage)
+
+  cb = afterAdd([name, spec], cb)
 
   // see if the spec is a url
   // otherwise, treat as name@version
@@ -264,6 +265,23 @@ function add (args, cb) {
 
   add_(name, spec, p, cb)
 }
+
+function afterAdd (arg, cb) { return function (er, data) {
+  if (er || !data || !data.name || !data.version) {
+    return cb(er, data)
+  }
+
+  // Save the resolved, shasum, etc. into the data so that the next
+  // time we load from this cached data, we have all the same info.
+  var name = data.name
+  var ver = data.version
+  var pj = path.join(npm.cache, name, ver, "package", "package.json")
+  fs.writeFile(pj, JSON.stringify(data), "utf8", function (er) {
+    cb(er, data)
+  })
+}}
+
+
 
 function maybeFile (spec, p, cb) {
   fs.stat(spec, function (er, stat) {
@@ -316,7 +334,15 @@ function fetchAndShaCheck (u, tmp, shasum, cb) {
       log.error("fetch failed", u)
       return cb(er, response)
     }
-    if (!shasum) return cb(null, response)
+
+    if (!shasum) {
+      // Well, we weren't given a shasum, so at least sha what we have
+      // in case we want to compare it to something else later
+      return sha.get(tmp, function (er, shasum) {
+        cb(er, response, shasum)
+      })
+    }
+
     // validate that the url we just downloaded matches the expected shasum.
     sha.check(tmp, shasum, function (er) {
       if (er != null && er.message) {
@@ -331,7 +357,8 @@ function fetchAndShaCheck (u, tmp, shasum, cb) {
 // Only have a single download action at once for a given url
 // additional calls stack the callbacks.
 var inFlightURLs = {}
-function addRemoteTarball (u, shasum, name, cb_) {
+function addRemoteTarball (u, shasum, name, version, cb_) {
+  if (typeof cb_ !== "function") cb_ = version, version = ""
   if (typeof cb_ !== "function") cb_ = name, name = ""
   if (typeof cb_ !== "function") cb_ = shasum, shasum = null
 
@@ -343,6 +370,7 @@ function addRemoteTarball (u, shasum, name, cb_) {
   function cb (er, data) {
     if (data) {
       data._from = u
+      data._shasum = data._shasum || shasum
       data._resolved = u
     }
     unlock(u, function () {
@@ -366,7 +394,7 @@ function addRemoteTarball (u, shasum, name, cb_) {
 
   function done (er, resp, shasum) {
     if (er) return cb(er)
-    addLocalTarball(tmp, name, shasum, cb)
+    addLocalTarball(tmp, name, version, shasum, cb)
   }
 }
 
@@ -791,9 +819,15 @@ function addNameVersion (name, v, data, cb) {
     response = null
     return next()
   }
-  registry.get(name + "/" + ver, function (er, d, json, resp) {
+  registry.get(name, function (er, d, json, resp) {
     if (er) return cb(er)
-    data = d
+    data = d && d.versions[ver]
+    if (!data) {
+      er = new Error('version not found: ' + name + '@' + ver)
+      er.package = name
+      er.statusCode = 404
+      return cb(er)
+    }
     response = resp
     next()
   })
@@ -853,7 +887,8 @@ function addNameVersion (name, v, data, cb) {
       }
       return addRemoteTarball( tb
                              , dist.shasum
-                             , name+"-"+ver
+                             , name
+                             , ver
                              , cb )
     }
   }
@@ -924,13 +959,23 @@ function maybeGithub (p, name, er, cb) {
   }
 }
 
-function addLocalTarball (p, name, shasum, cb_) {
+function addLocalTarball (p, name, version, shasum, cb_) {
   if (typeof cb_ !== "function") cb_ = shasum, shasum = null
+  if (typeof cb_ !== "function") cb_ = version, version = ""
   if (typeof cb_ !== "function") cb_ = name, name = ""
+
+  // If we don't have a shasum yet, then get the shasum now.
+  if (!shasum) {
+    return sha.get(p, function (er, shasum) {
+      if (er) return cb_(er)
+      addLocalTarball(p, name, version, shasum, cb_)
+    })
+  }
+
   // if it's a tar, and not in place,
   // then unzip to .tmp, add the tmp folder, and clean up tmp
   if (pathIsInside(p, npm.tmp))
-    return addTmpTarball(p, name, shasum, cb_)
+    return addTmpTarball(p, name, version, shasum, cb_)
 
   if (pathIsInside(p, npm.cache)) {
     if (path.basename(p) !== "package.tgz") return cb_(new Error(
@@ -939,7 +984,10 @@ function addLocalTarball (p, name, shasum, cb_) {
   }
 
   function cb (er, data) {
-    if (data) data._resolved = p
+    if (data) {
+      data._resolved = p
+      data._shasum = data._shasum || shasum
+    }
     return cb_(er, data)
   }
 
@@ -962,7 +1010,7 @@ function addLocalTarball (p, name, shasum, cb_) {
       log.verbose("chmod", tmp, npm.modes.file.toString(8))
       fs.chmod(tmp, npm.modes.file, function (er) {
         if (er) return cb(er)
-        addTmpTarball(tmp, name, shasum, cb)
+        addTmpTarball(tmp, name, null, shasum, cb)
       })
     })
     from.pipe(to)
@@ -1188,6 +1236,10 @@ function addLocalDirectory (p, name, shasum, cb) {
                              , data.version, "package.tgz" )
       , placeDirect = path.basename(p) === "package"
       , tgz = placeDirect ? placed : tmptgz
+      , version = data.version
+
+    name = data.name
+
     getCacheStat(function (er, cs) {
       mkdir(path.dirname(tgz), function (er, made) {
         if (er) return cb(er)
@@ -1207,7 +1259,7 @@ function addLocalDirectory (p, name, shasum, cb) {
 
           chownr(made || tgz, cs.uid, cs.gid, function (er) {
             if (er) return cb(er)
-            addLocalTarball(tgz, name, shasum, cb)
+            addLocalTarball(tgz, name, version, shasum, cb)
           })
         })
       })
@@ -1215,21 +1267,75 @@ function addLocalDirectory (p, name, shasum, cb) {
   })
 }
 
-function addTmpTarball (tgz, name, shasum, cb) {
-  if (!cb) cb = name, name = ""
+// XXX This is where it should be fixed
+// Right now it's unpacking to a "package" folder, and then
+// adding that local folder, for historical reasons.
+// Instead, unpack to the *cache* folder, and then copy the
+// tgz into place in the cache, so the shasum doesn't change.
+function addTmpTarball (tgz, name, version, shasum, cb) {
+  // Just have a placeholder here so we can move it into place after.
+  var tmp = false
+  if (!version) {
+    tmp = true
+    version = 'tmp_' + crypto.randomBytes(6).toString('hex')
+  }
+  if (!name) {
+    tmp = true
+    name = 'tmp_' + crypto.randomBytes(6).toString('hex')
+  }
+  if (!tmp) {
+    var pdir = path.resolve(npm.cache, name, version, "package")
+  } else {
+    var pdir = path.resolve(npm.cache, name + version + "package")
+  }
+
   getCacheStat(function (er, cs) {
     if (er) return cb(er)
-    var contents = path.dirname(tgz)
-    tar.unpack( tgz, path.resolve(contents, "package")
-              , null, null
-              , cs.uid, cs.gid
-              , function (er) {
-      if (er) {
-        return cb(er)
-      }
-      addLocalDirectory(path.resolve(contents, "package"), name, shasum, cb)
-    })
+    tar.unpack(tgz, pdir, null, null, cs.uid, cs.gid, next)
   })
+
+  function next (er) {
+    if (er) return cb(er)
+    // it MUST be able to get a version now!
+    var pj = path.resolve(pdir, "package.json")
+    readJson(pj, function (er, data) {
+      if (er) return cb(er)
+      if (version === data.version && name === data.name && !tmp) {
+        addTmpTarball_(tgz, data, name, version, shasum, cb)
+      } else {
+        var old = pdir
+        name = data.name
+        version = data.version
+        pdir = path.resolve(npm.cache, name, version, "package")
+        mkdir(path.dirname(pdir), function(er) {
+          if (er) return cb(er)
+          rm(pdir, function(er) {
+            if (er) return cb(er)
+            fs.rename(old, pdir, function(er) {
+              if (er) return cb(er)
+              rm(old, function(er) {
+                if (er) return cb(er)
+                addTmpTarball_(tgz, data, name, version, shasum, cb)
+              })
+            })
+          })
+        })
+      }
+    })
+  }
+}
+
+function addTmpTarball_ (tgz, data, name, version, shasum, cb) {
+  cb = once(cb)
+  var target = path.resolve(npm.cache, name, version, "package.tgz")
+  var read = fs.createReadStream(tgz)
+  var write = fs.createWriteStream(target)
+  read.on("error", cb).pipe(write).on("error", cb).on("close", done)
+
+  function done() {
+    data._shasum = data._shasum || shasum
+    cb(null, data)
+  }
 }
 
 function unpack (pkg, ver, unpackTarget, dMode, fMode, uid, gid, cb) {

--- a/deps/npm/lib/dedupe.js
+++ b/deps/npm/lib/dedupe.js
@@ -354,4 +354,3 @@ function whoDepends_ (pkg, who, test) {
   })
   return who
 }
-

--- a/deps/npm/lib/install.js
+++ b/deps/npm/lib/install.js
@@ -337,6 +337,7 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
   }
 
   var saveBundle = npm.config.get('save-bundle')
+  var savePrefix = npm.config.get('save-prefix') || "^";
 
   // each item in the tree is a top-level thing that should be saved
   // to the package.json file.
@@ -353,7 +354,7 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
         var rangeDescriptor = semver.valid(k[1], true) &&
                               semver.gte(k[1], "0.1.0", true) &&
                               !npm.config.get("save-exact")
-                            ? "^" : ""
+                            ? savePrefix : ""
         set[k[0]] = rangeDescriptor + k[1]
         return set
       }, {})

--- a/deps/npm/lib/shrinkwrap.js
+++ b/deps/npm/lib/shrinkwrap.js
@@ -59,7 +59,7 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
 function save (pkginfo, silent, cb) {
   // copy the keys over in a well defined order
   // because javascript objects serialize arbitrarily
-  pkginfo.dependencies = sortedObject(pkginfo.dependencies)
+  pkginfo.dependencies = sortedObject(pkginfo.dependencies || {})
   try {
     var swdata = JSON.stringify(pkginfo, null, 2) + "\n"
   } catch (er) {

--- a/deps/npm/lib/utils/error-handler.js
+++ b/deps/npm/lib/utils/error-handler.js
@@ -146,9 +146,10 @@ function errorHandler (er) {
 
   case "E404":
     er.code = "E404"
+    var msg = [er.message]
     if (er.pkgid && er.pkgid !== "-") {
-      var msg = ["'"+er.pkgid+"' is not in the npm registry."
-                ,"You should bug the author to publish it"]
+      msg.push("", "'"+er.pkgid+"' is not in the npm registry."
+              ,"You should bug the author to publish it")
       if (er.parent) {
         msg.push("It was specified as a dependency of '"+er.parent+"'")
       }
@@ -161,8 +162,8 @@ function errorHandler (er) {
       }
       msg.push("\nNote that you can also install from a"
               ,"tarball, folder, or http url, or git url.")
-      log.error("404", msg.join("\n"))
     }
+    log.error("404", msg.join("\n"))
     break
 
   case "EPUBLISHCONFLICT":

--- a/deps/npm/lib/utils/lifecycle.js
+++ b/deps/npm/lib/utils/lifecycle.js
@@ -1,4 +1,3 @@
-
 exports = module.exports = lifecycle
 exports.cmd = cmd
 
@@ -161,7 +160,9 @@ function runCmd (note, cmd, pkg, env, stage, wd, unsafe, cb) {
   var user = unsafe ? null : npm.config.get("user")
     , group = unsafe ? null : npm.config.get("group")
 
-  console.log(note)
+  if (log.level !== 'silent') {
+    console.log(note)
+  }
   log.verbose("unsafe-perm in lifecycle", unsafe)
 
   if (process.platform === "win32") {

--- a/deps/npm/lib/view.js
+++ b/deps/npm/lib/view.js
@@ -58,13 +58,24 @@ function view (args, silent, cb) {
   // get the data about this package
   registry.get(name, function (er, data) {
     if (er) return cb(er)
-    if (data["dist-tags"].hasOwnProperty(version)) {
+    if (data["dist-tags"] && data["dist-tags"].hasOwnProperty(version)) {
       version = data["dist-tags"][version]
     }
+
+    if (data.time && data.time.unpublished) {
+      var u = data.time.unpublished
+      var er = new Error("Unpublished by " + u.name + " on " + u.time)
+      er.statusCode = 404
+      er.code = "E404"
+      er.pkgid = data._id
+      return cb(er, data)
+    }
+
+
     var results = []
       , error = null
-      , versions = data.versions
-    data.versions = Object.keys(data.versions).sort(semver.compareLoose)
+      , versions = data.versions || {}
+    data.versions = Object.keys(versions).sort(semver.compareLoose)
     if (!args.length) args = [""]
 
     // remove readme unless we asked for it

--- a/deps/npm/man/man1/npm-README.1
+++ b/deps/npm/man/man1/npm-README.1
@@ -1,12 +1,13 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM" "1" "March 2014" "" ""
+.TH "NPM" "1" "April 2014" "" ""
 .
 .SH "NAME"
-\fBnpm\fR \-\- node package manager
+\fBnpm\fR \-\- node package manager![Build Status \fIhttps://img\.shields\.io/travis/npm/npm/master\.svg)](https://travis\-ci\.org/npm/npm\fR
+## SYNOPSIS
 .
-.SH "SYNOPSIS"
+.P
 This is just enough info to get you up and running\.
 .
 .P

--- a/deps/npm/man/man1/npm-adduser.1
+++ b/deps/npm/man/man1/npm-adduser.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-ADDUSER" "1" "March 2014" "" ""
+.TH "NPM\-ADDUSER" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-adduser\fR \-\- Add a registry user account

--- a/deps/npm/man/man1/npm-bin.1
+++ b/deps/npm/man/man1/npm-bin.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-BIN" "1" "March 2014" "" ""
+.TH "NPM\-BIN" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-bin\fR \-\- Display npm bin folder

--- a/deps/npm/man/man1/npm-bugs.1
+++ b/deps/npm/man/man1/npm-bugs.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-BUGS" "1" "March 2014" "" ""
+.TH "NPM\-BUGS" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-bugs\fR \-\- Bugs for a package in a web browser maybe

--- a/deps/npm/man/man1/npm-build.1
+++ b/deps/npm/man/man1/npm-build.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-BUILD" "1" "March 2014" "" ""
+.TH "NPM\-BUILD" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-build\fR \-\- Build a package

--- a/deps/npm/man/man1/npm-bundle.1
+++ b/deps/npm/man/man1/npm-bundle.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-BUNDLE" "1" "March 2014" "" ""
+.TH "NPM\-BUNDLE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-bundle\fR \-\- REMOVED

--- a/deps/npm/man/man1/npm-cache.1
+++ b/deps/npm/man/man1/npm-cache.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-CACHE" "1" "March 2014" "" ""
+.TH "NPM\-CACHE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-cache\fR \-\- Manipulates packages cache

--- a/deps/npm/man/man1/npm-completion.1
+++ b/deps/npm/man/man1/npm-completion.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-COMPLETION" "1" "March 2014" "" ""
+.TH "NPM\-COMPLETION" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-completion\fR \-\- Tab Completion for npm

--- a/deps/npm/man/man1/npm-config.1
+++ b/deps/npm/man/man1/npm-config.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-CONFIG" "1" "March 2014" "" ""
+.TH "NPM\-CONFIG" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-config\fR \-\- Manage the npm configuration files

--- a/deps/npm/man/man1/npm-dedupe.1
+++ b/deps/npm/man/man1/npm-dedupe.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DEDUPE" "1" "March 2014" "" ""
+.TH "NPM\-DEDUPE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-dedupe\fR \-\- Reduce duplication

--- a/deps/npm/man/man1/npm-deprecate.1
+++ b/deps/npm/man/man1/npm-deprecate.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DEPRECATE" "1" "March 2014" "" ""
+.TH "NPM\-DEPRECATE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-deprecate\fR \-\- Deprecate a version of a package

--- a/deps/npm/man/man1/npm-docs.1
+++ b/deps/npm/man/man1/npm-docs.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DOCS" "1" "March 2014" "" ""
+.TH "NPM\-DOCS" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-docs\fR \-\- Docs for a package in a web browser maybe

--- a/deps/npm/man/man1/npm-edit.1
+++ b/deps/npm/man/man1/npm-edit.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-EDIT" "1" "March 2014" "" ""
+.TH "NPM\-EDIT" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-edit\fR \-\- Edit an installed package

--- a/deps/npm/man/man1/npm-explore.1
+++ b/deps/npm/man/man1/npm-explore.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-EXPLORE" "1" "March 2014" "" ""
+.TH "NPM\-EXPLORE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-explore\fR \-\- Browse an installed package

--- a/deps/npm/man/man1/npm-help-search.1
+++ b/deps/npm/man/man1/npm-help-search.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-HELP\-SEARCH" "1" "March 2014" "" ""
+.TH "NPM\-HELP\-SEARCH" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-help-search\fR \-\- Search npm help documentation

--- a/deps/npm/man/man1/npm-help.1
+++ b/deps/npm/man/man1/npm-help.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-HELP" "1" "March 2014" "" ""
+.TH "NPM\-HELP" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-help\fR \-\- Get help on npm

--- a/deps/npm/man/man1/npm-init.1
+++ b/deps/npm/man/man1/npm-init.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-INIT" "1" "March 2014" "" ""
+.TH "NPM\-INIT" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-init\fR \-\- Interactively create a package\.json file

--- a/deps/npm/man/man1/npm-install.1
+++ b/deps/npm/man/man1/npm-install.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-INSTALL" "1" "March 2014" "" ""
+.TH "NPM\-INSTALL" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-install\fR \-\- Install a package

--- a/deps/npm/man/man1/npm-link.1
+++ b/deps/npm/man/man1/npm-link.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-LINK" "1" "March 2014" "" ""
+.TH "NPM\-LINK" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-link\fR \-\- Symlink a package folder

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-LS" "1" "March 2014" "" ""
+.TH "NPM\-LS" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-ls\fR \-\- List installed packages
@@ -29,7 +29,7 @@ For example, running \fBnpm ls promzard\fR in npm\'s source tree will show:
 .IP "" 4
 .
 .nf
-npm@1.4.6 /path/to/npm
+npm@1.4.7 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .

--- a/deps/npm/man/man1/npm-outdated.1
+++ b/deps/npm/man/man1/npm-outdated.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-OUTDATED" "1" "March 2014" "" ""
+.TH "NPM\-OUTDATED" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-outdated\fR \-\- Check for outdated packages

--- a/deps/npm/man/man1/npm-owner.1
+++ b/deps/npm/man/man1/npm-owner.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-OWNER" "1" "March 2014" "" ""
+.TH "NPM\-OWNER" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-owner\fR \-\- Manage package owners

--- a/deps/npm/man/man1/npm-pack.1
+++ b/deps/npm/man/man1/npm-pack.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PACK" "1" "March 2014" "" ""
+.TH "NPM\-PACK" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-pack\fR \-\- Create a tarball from a package

--- a/deps/npm/man/man1/npm-prefix.1
+++ b/deps/npm/man/man1/npm-prefix.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PREFIX" "1" "March 2014" "" ""
+.TH "NPM\-PREFIX" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-prefix\fR \-\- Display prefix

--- a/deps/npm/man/man1/npm-prune.1
+++ b/deps/npm/man/man1/npm-prune.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PRUNE" "1" "March 2014" "" ""
+.TH "NPM\-PRUNE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-prune\fR \-\- Remove extraneous packages

--- a/deps/npm/man/man1/npm-publish.1
+++ b/deps/npm/man/man1/npm-publish.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PUBLISH" "1" "March 2014" "" ""
+.TH "NPM\-PUBLISH" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-publish\fR \-\- Publish a package

--- a/deps/npm/man/man1/npm-rebuild.1
+++ b/deps/npm/man/man1/npm-rebuild.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-REBUILD" "1" "March 2014" "" ""
+.TH "NPM\-REBUILD" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-rebuild\fR \-\- Rebuild a package

--- a/deps/npm/man/man1/npm-repo.1
+++ b/deps/npm/man/man1/npm-repo.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-REPO" "1" "March 2014" "" ""
+.TH "NPM\-REPO" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-repo\fR \-\- Open package repository page in the browser

--- a/deps/npm/man/man1/npm-restart.1
+++ b/deps/npm/man/man1/npm-restart.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-RESTART" "1" "March 2014" "" ""
+.TH "NPM\-RESTART" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-restart\fR \-\- Start a package

--- a/deps/npm/man/man1/npm-rm.1
+++ b/deps/npm/man/man1/npm-rm.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-RM" "1" "March 2014" "" ""
+.TH "NPM\-RM" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-rm\fR \-\- Remove a package

--- a/deps/npm/man/man1/npm-root.1
+++ b/deps/npm/man/man1/npm-root.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-ROOT" "1" "March 2014" "" ""
+.TH "NPM\-ROOT" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-root\fR \-\- Display npm root

--- a/deps/npm/man/man1/npm-run-script.1
+++ b/deps/npm/man/man1/npm-run-script.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-RUN\-SCRIPT" "1" "March 2014" "" ""
+.TH "NPM\-RUN\-SCRIPT" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-run-script\fR \-\- Run arbitrary package scripts

--- a/deps/npm/man/man1/npm-search.1
+++ b/deps/npm/man/man1/npm-search.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SEARCH" "1" "March 2014" "" ""
+.TH "NPM\-SEARCH" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-search\fR \-\- Search for packages

--- a/deps/npm/man/man1/npm-shrinkwrap.1
+++ b/deps/npm/man/man1/npm-shrinkwrap.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SHRINKWRAP" "1" "March 2014" "" ""
+.TH "NPM\-SHRINKWRAP" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-shrinkwrap\fR \-\- Lock down dependency versions

--- a/deps/npm/man/man1/npm-star.1
+++ b/deps/npm/man/man1/npm-star.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-STAR" "1" "March 2014" "" ""
+.TH "NPM\-STAR" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-star\fR \-\- Mark your favorite packages

--- a/deps/npm/man/man1/npm-stars.1
+++ b/deps/npm/man/man1/npm-stars.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-STARS" "1" "March 2014" "" ""
+.TH "NPM\-STARS" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-stars\fR \-\- View packages marked as favorites

--- a/deps/npm/man/man1/npm-start.1
+++ b/deps/npm/man/man1/npm-start.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-START" "1" "March 2014" "" ""
+.TH "NPM\-START" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-start\fR \-\- Start a package

--- a/deps/npm/man/man1/npm-stop.1
+++ b/deps/npm/man/man1/npm-stop.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-STOP" "1" "March 2014" "" ""
+.TH "NPM\-STOP" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-stop\fR \-\- Stop a package

--- a/deps/npm/man/man1/npm-submodule.1
+++ b/deps/npm/man/man1/npm-submodule.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SUBMODULE" "1" "March 2014" "" ""
+.TH "NPM\-SUBMODULE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-submodule\fR \-\- Add a package as a git submodule

--- a/deps/npm/man/man1/npm-tag.1
+++ b/deps/npm/man/man1/npm-tag.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-TAG" "1" "March 2014" "" ""
+.TH "NPM\-TAG" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-tag\fR \-\- Tag a published version

--- a/deps/npm/man/man1/npm-test.1
+++ b/deps/npm/man/man1/npm-test.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-TEST" "1" "March 2014" "" ""
+.TH "NPM\-TEST" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-test\fR \-\- Test a package

--- a/deps/npm/man/man1/npm-uninstall.1
+++ b/deps/npm/man/man1/npm-uninstall.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-RM" "1" "March 2014" "" ""
+.TH "NPM\-RM" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-rm\fR \-\- Remove a package

--- a/deps/npm/man/man1/npm-unpublish.1
+++ b/deps/npm/man/man1/npm-unpublish.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-UNPUBLISH" "1" "March 2014" "" ""
+.TH "NPM\-UNPUBLISH" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-unpublish\fR \-\- Remove a package from the registry

--- a/deps/npm/man/man1/npm-update.1
+++ b/deps/npm/man/man1/npm-update.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-UPDATE" "1" "March 2014" "" ""
+.TH "NPM\-UPDATE" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-update\fR \-\- Update a package

--- a/deps/npm/man/man1/npm-version.1
+++ b/deps/npm/man/man1/npm-version.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-VERSION" "1" "March 2014" "" ""
+.TH "NPM\-VERSION" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-version\fR \-\- Bump a package version

--- a/deps/npm/man/man1/npm-view.1
+++ b/deps/npm/man/man1/npm-view.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-VIEW" "1" "March 2014" "" ""
+.TH "NPM\-VIEW" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-view\fR \-\- View registry info

--- a/deps/npm/man/man1/npm-whoami.1
+++ b/deps/npm/man/man1/npm-whoami.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-WHOAMI" "1" "March 2014" "" ""
+.TH "NPM\-WHOAMI" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-whoami\fR \-\- Display npm username

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM" "1" "March 2014" "" ""
+.TH "NPM" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm\fR \-\- node package manager
@@ -14,7 +14,7 @@ npm <command> [args]
 .fi
 .
 .SH "VERSION"
-1.4.6
+1.4.7
 .
 .SH "DESCRIPTION"
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man3/npm-bin.3
+++ b/deps/npm/man/man3/npm-bin.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-BIN" "3" "March 2014" "" ""
+.TH "NPM\-BIN" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-bin\fR \-\- Display npm bin folder

--- a/deps/npm/man/man3/npm-bugs.3
+++ b/deps/npm/man/man3/npm-bugs.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-BUGS" "3" "March 2014" "" ""
+.TH "NPM\-BUGS" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-bugs\fR \-\- Bugs for a package in a web browser maybe

--- a/deps/npm/man/man3/npm-commands.3
+++ b/deps/npm/man/man3/npm-commands.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-COMMANDS" "3" "March 2014" "" ""
+.TH "NPM\-COMMANDS" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-commands\fR \-\- npm commands

--- a/deps/npm/man/man3/npm-config.3
+++ b/deps/npm/man/man3/npm-config.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-CONFIG" "3" "March 2014" "" ""
+.TH "NPM\-CONFIG" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-config\fR \-\- Manage the npm configuration files

--- a/deps/npm/man/man3/npm-deprecate.3
+++ b/deps/npm/man/man3/npm-deprecate.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DEPRECATE" "3" "March 2014" "" ""
+.TH "NPM\-DEPRECATE" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-deprecate\fR \-\- Deprecate a version of a package

--- a/deps/npm/man/man3/npm-docs.3
+++ b/deps/npm/man/man3/npm-docs.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DOCS" "3" "March 2014" "" ""
+.TH "NPM\-DOCS" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-docs\fR \-\- Docs for a package in a web browser maybe

--- a/deps/npm/man/man3/npm-edit.3
+++ b/deps/npm/man/man3/npm-edit.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-EDIT" "3" "March 2014" "" ""
+.TH "NPM\-EDIT" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-edit\fR \-\- Edit an installed package

--- a/deps/npm/man/man3/npm-explore.3
+++ b/deps/npm/man/man3/npm-explore.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-EXPLORE" "3" "March 2014" "" ""
+.TH "NPM\-EXPLORE" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-explore\fR \-\- Browse an installed package

--- a/deps/npm/man/man3/npm-help-search.3
+++ b/deps/npm/man/man3/npm-help-search.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-HELP\-SEARCH" "3" "March 2014" "" ""
+.TH "NPM\-HELP\-SEARCH" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-help-search\fR \-\- Search the help pages

--- a/deps/npm/man/man3/npm-init.3
+++ b/deps/npm/man/man3/npm-init.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "INIT" "3" "March 2014" "" ""
+.TH "INIT" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBinit\fR \-\- Interactively create a package\.json file

--- a/deps/npm/man/man3/npm-install.3
+++ b/deps/npm/man/man3/npm-install.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-INSTALL" "3" "March 2014" "" ""
+.TH "NPM\-INSTALL" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-install\fR \-\- install a package programmatically

--- a/deps/npm/man/man3/npm-link.3
+++ b/deps/npm/man/man3/npm-link.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-LINK" "3" "March 2014" "" ""
+.TH "NPM\-LINK" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-link\fR \-\- Symlink a package folder

--- a/deps/npm/man/man3/npm-load.3
+++ b/deps/npm/man/man3/npm-load.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-LOAD" "3" "March 2014" "" ""
+.TH "NPM\-LOAD" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-load\fR \-\- Load config settings

--- a/deps/npm/man/man3/npm-ls.3
+++ b/deps/npm/man/man3/npm-ls.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-LS" "3" "March 2014" "" ""
+.TH "NPM\-LS" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-ls\fR \-\- List installed packages

--- a/deps/npm/man/man3/npm-outdated.3
+++ b/deps/npm/man/man3/npm-outdated.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-OUTDATED" "3" "March 2014" "" ""
+.TH "NPM\-OUTDATED" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-outdated\fR \-\- Check for outdated packages

--- a/deps/npm/man/man3/npm-owner.3
+++ b/deps/npm/man/man3/npm-owner.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-OWNER" "3" "March 2014" "" ""
+.TH "NPM\-OWNER" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-owner\fR \-\- Manage package owners

--- a/deps/npm/man/man3/npm-pack.3
+++ b/deps/npm/man/man3/npm-pack.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PACK" "3" "March 2014" "" ""
+.TH "NPM\-PACK" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-pack\fR \-\- Create a tarball from a package

--- a/deps/npm/man/man3/npm-prefix.3
+++ b/deps/npm/man/man3/npm-prefix.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PREFIX" "3" "March 2014" "" ""
+.TH "NPM\-PREFIX" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-prefix\fR \-\- Display prefix

--- a/deps/npm/man/man3/npm-prune.3
+++ b/deps/npm/man/man3/npm-prune.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PRUNE" "3" "March 2014" "" ""
+.TH "NPM\-PRUNE" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-prune\fR \-\- Remove extraneous packages

--- a/deps/npm/man/man3/npm-publish.3
+++ b/deps/npm/man/man3/npm-publish.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-PUBLISH" "3" "March 2014" "" ""
+.TH "NPM\-PUBLISH" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-publish\fR \-\- Publish a package

--- a/deps/npm/man/man3/npm-rebuild.3
+++ b/deps/npm/man/man3/npm-rebuild.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-REBUILD" "3" "March 2014" "" ""
+.TH "NPM\-REBUILD" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-rebuild\fR \-\- Rebuild a package

--- a/deps/npm/man/man3/npm-repo.3
+++ b/deps/npm/man/man3/npm-repo.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-REPO" "3" "March 2014" "" ""
+.TH "NPM\-REPO" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-repo\fR \-\- Open package repository page in the browser

--- a/deps/npm/man/man3/npm-restart.3
+++ b/deps/npm/man/man3/npm-restart.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-RESTART" "3" "March 2014" "" ""
+.TH "NPM\-RESTART" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-restart\fR \-\- Start a package

--- a/deps/npm/man/man3/npm-root.3
+++ b/deps/npm/man/man3/npm-root.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-ROOT" "3" "March 2014" "" ""
+.TH "NPM\-ROOT" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-root\fR \-\- Display npm root

--- a/deps/npm/man/man3/npm-run-script.3
+++ b/deps/npm/man/man3/npm-run-script.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-RUN\-SCRIPT" "3" "March 2014" "" ""
+.TH "NPM\-RUN\-SCRIPT" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-run-script\fR \-\- Run arbitrary package scripts

--- a/deps/npm/man/man3/npm-search.3
+++ b/deps/npm/man/man3/npm-search.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SEARCH" "3" "March 2014" "" ""
+.TH "NPM\-SEARCH" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-search\fR \-\- Search for packages

--- a/deps/npm/man/man3/npm-shrinkwrap.3
+++ b/deps/npm/man/man3/npm-shrinkwrap.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SHRINKWRAP" "3" "March 2014" "" ""
+.TH "NPM\-SHRINKWRAP" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-shrinkwrap\fR \-\- programmatically generate package shrinkwrap file

--- a/deps/npm/man/man3/npm-start.3
+++ b/deps/npm/man/man3/npm-start.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-START" "3" "March 2014" "" ""
+.TH "NPM\-START" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-start\fR \-\- Start a package

--- a/deps/npm/man/man3/npm-stop.3
+++ b/deps/npm/man/man3/npm-stop.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-STOP" "3" "March 2014" "" ""
+.TH "NPM\-STOP" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-stop\fR \-\- Stop a package

--- a/deps/npm/man/man3/npm-submodule.3
+++ b/deps/npm/man/man3/npm-submodule.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SUBMODULE" "3" "March 2014" "" ""
+.TH "NPM\-SUBMODULE" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-submodule\fR \-\- Add a package as a git submodule

--- a/deps/npm/man/man3/npm-tag.3
+++ b/deps/npm/man/man3/npm-tag.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-TAG" "3" "March 2014" "" ""
+.TH "NPM\-TAG" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-tag\fR \-\- Tag a published version

--- a/deps/npm/man/man3/npm-test.3
+++ b/deps/npm/man/man3/npm-test.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-TEST" "3" "March 2014" "" ""
+.TH "NPM\-TEST" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-test\fR \-\- Test a package

--- a/deps/npm/man/man3/npm-uninstall.3
+++ b/deps/npm/man/man3/npm-uninstall.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-UNINSTALL" "3" "March 2014" "" ""
+.TH "NPM\-UNINSTALL" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-uninstall\fR \-\- uninstall a package programmatically

--- a/deps/npm/man/man3/npm-unpublish.3
+++ b/deps/npm/man/man3/npm-unpublish.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-UNPUBLISH" "3" "March 2014" "" ""
+.TH "NPM\-UNPUBLISH" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-unpublish\fR \-\- Remove a package from the registry

--- a/deps/npm/man/man3/npm-update.3
+++ b/deps/npm/man/man3/npm-update.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-UPDATE" "3" "March 2014" "" ""
+.TH "NPM\-UPDATE" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-update\fR \-\- Update a package

--- a/deps/npm/man/man3/npm-version.3
+++ b/deps/npm/man/man3/npm-version.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-VERSION" "3" "March 2014" "" ""
+.TH "NPM\-VERSION" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-version\fR \-\- Bump a package version

--- a/deps/npm/man/man3/npm-view.3
+++ b/deps/npm/man/man3/npm-view.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-VIEW" "3" "March 2014" "" ""
+.TH "NPM\-VIEW" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-view\fR \-\- View registry info

--- a/deps/npm/man/man3/npm-whoami.3
+++ b/deps/npm/man/man3/npm-whoami.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-WHOAMI" "3" "March 2014" "" ""
+.TH "NPM\-WHOAMI" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-whoami\fR \-\- Display npm username

--- a/deps/npm/man/man3/npm.3
+++ b/deps/npm/man/man3/npm.3
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM" "3" "March 2014" "" ""
+.TH "NPM" "3" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm\fR \-\- node package manager
@@ -21,7 +21,7 @@ npm\.load([configObject], function (er, npm) {
 .fi
 .
 .SH "VERSION"
-1.4.6
+1.4.7
 .
 .SH "DESCRIPTION"
 This is the API documentation for npm\.

--- a/deps/npm/man/man5/npm-folders.5
+++ b/deps/npm/man/man5/npm-folders.5
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-FOLDERS" "5" "March 2014" "" ""
+.TH "NPM\-FOLDERS" "5" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-folders\fR \-\- Folder Structures Used by npm

--- a/deps/npm/man/man5/npm-global.5
+++ b/deps/npm/man/man5/npm-global.5
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-FOLDERS" "5" "March 2014" "" ""
+.TH "NPM\-FOLDERS" "5" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-folders\fR \-\- Folder Structures Used by npm

--- a/deps/npm/man/man5/npm-json.5
+++ b/deps/npm/man/man5/npm-json.5
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "PACKAGE\.JSON" "5" "March 2014" "" ""
+.TH "PACKAGE\.JSON" "5" "April 2014" "" ""
 .
 .SH "NAME"
 \fBpackage.json\fR \-\- Specifics of npm\'s package\.json handling
@@ -566,6 +566,57 @@ The \fBprepublish\fR script will be run before publishing, so that users
 can consume the functionality without requiring them to compile it
 themselves\.  In dev mode (ie, locally running \fBnpm install\fR), it\'ll
 run this script as well, so that you can test it easily\.
+.
+.SH "peerDependencies"
+In some cases, you want to express the compatibility of your package with an
+host tool or library, while not necessarily doing a \fBrequire\fR of this host\.
+This is usually refered to as a \fIplugin\fR\|\. Notably, your module may be exposing
+a specific interface, expected and specified by the host documentation\.
+.
+.P
+For example:
+.
+.IP "" 4
+.
+.nf
+{
+  "name": "tea\-latte",
+  "version": "1\.3\.5"
+  "peerDependencies": {
+    "tea": "2\.x"
+  }
+}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This ensures your package \fBtea\-latte\fR can be installed \fIalong\fR with the second
+major version of the host package \fBtea\fR only\. The host package is automatically
+installed if needed\. \fBnpm install tea\-latte\fR could possibly yield the following
+dependency graph:
+.
+.IP "" 4
+.
+.nf
+├── tea\-latte@1\.3\.5
+└── tea@2\.2\.0
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Trying to install another plugin with a conflicting requirement will cause an
+error\. For this reason, make sure your plugin requirement is as broad as
+possible, and not to lock it down to specific patch versions\.
+.
+.P
+Assuming the host complies with semver \fIhttp://semver\.org/\fR, only changes in
+the host package\'s major version will break your plugin\. Thus, if you\'ve worked
+with every 1\.x version of the host package, use \fB"^1\.0"\fR or \fB"1\.x"\fR to express
+this\. If you depend on features introduced in 1\.5\.2, use \fB">= 1\.5\.2 < 2"\fR\|\.
 .
 .SH "bundledDependencies"
 Array of package names that will be bundled when publishing the package\.

--- a/deps/npm/man/man5/npmrc.5
+++ b/deps/npm/man/man5/npmrc.5
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPMRC" "5" "March 2014" "" ""
+.TH "NPMRC" "5" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpmrc\fR \-\- The npm config files

--- a/deps/npm/man/man5/package.json.5
+++ b/deps/npm/man/man5/package.json.5
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "PACKAGE\.JSON" "5" "March 2014" "" ""
+.TH "PACKAGE\.JSON" "5" "April 2014" "" ""
 .
 .SH "NAME"
 \fBpackage.json\fR \-\- Specifics of npm\'s package\.json handling
@@ -566,6 +566,57 @@ The \fBprepublish\fR script will be run before publishing, so that users
 can consume the functionality without requiring them to compile it
 themselves\.  In dev mode (ie, locally running \fBnpm install\fR), it\'ll
 run this script as well, so that you can test it easily\.
+.
+.SH "peerDependencies"
+In some cases, you want to express the compatibility of your package with an
+host tool or library, while not necessarily doing a \fBrequire\fR of this host\.
+This is usually refered to as a \fIplugin\fR\|\. Notably, your module may be exposing
+a specific interface, expected and specified by the host documentation\.
+.
+.P
+For example:
+.
+.IP "" 4
+.
+.nf
+{
+  "name": "tea\-latte",
+  "version": "1\.3\.5"
+  "peerDependencies": {
+    "tea": "2\.x"
+  }
+}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This ensures your package \fBtea\-latte\fR can be installed \fIalong\fR with the second
+major version of the host package \fBtea\fR only\. The host package is automatically
+installed if needed\. \fBnpm install tea\-latte\fR could possibly yield the following
+dependency graph:
+.
+.IP "" 4
+.
+.nf
+├── tea\-latte@1\.3\.5
+└── tea@2\.2\.0
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Trying to install another plugin with a conflicting requirement will cause an
+error\. For this reason, make sure your plugin requirement is as broad as
+possible, and not to lock it down to specific patch versions\.
+.
+.P
+Assuming the host complies with semver \fIhttp://semver\.org/\fR, only changes in
+the host package\'s major version will break your plugin\. Thus, if you\'ve worked
+with every 1\.x version of the host package, use \fB"^1\.0"\fR or \fB"1\.x"\fR to express
+this\. If you depend on features introduced in 1\.5\.2, use \fB">= 1\.5\.2 < 2"\fR\|\.
 .
 .SH "bundledDependencies"
 Array of package names that will be bundled when publishing the package\.

--- a/deps/npm/man/man7/npm-coding-style.7
+++ b/deps/npm/man/man7/npm-coding-style.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-CODING\-STYLE" "7" "March 2014" "" ""
+.TH "NPM\-CODING\-STYLE" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-coding-style\fR \-\- npm\'s "funny" coding style

--- a/deps/npm/man/man7/npm-config.7
+++ b/deps/npm/man/man7/npm-config.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-CONFIG" "7" "March 2014" "" ""
+.TH "NPM\-CONFIG" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-config\fR \-\- More than you probably want to know about npm configuration
@@ -1136,6 +1136,27 @@ devDependencies hash\.
 .
 .P
 Only works if there is already a package\.json file present\.
+.
+.SS "save\-prefix"
+.
+.IP "\(bu" 4
+Default: \'^\'
+.
+.IP "\(bu" 4
+Type: String
+.
+.IP "" 0
+.
+.P
+Configure how versions of packages installed to a package\.json file via  \fB\-\-save\fR or \fB\-\-save\-dev\fR get prefixed\.
+.
+.P
+For example if a package has version \fB1\.2\.3\fR, by default it\'s version is
+set to \fB^1\.2\.3\fR which allows minor upgrades for that package, but after
+.
+.br
+\fBnpm config set save\-prefix=\'~\'\fR it would be set to \fB~1\.2\.3\fR which only allows
+patch upgrades\.
 .
 .SS "searchopts"
 .

--- a/deps/npm/man/man7/npm-developers.7
+++ b/deps/npm/man/man7/npm-developers.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DEVELOPERS" "7" "March 2014" "" ""
+.TH "NPM\-DEVELOPERS" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-developers\fR \-\- Developer Guide

--- a/deps/npm/man/man7/npm-disputes.7
+++ b/deps/npm/man/man7/npm-disputes.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-DISPUTES" "7" "March 2014" "" ""
+.TH "NPM\-DISPUTES" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-disputes\fR \-\- Handling Module Name Disputes

--- a/deps/npm/man/man7/npm-faq.7
+++ b/deps/npm/man/man7/npm-faq.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-FAQ" "7" "March 2014" "" ""
+.TH "NPM\-FAQ" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-faq\fR \-\- Frequently Asked Questions
@@ -94,7 +94,7 @@ npm will not help you do something that is known to be a bad idea\.
 Mikeal Rogers answered this question very well:
 .
 .P
-\fIhttp://www\.mikealrogers\.com/posts/nodemodules\-in\-git\.html\fR
+\fIhttp://www\.futurealoof\.com/posts/nodemodules\-in\-git\.html\fR
 .
 .P
 tl;dr

--- a/deps/npm/man/man7/npm-index.7
+++ b/deps/npm/man/man7/npm-index.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-INDEX" "7" "March 2014" "" ""
+.TH "NPM\-INDEX" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-index\fR \-\- Index of all npm documentation

--- a/deps/npm/man/man7/npm-registry.7
+++ b/deps/npm/man/man7/npm-registry.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-REGISTRY" "7" "March 2014" "" ""
+.TH "NPM\-REGISTRY" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-registry\fR \-\- The JavaScript Package Registry

--- a/deps/npm/man/man7/npm-scripts.7
+++ b/deps/npm/man/man7/npm-scripts.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SCRIPTS" "7" "March 2014" "" ""
+.TH "NPM\-SCRIPTS" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-scripts\fR \-\- How npm handles the "scripts" field

--- a/deps/npm/man/man7/removing-npm.7
+++ b/deps/npm/man/man7/removing-npm.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-REMOVAL" "1" "March 2014" "" ""
+.TH "NPM\-REMOVAL" "1" "April 2014" "" ""
 .
 .SH "NAME"
 \fBnpm-removal\fR \-\- Cleaning the Slate

--- a/deps/npm/man/man7/semver.7
+++ b/deps/npm/man/man7/semver.7
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs 0.3.8
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "SEMVER" "7" "March 2014" "" ""
+.TH "SEMVER" "7" "April 2014" "" ""
 .
 .SH "NAME"
 \fBsemver\fR \-\- The semantic versioner for npm

--- a/deps/npm/node_modules/npm-registry-client/lib/request.js
+++ b/deps/npm/node_modules/npm-registry-client/lib/request.js
@@ -112,6 +112,8 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
         self.log.info("retry", "will retry, error on last attempt: " + er)
         return
       }
+      if (response)
+        this.log.verbose("headers", response.headers)
       cb.apply(null, arguments)
     }.bind(this))
   }.bind(this))
@@ -188,6 +190,12 @@ function makeRequest (method, remote, where, what, etag, nofollow, cb_) {
 function decodeResponseBody(cb) {
   return function (er, response, data) {
     if (er) return cb(er, response, data)
+
+    // don't ever re-use connections that had server errors.
+    // those sockets connect to the Bad Place!
+    if (response.socket && response.statusCode > 500) {
+      response.socket.destroy()
+    }
 
     if (response.headers['content-encoding'] !== 'gzip') return cb(er, response, data)
 

--- a/deps/npm/node_modules/npm-registry-client/package.json
+++ b/deps/npm/node_modules/npm-registry-client/package.json
@@ -6,7 +6,7 @@
   },
   "name": "npm-registry-client",
   "description": "Client for the npm registry",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "repository": {
     "url": "git://github.com/isaacs/npm-registry-client"
   },
@@ -38,6 +38,6 @@
     "url": "https://github.com/isaacs/npm-registry-client/issues"
   },
   "homepage": "https://github.com/isaacs/npm-registry-client",
-  "_id": "npm-registry-client@0.4.5",
+  "_id": "npm-registry-client@0.4.7",
   "_from": "npm-registry-client@latest"
 }

--- a/deps/npm/node_modules/npmconf/config-defs.js
+++ b/deps/npm/node_modules/npmconf/config-defs.js
@@ -188,6 +188,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , "save-dev" : false
     , "save-exact" : false
     , "save-optional" : false
+    , "save-prefix": "^"
     , searchopts: ""
     , searchexclude: null
     , searchsort: "name"
@@ -290,6 +291,7 @@ exports.types =
   , "save-dev" : Boolean
   , "save-exact" : Boolean
   , "save-optional" : Boolean
+  , "save-prefix": String
   , searchopts : String
   , searchexclude: [null, String]
   , searchsort: [ "name", "-name"

--- a/deps/npm/node_modules/npmconf/node_modules/config-chain/node_modules/proto-list/package.json
+++ b/deps/npm/node_modules/npmconf/node_modules/config-chain/node_modules/proto-list/package.json
@@ -29,9 +29,7 @@
   },
   "homepage": "https://github.com/isaacs/proto-list",
   "_id": "proto-list@1.2.2",
-  "dist": {
-    "shasum": "48b88798261ec2c4a785720cdfec6200d57d3326"
-  },
+  "_shasum": "48b88798261ec2c4a785720cdfec6200d57d3326",
   "_from": "proto-list@~1.2.1",
   "_resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.2.tgz"
 }

--- a/deps/npm/node_modules/npmconf/node_modules/config-chain/package.json
+++ b/deps/npm/node_modules/npmconf/node_modules/config-chain/package.json
@@ -28,9 +28,7 @@
     "url": "https://github.com/dominictarr/config-chain/issues"
   },
   "_id": "config-chain@1.1.8",
-  "dist": {
-    "shasum": "a3b9ae699dedb3a7837615001f3cf646ca37c77a"
-  },
+  "_shasum": "0943d0b7227213a20d4eaff4434f4a1c0a052cad",
   "_from": "config-chain@~1.1.8",
   "_resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz"
 }

--- a/deps/npm/node_modules/npmconf/package.json
+++ b/deps/npm/node_modules/npmconf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmconf",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "The config thing npm uses",
   "main": "npmconf.js",
   "directories": {
@@ -45,6 +45,7 @@
     "url": "https://github.com/isaacs/npmconf/issues"
   },
   "homepage": "https://github.com/isaacs/npmconf",
-  "_id": "npmconf@0.1.13",
+  "_id": "npmconf@0.1.14",
+  "_shasum": "aea4bc12c5a84191a32cd350e325da4fe8b127e7",
   "_from": "npmconf@latest"
 }

--- a/deps/npm/node_modules/read-installed/package.json
+++ b/deps/npm/node_modules/read-installed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "read-installed",
   "description": "Read all the installed packages in a folder, and return a tree structure with all the data.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/read-installed"
@@ -35,6 +35,6 @@
     "url": "https://github.com/isaacs/read-installed/issues"
   },
   "homepage": "https://github.com/isaacs/read-installed",
-  "_id": "read-installed@2.0.1",
+  "_id": "read-installed@2.0.2",
   "_from": "read-installed@latest"
 }

--- a/deps/npm/node_modules/read-installed/read-installed.js
+++ b/deps/npm/node_modules/read-installed/read-installed.js
@@ -334,10 +334,13 @@ function findUnmet (obj, opts) {
       dependency = obj.parent.dependencies && obj.parent.dependencies[d]
     }
 
-    if (!dependency) return
-
-    if (!semver.satisfies(dependency.version, peerDeps[d], true)) {
+    if (!dependency) {
+      // mark as a missing dep!
+      obj.dependencies[d] = peerDeps[d]
+    } else if (!semver.satisfies(dependency.version, peerDeps[d], true)) {
       dependency.peerInvalid = true
+    } else {
+      dependency.extraneous = false
     }
   })
 

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.6",
+  "version": "1.4.7",
   "name": "npm",
   "publishConfig": {
     "proprietary-attribs": false
@@ -61,9 +61,9 @@
     "node-gyp": "~0.13.0",
     "nopt": "~2.2.0",
     "npm-install-checks": "~1.0.0",
-    "npm-registry-client": "~0.4.5",
+    "npm-registry-client": "~0.4.7",
     "npm-user-validate": "0.0.3",
-    "npmconf": "~0.1.13",
+    "npmconf": "~0.1.14",
     "npmlog": "0.0.6",
     "once": "~1.3.0",
     "opener": "~1.3.0",
@@ -138,7 +138,7 @@
     "which"
   ],
   "devDependencies": {
-    "npm-registry-mock": "~0.5",
+    "npm-registry-mock": "~0.6.3",
     "ronn": "~0.3.6",
     "tap": "~0.4.0"
   },
@@ -147,11 +147,12 @@
     "npm": "1"
   },
   "scripts": {
-    "test": "node ./test/run.js && tap test/tap/*.js",
-    "tap": "tap test/tap/*.js",
+    "test-legacy": "node ./test/run.js",
+    "test": "tap --timeout 120 test/tap/*.js",
+    "tap": "tap --timeout 120 test/tap/*.js",
+    "test-all": "node ./test/run.js && tap test/tap/*.js",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rm -rf test/*/*/node_modules && make -j32 doc",
-    "dumpconf": "env | grep npm | sort | uniq",
-    "echo": "node bin/npm-cli.js"
+    "dumpconf": "env | grep npm | sort | uniq"
   },
   "license": "Artistic-2.0"
 }

--- a/deps/npm/scripts/doc-build.sh
+++ b/deps/npm/scripts/doc-build.sh
@@ -53,11 +53,13 @@ case $dest in
     exit $?
     ;;
   *.html)
+    url=${dest/html\//}
     (cat html/dochead.html && \
      ./node_modules/.bin/ronn -f $src &&
      cat html/docfoot.html)\
     | sed "s|@NAME@|$name|g" \
     | sed "s|@DATE@|$date|g" \
+    | sed "s|@URL@|$url|g" \
     | sed "s|@VERSION@|$version|g" \
     | perl -pi -e 's/<h1>([^\(]*\([0-9]\)) -- (.*?)<\/h1>/<h1>\1<\/h1> <p>\2<\/p>/g' \
     | perl -pi -e 's/npm-npm/npm/g' \

--- a/deps/npm/test/tap/00-check-mock-dep.js
+++ b/deps/npm/test/tap/00-check-mock-dep.js
@@ -1,0 +1,15 @@
+console.log("TAP Version 13")
+
+process.on("uncaughtException", function(er) {
+  console.log("not ok - Failed checking mock registry dep. Expect much fail!")
+  console.log("1..1")
+  process.exit(1)
+})
+
+var assert = require("assert")
+var semver = require("semver")
+var mock = require("npm-registry-mock/package.json").version
+var req = require("../../package.json").devDependencies["npm-registry-mock"]
+assert(semver.satisfies(mock, req))
+console.log("ok")
+console.log("1..1")

--- a/deps/npm/test/tap/404-parent.js
+++ b/deps/npm/test/tap/404-parent.js
@@ -7,6 +7,7 @@ var fs = require('fs')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var pkg = path.resolve(__dirname, '404-parent')
+var mr = require("npm-registry-mock")
 
 test('404-parent: if parent exists, specify parent in error message', function(t) {
   setup()
@@ -41,9 +42,12 @@ function setup() {
 }
 
 function performInstall(cb) {
-  npm.load(function() {
-    npm.commands.install(pkg, [], function(err) {
-      cb(err)
+  mr(common.port, function (s) { // create mock registry.
+    npm.load({registry: common.registry}, function() {
+      npm.commands.install(pkg, [], function(err) {
+        cb(err)
+        s.close() // shutdown mock npm server.
+      })
     })
   })
 }

--- a/deps/npm/test/tap/cache-shasum.js
+++ b/deps/npm/test/tap/cache-shasum.js
@@ -1,0 +1,60 @@
+var npm = require.resolve("../../")
+var test = require("tap").test
+var path = require("path")
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var mr = require("npm-registry-mock")
+var common = require("../common-tap.js")
+var cache = path.resolve(__dirname, "cache-shasum")
+var spawn = require("child_process").spawn
+var sha = require("sha")
+var server
+
+test("mock reg", function(t) {
+  rimraf.sync(cache)
+  mkdirp.sync(cache)
+  mr(common.port, function (s) {
+    server = s
+    t.pass("ok")
+    t.end()
+  })
+})
+
+test("npm cache add request", function(t) {
+  var c = spawn(process.execPath, [
+    npm, "cache", "add", "request@2.27.0",
+    "--cache=" + cache,
+    "--registry=" + common.registry,
+    "--loglevel=quiet"
+  ])
+  c.stderr.pipe(process.stderr)
+
+  c.stdout.on("data", function(d) {
+    t.fail("Should not get data on stdout: " + d)
+  })
+
+  c.on("close", function(code) {
+    t.notOk(code, "exit ok")
+    t.end()
+  })
+})
+
+test("compare", function(t) {
+  var d = path.resolve(__dirname, "cache-shasum/request")
+  var p = path.resolve(d, "2.27.0/package.tgz")
+  var r = require(path.resolve(d, ".cache.json"))
+  var rshasum = r.versions['2.27.0'].dist.shasum
+  sha.get(p, function (er, pshasum) {
+    if (er)
+      throw er
+    t.equal(pshasum, rshasum)
+    t.end()
+  })
+})
+
+test("cleanup", function(t) {
+  server.close()
+  rimraf.sync(cache)
+  t.end()
+})

--- a/deps/npm/test/tap/dedupe.js
+++ b/deps/npm/test/tap/dedupe.js
@@ -4,17 +4,19 @@ var test = require("tap").test
   , existsSync = fs.existsSync || path.existsSync
   , npm = require("../../")
   , rimraf = require("rimraf")
+  , mr = require("npm-registry-mock")
+  , common = require('../common-tap.js')
 
 test("dedupe finds the common module and moves it up one level", function (t) {
-  t.plan(2)
-
-  setup(function () {
+  setup(function (s) {
     npm.install(".", function (err) {
       if (err) return t.fail(err)
       npm.dedupe(function(err) {
         if (err) return t.fail(err)
         t.ok(existsSync(path.join(__dirname, "dedupe", "node_modules", "minimist")))
-        t.ok(!existsSync(path.join(__dirname, "dedupe", "node_modules", "prime")))
+        t.ok(!existsSync(path.join(__dirname, "dedupe", "node_modules", "checker")))
+        s.close() // shutdown mock registry.
+        t.end()
       })
     })
   })
@@ -22,9 +24,11 @@ test("dedupe finds the common module and moves it up one level", function (t) {
 
 function setup (cb) {
   process.chdir(path.join(__dirname, "dedupe"))
-  npm.load(function () {
-    rimraf.sync(path.join(__dirname, "dedupe", "node_modules"))
-    fs.mkdirSync(path.join(__dirname, "dedupe", "node_modules"))
-    cb()
+  mr(common.port, function (s) { // create mock registry.
+    npm.load({registry: common.registry}, function() {
+      rimraf.sync(path.join(__dirname, "dedupe", "node_modules"))
+      fs.mkdirSync(path.join(__dirname, "dedupe", "node_modules"))
+      cb(s)
+    })
   })
 }

--- a/deps/npm/test/tap/dedupe/package.json
+++ b/deps/npm/test/tap/dedupe/package.json
@@ -4,8 +4,6 @@
   "version": "0.0.0",
   "dependencies": {
     "optimist": "0.6.0",
-    "clean": "2.1.6",
-    "informal": "0.0.1",
-    "pathogen": "0.1.5"
+    "clean": "2.1.6"
   }
 }

--- a/deps/npm/test/tap/git-cache-locking.js
+++ b/deps/npm/test/tap/git-cache-locking.js
@@ -21,6 +21,9 @@ test("setup", function (t) {
 
 test("git-cache-locking: install a git dependency", function (t) {
 
+  // disable git integration tests on Travis.
+  if (process.env.TRAVIS) return t.end()
+
   // package c depends on a.git#master and b.git#master
   // package b depends on a.git#master
   var child = spawn(node, [npm, "install", "git://github.com/nigelzor/npm-4503-c.git"], {

--- a/deps/npm/test/tap/ignore-scripts.js
+++ b/deps/npm/test/tap/ignore-scripts.js
@@ -35,7 +35,7 @@ var scripts = [
 ]
 
 scripts.forEach(function(script) {
-  test("ignore-scripts: run-script"+script+" using the option", function(t) {
+  test("ignore-scripts: run-script "+script+" using the option", function(t) {
     createChild([npm, "--ignore-scripts", "run-script", script])
       .on("close", function(code) {
         t.equal(code, 0)
@@ -57,7 +57,8 @@ function createChild (args) {
   var env = {
     HOME: process.env.HOME,
     Path: process.env.PATH,
-    PATH: process.env.PATH
+    PATH: process.env.PATH,
+    npm_config_loglevel: "silent"
   }
 
   if (process.platform === "win32")

--- a/deps/npm/test/tap/install-save-prefix.js
+++ b/deps/npm/test/tap/install-save-prefix.js
@@ -1,0 +1,140 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.join(__dirname, 'install-save-prefix')
+var mr = require("npm-registry-mock")
+
+test("setup", function (t) {
+  mkdirp.sync(pkg)
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  process.chdir(pkg)
+  t.end()
+})
+
+test('"npm install --save with default save-prefix should install local pkg versioned to allow minor updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save', true)
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.dependencies, {
+            'underscore': '^1.3.1'
+          }, 'Underscore dependency should specify ^1.3.1')
+          npm.config.set('save', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save-dev with default save-prefix should install local pkg to dev dependencies versioned to allow minor updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save-dev', true)
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.devDependencies, {
+            'underscore': '^1.3.1'
+          }, 'Underscore devDependency should specify ^1.3.1')
+          npm.config.set('save-dev', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save with "~" save-prefix should install local pkg versioned to allow patch updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save', true)
+        npm.config.set('save-prefix', '~')
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.dependencies, {
+            'underscore': '~1.3.1'
+          }, 'Underscore dependency should specify ~1.3.1')
+          npm.config.set('save', undefined)
+          npm.config.set('save-prefix', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save-dev with "~" save-prefix should install local pkg to dev dependencies versioned to allow patch updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save-dev', true)
+        npm.config.set('save-prefix', '~')
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.devDependencies, {
+            'underscore': '~1.3.1'
+          }, 'Underscore devDependency should specify ~1.3.1')
+          npm.config.set('save-dev', undefined)
+          npm.config.set('save-prefix', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  rimraf.sync(path.resolve(pkg, 'cache'))
+  resetPackageJSON(pkg)
+  t.end()
+})
+
+function resetPackageJSON(pkg) {
+  var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+  delete pkgJson.dependencies
+  delete pkgJson.devDependencies
+  delete pkgJson.optionalDependencies
+  var json = JSON.stringify(pkgJson, null, 2) + "\n"
+  fs.writeFileSync(pkg + '/package.json', json, "ascii")
+}
+
+

--- a/deps/npm/test/tap/install-save-prefix/README.md
+++ b/deps/npm/test/tap/install-save-prefix/README.md
@@ -1,0 +1,1 @@
+# just a test

--- a/deps/npm/test/tap/install-save-prefix/index.js
+++ b/deps/npm/test/tap/install-save-prefix/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/deps/npm/test/tap/install-save-prefix/package.json
+++ b/deps/npm/test/tap/install-save-prefix/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bla",
+  "description": "fixture",
+  "version": "0.0.1",
+  "main": "index.js",
+  "repository": "git://github.com/robertkowalski/bogusfixture"
+}

--- a/deps/npm/test/tap/lifecycle-signal.js
+++ b/deps/npm/test/tap/lifecycle-signal.js
@@ -7,11 +7,19 @@ var pkg = path.resolve(__dirname, "lifecycle-signal")
 
 test("lifecycle signal abort", function (t) {
   // windows does not use lifecycle signals, abort
-  if (process.platform === "win32") return t.end()
+  if (process.platform === "win32" || process.env.TRAVIS) return t.end()
+
   var child = spawn(node, [npm, "install"], {
     cwd: pkg
   })
   child.on("close", function (code, signal) {
+    // GNU shell returns a code, no signal
+    if (process.platform === "linux") {
+      t.equal(code, 1)
+      t.equal(signal, null)
+      return t.end()
+    }
+
     t.equal(code, null)
     t.equal(signal, "SIGSEGV")
     t.end()

--- a/deps/npm/test/tap/outdated-color.js
+++ b/deps/npm/test/tap/outdated-color.js
@@ -5,6 +5,7 @@ var mkdirp = require("mkdirp")
 var rimraf = require("rimraf")
 var mr = require("npm-registry-mock")
 var exec = require('child_process').exec
+var mr = require("npm-registry-mock")
 
 var pkg = __dirname + '/outdated'
 var NPM_BIN = __dirname + '/../../bin/npm-cli.js'
@@ -25,12 +26,15 @@ function ansiTrim (str) {
 // it's not running in a tty
 test("does not use ansi styling", function (t) {
   t.plan(3)
-  exec('node ' + NPM_BIN + ' outdated --color false', {
-    cwd: pkg
-  }, function(err, stdout) {
-    t.ifError(err)
-    t.ok(stdout, stdout.length)
-    t.ok(!hasControlCodes(stdout)) 
+  mr(common.port, function (s) { // create mock registry.
+    exec('node ' + NPM_BIN + ' outdated --registry ' + common.registry + ' --color false underscore', {
+      cwd: pkg
+    }, function(err, stdout) {
+      t.ifError(err)
+      t.ok(stdout, stdout.length)
+      t.ok(!hasControlCodes(stdout))
+      s.close()
+    })
   })
 })
 
@@ -38,4 +42,3 @@ test("cleanup", function (t) {
   rimraf.sync(pkg + "/cache")
   t.end()
 })
-

--- a/deps/npm/test/tap/peer-deps-invalid.js
+++ b/deps/npm/test/tap/peer-deps-invalid.js
@@ -4,18 +4,19 @@ var test = require("tap").test
 var rimraf = require("rimraf")
 var npm = require("../../")
 var http = require("http")
+var mr = require("npm-registry-mock")
 
 var okFile = new Buffer(
-'/**package\n' + 
-' * { "name": "npm-test-peer-deps-file"\n' + 
-' * , "main": "index.js"\n' + 
-' * , "version": "1.2.3"\n' + 
-' * , "description":"No package.json in sight!"\n' + 
-' * , "peerDependencies": { "dict": "1.1.0" }\n' + 
-' * , "dependencies": { "opener": "1.3.0" }\n' + 
-' * }\n' + 
-' **/\n' + 
-'\n' + 
+'/**package\n' +
+' * { "name": "npm-test-peer-deps-file"\n' +
+' * , "main": "index.js"\n' +
+' * , "version": "1.2.3"\n' +
+' * , "description":"No package.json in sight!"\n' +
+' * , "peerDependencies": { "underscore": "1.3.1" }\n' +
+' * , "dependencies": { "mkdirp": "0.3.5" }\n' +
+' * }\n' +
+' **/\n' +
+'\n' +
 'module.exports = "I\'m just a lonely index, naked as the day I was born."\n'
 )
 
@@ -25,7 +26,7 @@ var failFile = new Buffer(
 ' * , "main": "index.js"\n' +
 ' * , "version": "1.2.3"\n' +
 ' * , "description":"This one should conflict with the other one"\n' +
-' * , "peerDependencies": { "dict": "1.0.0" }\n' +
+' * , "peerDependencies": { "underscore": "1.3.3" }\n' +
 ' * }\n' +
 ' **/\n' +
 '\n' +
@@ -51,20 +52,25 @@ test("setup", function(t) {
 
 
 
-test("installing dependencies that having conflicting peerDependencies", function (t) {
+test("installing dependencies that have conflicting peerDependencies", function (t) {
   rimraf.sync(__dirname + "/peer-deps-invalid/node_modules")
   process.chdir(__dirname + "/peer-deps-invalid")
 
-  npm.load(function () {
-    console.error('back from load')
-    npm.commands.install([], function (err) {
-      console.error('back from install')
-      if (!err) {
-        t.fail("No error!")
-      } else {
-        t.equal(err.code, "EPEERINVALID")
-      }
-      t.end()
+  // we're already listening on common.port,
+  // use an alternative port for this test.
+  mr(1331, function (s) { // create mock registry.
+    npm.load({registry: "http://localhost:1331"}, function () {
+      console.error('back from load')
+      npm.commands.install([], function (err) {
+        console.error('back from install')
+        if (!err) {
+          t.fail("No error!")
+        } else {
+          t.equal(err.code, "EPEERINVALID")
+        }
+        t.end()
+        s.close() // shutdown mock registry.
+      })
     })
   })
 })

--- a/deps/npm/test/tap/peer-deps-without-package-json.js
+++ b/deps/npm/test/tap/peer-deps-without-package-json.js
@@ -3,7 +3,7 @@ var fs = require("fs")
 var test = require("tap").test
 var rimraf = require("rimraf")
 var npm = require("../../")
-
+var mr = require("npm-registry-mock")
 var http = require("http")
 
 
@@ -13,8 +13,8 @@ var js = new Buffer(
 ' * , "main": "index.js"\n' +
 ' * , "version": "1.2.3"\n' +
 ' * , "description":"No package.json in sight!"\n' +
-' * , "peerDependencies": { "dict": "1.1.0" }\n' +
-' * , "dependencies": { "opener": "1.3.0" }\n' +
+' * , "peerDependencies": { "underscore": "1.3.1" }\n' +
+' * , "dependencies": { "mkdirp": "0.3.5" }\n' +
 ' * }\n' +
 ' **/\n' +
 '\n' +
@@ -38,15 +38,20 @@ test("installing a peerDependencies-using package without a package.json present
   fs.mkdirSync(__dirname + "/peer-deps-without-package-json/node_modules")
   process.chdir(__dirname + "/peer-deps-without-package-json")
 
-  npm.load(function () {
-    npm.install(common.registry, function (err) {
-      if (err) {
-        t.fail(err)
-      } else {
-        t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/npm-test-peer-deps-file"))
-        t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/dict"))
-      }
-      t.end()
+  // we're already listening on common.port,
+  // use an alternative port for this test.
+  mr(1331, function (s) { // create mock registry.
+    npm.load({registry: 'http://localhost:1331'}, function () {
+      npm.install(common.registry, function (err) {
+        if (err) {
+          t.fail(err)
+        } else {
+          t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/npm-test-peer-deps-file"))
+          t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/underscore"))
+        }
+        t.end()
+        s.close() // shutdown mock registry.
+      })
     })
   })
 })

--- a/deps/npm/test/tap/shrinkwrap-empty-deps.js
+++ b/deps/npm/test/tap/shrinkwrap-empty-deps.js
@@ -1,0 +1,47 @@
+var test = require("tap").test
+  , npm = require("../../")
+  , mr = require("npm-registry-mock")
+  , common = require("../common-tap.js")
+  , path = require("path")
+  , fs = require("fs")
+  , osenv = require("osenv")
+  , rimraf = require("rimraf")
+  , pkg = __dirname + "/shrinkwrap-empty-deps"
+
+test("returns a list of removed items", function (t) {
+  var desiredResultsPath = path.resolve(pkg, "npm-shrinkwrap.json")
+
+  cleanup()
+
+  mr(common.port, function (s) {
+    setup(function () {
+      npm.shrinkwrap([], function (err) {
+        if (err) return t.fail(err)
+        fs.readFile(desiredResultsPath, function (err, desired) {
+          if (err) return t.fail(err)
+          t.deepEqual({
+            "name": "npm-test-shrinkwrap-empty-deps",
+            "version": "0.0.0",
+            "dependencies": {}
+          }, JSON.parse(desired))
+          cleanup()
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+function setup (cb) {
+  cleanup()
+  process.chdir(pkg)
+  npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
+    cb()
+  })
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path.resolve(pkg, "npm-shrinkwrap.json"))
+}

--- a/deps/npm/test/tap/shrinkwrap-empty-deps/package.json
+++ b/deps/npm/test/tap/shrinkwrap-empty-deps/package.json
@@ -1,0 +1,7 @@
+{
+  "author": "Rockbert",
+  "name": "npm-test-shrinkwrap-empty-deps",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/deps/npm/test/tap/sorted-package-json.js
+++ b/deps/npm/test/tap/sorted-package-json.js
@@ -24,7 +24,7 @@ test("sorting dependencies", function (t) {
 
   var before = JSON.parse(fs.readFileSync(packageJson).toString())
 
-  mr({port: common.port}, function (s) {
+  mr(common.port, function (s) {
     // underscore is already in the package.json,
     // but --save will trigger a rewrite with sort
     var child = spawn(node, [npm, "install", "--save", "underscore@1.3.3"], {

--- a/lib/url.js
+++ b/lib/url.js
@@ -107,6 +107,12 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
   }
 
+  // Copy chrome, IE, opera backslash-handling behavior.
+  // See: https://code.google.com/p/chromium/issues/detail?id=25916
+  var hashSplit = url.split('#');
+  hashSplit[0] = hashSplit[0].replace(/\\/g, '/');
+  url = hashSplit.join('#');
+
   var rest = url;
 
   // trim before proceeding.

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -34,6 +34,28 @@ var parseTests = {
     'path': '//some_path'
   },
 
+  'http:\\\\evil-phisher\\foo.html#h\\a\\s\\h': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'evil-phisher',
+    hostname: 'evil-phisher',
+    pathname: '/foo.html',
+    path: '/foo.html',
+    hash: '#h\\a\\s\\h',
+    href: 'http://evil-phisher/foo.html#h\\a\\s\\h'
+  },
+
+
+  'http:\\\\evil-phisher\\foo.html': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'evil-phisher',
+    hostname: 'evil-phisher',
+    pathname: '/foo.html',
+    path: '/foo.html',
+    href: 'http://evil-phisher/foo.html'
+  },
+
   'HTTP://www.example.com/' : {
     'href': 'http://www.example.com/',
     'protocol': 'http:',
@@ -1457,3 +1479,7 @@ relativeTests2.forEach(function(relativeTest) {
                'format(' + relativeTest[1] + ') == ' + expected +
                '\nactual:' + actual);
 });
+
+// backslashes should be like forward slashes
+var res = url.resolve('http://example.com/x', '\\\\foo.com\\bar');
+assert.equal(res, 'http://foo.com/bar');


### PR DESCRIPTION
Bump npm to 1.4.7, and also that url thing that should probably get landed anyway.

Executive summary of npm changes:
- tests are better
- shrinkwrap doesn't crash as much
- shasums don't get borked
- added `--save-prefix` for saving as `~` or `>=` instead of `^`
- don't print the scripts log message to stdout if `--loglevel=silent`

Can I get a LGTM and land this puppy?
