### PR TITLE
New failing test: 'finish' firing before _flush is done in async case.

### DIFF
--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -520,3 +520,39 @@ test('object transform (json stringify)', function(t) {
     t.end();
   })
 });
+
+test("_flush with async call should complete before 'finish' is triggered", function (t) {
+  var stream = new Transform();
+
+  var order = [];
+
+  // Nothing interesting here
+  stream._transform = function (chunk, enc, next) {
+    next();
+  };
+
+  // _flush makes an async call.
+  stream._flush = function (callback) {
+    order.push("Expecting 1st: starting flush");
+
+    return process.nextTick(function () {
+      order.push("Expecting 2nd: finishing flush");
+      callback();
+    });
+  };
+
+  stream.on('finish',function () {
+    order.push("Expecting 3rd: finish triggered after flush is done");
+
+    t.same(order,[
+      "Expecting 1st: starting flush",
+      "Expecting 2nd: finishing flush",
+      "Expecting 3rd: finish triggered after flush is done"
+   ]);
+   t.end();
+
+  });
+
+  stream.end("chunk");
+
+});

--- a/test/simple/test-stream2-transform.js
+++ b/test/simple/test-stream2-transform.js
@@ -230,7 +230,7 @@ test('assymetric transform (expand)', function(t) {
   });
 });
 
-test('assymetric transform (compress)', function(t) {
+test('asymmetric transform (compress)', function(t) {
   var pt = new Transform;
 
   // each output is the first char of 3 consecutive chunks,


### PR DESCRIPTION
The 'finish' event is documented to fire with flushing is done: When "all
data has been flushed to the underlying system".

However, it appears be fired too early in the case of Transform streams
which make an async call. process.nextTick is used here but I ran into this
in a real-world case of making a call to a Mongo database.

This new failing test illustrates the apparent bug. When the code is
_flush is synchronous, there's no problem.

It fails with both 0.10.x and the latest from the 0.11 branch as well.
