### PR TITLE
lib/path.js: Use '===' instead of '==' for comparison

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -286,7 +286,7 @@ if (isWindows) {
       }
     }
 
-    if (samePartsLength == 0) {
+    if (samePartsLength === 0) {
       return to;
     }
 


### PR DESCRIPTION
path: Use '===' instead of '==' for comparison

I've started rewriting node modules to practice typing and noticed that
you're evaluating this `if (samePartsLength == 0) {` condition without
type-checking. I thought I might submit a quick pull request to fix
this issue.
