### PR TITLE
build: disable v8 handle zapping

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -35,6 +35,9 @@
     'default_configuration': 'Release',
     'configurations': {
       'Debug': {
+        'variables': {
+          'v8_enable_handle_zapping%': 1,
+        },
         'defines': [ 'DEBUG', '_DEBUG' ],
         'cflags': [ '-g', '-O0' ],
         'conditions': [
@@ -59,6 +62,9 @@
         },
       },
       'Release': {
+        'variables': {
+          'v8_enable_handle_zapping%': 0,
+        },
         'cflags': [ '-O3', '-ffunction-sections', '-fdata-sections' ],
         'conditions': [
           ['target_arch=="x64"', {


### PR DESCRIPTION
See also commit e7bfbaf.  Don't depend on deps/v8/build/features.gypi
to disable handle zapping, be explicit about it.

R=@tjfontaine
