### PR TITLE
url: treat \ the same as /

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -107,6 +107,12 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
   }
 
+  // Copy chrome, IE, opera backslash-handling behavior.
+  // See: https://code.google.com/p/chromium/issues/detail?id=25916
+  var hashSplit = url.split('#');
+  hashSplit[0] = hashSplit[0].replace(/\\/g, '/');
+  url = hashSplit.join('#');
+
   var rest = url;
 
   // trim before proceeding.

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -34,6 +34,28 @@ var parseTests = {
     'path': '//some_path'
   },
 
+  'http:\\\\evil-phisher\\foo.html#h\\a\\s\\h': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'evil-phisher',
+    hostname: 'evil-phisher',
+    pathname: '/foo.html',
+    path: '/foo.html',
+    hash: '#h%5Ca%5Cs%5Ch',
+    href: 'http://evil-phisher/foo.html#h%5Ca%5Cs%5Ch'
+  },
+
+
+  'http:\\\\evil-phisher\\foo.html': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'evil-phisher',
+    hostname: 'evil-phisher',
+    pathname: '/foo.html',
+    path: '/foo.html',
+    href: 'http://evil-phisher/foo.html'
+  },
+
   'HTTP://www.example.com/' : {
     'href': 'http://www.example.com/',
     'protocol': 'http:',
@@ -757,9 +779,9 @@ var parseTests = {
     host: 'x:1',
     port: '1',
     hostname: 'x',
-    pathname: '/%27%20%3C%3E%22%60/%7B%7D%7C%5C%5E~%60/',
-    path: '/%27%20%3C%3E%22%60/%7B%7D%7C%5C%5E~%60/',
-    href: 'http://x:1/%27%20%3C%3E%22%60/%7B%7D%7C%5C%5E~%60/'
+    pathname: '/%27%20%3C%3E%22%60/%7B%7D%7C/%5E~%60/',
+    path: '/%27%20%3C%3E%22%60/%7B%7D%7C/%5E~%60/',
+    href: 'http://x:1/%27%20%3C%3E%22%60/%7B%7D%7C/%5E~%60/'
   },
 
   'http://a@b@c/': {


### PR DESCRIPTION
See https://code.google.com/p/chromium/issues/detail?id=25916

Parse URLs with backslashes the same as web browsers, by replacing all
backslashes with forward slashes, except those that occur after the
first # character.

Manual rebase of 9520ade
