### PR TITLE
crypto, zlib: change _binding to _handle for consistency

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -94,20 +94,20 @@ exports.createHash = exports.Hash = Hash;
 function Hash(algorithm, options) {
   if (!(this instanceof Hash))
     return new Hash(algorithm, options);
-  this._binding = new binding.Hash(algorithm);
+  this._handle = new binding.Hash(algorithm);
   LazyTransform.call(this, options);
 }
 
 util.inherits(Hash, LazyTransform);
 
 Hash.prototype._transform = function(chunk, encoding, callback) {
-  this._binding.update(chunk, encoding);
+  this._handle.update(chunk, encoding);
   callback();
 };
 
 Hash.prototype._flush = function(callback) {
   var encoding = this._readableState.encoding || 'buffer';
-  this.push(this._binding.digest(encoding), encoding);
+  this.push(this._handle.digest(encoding), encoding);
   callback();
 };
 
@@ -115,14 +115,14 @@ Hash.prototype.update = function(data, encoding) {
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding === 'buffer' && util.isString(data))
     encoding = 'binary';
-  this._binding.update(data, encoding);
+  this._handle.update(data, encoding);
   return this;
 };
 
 
 Hash.prototype.digest = function(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  return this._binding.digest(outputEncoding);
+  return this._handle.digest(outputEncoding);
 };
 
 
@@ -131,8 +131,8 @@ exports.createHmac = exports.Hmac = Hmac;
 function Hmac(hmac, key, options) {
   if (!(this instanceof Hmac))
     return new Hmac(hmac, key, options);
-  this._binding = new binding.Hmac();
-  this._binding.init(hmac, toBuf(key));
+  this._handle = new binding.Hmac();
+  this._handle.init(hmac, toBuf(key));
   LazyTransform.call(this, options);
 }
 
@@ -156,9 +156,9 @@ exports.createCipher = exports.Cipher = Cipher;
 function Cipher(cipher, password, options) {
   if (!(this instanceof Cipher))
     return new Cipher(cipher, password, options);
-  this._binding = new binding.CipherBase(true);
+  this._handle = new binding.CipherBase(true);
 
-  this._binding.init(cipher, toBuf(password));
+  this._handle.init(cipher, toBuf(password));
   this._decoder = null;
 
   LazyTransform.call(this, options);
@@ -167,13 +167,13 @@ function Cipher(cipher, password, options) {
 util.inherits(Cipher, LazyTransform);
 
 Cipher.prototype._transform = function(chunk, encoding, callback) {
-  this.push(this._binding.update(chunk, encoding));
+  this.push(this._handle.update(chunk, encoding));
   callback();
 };
 
 Cipher.prototype._flush = function(callback) {
   try {
-    this.push(this._binding.final());
+    this.push(this._handle.final());
   } catch (e) {
     callback(e);
     return;
@@ -185,7 +185,7 @@ Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
   inputEncoding = inputEncoding || exports.DEFAULT_ENCODING;
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
 
-  var ret = this._binding.update(data, inputEncoding);
+  var ret = this._handle.update(data, inputEncoding);
 
   if (outputEncoding && outputEncoding !== 'buffer') {
     this._decoder = getDecoder(this._decoder, outputEncoding);
@@ -198,7 +198,7 @@ Cipher.prototype.update = function(data, inputEncoding, outputEncoding) {
 
 Cipher.prototype.final = function(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  var ret = this._binding.final();
+  var ret = this._handle.final();
 
   if (outputEncoding && outputEncoding !== 'buffer') {
     this._decoder = getDecoder(this._decoder, outputEncoding);
@@ -210,7 +210,7 @@ Cipher.prototype.final = function(outputEncoding) {
 
 
 Cipher.prototype.setAutoPadding = function(ap) {
-  this._binding.setAutoPadding(ap);
+  this._handle.setAutoPadding(ap);
   return this;
 };
 
@@ -220,8 +220,8 @@ exports.createCipheriv = exports.Cipheriv = Cipheriv;
 function Cipheriv(cipher, key, iv, options) {
   if (!(this instanceof Cipheriv))
     return new Cipheriv(cipher, key, iv, options);
-  this._binding = new binding.CipherBase(true);
-  this._binding.initiv(cipher, toBuf(key), toBuf(iv));
+  this._handle = new binding.CipherBase(true);
+  this._handle.initiv(cipher, toBuf(key), toBuf(iv));
   this._decoder = null;
 
   LazyTransform.call(this, options);
@@ -236,16 +236,16 @@ Cipheriv.prototype.final = Cipher.prototype.final;
 Cipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
 
 Cipheriv.prototype.getAuthTag = function() {
-  return this._binding.getAuthTag();
+  return this._handle.getAuthTag();
 };
 
 
 Cipheriv.prototype.setAuthTag = function(tagbuf) {
-  this._binding.setAuthTag(tagbuf);
+  this._handle.setAuthTag(tagbuf);
 };
 
 Cipheriv.prototype.setAAD = function(aadbuf) {
-  this._binding.setAAD(aadbuf);
+  this._handle.setAAD(aadbuf);
 };
 
 
@@ -254,8 +254,8 @@ function Decipher(cipher, password, options) {
   if (!(this instanceof Decipher))
     return new Decipher(cipher, password, options);
 
-  this._binding = new binding.CipherBase(false);
-  this._binding.init(cipher, toBuf(password));
+  this._handle = new binding.CipherBase(false);
+  this._handle.init(cipher, toBuf(password));
   this._decoder = null;
 
   LazyTransform.call(this, options);
@@ -277,8 +277,8 @@ function Decipheriv(cipher, key, iv, options) {
   if (!(this instanceof Decipheriv))
     return new Decipheriv(cipher, key, iv, options);
 
-  this._binding = new binding.CipherBase(false);
-  this._binding.initiv(cipher, toBuf(key), toBuf(iv));
+  this._handle = new binding.CipherBase(false);
+  this._handle.initiv(cipher, toBuf(key), toBuf(iv));
   this._decoder = null;
 
   LazyTransform.call(this, options);
@@ -302,8 +302,8 @@ exports.createSign = exports.Sign = Sign;
 function Sign(algorithm, options) {
   if (!(this instanceof Sign))
     return new Sign(algorithm, options);
-  this._binding = new binding.Sign();
-  this._binding.init(algorithm);
+  this._handle = new binding.Sign();
+  this._handle.init(algorithm);
 
   stream.Writable.call(this, options);
 }
@@ -311,7 +311,7 @@ function Sign(algorithm, options) {
 util.inherits(Sign, stream.Writable);
 
 Sign.prototype._write = function(chunk, encoding, callback) {
-  this._binding.update(chunk, encoding);
+  this._handle.update(chunk, encoding);
   callback();
 };
 
@@ -323,7 +323,7 @@ Sign.prototype.sign = function(options, encoding) {
 
   var key = options.key || options;
   var passphrase = options.passphrase || null;
-  var ret = this._binding.sign(toBuf(key), null, passphrase);
+  var ret = this._handle.sign(toBuf(key), null, passphrase);
 
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
@@ -339,8 +339,8 @@ function Verify(algorithm, options) {
   if (!(this instanceof Verify))
     return new Verify(algorithm, options);
 
-  this._binding = new binding.Verify;
-  this._binding.init(algorithm);
+  this._handle = new binding.Verify;
+  this._handle.init(algorithm);
 
   stream.Writable.call(this, options);
 }
@@ -352,7 +352,7 @@ Verify.prototype.update = Sign.prototype.update;
 
 Verify.prototype.verify = function(object, signature, sigEncoding) {
   sigEncoding = sigEncoding || exports.DEFAULT_ENCODING;
-  return this._binding.verify(toBuf(object), toBuf(signature, sigEncoding));
+  return this._handle.verify(toBuf(object), toBuf(signature, sigEncoding));
 };
 
 
@@ -383,10 +383,10 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
   else if (typeof generator !== 'number')
     generator = toBuf(generator, genEncoding);
 
-  this._binding = new binding.DiffieHellman(sizeOrKey, generator);
+  this._handle = new binding.DiffieHellman(sizeOrKey, generator);
   Object.defineProperty(this, 'verifyError', {
     enumerable: true,
-    value: this._binding.verifyError,
+    value: this._handle.verifyError,
     writable: false
   });
 }
@@ -399,10 +399,10 @@ exports.DiffieHellmanGroup =
 function DiffieHellmanGroup(name) {
   if (!(this instanceof DiffieHellmanGroup))
     return new DiffieHellmanGroup(name);
-  this._binding = new binding.DiffieHellmanGroup(name);
+  this._handle = new binding.DiffieHellmanGroup(name);
   Object.defineProperty(this, 'verifyError', {
     enumerable: true,
-    value: this._binding.verifyError,
+    value: this._handle.verifyError,
     writable: false
   });
 }
@@ -413,7 +413,7 @@ DiffieHellmanGroup.prototype.generateKeys =
     dhGenerateKeys;
 
 function dhGenerateKeys(encoding) {
-  var keys = this._binding.generateKeys();
+  var keys = this._handle.generateKeys();
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     keys = keys.toString(encoding);
@@ -428,7 +428,7 @@ DiffieHellmanGroup.prototype.computeSecret =
 function dhComputeSecret(key, inEnc, outEnc) {
   inEnc = inEnc || exports.DEFAULT_ENCODING;
   outEnc = outEnc || exports.DEFAULT_ENCODING;
-  var ret = this._binding.computeSecret(toBuf(key, inEnc));
+  var ret = this._handle.computeSecret(toBuf(key, inEnc));
   if (outEnc && outEnc !== 'buffer')
     ret = ret.toString(outEnc);
   return ret;
@@ -440,7 +440,7 @@ DiffieHellmanGroup.prototype.getPrime =
     dhGetPrime;
 
 function dhGetPrime(encoding) {
-  var prime = this._binding.getPrime();
+  var prime = this._handle.getPrime();
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     prime = prime.toString(encoding);
@@ -453,7 +453,7 @@ DiffieHellmanGroup.prototype.getGenerator =
     dhGetGenerator;
 
 function dhGetGenerator(encoding) {
-  var generator = this._binding.getGenerator();
+  var generator = this._handle.getGenerator();
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     generator = generator.toString(encoding);
@@ -466,7 +466,7 @@ DiffieHellmanGroup.prototype.getPublicKey =
     dhGetPublicKey;
 
 function dhGetPublicKey(encoding) {
-  var key = this._binding.getPublicKey();
+  var key = this._handle.getPublicKey();
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     key = key.toString(encoding);
@@ -479,7 +479,7 @@ DiffieHellmanGroup.prototype.getPrivateKey =
     dhGetPrivateKey;
 
 function dhGetPrivateKey(encoding) {
-  var key = this._binding.getPrivateKey();
+  var key = this._handle.getPrivateKey();
   encoding = encoding || exports.DEFAULT_ENCODING;
   if (encoding && encoding !== 'buffer')
     key = key.toString(encoding);
@@ -489,14 +489,14 @@ function dhGetPrivateKey(encoding) {
 
 DiffieHellman.prototype.setPublicKey = function(key, encoding) {
   encoding = encoding || exports.DEFAULT_ENCODING;
-  this._binding.setPublicKey(toBuf(key, encoding));
+  this._handle.setPublicKey(toBuf(key, encoding));
   return this;
 };
 
 
 DiffieHellman.prototype.setPrivateKey = function(key, encoding) {
   encoding = encoding || exports.DEFAULT_ENCODING;
-  this._binding.setPrivateKey(toBuf(key, encoding));
+  this._handle.setPrivateKey(toBuf(key, encoding));
   return this;
 };
 
@@ -554,22 +554,22 @@ function Certificate() {
   if (!(this instanceof Certificate))
     return new Certificate();
 
-  this._binding = new binding.Certificate();
+  this._handle = new binding.Certificate();
 }
 
 
 Certificate.prototype.verifySpkac = function(object) {
-  return this._binding.verifySpkac(object);
+  return this._handle.verifySpkac(object);
 };
 
 
 Certificate.prototype.exportPublicKey = function(object, encoding) {
-  return this._binding.exportPublicKey(toBuf(object, encoding));
+  return this._handle.exportPublicKey(toBuf(object, encoding));
 };
 
 
 Certificate.prototype.exportChallenge = function(object, encoding) {
-  return this._binding.exportChallenge(toBuf(object, encoding));
+  return this._handle.exportChallenge(toBuf(object, encoding));
 };
 
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -348,14 +348,14 @@ function Zlib(opts, mode) {
     }
   }
 
-  this._binding = new binding.Zlib(mode);
+  this._handle = new binding.Zlib(mode);
 
   var self = this;
   this._hadError = false;
-  this._binding.onerror = function(message, errno) {
+  this._handle.onerror = function(message, errno) {
     // there is no way to cleanly recover.
     // continuing only obscures problems.
-    self._binding = null;
+    self._handle = null;
     self._hadError = true;
 
     var error = new Error(message);
@@ -370,7 +370,7 @@ function Zlib(opts, mode) {
   var strategy = exports.Z_DEFAULT_STRATEGY;
   if (util.isNumber(opts.strategy)) strategy = opts.strategy;
 
-  this._binding.init(opts.windowBits || exports.Z_DEFAULT_WINDOWBITS,
+  this._handle.init(opts.windowBits || exports.Z_DEFAULT_WINDOWBITS,
                      level,
                      opts.memLevel || exports.Z_DEFAULT_MEMLEVEL,
                      strategy,
@@ -403,7 +403,7 @@ Zlib.prototype.params = function(level, strategy, callback) {
   if (this._level !== level || this._strategy !== strategy) {
     var self = this;
     this.flush(binding.Z_SYNC_FLUSH, function() {
-      self._binding.params(level, strategy);
+      self._handle.params(level, strategy);
       if (!self._hadError) {
         self._level = level;
         self._strategy = strategy;
@@ -416,7 +416,7 @@ Zlib.prototype.params = function(level, strategy, callback) {
 };
 
 Zlib.prototype.reset = function() {
-  return this._binding.reset();
+  return this._handle.reset();
 };
 
 // This is the _flush function called by the transform class,
@@ -459,7 +459,7 @@ Zlib.prototype.close = function(callback) {
 
   this._closed = true;
 
-  this._binding.close();
+  this._handle.close();
 
   var self = this;
   process.nextTick(function() {
@@ -514,7 +514,7 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
     });
 
     do {
-      var res = this._binding.writeSync(flushFlag,
+      var res = this._handle.writeSync(flushFlag,
                                         chunk, // in
                                         inOff, // in_off
                                         availInBefore, // in_len
@@ -533,7 +533,7 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
     return buf;
   }
 
-  var req = this._binding.write(flushFlag,
+  var req = this._handle.write(flushFlag,
                                 chunk, // in
                                 inOff, // in_off
                                 availInBefore, // in_len
@@ -581,7 +581,7 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
       if (!async)
         return true;
 
-      var newReq = self._binding.write(flushFlag,
+      var newReq = self._handle.write(flushFlag,
                                        chunk,
                                        inOff,
                                        availInBefore,


### PR DESCRIPTION
As mentioned in #7372, replacing all instances of `_binding` with `_handle` for consistency with the rest of node's internal code.
