### PR TITLE
http: use once() instead of on() for timeout listeners

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -82,7 +82,7 @@ exports.IncomingMessage = IncomingMessage;
 
 IncomingMessage.prototype.setTimeout = function(msecs, callback) {
   if (callback)
-    this.on('timeout', callback);
+    this.once('timeout', callback);
   this.socket.setTimeout(msecs);
 };
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -94,7 +94,7 @@ exports.OutgoingMessage = OutgoingMessage;
 
 OutgoingMessage.prototype.setTimeout = function(msecs, callback) {
   if (callback)
-    this.on('timeout', callback);
+    this.once('timeout', callback);
   if (!this.socket) {
     this.once('socket', function(socket) {
       socket.setTimeout(msecs);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -315,7 +315,8 @@ function connectionListener(socket) {
   // otherwise, destroy on timeout by default
   if (self.timeout)
     socket.setTimeout(self.timeout);
-  socket.on('timeout', function() {
+
+  socket.once('timeout', function() {
     var req = socket.parser && socket.parser.incoming;
     var reqTimeout = req && !req.complete && req.emit('timeout', socket);
     var res = socket._httpMessage;


### PR DESCRIPTION
Switching to `once()` helps to avoid potential memory leaks
and reduces the need to call `removeListener()`.

Closes #7297
