### PR TITLE
net: do not prefer IPv4 addresses during resolution.

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -31,18 +31,27 @@ resolves the IP addresses which are returned.
       });
     });
 
-## dns.lookup(hostname, [family], callback)
+## dns.lookup(hostname, [options], callback)
 
 Resolves a hostname (e.g. `'google.com'`) into the first found A (IPv4) or
-AAAA (IPv6) record.
-The `family` can be the integer `4` or `6`. Defaults to `null` that indicates
-both Ip v4 and v6 address family.
+AAAA (IPv6) record. `options` can be an object or integer. If `options` is 
+not provided, then IP v4 and v6 addresses are both valid. If `options` is 
+an integer, then it must be `4` or `6`.
 
-Alternatively, `family` can be an object containing two properties, `family` 
-and `hints`. The `family` property can be the integer `4` or `6`, and 
-defaults to `null`, meaning that both Ip v4 and v6 addresses are accepted. 
-The `hints` field should be one or more of the supported `getaddrinfo` 
-flags.
+Alternatively, `options` can be an object containing two properties, 
+`family` and `hints`. Both properties are optional. If `family` is provided, 
+it must be the integer `4` or `6`. If `family` is not provided then IP v4 
+and v6 addresses are accepted. The `hints` field, if present, should be one 
+or more of the supported `getaddrinfo` flags. If `hints` is not provided, 
+then no flags are passed to `getaddrinfo`. Multiple flags can be passed 
+through `hints` by logically `OR`ing their values. An example usage of 
+`hints` (without `family`) is shown below.
+
+```
+{
+  hints: dns.ADDRCONFIG | dns.V4MAPPED
+}
+```
 
 The callback has arguments `(err, address, family)`.  The `address` argument
 is a string representation of a IP v4 or v6 address. The `family` argument

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -45,7 +45,9 @@ and v6 addresses are accepted. The `hints` field, if present, should be one
 or more of the supported `getaddrinfo` flags. If `hints` is not provided, 
 then no flags are passed to `getaddrinfo`. Multiple flags can be passed 
 through `hints` by logically `OR`ing their values. An example usage of 
-`hints` (without `family`) is shown below. See [Supported `getaddrinfo` flags](#supported-getaddrinfo-flags) below for more information on supported flags.
+`hints` (without `family`) is shown below. See 
+[Supported `getaddrinfo` flags](#supported-getaddrinfo-flags) below for 
+more information on supported flags.
 
 ```
 {

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -38,6 +38,12 @@ AAAA (IPv6) record.
 The `family` can be the integer `4` or `6`. Defaults to `null` that indicates
 both Ip v4 and v6 address family.
 
+Alternatively, `family` can be an object containing two properties, `family` 
+and `hints`. The `family` property can be the integer `4` or `6`, and 
+defaults to `null`, meaning that both Ip v4 and v6 addresses are accepted. 
+The `hints` field should be one or more of the supported `getaddrinfo` 
+flags.
+
 The callback has arguments `(err, address, family)`.  The `address` argument
 is a string representation of a IP v4 or v6 address. The `family` argument
 is either the integer 4 or 6 and denotes the family of `address` (not
@@ -201,3 +207,14 @@ Each DNS query can return one of the following error codes:
 - `dns.LOADIPHLPAPI`: Error loading iphlpapi.dll.
 - `dns.ADDRGETNETWORKPARAMS`: Could not find GetNetworkParams function.
 - `dns.CANCELLED`: DNS query cancelled.
+
+## Supported `getaddrinfo` flags
+
+The following flags can be passed as hints to `dns.lookup`.
+
+- `dns.ADDRCONFIG`: Returned address types are determined by the types
+of addresses supported by the current system. For example, IPv4 addresses 
+are only returned if the current system has at least one IPv4 address 
+configured. Loopback addresses are not considered.
+- `dns.V4MAPPED`: If the IPv6 family was specified, but no IPv6 addresses 
+were found, then return IPv4 mapped IPv6 addresses.

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -45,10 +45,11 @@ and v6 addresses are accepted. The `hints` field, if present, should be one
 or more of the supported `getaddrinfo` flags. If `hints` is not provided, 
 then no flags are passed to `getaddrinfo`. Multiple flags can be passed 
 through `hints` by logically `OR`ing their values. An example usage of 
-`hints` (without `family`) is shown below.
+`hints` (without `family`) is shown below. See [Supported `getaddrinfo` flags](#supported-getaddrinfo-flags) below for more information on supported flags.
 
 ```
 {
+  family: 4,
   hints: dns.ADDRCONFIG | dns.V4MAPPED
 }
 ```

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -100,7 +100,7 @@ function onlookup(err, addresses) {
 
 // Easy DNS A/AAAA look up
 // lookup(hostname, [options,] callback)
-exports.lookup = function(hostname, options, callback) {
+exports.lookup = function lookup(hostname, options, callback) {
   var hints = 0;
   var family;
 
@@ -111,20 +111,21 @@ exports.lookup = function(hostname, options, callback) {
   } else if (!options) {
     family = 0;
   } else if (util.isObject(options)) {
-    hints = ~~options.hints; // force to int
+    hints = options.hints >>> 0; // force to uint
     family = options.family || 0;
 
-    if (hints !== 0 && hints !== exports.ADDRCONFIG &&
+    if (hints !== 0 &&
+        hints !== exports.ADDRCONFIG &&
         hints !== exports.V4MAPPED &&
         hints !== (exports.ADDRCONFIG | exports.V4MAPPED)) {
-      throw new Error('invalid argument: `hints` must use valid flags');
+      throw new TypeError('invalid argument: hints must use valid flags');
     }
   } else {
-    family = +options;
+    family = options >>> 0;
   }
 
   if (family !== 0 && family !== 4 && family !== 6) {
-    throw new Error('invalid argument: `family` must be 4 or 6');
+    throw new TypeError('invalid argument: family must be 4 or 6');
   }
 
   callback = makeAsync(callback);

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -99,21 +99,28 @@ function onlookup(err, addresses) {
 
 
 // Easy DNS A/AAAA look up
-// lookup(hostname, [family,] callback)
-exports.lookup = function(hostname, family, callback) {
+// lookup(hostname, [options,] callback)
+exports.lookup = function(hostname, options, callback) {
   var hints = 0;
+  var family;
 
   // parse arguments
   if (arguments.length === 2) {
-    callback = family;
+    callback = options;
     family = 0;
-  } else if (!family) {
+  } else if (!options) {
     family = 0;
-  } else if (util.isObject(family)) {
-    hints = ~~family.hints; // force to int
-    family = family.family || 0;
+  } else if (util.isObject(options)) {
+    hints = ~~options.hints; // force to int
+    family = options.family || 0;
+
+    if (hints !== 0 && hints !== exports.ADDRCONFIG &&
+        hints !== exports.V4MAPPED &&
+        hints !== (exports.ADDRCONFIG | exports.V4MAPPED)) {
+      throw new Error('invalid argument: `hints` must use valid flags');
+    }
   } else {
-    family = +family;
+    family = +options;
   }
 
   if (family !== 0 && family !== 4 && family !== 6) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -101,18 +101,25 @@ function onlookup(err, addresses) {
 // Easy DNS A/AAAA look up
 // lookup(hostname, [family,] callback)
 exports.lookup = function(hostname, family, callback) {
+  var hints = 0;
+
   // parse arguments
   if (arguments.length === 2) {
     callback = family;
     family = 0;
   } else if (!family) {
     family = 0;
+  } else if (util.isObject(family)) {
+    hints = ~~family.hints; // force to int
+    family = family.family || 0;
   } else {
     family = +family;
-    if (family !== 4 && family !== 6) {
-      throw new Error('invalid argument: `family` must be 4 or 6');
-    }
   }
+
+  if (family !== 0 && family !== 4 && family !== 6) {
+    throw new Error('invalid argument: `family` must be 4 or 6');
+  }
+
   callback = makeAsync(callback);
 
   if (!hostname) {
@@ -133,7 +140,7 @@ exports.lookup = function(hostname, family, callback) {
     oncomplete: onlookup
   };
 
-  var err = cares.getaddrinfo(req, hostname, family);
+  var err = cares.getaddrinfo(req, hostname, family, hints);
   if (err) {
     callback(errnoException(err, 'getaddrinfo', hostname));
     return {};
@@ -290,6 +297,9 @@ exports.setServers = function(servers) {
   }
 };
 
+// uv_getaddrinfo flags
+exports.ADDRCONFIG = cares.AI_ADDRCONFIG;
+exports.V4MAPPED = cares.AI_V4MAPPED;
 
 // ERROR CODES
 exports.NODATA = 'ENODATA';

--- a/lib/net.js
+++ b/lib/net.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var dns = require('dns');
 var events = require('events');
 var stream = require('stream');
 var timers = require('timers');
@@ -882,10 +883,18 @@ Socket.prototype.connect = function(options, cb) {
 
   } else {
     var host = options.host;
+    var family = {
+      family: options.family,
+      hints: 0
+    };
+
+    if (family.family !== 4 && family.family !== 6) {
+      family.hints = dns.ADDRCONFIG | dns.V4MAPPED;
+    }
 
     debug('connect: find host ' + host);
     self._host = host;
-    require('dns').lookup(host, options.family, function(err, ip, addressType) {
+    dns.lookup(host, family, function(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType);
 
       // It's possible we were destroyed while looking this up.
@@ -1230,7 +1239,7 @@ Server.prototype.listen = function() {
 
   } else {
     // The first argument is the port, the second an IP.
-    require('dns').lookup(arguments[1], function(err, ip, addressType) {
+    dns.lookup(arguments[1], function(err, ip, addressType) {
       if (err) {
         self.emit('error', err);
       } else {

--- a/lib/net.js
+++ b/lib/net.js
@@ -882,10 +882,10 @@ Socket.prototype.connect = function(options, cb) {
 
   } else {
     var host = options.host;
-    var family = options.family || 4;
+
     debug('connect: find host ' + host);
     self._host = host;
-    require('dns').lookup(host, family, function(err, ip, addressType) {
+    require('dns').lookup(host, options.family, function(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType);
 
       // It's possible we were destroyed while looking this up.

--- a/lib/net.js
+++ b/lib/net.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var dns = require('dns');
 var events = require('events');
 var stream = require('stream');
 var timers = require('timers');
@@ -882,6 +881,7 @@ Socket.prototype.connect = function(options, cb) {
     connect(self, self._host, options.port, 4);
 
   } else {
+    var dns = require('dns');
     var host = options.host;
     var dnsopts = {
       family: options.family,
@@ -1240,7 +1240,7 @@ Server.prototype.listen = function() {
 
   } else {
     // The first argument is the port, the second an IP.
-    dns.lookup(arguments[1], function(err, ip, addressType) {
+    require('dns').lookup(arguments[1], function(err, ip, addressType) {
       if (err) {
         self.emit('error', err);
       } else {

--- a/lib/net.js
+++ b/lib/net.js
@@ -883,18 +883,19 @@ Socket.prototype.connect = function(options, cb) {
 
   } else {
     var host = options.host;
-    var family = {
+    var dnsopts = {
       family: options.family,
       hints: 0
     };
 
-    if (family.family !== 4 && family.family !== 6) {
-      family.hints = dns.ADDRCONFIG | dns.V4MAPPED;
+    if (dnsopts.family !== 4 && dnsopts.family !== 6) {
+      dnsopts.hints = dns.ADDRCONFIG | dns.V4MAPPED;
     }
 
     debug('connect: find host ' + host);
+    debug('connect: dns options ' + dnsopts);
     self._host = host;
-    dns.lookup(host, family, function(err, ip, addressType) {
+    dns.lookup(host, dnsopts, function(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType);
 
       // It's possible we were destroyed while looking this up.

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1014,16 +1014,16 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
   assert(args[2]->IsInt32());
+  assert(args[3]->IsInt32());
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value hostname(args[1]);
 
   int family;
-  int flags = 0;
+  int flags = args[3]->Int32Value();
 
   switch (args[2]->Int32Value()) {
   case 0:
     family = AF_UNSPEC;
-    flags = AI_ADDRCONFIG | AI_V4MAPPED;
     break;
   case 4:
     family = AF_INET;
@@ -1250,6 +1250,10 @@ static void Initialize(Handle<Object> target,
               Integer::New(env->isolate(), AF_INET6));
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AF_UNSPEC"),
               Integer::New(env->isolate(), AF_UNSPEC));
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AI_ADDRCONFIG"),
+              Integer::New(env->isolate(), AI_ADDRCONFIG));
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AI_V4MAPPED"),
+              Integer::New(env->isolate(), AI_V4MAPPED));
 }
 
 }  // namespace cares_wrap

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1018,9 +1018,12 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value hostname(args[1]);
 
   int family;
+  int flags = 0;
+
   switch (args[2]->Int32Value()) {
   case 0:
     family = AF_UNSPEC;
+    flags = AI_ADDRCONFIG | AI_V4MAPPED;
     break;
   case 4:
     family = AF_INET;
@@ -1042,6 +1045,7 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family = family;
   hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags = flags;
 
   int err = uv_getaddrinfo(env->event_loop(),
                            &req_wrap->req_,

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1019,7 +1019,7 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value hostname(args[1]);
 
   int family;
-  int flags = args[3]->Int32Value();
+  int32_t flags = args[3]->Int32Value();
 
   switch (args[2]->Int32Value()) {
   case 0:

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -352,6 +352,21 @@ TEST(function test_lookup_ipv4_explicit_object(done) {
 });
 
 
+TEST(function test_lookup_ipv4_hint_addrconfig(done) {
+  var req = dns.lookup('www.google.com', {
+    hint: dns.ADDRCONFIG
+  }, function(err, ip, family) {
+    if (err) throw err;
+    assert.ok(net.isIPv4(ip));
+    assert.strictEqual(family, 4);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+
 TEST(function test_lookup_ipv6_explicit(done) {
   var req = dns.lookup('ipv6.google.com', 6, function(err, ip, family) {
     if (err) throw err;
@@ -383,6 +398,21 @@ TEST(function test_lookup_ipv6_implicit(done) {
 TEST(function test_lookup_ipv6_explicit_object(done) {
   var req = dns.lookup('ipv6.google.com', {
     family: 6
+  }, function(err, ip, family) {
+    if (err) throw err;
+    assert.ok(net.isIPv6(ip));
+    assert.strictEqual(family, 6);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+
+TEST(function test_lookup_ipv6_hint(done) {
+  var req = dns.lookup('ipv6.google.com', {
+    hint: dns.V4MAPPED
   }, function(err, ip, family) {
     if (err) throw err;
     assert.ok(net.isIPv6(ip));

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -337,6 +337,21 @@ TEST(function test_lookup_ipv4_implicit(done) {
 });
 
 
+TEST(function test_lookup_ipv4_explicit_object(done) {
+  var req = dns.lookup('www.google.com', {
+    family: 4
+  }, function(err, ip, family) {
+    if (err) throw err;
+    assert.ok(net.isIPv4(ip));
+    assert.strictEqual(family, 4);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+
 TEST(function test_lookup_ipv6_explicit(done) {
   var req = dns.lookup('ipv6.google.com', 6, function(err, ip, family) {
     if (err) throw err;
@@ -363,6 +378,21 @@ TEST(function test_lookup_ipv6_implicit(done) {
   checkWrap(req);
 });
 */
+
+
+TEST(function test_lookup_ipv6_explicit_object(done) {
+  var req = dns.lookup('ipv6.google.com', {
+    family: 6
+  }, function(err, ip, family) {
+    if (err) throw err;
+    assert.ok(net.isIPv6(ip));
+    assert.strictEqual(family, 6);
+
+    done();
+  });
+
+  checkWrap(req);
+});
 
 
 TEST(function test_lookup_failure(done) {

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -70,3 +70,55 @@ assert.throws(
   },
   "Unexpected error"
 );
+
+assert.throws(
+  function() {
+    dns.lookup('www.google.com', { hints: 1 }, new Function);
+  }
+);
+
+assert.doesNotThrow(
+  function() {
+    dns.lookup('www.google.com', 6, new Function);
+  }
+);
+
+assert.doesNotThrow(
+  function() {
+    dns.lookup('www.google.com', {}, new Function);
+  }
+);
+
+assert.doesNotThrow(
+  function() {
+    dns.lookup('www.google.com', {
+      family: 4,
+      hints: 0
+    }, new Function);
+  }
+);
+
+assert.doesNotThrow(
+  function() {
+    dns.lookup('www.google.com', {
+      family: 6,
+      hints: dns.ADDRCONFIG
+    }, new Function);
+  }
+);
+
+assert.doesNotThrow(
+  function() {
+    dns.lookup('www.google.com', {
+      hints: dns.V4MAPPED
+    }, new Function);
+  }
+);
+
+assert.doesNotThrow(
+  function() {
+    dns.lookup('www.google.com', {
+      hints: dns.ADDRCONFIG | dns.V4MAPPED
+    }, new Function);
+  }
+);

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -27,6 +27,8 @@ var dns = require('dns');
 var existing = dns.getServers();
 assert(existing.length);
 
+function noop() {}
+
 var goog = [
   '8.8.8.8',
   '8.8.4.4',
@@ -61,64 +63,46 @@ assert.deepEqual(dns.getServers(), portsExpected);
 assert.doesNotThrow(function () { dns.setServers([]); });
 assert.deepEqual(dns.getServers(), []);
 
-assert.throws(
-  function() {
-    dns.resolve('test.com', [], new Function);
-  },
-  function(err) {
-    return !(err instanceof TypeError);
-  },
-  "Unexpected error"
-);
+assert.throws(function() {
+  dns.resolve('test.com', [], noop);
+}, function(err) {
+  return !(err instanceof TypeError);
+}, 'Unexpected error');
 
-assert.throws(
-  function() {
-    dns.lookup('www.google.com', { hints: 1 }, new Function);
-  }
-);
+assert.throws(function() {
+  dns.lookup('www.google.com', { hints: 1 }, noop);
+});
 
-assert.doesNotThrow(
-  function() {
-    dns.lookup('www.google.com', 6, new Function);
-  }
-);
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', 6, noop);
+});
 
-assert.doesNotThrow(
-  function() {
-    dns.lookup('www.google.com', {}, new Function);
-  }
-);
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {}, noop);
+});
 
-assert.doesNotThrow(
-  function() {
-    dns.lookup('www.google.com', {
-      family: 4,
-      hints: 0
-    }, new Function);
-  }
-);
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    family: 4,
+    hints: 0
+  }, noop);
+});
 
-assert.doesNotThrow(
-  function() {
-    dns.lookup('www.google.com', {
-      family: 6,
-      hints: dns.ADDRCONFIG
-    }, new Function);
-  }
-);
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    family: 6,
+    hints: dns.ADDRCONFIG
+  }, noop);
+});
 
-assert.doesNotThrow(
-  function() {
-    dns.lookup('www.google.com', {
-      hints: dns.V4MAPPED
-    }, new Function);
-  }
-);
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    hints: dns.V4MAPPED
+  }, noop);
+});
 
-assert.doesNotThrow(
-  function() {
-    dns.lookup('www.google.com', {
-      hints: dns.ADDRCONFIG | dns.V4MAPPED
-    }, new Function);
-  }
-);
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED
+  }, noop);
+});


### PR DESCRIPTION
Currently, the address resolution family defaults to IPv4. This commit removes that preference, and instead attempts to resolve to a family suitable for the host.

@tjfontaine is this along the lines of what you wanted? This is my first time venturing into the core C++ layer, so forgive me if it's way off.

Closes #7637
