### PR TITLE
buffer: add 24-bit operators for buffer module

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -162,6 +162,37 @@ The method will not write partial characters.
     len = buf.write('\u00bd + \u00bc = \u00be', 0);
     console.log(len + " bytes: " + buf.toString('utf8', 0, len));
 
+### buf.writeUIntLE(value, offset, [byteLength], [noAssert])
+### buf.writeUIntBE(value, offset, [byteLength], [noAssert])
+### buf.writeIntLE(value, offset, [byteLength], [noAssert])
+### buf.writeIntBE(value, offset, [byteLength], [noAssert])
+
+* `value` Number - bytes to be written to buffer
+* `offset` Number, Optional
+* `byteLength` Number, Optional, Default: 1
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset and byteLength.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+### buf.readUIntLE(offset, [byteLength], [noAssert])
+### buf.readUIntBE(offset, [byteLength], [noAssert])
+### buf.readIntLE(offset, [byteLength], [noAssert])
+### buf.readIntBE(offset, [byteLength], [noAssert])
+
+* `offset` Number
+* `byteLength` Number, Optional, Default: 1
+* `noAssert` Boolean, Optional, Default: false
+
+Reads an arbitrary bit that specified by `byteLength` integer from the 
+buffer at the specified offset.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
 
 ### buf.toString([encoding], [start], [end])
 
@@ -358,38 +389,6 @@ Example:
     // 0x2342
     // 0x4223
 
-### buf.readUInt24LE(offset, [noAssert])
-### buf.readUInt24BE(offset, [noAssert])
-
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
-
-Reads an unsigned 24 bit integer from the buffer at the specified offset with
-specified endian format.
-
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
-
-Example:
-
-    var buf = new Buffer(4);
-
-    buf[0] = 0x03;
-    buf[1] = 0x04;
-    buf[2] = 0x23;
-    buf[3] = 0x42;
-
-    console.log(buf.readUInt24BE(0));
-    console.log(buf.readUInt24LE(0));
-    console.log(buf.readUInt24BE(1));
-    console.log(buf.readUInt24LE(1));
-
-    // 0x030423
-    // 0x230403
-    // 0x042342
-    // 0x422304
-
 ### buf.readUInt32LE(offset, [noAssert])
 ### buf.readUInt32BE(offset, [noAssert])
 
@@ -446,22 +445,6 @@ Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.
 
 Works as `buffer.readUInt16*`, except buffer contents are treated as two's
-complement signed values.
-
-### buf.readInt24LE(offset, [noAssert])
-### buf.readInt24BE(offset, [noAssert])
-
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
-
-Reads an unsigned 24 bit integer from the buffer at the specified offset with
-specified endian format.
-
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
-
-Works as `buffer.readUInt24*`, except buffer contents are treated as two's
 complement signed values.
 
 ### buf.readInt32LE(offset, [noAssert])
@@ -593,33 +576,6 @@ Example:
     // <Buffer de ad be ef>
     // <Buffer ad de ef be>
 
-### buf.writeUInt24LE(value, offset, [noAssert])
-### buf.writeUInt24BE(value, offset, [noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid unsigned 24 bit integer.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Example:
-
-    var buf = new Buffer(3);
-    buf.writeUInt24BE(0xdeadff, 0);
-    console.log(buf);
-    
-    buf.writeUInt24LE(0xdeadff, 0);
-    console.log(buf);
-
-    // <Buffer de ad ff>
-    // <Buffer ff ad de>
-
 ### buf.writeUInt32LE(value, offset, [noAssert])
 ### buf.writeUInt32BE(value, offset, [noAssert])
 
@@ -682,24 +638,6 @@ beyond the end of the buffer leading to the values being silently dropped. This
 should not be used unless you are certain of correctness. Defaults to `false`.
 
 Works as `buffer.writeUInt16*`, except value is written out as a two's
-complement signed integer into `buffer`.
-
-### buf.writeUInt24LE(value, offset, [noAssert])
-### buf.writeUInt24BE(value, offset, [noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid unsigned 24 bit integer.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Works as `buffer.writeUInt24*`, except value is written out as a two's
 complement signed integer into `buffer`.
 
 ### buf.writeInt32LE(value, offset, [noAssert])

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -162,36 +162,41 @@ The method will not write partial characters.
     len = buf.write('\u00bd + \u00bc = \u00be', 0);
     console.log(len + " bytes: " + buf.toString('utf8', 0, len));
 
-### buf.writeUIntLE(value, offset, [byteLength], [noAssert])
-### buf.writeUIntBE(value, offset, [byteLength], [noAssert])
-### buf.writeIntLE(value, offset, [byteLength], [noAssert])
-### buf.writeIntBE(value, offset, [byteLength], [noAssert])
+### buf.writeUIntLE(value, offset, byteLength[, noAssert])
+### buf.writeUIntBE(value, offset, byteLength[, noAssert])
+### buf.writeIntLE(value, offset, byteLength[, noAssert])
+### buf.writeIntBE(value, offset, byteLength[, noAssert])
 
-* `value` Number - bytes to be written to buffer
-* `offset` Number, Optional
-* `byteLength` Number, Optional, should be `<= 4`, Default: 1
-* `noAssert` Boolean, Optional, Default: false
-* Return: `offset + byteLength`
+* `value` {Number} - bytes to be written to buffer
+* `offset` {Number}
+* `byteLength` {Number}, must be `<= 4`, Default: 1
+* `noAssert` {Boolean}, Optional, Default: false
+* Return: {null}
 
 Writes `value` to the buffer at the specified offset and byteLength.
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
+`byteLength` must be `<= 4` because of limitation in javascript's bitwise([Mozila Dodumentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators))
+
+Set `noAssert` to `true` to skip validation of `value` and `offset`. This means
 that `value` may be too large for the specific function and `offset` may be
 beyond the end of the buffer leading to the values being silently dropped. This
 should not be used unless you are certain of correctness. Defaults to `false`.
 
-### buf.readUIntLE(offset, [byteLength], [noAssert])
-### buf.readUIntBE(offset, [byteLength], [noAssert])
-### buf.readIntLE(offset, [byteLength], [noAssert])
-### buf.readIntBE(offset, [byteLength], [noAssert])
+### buf.readUIntLE(offset, byteLength[, noAssert])
+### buf.readUIntBE(offset, byteLength[, noAssert])
+### buf.readIntLE(offset, byteLength[, noAssert])
+### buf.readIntBE(offset, byteLength[, noAssert])
 
-* `offset` Number
-* `byteLength` Number, Optional, should be `<= 4`, Default: 1
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `byteLength` {Number}, Optional, should be `<= 4`, Default: 1
+* `noAssert` {Boolean}, Optional, Default: false
+* Return: {Number}
 
 Reads an arbitrary bit that specified by `byteLength` integer from the 
 buffer at the specified offset.
+
+`byteLength` in `.read(U)Int(LE|BE)` functions are allowed to be `>= 4`, however we don't recommend
+you to pass a `>= 4` value, that will cause your application slower and CPU-comsumed.
 
 Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -358,6 +358,38 @@ Example:
     // 0x2342
     // 0x4223
 
+### buf.readUInt24LE(offset, [noAssert])
+### buf.readUInt24BE(offset, [noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads an unsigned 24 bit integer from the buffer at the specified offset with
+specified endian format.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Example:
+
+    var buf = new Buffer(4);
+
+    buf[0] = 0x03;
+    buf[1] = 0x04;
+    buf[2] = 0x23;
+    buf[3] = 0x42;
+
+    console.log(buf.readUInt24BE(0));
+    console.log(buf.readUInt24LE(0));
+    console.log(buf.readUInt24BE(1));
+    console.log(buf.readUInt24LE(1));
+
+    // 0x030423
+    // 0x230403
+    // 0x042342
+    // 0x422304
+
 ### buf.readUInt32LE(offset, [noAssert])
 ### buf.readUInt32BE(offset, [noAssert])
 
@@ -414,6 +446,22 @@ Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.
 
 Works as `buffer.readUInt16*`, except buffer contents are treated as two's
+complement signed values.
+
+### buf.readInt24LE(offset, [noAssert])
+### buf.readInt24BE(offset, [noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads an unsigned 24 bit integer from the buffer at the specified offset with
+specified endian format.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Works as `buffer.readUInt24*`, except buffer contents are treated as two's
 complement signed values.
 
 ### buf.readInt32LE(offset, [noAssert])
@@ -545,6 +593,33 @@ Example:
     // <Buffer de ad be ef>
     // <Buffer ad de ef be>
 
+### buf.writeUInt24LE(value, offset, [noAssert])
+### buf.writeUInt24BE(value, offset, [noAssert])
+
+* `value` Number
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset with specified endian
+format. Note, `value` must be a valid unsigned 24 bit integer.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+Example:
+
+    var buf = new Buffer(3);
+    buf.writeUInt24BE(0xdeadff, 0);
+    console.log(buf);
+    
+    buf.writeUInt24LE(0xdeadff, 0);
+    console.log(buf);
+
+    // <Buffer de ad ff>
+    // <Buffer ff ad de>
+
 ### buf.writeUInt32LE(value, offset, [noAssert])
 ### buf.writeUInt32BE(value, offset, [noAssert])
 
@@ -607,6 +682,24 @@ beyond the end of the buffer leading to the values being silently dropped. This
 should not be used unless you are certain of correctness. Defaults to `false`.
 
 Works as `buffer.writeUInt16*`, except value is written out as a two's
+complement signed integer into `buffer`.
+
+### buf.writeUInt24LE(value, offset, [noAssert])
+### buf.writeUInt24BE(value, offset, [noAssert])
+
+* `value` Number
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset with specified endian
+format. Note, `value` must be a valid unsigned 24 bit integer.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+Works as `buffer.writeUInt24*`, except value is written out as a two's
 complement signed integer into `buffer`.
 
 ### buf.writeInt32LE(value, offset, [noAssert])

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -171,7 +171,7 @@ The method will not write partial characters.
 * `offset` {Number}
 * `byteLength` {Number}, must be `<= 4`, Default: 1
 * `noAssert` {Boolean}, Optional, Default: false
-* Return: {null}
+* Return: {Number}
 
 Writes `value` to the buffer at the specified offset and byteLength.
 
@@ -196,7 +196,7 @@ Reads an arbitrary bit that specified by `byteLength` integer from the
 buffer at the specified offset.
 
 `byteLength` in `.read(U)Int(LE|BE)` functions are allowed to be `>= 4`, however we don't recommend
-you to pass a `>= 4` value, that will cause your application slower and CPU-comsumed.
+you to pass a `> 4` value, that will cause your application slower and CPU-comsumed.
 
 Set `noAssert` to true to skip validation of `offset`. This means that `offset`
 may be beyond the end of the buffer. Defaults to `false`.

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -169,8 +169,9 @@ The method will not write partial characters.
 
 * `value` Number - bytes to be written to buffer
 * `offset` Number, Optional
-* `byteLength` Number, Optional, Default: 1
+* `byteLength` Number, Optional, should be `<= 4`, Default: 1
 * `noAssert` Boolean, Optional, Default: false
+* Return: `offset + byteLength`
 
 Writes `value` to the buffer at the specified offset and byteLength.
 
@@ -185,8 +186,9 @@ should not be used unless you are certain of correctness. Defaults to `false`.
 ### buf.readIntBE(offset, [byteLength], [noAssert])
 
 * `offset` Number
-* `byteLength` Number, Optional, Default: 1
+* `byteLength` Number, Optional, should be `<= 4`, Default: 1
 * `noAssert` Boolean, Optional, Default: false
+* Return: Number
 
 Reads an arbitrary bit that specified by `byteLength` integer from the 
 buffer at the specified offset.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -458,157 +458,143 @@ function checkOffset(offset, ext, length) {
 }
 
 
+function getLeftShiftValue(bits) {
+  // 1 << 32 will returns 1, so we should handle this
+  if (bits > 24) {
+    return (1 << 24) * Math.pow(2, bits - 24);
+  } else {
+    return 1 << bits;
+  }
+}
+
+
+function getBitwiseOrValue(base, num) {
+  var max = 1 << 24;
+  if (base > max || num > max)
+    return base + num;
+  else
+    return base | num;
+}
+
+
 Buffer.prototype.readUIntLE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
   if (!noAssert)
     checkOffset(offset, byteLength, this.length);
-  var i = byteLength || 1;
+
   var val = this[offset];
-  while (--i) {
-    var offset2 = 1;
-    for (var j = 0; j < i; j++) {
-      offset2 *= 0x100;
-    }
-    val += this[offset + i] * offset2;
-  }
+  while (--byteLength)
+    val += this[offset + byteLength] * getLeftShiftValue(8 * byteLength);
   return val;
 };
 
 
 Buffer.prototype.readUIntBE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
   if (!noAssert)
     checkOffset(offset, byteLength, this.length);
-  var i = byteLength || 1;
+  var i = byteLength;
   var val = this[offset + byteLength - 1];
-  while (--i) {
-    var offset2 = 1;
-    for (var j = 0; j < i; j++) {
-      offset2 *= 0x100;
-    }
-    val += this[offset + byteLength - 1 - i] * offset2;
-  }
+  while (--i)
+    val += this[offset + byteLength - 1 - i] * getLeftShiftValue(8 * i);
   return val;
 };
 
 
 Buffer.prototype.readUInt8 = function(offset, noAssert) {
-  value = +value;
   offset = offset >>> 0;
   if (!noAssert)
-    checkInt(this, value, offset, 1, 0xff, 0);
-  this[offset] = value;
-  return offset + 1;
+    checkOffset(offset, 1, this.length);
+  return this[offset];
 };
 
 
 Buffer.prototype.readUInt16LE = function(offset, noAssert) {
-  value = +value;
   offset = offset >>> 0;
   if (!noAssert)
-    checkInt(this, value, offset, 2, 0xffff, 0);
-  this[offset] = value;
-  this[offset + 1] = (value >>> 8);
-  return offset + 2;
+    checkOffset(offset, 2, this.length);
+  return this[offset] | (this[offset + 1] << 8);
 };
 
 
 Buffer.prototype.readUInt16BE = function(offset, noAssert) {
-  value = +value;
   offset = offset >>> 0;
   if (!noAssert)
-    checkInt(this, value, offset, 2, 0xffff, 0);
-  this[offset] = (value >>> 8);
-  this[offset + 1] = value;
-  return offset + 2;
+    checkOffset(offset, 2, this.length);
+  return (this[offset] << 8) | this[offset + 1];
 };
 
 
 Buffer.prototype.readUInt32LE = function(offset, noAssert) {
-  value = +value;
   offset = offset >>> 0;
   if (!noAssert)
-    checkInt(this, value, offset, 4, 0xffffffff, 0);
-  this[offset + 3] = (value >>> 24);
-  this[offset + 2] = (value >>> 16);
-  this[offset + 1] = (value >>> 8);
-  this[offset] = value;
-  return offset + 4;
+    checkOffset(offset, 4, this.length);
+
+  return ((this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16)) +
+      (this[offset + 3] * 0x1000000);
 };
 
 
 Buffer.prototype.readUInt32BE = function(offset, noAssert) {
-  value = +value;
   offset = offset >>> 0;
   if (!noAssert)
-    checkInt(this, value, offset, 4, 0xffffffff, 0);
-  this[offset] = (value >>> 24);
-  this[offset + 1] = (value >>> 16);
-  this[offset + 2] = (value >>> 8);
-  this[offset + 3] = value;
-  return offset + 4;
+    checkOffset(offset, 4, this.length);
+
+  return (this[offset] * 0x1000000) +
+      ((this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      (this[offset + 3]) >>> 0);
 };
 
 
 Buffer.prototype.readIntLE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
   if (!noAssert)
     checkOffset(offset, byteLength, this.length);
-  var i = byteLength || 1;
-  var val = this[offset];
-  while (--i) {
-    var offset2 = 1;
-    for (var j = 0; j < i; j++) {
-      offset2 *= 0x100;
-    }
-    val = val | this[offset + i] * offset2;
-  }
+  var signPos = offset + byteLength - 1;
+  var signNum = getLeftShiftValue(8 * (byteLength - 1));
+  var i = signPos - 1;
+  var val = 0;
+  do {
+    val = val | this[i] * getLeftShiftValue(8 * i);
+  } while (i-- > 0);
 
-  var offset3 = 1;
-  for (var j = 0; j < byteLength - 1; j++) {
-    offset3 *= 0x100;
-  }
-
-  if (!(val & (0x80 * offset3))) {
-    return val;
-  } else if (byteLength === 1) {
-    return (0xff - val + 1) * -1;
-  } else if (byteLength === 2) {
-    return val | 0xffff0000;
+  if (this[signPos] & 0x80) {
+    val = getBitwiseOrValue(val, (this[signPos] - 0x80) * signNum);
+    val = getBitwiseOrValue(val, -0x80 * signNum);
   } else {
-    return val;
+    val = getBitwiseOrValue(val, this[signPos] * signNum);
   }
+  return val;
 };
 
 
 Buffer.prototype.readIntBE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
   if (!noAssert)
     checkOffset(offset, byteLength, this.length);
-  var i = byteLength || 1;
-  var val = this[offset + byteLength - 1];
-  while (--i) {
-    var offset2 = 1;
-    for (var j = 0; j < i; j++) {
-      offset2 *= 0x100;
-    }
-    val = val | this[offset + byteLength - 1 - i] * offset2;
-  }
+  var signPos = offset;
+  var signNum = getLeftShiftValue(8 * (byteLength - 1));
+  var start = offset + byteLength - 1;
+  var i = start;
+  var val = 0;
+  do {
+    val = val | this[start - i] * getLeftShiftValue(8 * i);
+  } while (i--);
 
-  var offset3 = 1;
-  for (var j = 0; j < byteLength - 1; j++) {
-    offset3 *= 0x100;
-  }
-
-  if (!(val & (0x80 * offset3))) {
-    return val;
-  } else if (byteLength === 1) {
-    return (0xff - val + 1) * -1;
-  } else if (byteLength === 2) {
-    return val | 0xffff0000;
+  if (this[signPos] & 0x80) {
+    val = getBitwiseOrValue(val, (this[signPos] - 0x80) * signNum);
+    val = getBitwiseOrValue(val, -0x80 * signNum);
   } else {
-    return val;
+    val = getBitwiseOrValue(val, this[signPos] * signNum);
   }
+  return val;
 };
 
 
@@ -676,17 +662,16 @@ function checkInt(buffer, value, offset, ext, max, min) {
 Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
   value = +value;
   offset = offset >>> 0;
-  var i = byteLength || 1;
-  var s = 0xff;
+  byteLength = byteLength >>> 0;
+  var s = Math.pow(2, byteLength * 8);
   var e = 0x00;
-  do {
-    s = s * 0x100 + 0xff;
-    this[offset + i] = (value >>> 8 * i);
-  }
-  while (i--);
-
   if (!noAssert)
     checkInt(this, value, offset, byteLength, s, e);
+  while (byteLength--) {
+    s = s * 0x100 + 0xff;
+    this[offset + byteLength] = (value >>> 8 * byteLength);
+  };
+
   return offset + byteLength;
 };
 
@@ -694,17 +679,17 @@ Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
 Buffer.prototype.writeUIntBE = function(value, offset, byteLength, noAssert) {
   value = +value;
   offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
   var i = byteLength || 1;
-  var s = 0xff;
+  var s = Math.pow(2, byteLength * 8);
   var e = 0x00;
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, s, e);
   do {
     s = s * 0x100 + 0xff;
     this[offset + byteLength - 1 - i] = (value >>> 8 * i);
-  }
-  while (i--);
+  } while (i--);
 
-  if (!noAssert)
-    checkInt(this, value, offset, byteLength, s, e);
   return offset + byteLength;
 };
 
@@ -768,21 +753,25 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
 
 
 Buffer.prototype.writeIntLE = function(value, offset, byteLength, noAssert) {
+  // shift opeators in javascript require < 32
+  if (byteLength > 4)
+    throw new Error('writeInt doesn\'t support >32 bytes');
   value = +value;
   offset = offset >>> 0;
   var i = byteLength || 1;
-  var s = 0x7f;
-  var e = -0x80;
+  var s = Math.pow(2, byteLength * 8 - 1) - 1;
+  var e = -(s + 1);
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, s, e);
+
+  this[offset] = value;
   while (i--) {
     if (i > 0) {
       s = s * 0x100 + 0xff;
       e = e * 0x100;
     }
-    this[offset + i] = (value >>> 8 * i);
+    this[offset + i] = value >>> 8 * i;
   }
-
-  if (!noAssert)
-    checkInt(this, value, offset, byteLength, s, e);
   return offset + byteLength;
 };
 
@@ -791,8 +780,12 @@ Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
   value = +value;
   offset = offset >>> 0;
   var i = byteLength || 1;
-  var s = 0x7f;
-  var e = -0x80;
+  var s = Math.pow(2, byteLength * 8 - 1) - 1;
+  var e = -(s + 1);
+  this[offset] = value >>> 8 * i;
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, s, e);
+
   while (i--) {
     if (i > 0) {
       s = s * 0x100 + 0xff;
@@ -800,10 +793,6 @@ Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
     }
     this[offset + byteLength - 1 - i] = (value >>> 8 * i);
   }
-
-  console.error(s, e, value);
-  if (!noAssert)
-    checkInt(this, value, offset, byteLength, s, e);
   return offset + byteLength;
 };
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -493,27 +493,60 @@ Buffer.prototype.readUIntBE = function(offset, byteLength, noAssert) {
 
 
 Buffer.prototype.readUInt8 = function(offset, noAssert) {
-  return this.readUIntLE(offset, 1, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 1, 0xff, 0);
+  this[offset] = value;
+  return offset + 1;
 };
 
 
 Buffer.prototype.readUInt16LE = function(offset, noAssert) {
-  return this.readUIntLE(offset, 2, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0xffff, 0);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
+  return offset + 2;
 };
 
 
 Buffer.prototype.readUInt16BE = function(offset, noAssert) {
-  return this.readUIntBE(offset, 2, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0xffff, 0);
+  this[offset] = (value >>> 8);
+  this[offset + 1] = value;
+  return offset + 2;
 };
 
 
 Buffer.prototype.readUInt32LE = function(offset, noAssert) {
-  return this.readUIntLE(offset, 4, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0xffffffff, 0);
+  this[offset + 3] = (value >>> 24);
+  this[offset + 2] = (value >>> 16);
+  this[offset + 1] = (value >>> 8);
+  this[offset] = value;
+  return offset + 4;
 };
 
 
 Buffer.prototype.readUInt32BE = function(offset, noAssert) {
-  return this.readUIntBE(offset, 4, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0xffffffff, 0);
+  this[offset] = (value >>> 24);
+  this[offset + 1] = (value >>> 16);
+  this[offset + 2] = (value >>> 8);
+  this[offset + 3] = value;
+  return offset + 4;
 };
 
 
@@ -536,17 +569,14 @@ Buffer.prototype.readIntLE = function(offset, byteLength, noAssert) {
     offset3 *= 0x100;
   }
 
-  if (!(val & (0x80 * offset3)))
+  if (!(val & (0x80 * offset3))) {
     return val;
-  else {
-    switch (byteLength) {
-      case 1:
-        return (0xff - val + 1) * -1;
-      case 2:
-        return val | 0xffff0000;
-      default:
-        return val;
-    }
+  } else if (byteLength === 1) {
+    return (0xff - val + 1) * -1;
+  } else if (byteLength === 2) {
+    return val | 0xffff0000;
+  } else {
+    return val;
   }
 };
 
@@ -570,43 +600,66 @@ Buffer.prototype.readIntBE = function(offset, byteLength, noAssert) {
     offset3 *= 0x100;
   }
 
-  if (!(val & (0x80 * offset3)))
+  if (!(val & (0x80 * offset3))) {
     return val;
-  else {
-    switch (byteLength) {
-      case 1:
-        return (0xff - val + 1) * -1;
-      case 2:
-        return val | 0xffff0000;
-      default:
-        return val;
-    }
+  } else if (byteLength === 1) {
+    return (0xff - val + 1) * -1;
+  } else if (byteLength === 2) {
+    return val | 0xffff0000;
+  } else {
+    return val;
   }
 };
 
 
 Buffer.prototype.readInt8 = function(offset, noAssert) {
-  return this.readIntLE(offset, 1, noAssert);
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 1, this.length);
+  var val = this[offset];
+  return !(val & 0x80) ? val : (0xff - val + 1) * -1;
 };
 
 
 Buffer.prototype.readInt16LE = function(offset, noAssert) {
-  return this.readIntLE(offset, 2, noAssert);
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 2, this.length);
+  var val = this[offset] | (this[offset + 1] << 8);
+  return (val & 0x8000) ? val | 0xFFFF0000 : val;
 };
 
 
 Buffer.prototype.readInt16BE = function(offset, noAssert) {
-  return this.readIntBE(offset, 2, noAssert);
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 2, this.length);
+  var val = this[offset + 1] | (this[offset] << 8);
+  return (val & 0x8000) ? val | 0xFFFF0000 : val;
 };
 
 
 Buffer.prototype.readInt32LE = function(offset, noAssert) {
-  return this.readIntLE(offset, 4, noAssert);
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 4, this.length);
+
+  return (this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16) |
+      (this[offset + 3] << 24);
 };
 
 
 Buffer.prototype.readInt32BE = function(offset, noAssert) {
-  return this.readIntBE(offset, 4, noAssert);
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 4, this.length);
+
+  return (this[offset] << 24) |
+      (this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      (this[offset + 3]);
 };
 
 
@@ -657,27 +710,60 @@ Buffer.prototype.writeUIntBE = function(value, offset, byteLength, noAssert) {
 
 
 Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
-  return this.writeUIntLE(value, offset, 1, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 1, 0xff, 0);
+  this[offset] = value;
+  return offset + 1;
 };
 
 
 Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
-  return this.writeUIntLE(value, offset, 2, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0xffff, 0);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
+  return offset + 2;
 };
 
 
 Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
-  return this.writeUIntBE(value, offset, 2, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0xffff, 0);
+  this[offset] = (value >>> 8);
+  this[offset + 1] = value;
+  return offset + 2;
 };
 
 
 Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
-  return this.writeUIntLE(value, offset, 4, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0xffffffff, 0);
+  this[offset + 3] = (value >>> 24);
+  this[offset + 2] = (value >>> 16);
+  this[offset + 1] = (value >>> 8);
+  this[offset] = value;
+  return offset + 4;
 };
 
 
 Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
-  return this.writeUIntBE(value, offset, 4, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0xffffffff, 0);
+  this[offset] = (value >>> 24);
+  this[offset + 1] = (value >>> 16);
+  this[offset + 2] = (value >>> 8);
+  this[offset + 3] = value;
+  return offset + 4;
 };
 
 
@@ -723,25 +809,58 @@ Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
 
 
 Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
-  return this.writeIntLE(value, offset, 1, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 1, 0x7f, -0x80);
+  this[offset] = value;
+  return offset + 1;
 };
 
 
 Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
-  return this.writeIntLE(value, offset, 2, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0x7fff, -0x8000);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
+  return offset + 2;
 };
 
 
 Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
-  return this.writeIntBE(value, offset, 2, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0x7fff, -0x8000);
+  this[offset] = (value >>> 8);
+  this[offset + 1] = value;
+  return offset + 2;
 };
 
 
 Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
-  return this.writeIntLE(value, offset, 4, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
+  this[offset] = value;
+  this[offset + 1] = (value >>> 8);
+  this[offset + 2] = (value >>> 16);
+  this[offset + 3] = (value >>> 24);
+  return offset + 4;
 };
 
 
 Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
-  return this.writeIntBE(value, offset, 4, noAssert);
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
+  this[offset] = (value >>> 24);
+  this[offset + 1] = (value >>> 16);
+  this[offset + 2] = (value >>> 8);
+  this[offset + 3] = value;
+  return offset + 4;
 };

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -660,6 +660,9 @@ function checkInt(buffer, value, offset, ext, max, min) {
 
 
 Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
+  // shift opeators in javascript require < 32
+  if (byteLength > 4)
+    throw new Error('writeInt doesn\'t support >32 bytes');
   value = +value;
   offset = offset >>> 0;
   byteLength = byteLength >>> 0;
@@ -677,6 +680,9 @@ Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
 
 
 Buffer.prototype.writeUIntBE = function(value, offset, byteLength, noAssert) {
+  // shift opeators in javascript require < 32
+  if (byteLength > 4)
+    throw new Error('writeInt doesn\'t support >32 bytes');
   value = +value;
   offset = offset >>> 0;
   byteLength = byteLength >>> 0;
@@ -777,6 +783,9 @@ Buffer.prototype.writeIntLE = function(value, offset, byteLength, noAssert) {
 
 
 Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
+  // shift opeators in javascript require < 32
+  if (byteLength > 4)
+    throw new Error('writeInt doesn\'t support >32 bytes');
   value = +value;
   offset = offset >>> 0;
   var i = byteLength || 1;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -458,102 +458,155 @@ function checkOffset(offset, ext, length) {
 }
 
 
-Buffer.prototype.readUInt8 = function(offset, noAssert) {
+Buffer.prototype.readUIntLE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
-    checkOffset(offset, 1, this.length);
-  return this[offset];
+    checkOffset(offset, byteLength, this.length);
+  var i = byteLength || 1;
+  var val = this[offset];
+  while (--i) {
+    var offset2 = 1;
+    for (var j = 0; j < i; j++) {
+      offset2 *= 0x100;
+    }
+    val += this[offset + i] * offset2;
+  }
+  return val;
+};
+
+
+Buffer.prototype.readUIntBE = function(offset, byteLength, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, byteLength, this.length);
+  var i = byteLength || 1;
+  var val = this[offset + byteLength - 1];
+  while (--i) {
+    var offset2 = 1;
+    for (var j = 0; j < i; j++) {
+      offset2 *= 0x100;
+    }
+    val += this[offset + byteLength - 1 - i] * offset2;
+  }
+  return val;
+};
+
+
+Buffer.prototype.readUInt8 = function(offset, noAssert) {
+  return this.readUIntLE(offset, 1, noAssert);
 };
 
 
 Buffer.prototype.readUInt16LE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 2, this.length);
-  return this[offset] | (this[offset + 1] << 8);
+  return this.readUIntLE(offset, 2, noAssert);
 };
 
 
 Buffer.prototype.readUInt16BE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 2, this.length);
-  return (this[offset] << 8) | this[offset + 1];
+  return this.readUIntBE(offset, 2, noAssert);
 };
 
 
 Buffer.prototype.readUInt32LE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 4, this.length);
-
-  return ((this[offset]) |
-      (this[offset + 1] << 8) |
-      (this[offset + 2] << 16)) +
-      (this[offset + 3] * 0x1000000);
+  return this.readUIntLE(offset, 4, noAssert);
 };
 
 
 Buffer.prototype.readUInt32BE = function(offset, noAssert) {
+  return this.readUIntBE(offset, 4, noAssert);
+};
+
+
+Buffer.prototype.readIntLE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
-    checkOffset(offset, 4, this.length);
+    checkOffset(offset, byteLength, this.length);
+  var i = byteLength || 1;
+  var val = this[offset];
+  while (--i) {
+    var offset2 = 1;
+    for (var j = 0; j < i; j++) {
+      offset2 *= 0x100;
+    }
+    val = val | this[offset + i] * offset2;
+  }
 
-  return (this[offset] * 0x1000000) +
-      ((this[offset + 1] << 16) |
-      (this[offset + 2] << 8) |
-      (this[offset + 3]) >>> 0);
+  var offset3 = 1;
+  for (var j = 0; j < byteLength - 1; j++) {
+    offset3 *= 0x100;
+  }
+
+  if (!(val & (0x80 * offset3)))
+    return val;
+  else {
+    switch (byteLength) {
+      case 1:
+        return (0xff - val + 1) * -1;
+      case 2:
+        return val | 0xffff0000;
+      default:
+        return val;
+    }
+  }
+};
+
+
+Buffer.prototype.readIntBE = function(offset, byteLength, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, byteLength, this.length);
+  var i = byteLength || 1;
+  var val = this[offset + byteLength - 1];
+  while (--i) {
+    var offset2 = 1;
+    for (var j = 0; j < i; j++) {
+      offset2 *= 0x100;
+    }
+    val = val | this[offset + byteLength - 1 - i] * offset2;
+  }
+
+  var offset3 = 1;
+  for (var j = 0; j < byteLength - 1; j++) {
+    offset3 *= 0x100;
+  }
+
+  if (!(val & (0x80 * offset3)))
+    return val;
+  else {
+    switch (byteLength) {
+      case 1:
+        return (0xff - val + 1) * -1;
+      case 2:
+        return val | 0xffff0000;
+      default:
+        return val;
+    }
+  }
 };
 
 
 Buffer.prototype.readInt8 = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 1, this.length);
-  var val = this[offset];
-  return !(val & 0x80) ? val : (0xff - val + 1) * -1;
+  return this.readIntLE(offset, 1, noAssert);
 };
 
 
 Buffer.prototype.readInt16LE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 2, this.length);
-  var val = this[offset] | (this[offset + 1] << 8);
-  return (val & 0x8000) ? val | 0xFFFF0000 : val;
+  return this.readIntLE(offset, 2, noAssert);
 };
 
 
 Buffer.prototype.readInt16BE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 2, this.length);
-  var val = this[offset + 1] | (this[offset] << 8);
-  return (val & 0x8000) ? val | 0xFFFF0000 : val;
+  return this.readIntBE(offset, 2, noAssert);
 };
 
 
 Buffer.prototype.readInt32LE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 4, this.length);
-
-  return (this[offset]) |
-      (this[offset + 1] << 8) |
-      (this[offset + 2] << 16) |
-      (this[offset + 3] << 24);
+  return this.readIntLE(offset, 4, noAssert);
 };
 
 
 Buffer.prototype.readInt32BE = function(offset, noAssert) {
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkOffset(offset, 4, this.length);
-
-  return (this[offset] << 24) |
-      (this[offset + 1] << 16) |
-      (this[offset + 2] << 8) |
-      (this[offset + 3]);
+  return this.readIntBE(offset, 4, noAssert);
 };
 
 
@@ -567,117 +620,128 @@ function checkInt(buffer, value, offset, ext, max, min) {
 }
 
 
-Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
+Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
   value = +value;
   offset = offset >>> 0;
+  var i = byteLength || 1;
+  var s = 0xff;
+  var e = 0x00;
+  do {
+    s = s * 0x100 + 0xff;
+    this[offset + i] = (value >>> 8 * i);
+  }
+  while (i--);
+
   if (!noAssert)
-    checkInt(this, value, offset, 1, 0xff, 0);
-  this[offset] = value;
-  return offset + 1;
+    checkInt(this, value, offset, byteLength, s, e);
+  return offset + byteLength;
+};
+
+
+Buffer.prototype.writeUIntBE = function(value, offset, byteLength, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  var i = byteLength || 1;
+  var s = 0xff;
+  var e = 0x00;
+  do {
+    s = s * 0x100 + 0xff;
+    this[offset + byteLength - 1 - i] = (value >>> 8 * i);
+  }
+  while (i--);
+
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, s, e);
+  return offset + byteLength;
+};
+
+
+Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
+  return this.writeUIntLE(value, offset, 1, noAssert);
 };
 
 
 Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 2, 0xffff, 0);
-  this[offset] = value;
-  this[offset + 1] = (value >>> 8);
-  return offset + 2;
+  return this.writeUIntLE(value, offset, 2, noAssert);
 };
 
 
 Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 2, 0xffff, 0);
-  this[offset] = (value >>> 8);
-  this[offset + 1] = value;
-  return offset + 2;
+  return this.writeUIntBE(value, offset, 2, noAssert);
 };
 
 
 Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 4, 0xffffffff, 0);
-  this[offset + 3] = (value >>> 24);
-  this[offset + 2] = (value >>> 16);
-  this[offset + 1] = (value >>> 8);
-  this[offset] = value;
-  return offset + 4;
+  return this.writeUIntLE(value, offset, 4, noAssert);
 };
 
 
 Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
+  return this.writeUIntBE(value, offset, 4, noAssert);
+};
+
+
+Buffer.prototype.writeIntLE = function(value, offset, byteLength, noAssert) {
   value = +value;
   offset = offset >>> 0;
+  var i = byteLength || 1;
+  var s = 0x7f;
+  var e = -0x80;
+  while (i--) {
+    if (i > 0) {
+      s = s * 0x100 + 0xff;
+      e = e * 0x100;
+    }
+    this[offset + i] = (value >>> 8 * i);
+  }
+
   if (!noAssert)
-    checkInt(this, value, offset, 4, 0xffffffff, 0);
-  this[offset] = (value >>> 24);
-  this[offset + 1] = (value >>> 16);
-  this[offset + 2] = (value >>> 8);
-  this[offset + 3] = value;
-  return offset + 4;
+    checkInt(this, value, offset, byteLength, s, e);
+  return offset + byteLength;
+};
+
+
+Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  var i = byteLength || 1;
+  var s = 0x7f;
+  var e = -0x80;
+  while (i--) {
+    if (i > 0) {
+      s = s * 0x100 + 0xff;
+      e = e * 0x100;
+    }
+    this[offset + byteLength - 1 - i] = (value >>> 8 * i);
+  }
+
+  console.error(s, e, value);
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, s, e);
+  return offset + byteLength;
 };
 
 
 Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 1, 0x7f, -0x80);
-  this[offset] = value;
-  return offset + 1;
+  return this.writeIntLE(value, offset, 1, noAssert);
 };
 
 
 Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 2, 0x7fff, -0x8000);
-  this[offset] = value;
-  this[offset + 1] = (value >>> 8);
-  return offset + 2;
+  return this.writeIntLE(value, offset, 2, noAssert);
 };
 
 
 Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 2, 0x7fff, -0x8000);
-  this[offset] = (value >>> 8);
-  this[offset + 1] = value;
-  return offset + 2;
+  return this.writeIntBE(value, offset, 2, noAssert);
 };
 
 
 Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
-  this[offset] = value;
-  this[offset + 1] = (value >>> 8);
-  this[offset + 2] = (value >>> 16);
-  this[offset + 3] = (value >>> 24);
-  return offset + 4;
+  return this.writeIntLE(value, offset, 4, noAssert);
 };
 
 
 Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
-  this[offset] = (value >>> 24);
-  this[offset + 1] = (value >>> 16);
-  this[offset + 2] = (value >>> 8);
-  this[offset + 3] = value;
-  return offset + 4;
+  return this.writeIntBE(value, offset, 4, noAssert);
 };

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -919,8 +919,6 @@ var buf = new Buffer([0xFF]);
 assert.equal(buf.readUInt8(0), 255);
 assert.equal(buf.readInt8(0), -1);
 
-
-
 [16, 32].forEach(function(bits) {
   var buf = new Buffer(bits / 8 - 1);
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -955,6 +955,58 @@ assert.equal(buf.readInt8(0), -1);
                 (0xFFFFFFFF >> (32 - bits)));
 });
 
+// test for common read(U)IntLE/BE
+(function() {
+  var buf24 = new Buffer([0x01, 0x02, 0x03]);
+  assert.equal(buf24.readUIntLE(0, 1), 0x01);
+  assert.equal(buf24.readUIntBE(0, 1), 0x01);
+  assert.equal(buf24.readUIntLE(0, 3), 0x030201);
+  assert.equal(buf24.readUIntBE(0, 3), 0x010203);
+  assert.equal(buf24.readIntLE(0, 1), 0x01);
+  assert.equal(buf24.readIntBE(0, 1), 0x01);
+  assert.equal(buf24.readIntLE(0, 3), 0x030201);
+  assert.equal(buf24.readIntBE(0, 3), 0x010203);
+
+  buf24.writeUIntLE(0xff00ff, 0, 3);
+  assert.equal(buf24[0], 0xff);
+  assert.equal(buf24.readIntBE(0, 3), 0x7f00ff - 0x800000);
+
+  var buf40 = new Buffer([0x01, 0x02, 0x03, 0x04, 0x05]);
+  assert.equal(buf40.readUIntLE(0, 5), 0x0504030201);
+  assert.equal(buf40.readUIntBE(0, 5), 0x0102030405);
+  assert.equal(buf40.readIntLE(0, 5), 0x0504030201);
+  assert.equal(buf40.readIntBE(0, 5), 0x0102030405);
+})();
+
+// test for common write(U)IntLE/BE
+(function() {
+  var buf24 = new Buffer([0x0, 0x0, 0x0]);
+  buf24.writeUIntLE(0xff, 0, 1);
+  assert.equal(buf24[0], 0xff);
+
+  buf24.writeUIntLE(0xff11, 0, 2);
+  assert.equal(buf24[0], 0x11);
+  assert.equal(buf24[1], 0xff);
+  
+  buf24.writeUIntLE(0xff1122, 0, 3);
+  assert.equal(buf24[0], 0x22);
+  assert.equal(buf24[1], 0x11);
+  assert.equal(buf24[2], 0xff);
+  
+  buf24.writeIntLE(-15, 0, 2);
+  assert.equal(buf24[0], 0xf1);
+  assert.equal(buf24[1], 0xff);
+
+  buf24.writeUIntBE(0xff1122, 0, 3);
+  assert.equal(buf24[0], 0xff);
+  assert.equal(buf24[1], 0x11);
+  assert.equal(buf24[2], 0x22);
+  
+  buf24.writeIntBE(-15, 0, 2);
+  assert.equal(buf24[0], 0xff);
+  assert.equal(buf24[1], 0xf1);
+})();
+
 // test Buffer slice
 (function() {
   var buf = new Buffer('0123456789');


### PR DESCRIPTION
Some of APIs of `Buffer` what I added listed below:
- `buf.readUIntLE(offset, byteLength, noAssert)`
- `buf.readUIntBE(offset, byteLength, noAssert)`
- `buf.readIntLE(offset, byteLength, noAssert)`
- `buf.readIntBE(offset, byteLength, noAssert)`
- `buf.writeUIntLE(value, offset, byteLength, noAssert)`
- `buf.writeUIntBE(value, offset, byteLength, noAssert)`
- `buf.writeIntLE(value, offset, byteLength, noAssert)`
- `buf.writeIntBE(value, offset, byteLength, noAssert)`

See: http://tools.ietf.org/html/rfc5246#section-7.4
In this spec or other protocols, `uint24` type is often used then these API would simplify related protocols implementation.
