### PR TITLE
child_process: fix assertion error in spawnSync

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -511,6 +511,11 @@ void SyncProcessRunner::CloseHandlesAndDeleteLoop() {
   if (uv_loop_ != NULL) {
     CloseStdioPipes();
     CloseKillTimer();
+    // Close the process handle when ExitCallback was not called.
+    uv_handle_t* uv_process_handle =
+        reinterpret_cast<uv_handle_t*>(&uv_process_);
+    if (!uv_is_closing(uv_process_handle))
+      uv_close(uv_process_handle, NULL);
 
     // Give closing watchers a chance to finish closing and get their close
     // callbacks called.

--- a/test/simple/test-child-process-spawnsync.js
+++ b/test/simple/test-child-process-spawnsync.js
@@ -39,6 +39,10 @@ console.log('sleep started');
 var ret = spawnSync('sleep', ['1']);
 console.log('sleep exited');
 
+// Error test when command does not exist
+var ret_err = spawnSync('command_does_not_exist');
+assert.strictEqual(ret_err.error.code, 'ENOENT');
+
 process.on('exit', function() {
   assert.strictEqual(ret.status, 0);
 


### PR DESCRIPTION
This is easy to reproduce  in my Ubuntu 14.04 of kernel-3.13.0-24 as

``` javascript
var spawnSync = require('child_process').spawnSync;
var ret = spawnSync('command_does_not_exit');
console.log(ret.error)
```

The following assertion error occurred.

``` sh
$ node ~/test.js
node: ../src/spawn_sync.cc:521: void node::SyncProcessRunner::CloseHandlesAndDeleteLoop(): Assertion `(uv_loop_close(uv_loop_)) == (0)' failed.
Aborted (core dumped)
```

It seems that `SIGCHILD` is not received in the parent in case of an error in the child so that ExitCallback is not called. This patch checks if the process handle is refed, then close it.  The result is

``` sh
$ ./node ~/test.js
{ [Error: spawnSync ENOENT] code: 'ENOENT', errno: 'ENOENT', syscall: 'spawnSync' }
```

I've not tested that this works well in other OSes. 
