### PR TITLE
child_process: Bug in spawn() sets env to null; also does not throw TypeError

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -700,6 +700,10 @@ var spawn = exports.spawn = function(file /*, args, options*/) {
   if (Array.isArray(arguments[1])) {
     args = arguments[1].slice(0);
     options = arguments[2];
+  } else if (arguments[1] && !Array.isArray(arguments[1])) {
+    args = [];
+    options = arguments[2];
+    throw new TypeError('Incorrect value of args option');
   } else {
     args = [];
     options = arguments[1];

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -707,7 +707,7 @@ var spawn = exports.spawn = function(file /*, args, options*/) {
 
   args.unshift(file);
 
-  var env = (options ? options.env : null) || process.env;
+  var env = (options && options.env ? options.env : null) || process.env;
   var envPairs = [];
   for (var key in env) {
     envPairs.push(key + '=' + env[key]);

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var spawn = require('child_process').spawn,
+  assert = require('assert'),
+  windows = (process.platform === 'win32'),
+  cmd = (windows) ? 'ls' : 'dir',
+  errors = 0;
+
+try {
+  // Ensure this throws a TypeError
+  var child = spawn(cmd, 'this is not an array');
+
+  child.on('error', function (err) {
+      errors++;
+  });
+    
+} catch (e) {
+  assert.equal(e instanceof TypeError, true);
+}
+
+process.on('exit', function() {
+  assert.equal(errors, 0);
+});

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -30,9 +30,9 @@ try {
   var child = spawn(cmd, 'this is not an array');
 
   child.on('error', function (err) {
-      errors++;
+    errors++;
   });
-    
+
 } catch (e) {
   assert.equal(e instanceof TypeError, true);
 }


### PR DESCRIPTION
Fixes a bug where `env` is being set to `null` instead of using `process.env` (issue #7456) and ensures TypeError is thrown.

For more information, read this comment from @trevnorris: https://github.com/joyent/node/issues/7456#issuecomment-40432657
