### PR TITLE
deps: fix v8 link error with glibc < 2.17

### DIFF
--- a/deps/v8/tools/gyp/v8.gyp
+++ b/deps/v8/tools/gyp/v8.gyp
@@ -643,6 +643,12 @@
                   '../../src/platform-linux.cc',
                   '../../src/platform-posix.cc'
                 ],
+                # XXX(bnoordhuis) Pull in definitions for clock_getres()
+                # and clock_gettime() with glibc < 2.17.
+                'libraries': [ '-lrt' ],
+                'direct_dependent_settings': {
+                  'libraries': [ '-lrt' ],
+                },
               }
             ],
             ['OS=="android"', {


### PR DESCRIPTION
Commit f9ced08 switches V8 on Linux over from gettimeofday() to
clock_getres() and clock_gettime().  As of glibc 2.17, those functions
live in libc.  For older versions, we need to pull them in from librt.

Fixes the following link-time error;

```
Release/obj.target/deps/v8/tools/gyp/libv8_base.a(platform-posix.o):
In function `v8::internal::OS::Ticks()':
platform-posix.cc:(.text+0x93c):
undefined reference to `clock_gettime'
platform-posix.cc:(.text+0x989):
undefined reference to `clock_getres'
```

Fixes #7514.

/cc @indutny @ozlatior - managed to reproduce it on a debian squeeze system.  The original patch was not re-exporting the librt dependency to its dependents.
