### PR TITLE
src: fix _XOPEN_SOURCE redefinition warning

### DIFF
--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -19,21 +19,27 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 500.
+#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 500
+#undef _XOPEN_SOURCE
+#endif
+
+#if !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 500
+#endif
+
 #include "node_constants.h"
 
 #include "uv.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #if !defined(_MSC_VER)
 #include <unistd.h>
 #endif
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-
-// O_NONBLOCK is not exported, unless _XOPEN_SOURCE is set
-#define _XOPEN_SOURCE 500
-#include <fcntl.h>
 
 #if HAVE_OPENSSL
 # include <openssl/ssl.h>


### PR DESCRIPTION
Fix the following compiler warning on systems where _XOPEN_SOURCE is
defined by default:

```
../src/node_constants.cc:35:0: warning: "_XOPEN_SOURCE" redefined
 #define _XOPEN_SOURCE 500
```

Move the (re)definition of _XOPEN_SOURCE to the top of the file while
we're here.  Commit 00890e4 adds a `#define _XOPEN_SOURCE 500` in order
to make <fcntl.h> expose O_NONBLOCK but it does so after other system
headers have been included.  If those headers include <fcntl.h>, then
the #include in node_constants.cc will be a no-op and O_NONBLOCK won't
be visible.

/cc @indutny
