### PR TITLE
Add slashes for RFC6920 ni:// URIs

### DIFF
--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -86,7 +86,7 @@ Here's how the formatting process works:
 
 * `href` will be ignored.
 * `protocol` is treated the same with or without the trailing `:` (colon).
-  * The protocols `http`, `https`, `ftp`, `gopher`, `file` will be
+  * The protocols `http`, `https`, `ftp`, `gopher`, `file`, `ni` will be
     postfixed with `://` (colon-slash-slash).
   * All other protocols `mailto`, `xmpp`, `aim`, `sftp`, `foo`, etc will
     be postfixed with `:` (colon)

--- a/lib/url.js
+++ b/lib/url.js
@@ -91,11 +91,13 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
       'ftp': true,
       'gopher': true,
       'file': true,
+      'ni': true,
       'http:': true,
       'https:': true,
       'ftp:': true,
       'gopher:': true,
-      'file:': true
+      'file:': true,
+      'ni:': true
     },
     querystring = require('querystring');
 

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -1520,7 +1520,15 @@ var relativeTests2 = [
   //changeing auth
   ['http://diff:auth@www.example.com',
    'http://asdf:qwer@www.example.com',
-   'http://diff:auth@www.example.com/']
+   'http://diff:auth@www.example.com/'],
+
+  // RFC6920
+   ['sha-256;UyaQV-Ev4rdLoHyJJWCi11OHfrYv9E1aGQAlMO2X_-Q',
+    'ni://example.com/',
+    'ni://example.com/sha-256;UyaQV-Ev4rdLoHyJJWCi11OHfrYv9E1aGQAlMO2X_-Q'],
+   ['sha-256-120;UyaQV+Ev4rdLoHyJJWCi',
+    'ni:///',
+    'ni:///sha-256-120;UyaQV+Ev4rdLoHyJJWCi']
 ];
 relativeTests2.forEach(function(relativeTest) {
   var a = url.resolve(relativeTest[1], relativeTest[0]),


### PR DESCRIPTION
[RFC6920](http://tools.ietf.org/html/rfc6920) ("Naming Things with Hashes") defines two new URI Schemes: "ni" and "nih" for use with Named Information.
The first one (ni) needs the double-slashes added. The second one (nih) is a human readable version and does not.

Examples:

```
ni:///sha-256;UyaQV-Ev4rdLoHyJJWCi11OHfrYv9E1aGQAlMO2X_-Q
nih:sha-256-120;5326-9057-e12f-e2b7-4ba0-7c89-2560-a2;f
```

This patch adds the ni-scheme to the list of protocols that get slashes added and also notes this in the documentation.
