### PR TITLE
Debugger: Fix crash when accessing `process.env` from WebStorm

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2363,8 +2363,10 @@ static void EnvDeleter(Local<String> property,
 
 
 static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
+  v8::Isolate* isolate = info.GetIsolate();
+  // I still havn't figured out why the Current Eviroment gets back coruppted
   Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(isolate);
 #ifdef __POSIX__
   int size = 0;
   while (environ[size])
@@ -2386,7 +2388,7 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
   WCHAR* environment = GetEnvironmentStringsW();
   if (environment == NULL)
     return;  // This should not happen.
-  Local<Array> envarr = Array::New(env->isolate());
+  Local<Array> envarr = Array::New(isolate);
   WCHAR* p = environment;
   int i = 0;
   while (*p != NULL) {
@@ -2403,7 +2405,7 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
     }
     const uint16_t* two_byte_buffer = reinterpret_cast<const uint16_t*>(p);
     const size_t two_byte_buffer_len = s - p;
-    Local<String> value = String::NewFromTwoByte(env->isolate(),
+	Local<String> value = String::NewFromTwoByte(isolate,
                                                  two_byte_buffer,
                                                  String::kNormalString,
                                                  two_byte_buffer_len);
@@ -3615,6 +3617,7 @@ int Start(int argc, char** argv) {
       RunAtExit(env);
     }
     env->Dispose();
+	locker.IsActive();
     env = NULL;
   }
 


### PR DESCRIPTION
I fixed the crash, but I haven't figured out what's the situation that causes env to be corrupt.
AFAICT is not made redundant by #7512
