### PR TITLE
test: fix test-http-flush on Windows

### DIFF
--- a/test/simple/test-http-flush.js
+++ b/test/simple/test-http-flush.js
@@ -26,11 +26,11 @@ var http = require('http');
 http.createServer(function(req, res) {
   res.end('ok');
   this.close();
-}).listen(function() {
+}).listen(common.PORT, '127.0.0.1', function() {
   var req = http.request({
     method: 'POST',
-    host: this.address().address,
-    port: this.address().port,
+    host: '127.0.0.1',
+    port: common.PORT,
   });
   req.flush();  // Flush the request headers.
   req.flush();  // Should be idempotent.


### PR DESCRIPTION
On Windows we cannot get the server address until a connection
is accepted.

From MSDN:
The getsockname function does not always return information about
the host address when the socket has been bound to an unspecified
address, unless the socket has been connected with connect or accept
(for example, using ADDR_ANY). A Windows Sockets application must not
assume that the address will be specified unless the socket is connected.
