### PR TITLE
fix 'ReferenceError: resp is not defined'

### DIFF
--- a/deps/npm/lib/cache.js
+++ b/deps/npm/lib/cache.js
@@ -711,7 +711,7 @@ function addNameTag (name, tag, data, cb_) {
 
   registry.get(name, function (er, data, json, response) {
     if (!er) {
-      er = errorResponse(name, resp)
+      er = errorResponse(name, response)
     }
     if (er) return cb(er)
     engineFilter(data)


### PR DESCRIPTION
Function argument is called 'response', however the code uses 'resp' instead, resulting in 'ReferenceError: resp is not defined'.
