### PR TITLE
child_process: use full path for cmd.exe on Win32

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -608,7 +608,7 @@ function normalizeExecArgs(command /*, options, callback */) {
   }
 
   if (process.platform === 'win32') {
-    file = 'cmd.exe';
+    file = process.env.comspec || 'cmd.exe';
     args = ['/s', '/c', '"' + command + '"'];
     // Make a shallow copy before patching so we don't clobber the user's
     // options object.


### PR DESCRIPTION
Currently child_process.exec() assumes that cmd.exe is on the PATH, and fails with a spawn ENOENT error if it is not.

An example of the failure pre-patch, using Node v0.10.28 on Windows 8.1 x64, inside an MSYS bash shell (where the path is overridden by my .bashrc for other reasons):

**test.js:**

``` node
var exec = require('child_process').exec,
    child;

child = exec('echo "foo"',
  function (error, stdout, stderr) {
    console.log('stdout: ' + stdout);
    console.log('stderr: ' + stderr);
    if (error !== null) {
      console.log('exec error: ' + error);
    }
});
```

**Output:**

```
[/c/test]$ echo $PATH
.:/c/Python27:/c/Python27/Scripts:/mingw/bin:/bin:/c/Program Files/nodejs:/c/Users/Ed/AppData/Roaming/npm
[/c/test]$ node test.js
stdout:
stderr:
exec error: Error: spawn ENOENT
[/c/test]$ export PATH="$PATH:/c/Windows/System32"
[/c/test]$ node test.js
stdout: "foo"

stderr:
```

The Windows 'comspec' environment variable contains the full filepath to the default command interpreter, eg "C:\Windows\System32\cmd.exe" (see http://ss64.com/nt/syntax-variables.html). Should it not be set, we fall-back to using 'cmd.exe' from PATH, as before.

This fixes issues downstream such as https://github.com/jharding/grunt-exec/issues/47
