### PR TITLE
child_process: don't throw on EMFILE/ENFILE

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1063,6 +1063,7 @@ util.inherits(ChildProcess, EventEmitter);
 
 
 function flushStdio(subprocess) {
+  if (subprocess.stdio == null) return;
   subprocess.stdio.forEach(function(stream, fd, stdio) {
     if (!stream || !stream.readable || stream._consuming ||
         stream._readableState.flowing)
@@ -1104,10 +1105,18 @@ ChildProcess.prototype.spawn = function(options) {
 
   var err = this._handle.spawn(options);
 
-  if (err == uv.UV_ENOENT) {
+  if (err === uv.UV_EMFILE ||
+      err === uv.UV_ENFILE ||
+      err === uv.UV_ENOENT) {
     process.nextTick(function() {
       self._handle.onexit(err);
     });
+    // There is no point in continuing when we've hit EMFILE or ENFILE
+    // because we won't be able to set up the stdio file descriptors.
+    // It's kind of silly that the de facto spec for ENOENT (the test suite)
+    // mandates that stdio _is_ set up, even if there is no process on the
+    // receiving end, but it is what it is.
+    if (err !== uv.UV_ENOENT) return err;
   } else if (err) {
     // Close all opened fds on error
     stdio.forEach(function(stdio) {

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -36,12 +36,14 @@ function pingPongTest(port, host, on_complete) {
   var server = net.createServer({ allowHalfOpen: true }, function(socket) {
     assert.equal(true, socket.remoteAddress !== null);
     assert.equal(true, socket.remoteAddress !== undefined);
-    if (host === '127.0.0.1' || host === 'localhost' || !host) {
-      assert.equal(socket.remoteAddress, '127.0.0.1');
+    var address = socket.remoteAddress;
+    if (host === '127.0.0.1') {
+      assert.equal(address, '127.0.0.1');
+    } else if (host == null || host === 'localhost') {
+      assert(address === '127.0.0.1' || address === '::ffff:127.0.0.1');
     } else {
-      console.log('host = ' + host +
-                  ', remoteAddress = ' + socket.remoteAddress);
-      assert.equal(socket.remoteAddress, '::1');
+      console.log('host = ' + host + ', remoteAddress = ' + address);
+      assert.equal(address, '::1');
     }
 
     socket.setEncoding('utf8');

--- a/test/simple/test-child-process-emfile.js
+++ b/test/simple/test-child-process-emfile.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var fs = require('fs');
+
+if (process.platform === 'win32') {
+  console.log('Skipping test, no RLIMIT_NOFILE on Windows.');
+  return;
+}
+
+for (;;) {
+  try {
+    fs.openSync(__filename, 'r');
+  } catch (err) {
+    assert(err.code === 'EMFILE' || err.code === 'ENFILE');
+    break;
+  }
+}
+
+// Should emit an error, not throw.
+var proc = spawn(process.execPath, ['-e', '0']);
+
+proc.on('error', common.mustCall(function(err) {
+  assert(err.code === 'EMFILE' || err.code === 'ENFILE');
+}));
+
+// 'exit' should not be emitted, the process was never spawned.
+proc.on('exit', assert.fail);


### PR DESCRIPTION
EMFILE and ENFILE mean 'out of file descriptors'.  It's a run-time error
and as such should emit an error on the child process object, not throw
an exception.

Fixes #7453.
