### PR TITLE
src: kill isolate on exit

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3622,10 +3622,10 @@ int Start(int argc, char** argv) {
     env = NULL;
   }
 
-#ifndef NDEBUG
-  // Clean up. Not strictly necessary.
+  CHECK_NE(node_isolate, NULL);
+  node_isolate->Dispose();
+  node_isolate = NULL;
   V8::Dispose();
-#endif  // NDEBUG
 
   delete[] exec_argv;
   exec_argv = NULL;


### PR DESCRIPTION
Otherwise it's not possible to check from inside a destructor if V8 is
still alive with v8::V8::IsDead().  In V8 3.25, that function returns
true until the last isolate is destroyed.

This used to work in v0.10 and is a standard trick to dispose persistent
handles conditionally.
