### PR TITLE
src: add timer queue to list of active handles

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -306,7 +306,7 @@ exports.clearInterval = function(timer) {
 };
 
 
-var Timeout = function(after) {
+function Timeout(after) {
   this._idleTimeout = after;
   this._idlePrev = this;
   this._idleNext = this;

--- a/src/env.h
+++ b/src/env.h
@@ -160,7 +160,6 @@ namespace node {
   V(onstop_string, "onstop")                                                  \
   V(output_string, "output")                                                  \
   V(order_string, "order")                                                    \
-  V(owner_string, "owner")                                                    \
   V(parse_error_string, "Parse Error")                                        \
   V(path_string, "path")                                                      \
   V(pbkdf2_error_string, "PBKDF2 Error")                                      \

--- a/test/simple/test-process-active-timers.js
+++ b/test/simple/test-process-active-timers.js
@@ -24,7 +24,9 @@ var assert = require('assert');
 var N = 42;
 
 function expect(activeHandles) {
-  assert.equal(process._getActiveHandles().length, activeHandles);
+  var handles = process._getActiveHandles();
+  assert.equal(handles.length, activeHandles);
+  handles.forEach(function(h) { assert.equal(h.constructor.name, 'Timeout') });
 }
 
 function ontimeout(n) {

--- a/test/simple/test-process-active-wraps.js
+++ b/test/simple/test-process-active-wraps.js
@@ -21,7 +21,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
 var net = require('net');
 
 function expect(activeHandles, activeRequests) {


### PR DESCRIPTION
Make process._getActiveHandles() add the timer queue in lib/timers.js
to the list of active handles.

The timer queue is backed by a single timer handle.  Before this commit,
process._getActiveHandles() only reported the handle but that's not very
useful: it doesn't tell you what timer is keeping the event loop alive.

R=@indutny?  I can back-port it to v0.10 if so desired.
