### PR TITLE
lib: name EventEmitter prototype methods

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -44,13 +44,13 @@ exports.EventEmitter = EventEmitter;
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.
 var defaultMaxListeners = 10;
-EventEmitter.prototype.setMaxListeners = function(n) {
+EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   if (typeof n !== 'number' || n < 0 || isNaN(n))
     throw TypeError('n must be a positive number');
   this._maxListeners = n;
 };
 
-EventEmitter.prototype.emit = function(type) {
+EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, listeners;
 
   if (!this._events)
@@ -123,7 +123,7 @@ EventEmitter.prototype.emit = function(type) {
   return true;
 };
 
-EventEmitter.prototype.addListener = function(type, listener) {
+EventEmitter.prototype.addListener = function addListener(type, listener) {
   var m;
 
   if (typeof listener !== 'function')
@@ -166,7 +166,7 @@ EventEmitter.prototype.addListener = function(type, listener) {
 
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
-EventEmitter.prototype.once = function(type, listener) {
+EventEmitter.prototype.once = function once(type, listener) {
   if (typeof listener !== 'function')
     throw TypeError('listener must be a function');
 
@@ -188,7 +188,8 @@ EventEmitter.prototype.once = function(type, listener) {
 };
 
 // emits a 'removeListener' event iff the listener was removed
-EventEmitter.prototype.removeListener = function(type, listener) {
+EventEmitter.prototype.removeListener =
+    function removeListener(type, listener) {
   var list, position, length, i;
 
   if (typeof listener !== 'function')
@@ -233,7 +234,8 @@ EventEmitter.prototype.removeListener = function(type, listener) {
   return this;
 };
 
-EventEmitter.prototype.removeAllListeners = function(type) {
+EventEmitter.prototype.removeAllListeners =
+    function removeAllListeners(type) {
   var key, listeners;
 
   if (!this._events)
@@ -273,7 +275,7 @@ EventEmitter.prototype.removeAllListeners = function(type) {
   return this;
 };
 
-EventEmitter.prototype.listeners = function(type) {
+EventEmitter.prototype.listeners = function listeners(type) {
   var ret;
   if (!this._events || !this._events[type])
     ret = [];

--- a/test/simple/test-event-emitter-method-names.js
+++ b/test/simple/test-event-emitter-method-names.js
@@ -1,0 +1,32 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var E = events.EventEmitter.prototype;
+assert.equal(E.constructor.name, 'EventEmitter');
+assert.equal(E.on, E.addListener);  // Same method.
+Object.getOwnPropertyNames(E).forEach(function(name) {
+  if (name === 'constructor' || name === 'on') return;
+  assert.equal(E[name].name, name);
+});


### PR DESCRIPTION
Before this commit the EventEmitter methods were anonymous functions.
V8 tries to infer names for anonymous functions based on the execution
context but it frequently gets it wrong and when that happens, the
stack trace is usually confusing and unhelpful.  This commit names all
methods so V8 can fall back to the method.name property.

The above gotcha applies to all anonymous functions but is exacerbated
for EventEmitter methods because those are invoked with a plenitude of
different receivers.

/cc @trevnorris
