### PR TITLE
deps: revert allocating typed arrays on heap

### DIFF
--- a/deps/v8/build/features.gypi
+++ b/deps/v8/build/features.gypi
@@ -115,7 +115,7 @@
       'Release': {
         'variables': {
           'v8_enable_extra_checks%': 0,
-          'v8_enable_handle_zapping%': 1,
+          'v8_enable_handle_zapping%': 0,
         },
         'conditions': [
           ['v8_enable_extra_checks==1', {

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -5571,7 +5571,7 @@ class Internals {
   static const int kNullValueRootIndex = 7;
   static const int kTrueValueRootIndex = 8;
   static const int kFalseValueRootIndex = 9;
-  static const int kEmptyStringRootIndex = 154;
+  static const int kEmptyStringRootIndex = 145;
 
   static const int kNodeClassIdOffset = 1 * kApiPointerSize;
   static const int kNodeFlagsOffset = 1 * kApiPointerSize + 3;

--- a/deps/v8/src/accessors.cc
+++ b/deps/v8/src/accessors.cc
@@ -119,7 +119,9 @@ bool Accessors::IsJSObjectFieldAccessor(typename T::TypeHandle type,
         CheckForName(name, isolate->heap()->byte_length_string(),
                      JSTypedArray::kByteLengthOffset, object_offset) ||
         CheckForName(name, isolate->heap()->byte_offset_string(),
-                     JSTypedArray::kByteOffsetOffset, object_offset);
+                     JSTypedArray::kByteOffsetOffset, object_offset) ||
+        CheckForName(name, isolate->heap()->buffer_string(),
+                     JSTypedArray::kBufferOffset, object_offset);
     case JS_ARRAY_BUFFER_TYPE:
       return
         CheckForName(name, isolate->heap()->byte_length_string(),
@@ -129,7 +131,9 @@ bool Accessors::IsJSObjectFieldAccessor(typename T::TypeHandle type,
         CheckForName(name, isolate->heap()->byte_length_string(),
                      JSDataView::kByteLengthOffset, object_offset) ||
         CheckForName(name, isolate->heap()->byte_offset_string(),
-                     JSDataView::kByteOffsetOffset, object_offset);
+                     JSDataView::kByteOffsetOffset, object_offset) ||
+        CheckForName(name, isolate->heap()->buffer_string(),
+                     JSDataView::kBufferOffset, object_offset);
     default:
       return false;
   }

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -6018,15 +6018,8 @@ Local<ArrayBuffer> v8::ArrayBuffer::New(Isolate* isolate, void* data,
 
 Local<ArrayBuffer> v8::ArrayBufferView::Buffer() {
   i::Handle<i::JSArrayBufferView> obj = Utils::OpenHandle(this);
-  i::Handle<i::JSArrayBuffer> buffer;
-  if (obj->IsJSDataView()) {
-    i::Handle<i::JSDataView> data_view(i::JSDataView::cast(*obj));
-    ASSERT(data_view->buffer()->IsJSArrayBuffer());
-    buffer = i::handle(i::JSArrayBuffer::cast(data_view->buffer()));
-  } else {
-    ASSERT(obj->IsJSTypedArray());
-    buffer = i::JSTypedArray::cast(*obj)->GetBuffer();
-  }
+  ASSERT(obj->buffer()->IsJSArrayBuffer());
+  i::Handle<i::JSArrayBuffer> buffer(i::JSArrayBuffer::cast(obj->buffer()));
   return Utils::ToLocal(buffer);
 }
 
@@ -6097,9 +6090,7 @@ i::Handle<i::JSTypedArray> NewTypedArray(
       isolate->factory()->NewExternalArray(
           static_cast<int>(length), array_type,
           static_cast<uint8_t*>(buffer->backing_store()) + byte_offset);
-  i::Handle<i::Map> map =
-      i::JSObject::GetElementsTransitionMap(obj, elements_kind);
-  obj->set_map_and_elements(*map, *elements);
+  obj->set_elements(*elements);
   return obj;
 }
 

--- a/deps/v8/src/bootstrapper.cc
+++ b/deps/v8/src/bootstrapper.cc
@@ -1099,7 +1099,7 @@ void Genesis::InitializeGlobal(Handle<GlobalObject> inner_global,
 #define INSTALL_TYPED_ARRAY(Type, type, TYPE, ctype, size)                    \
     {                                                                         \
       Handle<JSFunction> fun = InstallTypedArray(#Type "Array",               \
-          TYPE##_ELEMENTS);                                                   \
+          EXTERNAL_##TYPE##_ELEMENTS);                                        \
       native_context()->set_##type##_array_fun(*fun);                         \
     }
     TYPED_ARRAYS(INSTALL_TYPED_ARRAY)

--- a/deps/v8/src/elements-kind.cc
+++ b/deps/v8/src/elements-kind.cc
@@ -142,27 +142,14 @@ int GetSequenceIndexFromFastElementsKind(ElementsKind elements_kind) {
 }
 
 
-ElementsKind GetNextTransitionElementsKind(ElementsKind kind) {
-  switch (kind) {
-#define FIXED_TYPED_ARRAY_CASE(Type, type, TYPE, ctype, size) \
-    case TYPE##_ELEMENTS: return EXTERNAL_##TYPE##_ELEMENTS;
-
-    TYPED_ARRAYS(FIXED_TYPED_ARRAY_CASE)
-#undef FIXED_TYPED_ARRAY_CASE
-    default: {
-      int index = GetSequenceIndexFromFastElementsKind(kind);
-      return GetFastElementsKindFromSequenceIndex(index + 1);
-    }
-  }
-}
-
-
 ElementsKind GetNextMoreGeneralFastElementsKind(ElementsKind elements_kind,
                                                 bool allow_only_packed) {
   ASSERT(IsFastElementsKind(elements_kind));
   ASSERT(elements_kind != TERMINAL_FAST_ELEMENTS_KIND);
   while (true) {
-    elements_kind = GetNextTransitionElementsKind(elements_kind);
+    int index =
+        GetSequenceIndexFromFastElementsKind(elements_kind) + 1;
+    elements_kind = GetFastElementsKindFromSequenceIndex(index);
     if (!IsFastHoleyElementsKind(elements_kind) || !allow_only_packed) {
       return elements_kind;
     }

--- a/deps/v8/src/elements-kind.h
+++ b/deps/v8/src/elements-kind.h
@@ -100,10 +100,10 @@ void PrintElementsKind(FILE* out, ElementsKind kind);
 
 ElementsKind GetInitialFastElementsKind();
 
-ElementsKind GetFastElementsKindFromSequenceIndex(int sequence_number);
+ElementsKind GetFastElementsKindFromSequenceIndex(int sequence_index);
+
 int GetSequenceIndexFromFastElementsKind(ElementsKind elements_kind);
 
-ElementsKind GetNextTransitionElementsKind(ElementsKind elements_kind);
 
 inline bool IsDictionaryElementsKind(ElementsKind kind) {
   return kind == DICTIONARY_ELEMENTS;
@@ -116,12 +116,6 @@ inline bool IsExternalArrayElementsKind(ElementsKind kind) {
 }
 
 
-inline bool IsTerminalElementsKind(ElementsKind kind) {
-  return kind == TERMINAL_FAST_ELEMENTS_KIND ||
-      IsExternalArrayElementsKind(kind);
-}
-
-
 inline bool IsFixedTypedArrayElementsKind(ElementsKind kind) {
   return kind >= FIRST_FIXED_TYPED_ARRAY_ELEMENTS_KIND &&
       kind <= LAST_FIXED_TYPED_ARRAY_ELEMENTS_KIND;
@@ -131,11 +125,6 @@ inline bool IsFixedTypedArrayElementsKind(ElementsKind kind) {
 inline bool IsFastElementsKind(ElementsKind kind) {
   ASSERT(FIRST_FAST_ELEMENTS_KIND == 0);
   return kind <= FAST_HOLEY_DOUBLE_ELEMENTS;
-}
-
-
-inline bool IsTransitionElementsKind(ElementsKind kind) {
-  return IsFastElementsKind(kind) || IsFixedTypedArrayElementsKind(kind);
 }
 
 

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -350,9 +350,6 @@ DEFINE_bool(omit_map_checks_for_leaf_maps, true,
             "do not emit check maps for constant values that have a leaf map, "
             "deoptimize the optimized code if the layout of the maps changes.")
 
-DEFINE_int(typed_array_max_size_in_heap, 64,
-    "threshold for in-heap typed array")
-
 // Profiler flags.
 DEFINE_int(frame_count, 1, "number of stack frames inspected by the profiler")
            // 0x1800 fits in the immediate field of an ARM instruction.

--- a/deps/v8/src/heap.h
+++ b/deps/v8/src/heap.h
@@ -164,16 +164,6 @@ namespace internal {
   V(Map, fixed_float32_array_map, FixedFloat32ArrayMap)                        \
   V(Map, fixed_float64_array_map, FixedFloat64ArrayMap)                        \
   V(Map, fixed_uint8_clamped_array_map, FixedUint8ClampedArrayMap)             \
-  V(FixedTypedArrayBase, empty_fixed_uint8_array, EmptyFixedUint8Array)        \
-  V(FixedTypedArrayBase, empty_fixed_int8_array, EmptyFixedInt8Array)          \
-  V(FixedTypedArrayBase, empty_fixed_uint16_array, EmptyFixedUint16Array)      \
-  V(FixedTypedArrayBase, empty_fixed_int16_array, EmptyFixedInt16Array)        \
-  V(FixedTypedArrayBase, empty_fixed_uint32_array, EmptyFixedUint32Array)      \
-  V(FixedTypedArrayBase, empty_fixed_int32_array, EmptyFixedInt32Array)        \
-  V(FixedTypedArrayBase, empty_fixed_float32_array, EmptyFixedFloat32Array)    \
-  V(FixedTypedArrayBase, empty_fixed_float64_array, EmptyFixedFloat64Array)    \
-  V(FixedTypedArrayBase, empty_fixed_uint8_clamped_array,                      \
-      EmptyFixedUint8ClampedArray)                                             \
   V(Map, sloppy_arguments_elements_map, SloppyArgumentsElementsMap)            \
   V(Map, function_context_map, FunctionContextMap)                             \
   V(Map, catch_context_map, CatchContextMap)                                   \
@@ -1665,9 +1655,7 @@ class Heap {
       ExternalArrayType array_type);
 
   RootListIndex RootIndexForEmptyExternalArray(ElementsKind kind);
-  RootListIndex RootIndexForEmptyFixedTypedArray(ElementsKind kind);
   ExternalArray* EmptyExternalArrayForMap(Map* map);
-  FixedTypedArrayBase* EmptyFixedTypedArrayForMap(Map* map);
 
   void RecordStats(HeapStats* stats, bool take_snapshot = false);
 
@@ -2231,10 +2219,6 @@ class Heap {
 
   // Allocate empty external array of given type.
   MUST_USE_RESULT MaybeObject* AllocateEmptyExternalArray(
-      ExternalArrayType array_type);
-
-  // Allocate empty fixed typed array of given type.
-  MUST_USE_RESULT MaybeObject* AllocateEmptyFixedTypedArray(
       ExternalArrayType array_type);
 
   // Allocate empty fixed double array.

--- a/deps/v8/src/hydrogen.cc
+++ b/deps/v8/src/hydrogen.cc
@@ -1904,19 +1904,6 @@ void HGraphBuilder::BuildCopySeqStringChars(HValue* src,
 }
 
 
-HValue* HGraphBuilder::BuildObjectSizeAlignment(
-    HValue* unaligned_size, int header_size) {
-  ASSERT((header_size & kObjectAlignmentMask) == 0);
-  HValue* size = AddUncasted<HAdd>(
-      unaligned_size, Add<HConstant>(static_cast<int32_t>(
-          header_size + kObjectAlignmentMask)));
-  size->ClearFlag(HValue::kCanOverflow);
-  return AddUncasted<HBitwise>(
-      Token::BIT_AND, size, Add<HConstant>(static_cast<int32_t>(
-          ~kObjectAlignmentMask)));
-}
-
-
 HValue* HGraphBuilder::BuildUncheckedStringAdd(
     HValue* left,
     HValue* right,
@@ -2017,7 +2004,13 @@ HValue* HGraphBuilder::BuildUncheckedStringAdd(
       // Calculate the number of bytes needed for the characters in the
       // string while observing object alignment.
       STATIC_ASSERT((SeqString::kHeaderSize & kObjectAlignmentMask) == 0);
-      HValue* size = BuildObjectSizeAlignment(Pop(), SeqString::kHeaderSize);
+      HValue* size = Pop();
+      size = AddUncasted<HAdd>(size, Add<HConstant>(static_cast<int32_t>(
+                  SeqString::kHeaderSize + kObjectAlignmentMask)));
+      size->ClearFlag(HValue::kCanOverflow);
+      size = AddUncasted<HBitwise>(
+          Token::BIT_AND, size, Add<HConstant>(static_cast<int32_t>(
+                  ~kObjectAlignmentMask)));
 
       // Allocate the string object. HAllocate does not care whether we pass
       // STRING_TYPE or ASCII_STRING_TYPE here, so we just use STRING_TYPE here.
@@ -6477,8 +6470,7 @@ HValue* HOptimizedGraphBuilder::HandlePolymorphicElementAccess(
       access = AddInstruction(BuildKeyedGeneric(access_type, object, key, val));
     } else {
       ASSERT(IsFastElementsKind(elements_kind) ||
-             IsExternalArrayElementsKind(elements_kind) ||
-             IsFixedTypedArrayElementsKind(elements_kind));
+             IsExternalArrayElementsKind(elements_kind));
       LoadKeyedHoleMode load_mode = BuildKeyedHoleMode(map);
       // Happily, mapcompare is a checked object.
       access = BuildUncheckedMonomorphicElementAccess(
@@ -8431,6 +8423,9 @@ void HGraphBuilder::BuildArrayBufferViewInitialization(
 
   Add<HStoreNamedField>(
       obj,
+      HObjectAccess::ForJSArrayBufferViewBuffer(), buffer);
+  Add<HStoreNamedField>(
+      obj,
       HObjectAccess::ForJSArrayBufferViewByteOffset(),
       byte_offset);
   Add<HStoreNamedField>(
@@ -8438,27 +8433,14 @@ void HGraphBuilder::BuildArrayBufferViewInitialization(
       HObjectAccess::ForJSArrayBufferViewByteLength(),
       byte_length);
 
-  if (buffer != NULL) {
-    Add<HStoreNamedField>(
-        obj,
-        HObjectAccess::ForJSArrayBufferViewBuffer(), buffer);
-    HObjectAccess weak_first_view_access =
-        HObjectAccess::ForJSArrayBufferWeakFirstView();
-    Add<HStoreNamedField>(obj,
-        HObjectAccess::ForJSArrayBufferViewWeakNext(),
-        Add<HLoadNamedField>(buffer,
-                             static_cast<HValue*>(NULL),
-                             weak_first_view_access));
-    Add<HStoreNamedField>(buffer, weak_first_view_access, obj);
-  } else {
-    Add<HStoreNamedField>(
-        obj,
-        HObjectAccess::ForJSArrayBufferViewBuffer(),
-        Add<HConstant>(static_cast<int32_t>(0)));
-    Add<HStoreNamedField>(obj,
-        HObjectAccess::ForJSArrayBufferViewWeakNext(),
-        graph()->GetConstantUndefined());
-  }
+  HObjectAccess weak_first_view_access =
+      HObjectAccess::ForJSArrayBufferWeakFirstView();
+  Add<HStoreNamedField>(obj,
+      HObjectAccess::ForJSArrayBufferViewWeakNext(),
+      Add<HLoadNamedField>(buffer, static_cast<HValue*>(NULL),
+                           weak_first_view_access));
+  Add<HStoreNamedField>(
+      buffer, weak_first_view_access, obj);
 }
 
 
@@ -8485,115 +8467,6 @@ void HOptimizedGraphBuilder::GenerateDataViewInitialize(
 }
 
 
-static Handle<Map> TypedArrayMap(Isolate* isolate,
-                                 ExternalArrayType array_type,
-                                 ElementsKind target_kind) {
-  Handle<Context> native_context = isolate->native_context();
-  Handle<JSFunction> fun;
-  switch (array_type) {
-#define TYPED_ARRAY_CASE(Type, type, TYPE, ctype, size)                       \
-    case kExternal##Type##Array:                                              \
-      fun = Handle<JSFunction>(native_context->type##_array_fun());           \
-      break;
-
-    TYPED_ARRAYS(TYPED_ARRAY_CASE)
-#undef TYPED_ARRAY_CASE
-  }
-  Handle<Map> map(fun->initial_map());
-  return Map::AsElementsKind(map, target_kind);
-}
-
-
-HValue* HOptimizedGraphBuilder::BuildAllocateExternalElements(
-    ExternalArrayType array_type,
-    bool is_zero_byte_offset,
-    HValue* buffer, HValue* byte_offset, HValue* length) {
-  Handle<Map> external_array_map(
-      isolate()->heap()->MapForExternalArrayType(array_type));
-  HValue* elements =
-      Add<HAllocate>(
-          Add<HConstant>(ExternalArray::kAlignedSize),
-          HType::Tagged(),
-          NOT_TENURED,
-          external_array_map->instance_type());
-
-  AddStoreMapConstant(elements, external_array_map);
-
-  HValue* backing_store = Add<HLoadNamedField>(
-      buffer, static_cast<HValue*>(NULL),
-      HObjectAccess::ForJSArrayBufferBackingStore());
-
-  HValue* typed_array_start;
-  if (is_zero_byte_offset) {
-    typed_array_start = backing_store;
-  } else {
-    HInstruction* external_pointer =
-        AddUncasted<HAdd>(backing_store, byte_offset);
-    // Arguments are checked prior to call to TypedArrayInitialize,
-    // including byte_offset.
-    external_pointer->ClearFlag(HValue::kCanOverflow);
-    typed_array_start = external_pointer;
-  }
-
-
-  Add<HStoreNamedField>(elements,
-      HObjectAccess::ForExternalArrayExternalPointer(),
-      typed_array_start);
-
-  Add<HStoreNamedField>(elements,
-      HObjectAccess::ForFixedArrayLength(), length);
-  return elements;
-}
-
-
-HValue* HOptimizedGraphBuilder::BuildAllocateFixedTypedArray(
-    ExternalArrayType array_type, size_t element_size,
-    ElementsKind fixed_elements_kind,
-    HValue* byte_length, HValue* length) {
-  STATIC_ASSERT(
-      (FixedTypedArrayBase::kHeaderSize & kObjectAlignmentMask) == 0);
-  HValue* total_size;
-
-  // if fixed array's elements are not aligned to object's alignment,
-  // we need to align the whole array to object alignment.
-  if (element_size % kObjectAlignment != 0) {
-    total_size = BuildObjectSizeAlignment(
-        byte_length, FixedTypedArrayBase::kHeaderSize);
-  } else {
-    total_size = AddUncasted<HAdd>(byte_length,
-        Add<HConstant>(FixedTypedArrayBase::kHeaderSize));
-    total_size->ClearFlag(HValue::kCanOverflow);
-  }
-
-  Handle<Map> fixed_typed_array_map(
-      isolate()->heap()->MapForFixedTypedArray(array_type));
-  HValue* elements =
-      Add<HAllocate>(total_size, HType::Tagged(),
-          NOT_TENURED,
-          fixed_typed_array_map->instance_type());
-  AddStoreMapConstant(elements, fixed_typed_array_map);
-
-  Add<HStoreNamedField>(elements,
-      HObjectAccess::ForFixedArrayLength(),
-      length);
-  HValue* filler = Add<HConstant>(static_cast<int32_t>(0));
-
-  {
-    LoopBuilder builder(this, context(), LoopBuilder::kPostIncrement);
-
-    HValue* key = builder.BeginBody(
-        Add<HConstant>(static_cast<int32_t>(0)),
-        length, Token::LT);
-    Add<HStoreKeyed>(elements, key, filler, fixed_elements_kind);
-
-    builder.EndBody();
-  }
-  Add<HStoreNamedField>(
-      elements, HObjectAccess::ForFixedArrayLength(), length);
-  return elements;
-}
-
-
 void HOptimizedGraphBuilder::GenerateTypedArrayInitialize(
     CallRuntime* expr) {
   ZoneList<Expression*>* arguments = expr->arguments();
@@ -8617,13 +8490,8 @@ void HOptimizedGraphBuilder::GenerateTypedArrayInitialize(
   ASSERT(value->IsSmi());
   int array_id = Smi::cast(*value)->value();
 
-  HValue* buffer;
-  if (!arguments->at(kBufferArg)->IsNullLiteral()) {
-    CHECK_ALIVE(VisitForValue(arguments->at(kBufferArg)));
-    buffer = Pop();
-  } else {
-    buffer = NULL;
-  }
+  CHECK_ALIVE(VisitForValue(arguments->at(kBufferArg)));
+  HValue* buffer = Pop();
 
   HValue* byte_offset;
   bool is_zero_byte_offset;
@@ -8637,7 +8505,6 @@ void HOptimizedGraphBuilder::GenerateTypedArrayInitialize(
     CHECK_ALIVE(VisitForValue(arguments->at(kByteOffsetArg)));
     byte_offset = Pop();
     is_zero_byte_offset = false;
-    ASSERT(buffer != NULL);
   }
 
   CHECK_ALIVE(VisitForValue(arguments->at(kByteLengthArg)));
@@ -8650,24 +8517,13 @@ void HOptimizedGraphBuilder::GenerateTypedArrayInitialize(
     byte_offset_smi.Then();
   }
 
-  ExternalArrayType array_type =
-      kExternalInt8Array;  // Bogus initialization.
-  size_t element_size = 1;  // Bogus initialization.
-  ElementsKind external_elements_kind =  // Bogus initialization.
-      EXTERNAL_INT8_ELEMENTS;
-  ElementsKind fixed_elements_kind =  // Bogus initialization.
-      INT8_ELEMENTS;
-  Runtime::ArrayIdToTypeAndSize(array_id,
-      &array_type,
-      &external_elements_kind,
-      &fixed_elements_kind,
-      &element_size);
-
-
   { //  byte_offset is Smi.
     BuildArrayBufferViewInitialization<JSTypedArray>(
         obj, buffer, byte_offset, byte_length);
 
+    ExternalArrayType array_type = kExternalInt8Array;  // Bogus initialization.
+    size_t element_size = 1;  // Bogus initialization.
+    Runtime::ArrayIdToTypeAndSize(array_id, &array_type, &element_size);
 
     HInstruction* length = AddUncasted<HDiv>(byte_length,
         Add<HConstant>(static_cast<int32_t>(element_size)));
@@ -8676,19 +8532,40 @@ void HOptimizedGraphBuilder::GenerateTypedArrayInitialize(
         HObjectAccess::ForJSTypedArrayLength(),
         length);
 
-    HValue* elements;
-    if (buffer != NULL) {
-      elements = BuildAllocateExternalElements(
-          array_type, is_zero_byte_offset, buffer, byte_offset, length);
-      Handle<Map> obj_map = TypedArrayMap(
-          isolate(), array_type, external_elements_kind);
-      AddStoreMapConstant(obj, obj_map);
+    Handle<Map> external_array_map(
+        isolate()->heap()->MapForExternalArrayType(array_type));
+
+    HValue* elements =
+        Add<HAllocate>(
+            Add<HConstant>(ExternalArray::kAlignedSize),
+            HType::Tagged(),
+            NOT_TENURED,
+            external_array_map->instance_type());
+
+    AddStoreMapConstant(elements, external_array_map);
+
+    HValue* backing_store = Add<HLoadNamedField>(
+        buffer, static_cast<HValue*>(NULL),
+        HObjectAccess::ForJSArrayBufferBackingStore());
+
+    HValue* typed_array_start;
+    if (is_zero_byte_offset) {
+      typed_array_start = backing_store;
     } else {
-      ASSERT(is_zero_byte_offset);
-      elements = BuildAllocateFixedTypedArray(
-          array_type, element_size, fixed_elements_kind,
-          byte_length, length);
+      HInstruction* external_pointer =
+          AddUncasted<HAdd>(backing_store, byte_offset);
+      // Arguments are checked prior to call to TypedArrayInitialize,
+      // including byte_offset.
+      external_pointer->ClearFlag(HValue::kCanOverflow);
+      typed_array_start = external_pointer;
     }
+
+    Add<HStoreNamedField>(elements,
+        HObjectAccess::ForExternalArrayExternalPointer(),
+        typed_array_start);
+    Add<HStoreNamedField>(elements,
+        HObjectAccess::ForFixedArrayLength(),
+        length);
     Add<HStoreNamedField>(
         obj, HObjectAccess::ForElementsPointer(), elements);
   }
@@ -8713,15 +8590,6 @@ void HOptimizedGraphBuilder::GenerateMaxSmi(CallRuntime* expr) {
   ASSERT(expr->arguments()->length() == 0);
   HConstant* max_smi = New<HConstant>(static_cast<int32_t>(Smi::kMaxValue));
   return ast_context()->ReturnInstruction(max_smi, expr->id());
-}
-
-
-void HOptimizedGraphBuilder::GenerateTypedArrayMaxSizeInHeap(
-    CallRuntime* expr) {
-  ASSERT(expr->arguments()->length() == 0);
-  HConstant* result = New<HConstant>(static_cast<int32_t>(
-        FLAG_typed_array_max_size_in_heap));
-  return ast_context()->ReturnInstruction(result, expr->id());
 }
 
 

--- a/deps/v8/src/hydrogen.h
+++ b/deps/v8/src/hydrogen.h
@@ -1372,10 +1372,6 @@ class HGraphBuilder {
                                HValue* dst_offset,
                                String::Encoding dst_encoding,
                                HValue* length);
-
-  // Align an object size to object alignment boundary
-  HValue* BuildObjectSizeAlignment(HValue* unaligned_size, int header_size);
-
   // Both operands are non-empty strings.
   HValue* BuildUncheckedStringAdd(HValue* left,
                                   HValue* right,
@@ -2325,15 +2321,6 @@ class HOptimizedGraphBuilder : public HGraphBuilder, public AstVisitor {
                                          HValue* value,
                                          SmallMapList* types,
                                          Handle<String> name);
-
-  HValue* BuildAllocateExternalElements(
-      ExternalArrayType array_type,
-      bool is_zero_byte_offset,
-      HValue* buffer, HValue* byte_offset, HValue* length);
-  HValue* BuildAllocateFixedTypedArray(
-      ExternalArrayType array_type, size_t element_size,
-      ElementsKind fixed_elements_kind,
-      HValue* byte_length, HValue* length);
 
   bool IsCallNewArrayInlineable(CallNew* expr);
   void BuildInlinedCallNewArray(CallNew* expr);

--- a/deps/v8/src/objects-debug.cc
+++ b/deps/v8/src/objects-debug.cc
@@ -774,8 +774,7 @@ void JSArrayBufferView::JSArrayBufferViewVerify() {
   CHECK(IsJSArrayBufferView());
   JSObjectVerify();
   VerifyPointer(buffer());
-  CHECK(buffer()->IsJSArrayBuffer() || buffer()->IsUndefined()
-        || buffer() == Smi::FromInt(0));
+  CHECK(buffer()->IsJSArrayBuffer() || buffer()->IsUndefined());
 
   VerifyPointer(byte_offset());
   CHECK(byte_offset()->IsSmi() || byte_offset()->IsHeapNumber()

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -2219,17 +2219,6 @@ class JSObject: public JSReceiver {
 
   inline bool HasFixedTypedArrayElements();
 
-  inline bool HasFixedUint8ClampedElements();
-  inline bool HasFixedArrayElements();
-  inline bool HasFixedInt8Elements();
-  inline bool HasFixedUint8Elements();
-  inline bool HasFixedInt16Elements();
-  inline bool HasFixedUint16Elements();
-  inline bool HasFixedInt32Elements();
-  inline bool HasFixedUint32Elements();
-  inline bool HasFixedFloat32Elements();
-  inline bool HasFixedFloat64Elements();
-
   bool HasFastArgumentsElements();
   bool HasDictionaryArgumentsElements();
   inline SeededNumberDictionary* element_dictionary();  // Gets slow elements.
@@ -4971,11 +4960,6 @@ class FixedTypedArrayBase: public FixedArrayBase {
 
   inline int size();
 
-  // Use with care: returns raw pointer into heap.
-  inline void* DataPtr();
-
-  inline int DataSize();
-
  private:
   DISALLOW_IMPLICIT_CONSTRUCTORS(FixedTypedArrayBase);
 };
@@ -5002,9 +4986,6 @@ class FixedTypedArray: public FixedTypedArrayBase {
   MUST_USE_RESULT inline MaybeObject* get(int index);
   inline void set(int index, ElementType value);
 
-  static inline ElementType from_int(int value);
-  static inline ElementType from_double(double value);
-
   // This accessor applies the correct conversion from Smi, HeapNumber
   // and undefined.
   MUST_USE_RESULT MaybeObject* SetValue(uint32_t index, Object* value);
@@ -5027,7 +5008,7 @@ class FixedTypedArray: public FixedTypedArrayBase {
       static const InstanceType kInstanceType = FIXED_##TYPE##_ARRAY_TYPE;    \
       static const char* Designator() { return #type " array"; }              \
       static inline MaybeObject* ToObject(Heap* heap, elementType scalar);    \
-      static inline elementType defaultValue();                               \
+      static elementType defaultValue() { return 0; }                         \
   };                                                                          \
                                                                               \
   typedef FixedTypedArray<Type##ArrayTraits> Fixed##Type##Array;
@@ -6246,10 +6227,8 @@ class Map: public HeapObject {
       Descriptor* descriptor,
       int index,
       TransitionFlag flag);
-
-  MUST_USE_RESULT MaybeObject* AsElementsKind(ElementsKind kind);
-
   static Handle<Map> AsElementsKind(Handle<Map> map, ElementsKind kind);
+  MUST_USE_RESULT MaybeObject* AsElementsKind(ElementsKind kind);
 
   MUST_USE_RESULT MaybeObject* CopyAsElementsKind(ElementsKind kind,
                                                   TransitionFlag flag);
@@ -9940,8 +9919,6 @@ class JSTypedArray: public JSArrayBufferView {
   ExternalArrayType type();
   size_t element_size();
 
-  Handle<JSArrayBuffer> GetBuffer();
-
   // Dispatched behavior.
   DECLARE_PRINTER(JSTypedArray)
   DECLARE_VERIFIER(JSTypedArray)
@@ -9953,9 +9930,6 @@ class JSTypedArray: public JSArrayBufferView {
       kSize + v8::ArrayBufferView::kInternalFieldCount * kPointerSize;
 
  private:
-  static Handle<JSArrayBuffer> MaterializeArrayBuffer(
-      Handle<JSTypedArray> typed_array);
-
   DISALLOW_IMPLICIT_CONSTRUCTORS(JSTypedArray);
 };
 

--- a/deps/v8/src/runtime.h
+++ b/deps/v8/src/runtime.h
@@ -408,15 +408,6 @@ namespace internal {
   F(HasExternalUint32Elements, 1, 1) \
   F(HasExternalFloat32Elements, 1, 1) \
   F(HasExternalFloat64Elements, 1, 1) \
-  F(HasFixedUint8ClampedElements, 1, 1) \
-  F(HasFixedInt8Elements, 1, 1) \
-  F(HasFixedUint8Elements, 1, 1) \
-  F(HasFixedInt16Elements, 1, 1) \
-  F(HasFixedUint16Elements, 1, 1) \
-  F(HasFixedInt32Elements, 1, 1) \
-  F(HasFixedUint32Elements, 1, 1) \
-  F(HasFixedFloat32Elements, 1, 1) \
-  F(HasFixedFloat64Elements, 1, 1) \
   F(HasFastProperties, 1, 1) \
   F(TransitionElementsKind, 2, 1) \
   F(HaveSameMap, 2, 1) \
@@ -695,8 +686,7 @@ namespace internal {
   F(ConstructDouble, 2, 1)                                                   \
   F(TypedArrayInitialize, 5, 1)                                              \
   F(DataViewInitialize, 4, 1)                                                \
-  F(MaxSmi, 0, 1)                                                            \
-  F(TypedArrayMaxSizeInHeap, 0, 1)
+  F(MaxSmi, 0, 1)
 
 
 //---------------------------------------------------------------------------
@@ -888,10 +878,7 @@ class Runtime : public AllStatic {
   };
 
   static void ArrayIdToTypeAndSize(int array_id,
-      ExternalArrayType *type,
-      ElementsKind* external_elements_kind,
-      ElementsKind* fixed_elements_kind,
-      size_t *element_size);
+      ExternalArrayType *type, size_t *element_size);
 
   // Helper functions used stubs.
   static void PerformGC(Object* result, Isolate* isolate);

--- a/deps/v8/src/typedarray.js
+++ b/deps/v8/src/typedarray.js
@@ -100,12 +100,8 @@ macro TYPED_ARRAY_CONSTRUCTOR(ARRAY_ID, NAME, ELEMENT_SIZE)
       throw MakeRangeError("invalid_typed_array_length");
     }
     var byteLength = l * ELEMENT_SIZE;
-    if (byteLength > %_TypedArrayMaxSizeInHeap()) {
-      var buffer = new $ArrayBuffer(byteLength);
-      %_TypedArrayInitialize(obj, ARRAY_ID, buffer, 0, byteLength);
-    } else {
-      %_TypedArrayInitialize(obj, ARRAY_ID, null, 0, byteLength);
-    }
+    var buffer = new $ArrayBuffer(byteLength);
+    %_TypedArrayInitialize(obj, ARRAY_ID, buffer, 0, byteLength);
   }
 
   function NAMEConstructByArrayLike(obj, arrayLike) {

--- a/deps/v8/test/mjsunit/elements-kind.js
+++ b/deps/v8/test/mjsunit/elements-kind.js
@@ -25,7 +25,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Flags: --allow-natives-syntax --smi-only-arrays --expose-gc --nostress-opt --typed-array-max_size_in-heap=2048
+// Flags: --allow-natives-syntax --smi-only-arrays --expose-gc --nostress-opt
 
 // Test element kind of objects.
 // Since --smi-only-arrays affects builtins, its default setting at compile
@@ -43,28 +43,19 @@ if (support_smi_only_arrays) {
 }
 
 var elements_kind = {
-  fast_smi_only             :  'fast smi only elements',
-  fast                      :  'fast elements',
-  fast_double               :  'fast double elements',
-  dictionary                :  'dictionary elements',
-  external_int32            :  'external int8 elements',
-  external_uint8            :  'external uint8 elements',
-  external_int16            :  'external int16 elements',
-  external_uint16           :  'external uint16 elements',
-  external_int32            :  'external int32 elements',
-  external_uint32           :  'external uint32 elements',
-  external_float32          :  'external float32 elements',
-  external_float64          :  'external float64 elements',
-  external_uint8_clamped    :  'external uint8_clamped elements',
-  fixed_int32               :  'fixed int8 elements',
-  fixed_uint8               :  'fixed uint8 elements',
-  fixed_int16               :  'fixed int16 elements',
-  fixed_uint16              :  'fixed uint16 elements',
-  fixed_int32               :  'fixed int32 elements',
-  fixed_uint32              :  'fixed uint32 elements',
-  fixed_float32             :  'fixed float32 elements',
-  fixed_float64             :  'fixed float64 elements',
-  fixed_uint8_clamped       :  'fixed uint8_clamped elements'
+  fast_smi_only            :  'fast smi only elements',
+  fast                     :  'fast elements',
+  fast_double              :  'fast double elements',
+  dictionary               :  'dictionary elements',
+  external_byte            :  'external byte elements',
+  external_unsigned_byte   :  'external unsigned byte elements',
+  external_short           :  'external short elements',
+  external_unsigned_short  :  'external unsigned short elements',
+  external_int             :  'external int elements',
+  external_unsigned_int    :  'external unsigned int elements',
+  external_float           :  'external float elements',
+  external_double          :  'external double elements',
+  external_pixel           :  'external pixel elements'
 }
 
 function getKind(obj) {
@@ -72,61 +63,34 @@ function getKind(obj) {
   if (%HasFastObjectElements(obj)) return elements_kind.fast;
   if (%HasFastDoubleElements(obj)) return elements_kind.fast_double;
   if (%HasDictionaryElements(obj)) return elements_kind.dictionary;
-
   // Every external kind is also an external array.
+  assertTrue(%HasExternalArrayElements(obj));
   if (%HasExternalInt8Elements(obj)) {
-    return elements_kind.external_int8;
+    return elements_kind.external_byte;
   }
   if (%HasExternalUint8Elements(obj)) {
-    return elements_kind.external_uint8;
+    return elements_kind.external_unsigned_byte;
   }
   if (%HasExternalInt16Elements(obj)) {
-    return elements_kind.external_int16;
+    return elements_kind.external_short;
   }
   if (%HasExternalUint16Elements(obj)) {
-    return elements_kind.external_uint16;
+    return elements_kind.external_unsigned_short;
   }
   if (%HasExternalInt32Elements(obj)) {
-    return elements_kind.external_int32;
+    return elements_kind.external_int;
   }
   if (%HasExternalUint32Elements(obj)) {
-    return elements_kind.external_uint32;
+    return elements_kind.external_unsigned_int;
   }
   if (%HasExternalFloat32Elements(obj)) {
-    return elements_kind.external_float32;
+    return elements_kind.external_float;
   }
   if (%HasExternalFloat64Elements(obj)) {
-    return elements_kind.external_float64;
+    return elements_kind.external_double;
   }
   if (%HasExternalUint8ClampedElements(obj)) {
-    return elements_kind.external_uint8_clamped;
-  }
-  if (%HasFixedInt8Elements(obj)) {
-    return elements_kind.fixed_int8;
-  }
-  if (%HasFixedUint8Elements(obj)) {
-    return elements_kind.fixed_uint8;
-  }
-  if (%HasFixedInt16Elements(obj)) {
-    return elements_kind.fixed_int16;
-  }
-  if (%HasFixedUint16Elements(obj)) {
-    return elements_kind.fixed_uint16;
-  }
-  if (%HasFixedInt32Elements(obj)) {
-    return elements_kind.fixed_int32;
-  }
-  if (%HasFixedUint32Elements(obj)) {
-    return elements_kind.fixed_uint32;
-  }
-  if (%HasFixedFloat32Elements(obj)) {
-    return elements_kind.fixed_float32;
-  }
-  if (%HasFixedFloat64Elements(obj)) {
-    return elements_kind.fixed_float64;
-  }
-  if (%HasFixedUint8ClampedElements(obj)) {
-    return elements_kind.fixed_uint8_clamped;
+    return elements_kind.external_pixel;
   }
 }
 
@@ -172,26 +136,15 @@ function test_wrapper() {
   for (var i = 0; i < 0xDECAF; i++) fast_double_array[i] = i / 2;
   assertKind(elements_kind.fast_double, fast_double_array);
 
-  assertKind(elements_kind.fixed_int8,    new Int8Array(007));
-  assertKind(elements_kind.fixed_uint8,   new Uint8Array(007));
-  assertKind(elements_kind.fixed_int16,   new Int16Array(666));
-  assertKind(elements_kind.fixed_uint16,  new Uint16Array(42));
-  assertKind(elements_kind.fixed_int32,   new Int32Array(0xF));
-  assertKind(elements_kind.fixed_uint32,  new Uint32Array(23));
-  assertKind(elements_kind.fixed_float32, new Float32Array(7));
-  assertKind(elements_kind.fixed_float64, new Float64Array(0));
-  assertKind(elements_kind.fixed_uint8_clamped, new Uint8ClampedArray(512));
-
-  var ab = new ArrayBuffer(128);
-  assertKind(elements_kind.external_int8,    new Int8Array(ab));
-  assertKind(elements_kind.external_uint8,   new Uint8Array(ab));
-  assertKind(elements_kind.external_int16,   new Int16Array(ab));
-  assertKind(elements_kind.external_uint16,  new Uint16Array(ab));
-  assertKind(elements_kind.external_int32,   new Int32Array(ab));
-  assertKind(elements_kind.external_uint32,  new Uint32Array(ab));
-  assertKind(elements_kind.external_float32, new Float32Array(ab));
-  assertKind(elements_kind.external_float64, new Float64Array(ab));
-  assertKind(elements_kind.external_uint8_clamped, new Uint8ClampedArray(ab));
+  assertKind(elements_kind.external_byte,           new Int8Array(9001));
+  assertKind(elements_kind.external_unsigned_byte,  new Uint8Array(007));
+  assertKind(elements_kind.external_short,          new Int16Array(666));
+  assertKind(elements_kind.external_unsigned_short, new Uint16Array(42));
+  assertKind(elements_kind.external_int,            new Int32Array(0xF));
+  assertKind(elements_kind.external_unsigned_int,   new Uint32Array(23));
+  assertKind(elements_kind.external_float,          new Float32Array(7));
+  assertKind(elements_kind.external_double,         new Float64Array(0));
+  assertKind(elements_kind.external_pixel,          new Uint8ClampedArray(512));
 
   // Crankshaft support for smi-only array elements.
   function monomorphic(array) {

--- a/deps/v8/test/mjsunit/external-array.js
+++ b/deps/v8/test/mjsunit/external-array.js
@@ -530,7 +530,6 @@ assertThrows(function() { ArrayBuffer.apply(null, [1000]); }, TypeError);
 assertThrows(function() { Float32Array.apply(null, [b, 128, 1]); }, TypeError);
 
 // Test array.set in different combinations.
-var b = new ArrayBuffer(4)
 
 function assertArrayPrefix(expected, array) {
   for (var i = 0; i < expected.length; ++i) {

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -434,9 +434,13 @@ def load_fields():
 # Emit a block of constants.
 #
 def emit_set(out, consts):
-        for ii in range(0, len(consts)):
-                out.write('int v8dbg_%s = %s;\n' %
-                    (consts[ii]['name'], consts[ii]['value']));
+        # Fix up overzealous parses.  This could be done inside the
+        # parsers but as there are several, it's easiest to do it here.
+        ws = re.compile('\s+')
+        for const in consts:
+                name = ws.sub('', const['name'])
+                value = ws.sub('', str(const['value']))  # Can be a number.
+                out.write('int v8dbg_%s = %s;\n' % (name, value))
         out.write('\n');
 
 #

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -434,13 +434,9 @@ def load_fields():
 # Emit a block of constants.
 #
 def emit_set(out, consts):
-        # Fix up overzealous parses.  This could be done inside the
-        # parsers but as there are several, it's easiest to do it here.
-        ws = re.compile('\s+')
-        for const in consts:
-                name = ws.sub('', const['name'])
-                value = ws.sub('', str(const['value']))  # Can be a number.
-                out.write('int v8dbg_%s = %s;\n' % (name, value))
+        for ii in range(0, len(consts)):
+                out.write('int v8dbg_%s = %s;\n' %
+                    (consts[ii]['name'], consts[ii]['value']));
         out.write('\n');
 
 #


### PR DESCRIPTION
Reverts the following v8 commit:

This implements allocating small typed arrays in heap.

R=mvstanton@chromium.org, verwaest@chromium.org

Review URL: https://codereview.chromium.org/150813004

git-svn-id: https://v8.googlecode.com/svn/branches/bleeding_edge@20279 ce2b1a6d-e550-0410-aec6-3dcde31c8c00

Conflicts:
    deps/v8/src/runtime.cc

---

The reason for this is because of the massive performance impact it has on setting object properties that have externally allocated array data. It's substantially slowed down Buffer instantiation time.

I think this should remain reverted until it's fixed upstream, or we revert back to 3.25.27 (the latest 3.25 tag that doesn't contain this commit).

/cc @tjfontaine @indutny
