### PR TITLE
net: don't throw on net.Server.close()

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -206,7 +206,8 @@ Stops the server from accepting new connections and keeps existing
 connections. This function is asynchronous, the server is finally
 closed when all connections are ended and the server emits a `'close'`
 event. Optionally, you can pass a callback to listen for the `'close'`
-event.
+event. If present, the callback is invoked with any potential error 
+as the first and only argument.
 
 ### server.address()
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1343,7 +1343,9 @@ Server.prototype.close = function(cb) {
 
   if (cb) {
     if (!this._handle) {
-      this.once('close', cb.bind(this, new Error('Not running')));
+      this.once('close', function() {
+        cb(new Error('Not running'));
+      });
     } else {
       this.once('close', cb);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1341,16 +1341,18 @@ Server.prototype.close = function(cb) {
     self._emitCloseIfDrained();
   }
 
-  if (!this._handle) {
-    // Throw error. Follows net_legacy behaviour.
-    throw new Error('Not running');
+  if (cb) {
+    if (!this._handle) {
+      this.once('close', cb.bind(this, new Error('Not running')));
+    } else {
+      this.once('close', cb);
+    }
   }
 
-  if (cb) {
-    this.once('close', cb);
+  if (this._handle) {
+    this._handle.close();
+    this._handle = null;
   }
-  this._handle.close();
-  this._handle = null;
 
   if (this._usingSlaves) {
     var self = this,

--- a/test/simple/test-http-unix-socket.js
+++ b/test/simple/test-http-unix-socket.js
@@ -62,7 +62,12 @@ server.listen(common.PIPE, function() {
     res.on('end', function() {
       assert.equal(res.body, 'hello world\n');
       body_ok = true;
-      server.close();
+      server.close(function(error) {
+        assert.equal(error, undefined);
+        server.close(function(error) {
+          assert.equal(error && error.message, 'Not running');
+        });
+      });
     });
   });
 
@@ -79,9 +84,4 @@ process.on('exit', function() {
   assert.ok(status_ok);
   assert.ok(headers_ok);
   assert.ok(body_ok);
-
-  // Double close should throw. Follows net_legacy behaviour.
-  assert.throws(function() {
-    server.close();
-  });
 });


### PR DESCRIPTION
When `close()` is called on a non-listening server, a synchronous error is thrown. This commit causes the error to be passed to the asynchronous callback function instead.

Closes #7295
Closes #7324
