### PR TITLE
crypto: improve memory usage

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -43,7 +43,6 @@
 
 #define EVP_F_EVP_DECRYPTFINAL 101
 
-
 namespace node {
 namespace crypto {
 
@@ -137,6 +136,16 @@ class ClientHelloParser {
                                      state_(kWaiting),
                                      offset_(0),
                                      body_offset_(0) {
+    data_ = new uint8_t[kBufferSize];
+    if (!data_)
+      abort();
+  }
+
+  ~ClientHelloParser() {
+    if (data_) {
+      delete[] data_;
+      data_ = NULL;
+    }
   }
 
   size_t Write(const uint8_t* data, size_t len);
@@ -145,11 +154,12 @@ class ClientHelloParser {
   inline bool ended() { return state_ == kEnded; }
 
  private:
+  static const int kBufferSize = 18432;
   Connection* conn_;
   ParseState state_;
   size_t frame_len_;
 
-  uint8_t data_[18432];
+  uint8_t* data_;
   size_t offset_;
   size_t body_offset_;
 };


### PR DESCRIPTION
ClientHelloParser used to contain an 18k buffer that was kept around
for the life of the connection, even though it was not needed in many
situations. I changed it to be deallocated when it's determined to
be no longer needed.
