### PR TITLE
stream: start old-mode read in a next tick

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -87,6 +87,9 @@ function ReadableState(options, stream) {
   // if true, a maybeReadMore has been scheduled
   this.readingMore = false;
 
+  // if true, stream is in old mode
+  this.oldMode = false;
+
   this.decoder = null;
   this.encoding = null;
   if (options.encoding) {
@@ -772,6 +775,9 @@ function emitDataEvents(stream, startPaused) {
     // now make it start, just in case it hadn't already.
     stream.emit('readable');
   });
+
+  // Let others know about our mode
+  state.oldMode = true;
 }
 
 // wrap an old-style stream as the async data source.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -766,8 +766,12 @@ function emitDataEvents(stream, startPaused) {
     this.emit('resume');
   };
 
-  // now make it start, just in case it hadn't already.
-  stream.emit('readable');
+  // Start reading in next tick to allow caller to set event listeners on
+  // the stream object (like `error`)
+  process.nextTick(function() {
+    // now make it start, just in case it hadn't already.
+    stream.emit('readable');
+  });
 }
 
 // wrap an old-style stream as the async data source.

--- a/lib/http.js
+++ b/lib/http.js
@@ -2078,7 +2078,7 @@ function connectionListener(socket) {
       // if the user never called req.read(), and didn't pipe() or
       // .resume() or .on('data'), then we call req._dump() so that the
       // bytes will be pulled off the wire.
-      if (!req._consuming)
+      if (!req._consuming && !req._readableState.oldMode)
         req._dump();
 
       res.detachSocket(socket);

--- a/test/simple/test-stream-readable-data-sync-race.js
+++ b/test/simple/test-stream-readable-data-sync-race.js
@@ -1,0 +1,41 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var Readable = require('stream').Readable;
+
+var r = new Readable();
+var errors = 0;
+
+// Setting `data` listener should not trigger `_read()` calls before we will
+// set the `error` listener below
+r.on('data', function() {
+});
+
+r.on('error', function() {
+  errors++;
+});
+
+process.on('exit', function() {
+  assert.equal(errors, 1);
+});

--- a/test/simple/test-stream2-compatibility.js
+++ b/test/simple/test-stream2-compatibility.js
@@ -47,4 +47,6 @@ TestReader.prototype._read = function(n) {
 };
 
 var reader = new TestReader();
-assert.equal(ondataCalled, 1);
+process.nextTick(function() {
+  assert.equal(ondataCalled, 1);
+});


### PR DESCRIPTION
Calling `.read()` in the same tick with `.on('data', ...)` may cause
users missing `error` events, because no `error` listeners were set yet.

fix #7618
