### PR TITLE
contexify: fix infinite recursion in delete cb

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -414,10 +414,6 @@ class ContextifyContext {
 
     bool success = PersistentToLocal(isolate,
                                      ctx->sandbox_)->Delete(property);
-    if (!success) {
-      success = PersistentToLocal(isolate,
-                                  ctx->proxy_global_)->Delete(property);
-    }
     args.GetReturnValue().Set(success);
   }
 

--- a/test/simple/test-vm-context.js
+++ b/test/simple/test-vm-context.js
@@ -73,3 +73,10 @@ script = vm.createScript('var assert = require(\'assert\'); assert.throws(' +
                          'function() { throw "hello world"; }, /hello/);',
                          'some.js');
 script.runInNewContext({ require : require });
+
+// Issue GH-7529
+script = vm.createScript('delete b');
+var ctx = {};
+Object.defineProperty(ctx, 'b', { configurable: false });
+ctx = vm.createContext(ctx);
+assert.equal(script.runInContext(ctx), false);


### PR DESCRIPTION
Do not ever call `Delete()` on `proxy_global_`, it will invoke
`GlobalPropertyDeleteCallback` and cause crash because of the infinite
recursion.

fix #7529
