### PR TITLE
child_process: Patch for issue #7456

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -711,8 +711,6 @@ var spawn = exports.spawn = function(file /*, args, options*/) {
     args = arguments[1].slice(0);
     options = arguments[2];
   } else if (arguments[1] && !Array.isArray(arguments[1])) {
-    args = [];
-    options = arguments[2];
     throw new TypeError('Incorrect value of args option');
   } else {
     args = [];


### PR DESCRIPTION
No point in setting args and options if TypeError
is being thrown.
