### PR TITLE
stream: don't try to finish if buffer is not empty

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -426,6 +426,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
 function needFinish(stream, state) {
   return (state.ending &&
           state.length === 0 &&
+          state.buffer.length === 0 &&
           !state.finished &&
           !state.writing);
 }

--- a/test/simple/test-stream2-writable.js
+++ b/test/simple/test-stream2-writable.js
@@ -391,3 +391,15 @@ test('finish does not come before sync _write cb', function(t) {
   });
   w.end();
 });
+
+test('finish is emitted if last chunk is empty', function(t) {
+  var w = new W();
+  w._write = function(chunk, e, cb) {
+    process.nextTick(cb);
+  };
+  w.on('finish', function() {
+    t.end();
+  });
+  w.write(Buffer(1));
+  w.end(Buffer(0));
+});


### PR DESCRIPTION
If writable stream is `ended`, but is has some 0-length chunks left in `buffer` it thinks that it is actually ready to finish. Since c38ce9bc0a143141abfa638289b458ddaaac26d6 it means that `prefinish` fires, but `finish` will fire only after callbacks for all writes are called, but these 0-length writes are never made.

Two possible solutions:
- ignore 0-length writes;
- check if buffer is not empty.

In the first case `state.length === 0` would imply that `state.buffer.length === 0`, but it breaks code that does something with 0-length chunks in `_write`.

fixes #5715
