### PR TITLE
missing close event after EPIPE error

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -336,7 +336,8 @@ The `connectListener` parameter will be added as an listener for the
 
 ### socket.bufferSize
 
-`net.Socket` has the property that `socket.write()` always works. This is to
+`net.Socket` has the property that `socket.write()` always works - as long
+as the socket is still open. This is to
 help users get up and running quickly. The computer cannot always keep up
 with the amount of data that is written to a socket - the network connection
 simply might be too slow. Node will internally queue up the data written to a
@@ -369,6 +370,9 @@ buffer. Returns `false` if all or part of the data was queued in user memory.
 
 The optional `callback` parameter will be executed when the data is finally
 written out - this may not be immediately.
+
+In case the socket is already closed, an ['error'][] event with code `EPIPE`
+will be emitted.
 
 ### socket.end([data], [encoding])
 
@@ -529,8 +533,7 @@ See also: the return values of `socket.write()`
 
 * {Error object}
 
-Emitted when an error occurs.  The `'close'` event will be called directly
-following this event.
+Emitted when an error occurs.
 
 ### Event: 'close'
 
@@ -538,6 +541,8 @@ following this event.
 
 Emitted once the socket is fully closed. The argument `had_error` is a boolean
 which says if the socket was closed due to a transmission error.
+
+This event will be emitted exactly once per socket.
 
 ## net.isIP(input)
 

--- a/test/simple/test-net-write-after-close.js
+++ b/test/simple/test-net-write-after-close.js
@@ -24,10 +24,12 @@ var assert = require('assert');
 var net = require('net');
 
 var gotError = false;
+var gotClose = false;
 var gotWriteCB = false;
 
 process.on('exit', function() {
   assert(gotError);
+  assert(gotClose);
   assert(gotWriteCB);
 });
 
@@ -35,9 +37,14 @@ var server = net.createServer(function(socket) {
   socket.resume();
 
   socket.on('error', function(error) {
-    console.error('got error, closing server', error);
-    server.close();
+    console.error('got error', error);
     gotError = true;
+
+    socket.on('close', function() {
+      console.error('got close, closing server');
+      gotClose = true;
+      server.close();
+    });
   });
 
   setTimeout(function() {


### PR DESCRIPTION
The documentation for a `net.Socket` states [here](http://nodejs.org/api/net.html#net_event_error_1):

> Event: 'error'#
> Error object
> Emitted when an error occurs. The 'close' event will be called directly following this event.

This does however not happen after an `EPIPE` error. I made the `net-write-after-close` test fail by waiting for that event.

I'm not sure how to fix this, of course we could just `self.emit('close')` [here](https://github.com/joyent/node/blob/master/lib/net.js#L278) in `writeAfterFIN`, but it seems like this should rather happen somewhere around [here](https://github.com/joyent/node/blob/master/lib/net.js#L261) in `onSocketEnd()` or `destroySoon()`.
