### PR TITLE
fs: add consistent flag fall throughs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -374,9 +374,11 @@ function stringToFlags(flag) {
 
   switch (flag) {
     case 'r' : return O_RDONLY;
-    case 'rs' : return O_RDONLY | O_SYNC;
+    case 'rs' : // fall through
+    case 'sr' : return O_RDONLY | O_SYNC;
     case 'r+' : return O_RDWR;
-    case 'rs+' : return O_RDWR | O_SYNC;
+    case 'rs+' : // fall through
+    case 'sr+' : return O_RDWR | O_SYNC;
 
     case 'w' : return O_TRUNC | O_CREAT | O_WRONLY;
     case 'wx' : // fall through


### PR DESCRIPTION
`stringToFlags()` has fall throughs in a case statement. However, they are not consistently implemented. This commit adds consistency.
