### PR TITLE
crypto: add RSA encryption

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -593,6 +593,22 @@ Exports the encoded public key from the supplied SPKAC.
 
 Exports the encoded challenge associated with the SPKAC.
 
+## crypto.publicEncrypt(public_key, buffer)
+
+Encrypts `buffer` with `public_key`. Only RSA is currently supported.
+
+## crypto.privateDecrypt(private_key, buffer)
+
+Decrypts `buffer` with `private_key`.
+
+`private_key` can be an object or a string. If `private_key` is a string, it is
+treated as the key with no passphrase.
+
+`private_key`:
+
+* `key` : A string holding the PEM encoded private key
+* `passphrase` : A string of passphrase for the private key
+
 ## crypto.DEFAULT_ENCODING
 
 The default encoding to use for functions that can take either strings

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -355,6 +355,10 @@ Verify.prototype.verify = function(object, signature, sigEncoding) {
   return this._handle.verify(toBuf(object), toBuf(signature, sigEncoding));
 };
 
+exports.publicEncrypt = function(object, buffer) {
+  return binding.publicEncrypt(toBuf(object), buffer);
+};
+
 
 
 exports.createDiffieHellman = exports.DiffieHellman = DiffieHellman;

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -359,6 +359,12 @@ exports.publicEncrypt = function(object, buffer) {
   return binding.publicEncrypt(toBuf(object), buffer);
 };
 
+exports.privateDecrypt = function(options, buffer) {
+  var key = options.key || options;
+  var passphrase = options.passphrase || null;
+  return binding.privateDecrypt(toBuf(key), buffer, passphrase);
+};
+
 
 
 exports.createDiffieHellman = exports.DiffieHellman = DiffieHellman;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3549,12 +3549,11 @@ bool PublicEncrypt(const char* key_pem,
                    const unsigned char* data,
                    int len,
                    unsigned char** out,
-                   unsigned int* out_len) {
+                   size_t* out_len) {
   EVP_PKEY* pkey = NULL;
   EVP_PKEY_CTX* ctx = NULL;
   BIO* bp = NULL;
   bool fatal = true;
-  int r = 0;
 
   bp = BIO_new(BIO_s_mem());
   if (bp == NULL)
@@ -3622,7 +3621,7 @@ void PublicEncrypt(const FunctionCallbackInfo<Value>& args) {
   ssize_t len = Buffer::Length(args[1]);
 
   unsigned char* out_value = NULL;
-  unsigned int out_len = -1;
+  size_t out_len = -1;
 
   bool r = PublicEncrypt(kbuf, klen, reinterpret_cast<const unsigned char*>(buf), len, &out_value, &out_len);
 
@@ -3648,12 +3647,11 @@ bool PrivateDecrypt(const char* key_pem,
                     const unsigned char* data,
                     int len,
                     unsigned char** out,
-                    unsigned int* out_len) {
+                    size_t* out_len) {
   EVP_PKEY* pkey = NULL;
   EVP_PKEY_CTX* ctx = NULL;
   BIO* bp = NULL;
   bool fatal = true;
-  int r = 0;
 
   bp = BIO_new(BIO_s_mem());
   if (bp == NULL)
@@ -3713,7 +3711,7 @@ void PrivateDecrypt(const FunctionCallbackInfo<Value>& args) {
   String::Utf8Value passphrase(args[2]);
 
   unsigned char* out_value = NULL;
-  unsigned int out_len = -1;
+  size_t out_len = -1;
 
   bool r = PrivateDecrypt(
       kbuf,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3544,9 +3544,11 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-template <int (*EVP_PKEY_cipher_init)(EVP_PKEY_CTX *ctx), int (*EVP_PKEY_cipher)(EVP_PKEY_CTX *,
+typedef int (*EVP_PKEY_cipher_init_t)(EVP_PKEY_CTX *ctx);
+typedef int (*EVP_PKEY_cipher_t)(EVP_PKEY_CTX *ctx,
 			unsigned char *out, size_t *outlen,
-			const unsigned char *in, size_t inlen)>
+			const unsigned char *in, size_t inlen);
+template <EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init, EVP_PKEY_cipher_t EVP_PKEY_cipher>
 bool PKEYCipher(EVP_PKEY* pkey,
                 const unsigned char* data,
                 int len,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3544,6 +3544,104 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+bool PublicEncrypt(const char* key_pem,
+                   int key_pem_len,
+                   const unsigned char* data,
+                   int len,
+                   unsigned char** out,
+                   unsigned int* out_len) {
+  EVP_PKEY* pkey = NULL;
+  EVP_PKEY_CTX* ctx = NULL;
+  BIO* bp = NULL;
+  bool fatal = true;
+  int r = 0;
+
+  bp = BIO_new(BIO_s_mem());
+  if (bp == NULL)
+    goto exit;
+
+  if (!BIO_write(bp, key_pem, key_pem_len))
+    goto exit;
+
+  // Check if this is a PKCS#8 or RSA public key
+  if (strncmp(key_pem, PUBLIC_KEY_PFX, PUBLIC_KEY_PFX_LEN) == 0) {
+    pkey = PEM_read_bio_PUBKEY(bp, NULL, NULL, NULL);
+    if (pkey == NULL)
+      goto exit;
+  } else {
+    RSA* rsa = PEM_read_bio_RSAPublicKey(bp, NULL, NULL, NULL);
+    if (rsa) {
+      pkey = EVP_PKEY_new();
+      if (pkey)
+        EVP_PKEY_set1_RSA(pkey, rsa);
+      RSA_free(rsa);
+    }
+    if (pkey == NULL)
+      goto exit;
+  }
+
+  ctx = EVP_PKEY_CTX_new(pkey, NULL);
+  if (!ctx)
+    goto exit;
+  if (EVP_PKEY_encrypt_init(ctx) <= 0)
+    goto exit;
+  if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0)
+    goto exit;
+  if (EVP_PKEY_encrypt(ctx, NULL, out_len, data, len) <= 0)
+    goto exit;
+
+  *out = new unsigned char[*out_len];
+
+  if (EVP_PKEY_encrypt(ctx, *out, out_len, data, len) <= 0)
+    goto exit;
+
+  fatal = false;
+
+exit:
+  if (pkey != NULL)
+    EVP_PKEY_free(pkey);
+  if (bp != NULL)
+    BIO_free_all(bp);
+  if (ctx != NULL)
+    EVP_PKEY_CTX_free(ctx);
+
+  return !fatal;
+}
+
+
+void PublicEncrypt(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope scope(env->isolate());
+
+  ASSERT_IS_BUFFER(args[0]);
+  char* kbuf = Buffer::Data(args[0]);
+  ssize_t klen = Buffer::Length(args[0]);
+
+  ASSERT_IS_BUFFER(args[1]);
+  char* buf = Buffer::Data(args[1]);
+  ssize_t len = Buffer::Length(args[1]);
+
+  unsigned char* out_value = NULL;
+  unsigned int out_len = -1;
+
+  bool r = PublicEncrypt(kbuf, klen, reinterpret_cast<const unsigned char*>(buf), len, &out_value, &out_len);
+
+  if (out_len <= 0 || !r) {
+    delete[] out_value;
+    out_value = NULL;
+    out_len = 0;
+    if (!r) {
+      return ThrowCryptoError(env,
+        ERR_get_error());
+    }
+  }
+
+  args.GetReturnValue().Set(
+    Buffer::New(env, reinterpret_cast<char*>(out_value), out_len));
+  delete[] out_value;
+}
+
+
 void DiffieHellman::Initialize(Environment* env, Handle<Object> target) {
   Local<FunctionTemplate> t = FunctionTemplate::New(env->isolate(), New);
 
@@ -4730,6 +4828,7 @@ void InitCrypto(Handle<Object> target,
   NODE_SET_METHOD(target, "getSSLCiphers", GetSSLCiphers);
   NODE_SET_METHOD(target, "getCiphers", GetCiphers);
   NODE_SET_METHOD(target, "getHashes", GetHashes);
+  NODE_SET_METHOD(target, "publicEncrypt", PublicEncrypt);
 }
 
 }  // namespace crypto

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -566,36 +566,25 @@ class PublicKeyCipher {
   			unsigned char *out, size_t *outlen,
   			const unsigned char *in, size_t inlen);
 
-  template <EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init, EVP_PKEY_cipher_t EVP_PKEY_cipher>
-  static bool Cipher(EVP_PKEY* pkey,
+  enum Operation {
+    kEncrypt,
+    kDecrypt
+  };
+
+  template <Operation operation,
+            EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
+            EVP_PKEY_cipher_t EVP_PKEY_cipher>
+  static bool Cipher(const char* key_pem,
+                     int key_pem_len,
+                     const char* passphrase,
                      const unsigned char* data,
                      int len,
                      unsigned char** out,
                      size_t* out_len);
 
-  static bool PublicEncrypt(const char* key_pem,
-                            int key_pem_len,
-                            const char* passphrase,
-                            const unsigned char* data,
-                            int len,
-                            unsigned char** out,
-                            size_t* out_len);
-
-  static bool PrivateDecrypt(const char* key_pem,
-                             int key_pem_len,
-                             const char* passphrase,
-                             const unsigned char* data,
-                             int len,
-                             unsigned char** out,
-                             size_t* out_len);
-
-  template <bool (*PKEYCipher)(const char* key_pem,
-                               int key_pem_len,
-                               const char* passphrase,
-                               const unsigned char* data,
-                               int len,
-                               unsigned char** out,
-                               size_t* out_len)>
+  template <Operation operation,
+            EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
+            EVP_PKEY_cipher_t EVP_PKEY_cipher>
   static void Cipher(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -559,6 +559,46 @@ class Verify : public SignBase {
   }
 };
 
+class PublicKeyCipher {
+ public:
+  typedef int (*EVP_PKEY_cipher_init_t)(EVP_PKEY_CTX *ctx);
+  typedef int (*EVP_PKEY_cipher_t)(EVP_PKEY_CTX *ctx,
+  			unsigned char *out, size_t *outlen,
+  			const unsigned char *in, size_t inlen);
+
+  template <EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init, EVP_PKEY_cipher_t EVP_PKEY_cipher>
+  static bool Cipher(EVP_PKEY* pkey,
+                     const unsigned char* data,
+                     int len,
+                     unsigned char** out,
+                     size_t* out_len);
+
+  static bool PublicEncrypt(const char* key_pem,
+                            int key_pem_len,
+                            const char* passphrase,
+                            const unsigned char* data,
+                            int len,
+                            unsigned char** out,
+                            size_t* out_len);
+
+  static bool PrivateDecrypt(const char* key_pem,
+                             int key_pem_len,
+                             const char* passphrase,
+                             const unsigned char* data,
+                             int len,
+                             unsigned char** out,
+                             size_t* out_len);
+
+  template <bool (*PKEYCipher)(const char* key_pem,
+                               int key_pem_len,
+                               const char* passphrase,
+                               const unsigned char* data,
+                               int len,
+                               unsigned char** out,
+                               size_t* out_len)>
+  static void Cipher(const v8::FunctionCallbackInfo<v8::Value>& args);
+};
+
 class DiffieHellman : public BaseObject {
  public:
   ~DiffieHellman() {

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -823,6 +823,30 @@ var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
 var bad_dh = crypto.createDiffieHellman(p, 'hex');
 assert.equal(bad_dh.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
 
+// Test RSA encryption/decryption
+(function() {
+  var input = 'I AM THE WALRUS';
+  var bufferToEncrypt = new Buffer(input);
+
+  var encryptedBuffer = crypto.publicEncrypt(rsaPubPem, bufferToEncrypt);
+
+  var decryptedBuffer = crypto.privateDecrypt(rsaKeyPem, encryptedBuffer);
+  assert.equal(input, decryptedBuffer.toString());
+
+  var decryptedBufferWithPassword = crypto.privateDecrypt({
+    key: rsaKeyPemEncrypted,
+    passphrase: 'password'
+  }, encryptedBuffer);
+  assert.equal(input, decryptedBufferWithPassword.toString());
+
+  assert.throws(function() {
+    crypto.privateDecrypt({
+      key: rsaKeyPemEncrypted,
+      passphrase: 'wrong'
+    }, encryptedBuffer);
+  });
+})();
+
 // Test RSA key signing/verification
 var rsaSign = crypto.createSign('RSA-SHA1');
 var rsaVerify = crypto.createVerify('RSA-SHA1');

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -839,6 +839,16 @@ assert.equal(bad_dh.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
   }, encryptedBuffer);
   assert.equal(input, decryptedBufferWithPassword.toString());
 
+  encryptedBuffer = crypto.publicEncrypt(certPem, bufferToEncrypt);
+
+  decryptedBuffer = crypto.privateDecrypt(keyPem, encryptedBuffer);
+  assert.equal(input, decryptedBuffer.toString());
+
+  encryptedBuffer = crypto.publicEncrypt(keyPem, bufferToEncrypt);
+
+  decryptedBuffer = crypto.privateDecrypt(keyPem, encryptedBuffer);
+  assert.equal(input, decryptedBuffer.toString());
+
   assert.throws(function() {
     crypto.privateDecrypt({
       key: rsaKeyPemEncrypted,


### PR DESCRIPTION
Continuing from #7359.

Just public encryption for now, since this is my personal use case that I can test in real life (and it works fine). I would like to receive feedback on this part before I continue.

The API is simple: `crypto.publicEncrypt(key, buf)` returns an encrypted buffer, where `buf` is the buffer to encrypt and `key` is the public key in PEM format.
