### PR TITLE
child_process: add file property to ENOENT Error

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1010,6 +1010,7 @@ function ChildProcess() {
   this.signalCode = null;
   this.exitCode = null;
   this.killed = false;
+  this.spawnfile = null;
 
   this._handle = new Process();
   this._handle.owner = this;
@@ -1041,6 +1042,9 @@ function ChildProcess() {
     self._handle = null;
 
     if (exitCode < 0) {
+      if (self.spawnfile)
+        err.path = self.spawnfile;
+      
       self.emit('error', err);
     } else {
       self.emit('exit', self.exitCode, self.signalCode);
@@ -1101,6 +1105,8 @@ ChildProcess.prototype.spawn = function(options) {
     options.envPairs = options.envPairs || [];
     options.envPairs.push('NODE_CHANNEL_FD=' + ipcFd);
   }
+
+  this.spawnfile = options.file;
 
   var err = this._handle.spawn(options);
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1026,7 +1026,8 @@ function ChildProcess() {
     //
     // - spawn failures are reported with exitCode < 0
     //
-    var err = (exitCode < 0) ? errnoException(exitCode, 'spawn') : null;
+    var syscall = self.spawnfile ? 'spawn ' + self.spawnfile : 'spawn';
+    var err = (exitCode < 0) ? errnoException(exitCode, syscall) : null;
 
     if (signalCode) {
       self.signalCode = signalCode;

--- a/test/simple/test-child-process-spawn-error.js
+++ b/test/simple/test-child-process-spawn-error.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var fs = require('fs');
+var spawn = require('child_process').spawn;
+var assert = require('assert');
+
+var errors = 0;
+
+var enoentPath = 'foo123';
+assert.equal(fs.existsSync(enoentPath), false);
+
+var enoentChild = spawn(enoentPath);
+enoentChild.on('error', function (err) {
+  assert.equal(err.path, enoentPath);
+  errors++;
+});
+
+process.on('exit', function() {
+  assert.equal(1, errors);
+});


### PR DESCRIPTION
Add a file property to the ENOENT Error returned from
ChildProcess's spawn function.

This attempts to alleviate frustrations as mentioned in
joyent/node#6659.
