### PR TITLE
benchmark: fix v8 benchmark

### DIFF
--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -5,14 +5,16 @@ var vm = require('vm');
 
 var dir = path.join(__dirname, '..', '..', 'deps', 'v8', 'benchmarks');
 
-global.print = function(s) {
-  if (s === '----') return;
-  console.log('misc/v8_bench.js %s', s);
-};
-
-global.load = function (x) {
-  var source = fs.readFileSync(path.join(dir, x), 'utf8');
-  vm.runInThisContext(source, x);
-}
+var sandbox = {print: print, load: load};
 
 load('run.js');
+
+function print(s) {
+  if (s === '----') return;
+  console.log('misc/v8_bench.js %s', s);
+}
+
+function load(x) {
+  var source = fs.readFileSync(path.join(dir, x), 'utf8');
+  vm.runInNewContext(source, sandbox, {filename: x});
+}


### PR DESCRIPTION
V8 benchmark redefines global RexExp variable that is used by
console.log. Because of that context can't be shared any more.
Also updates the vm API change for passing the filename.

RegExp is redefined in https://github.com/joyent/node/blob/2c6b424/deps/v8/benchmarks/regexp.js#L40
Appears after 896b2aa7074
