### PR TITLE
net: throw on write after close

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -371,6 +371,9 @@ buffer. Returns `false` if all or part of the data was queued in user memory.
 The optional `callback` parameter will be executed when the data is finally
 written out - this may not be immediately.
 
+In case the socket is already closed, throws or passes an error to the
+`callback`.
+
 ### socket.end([data], [encoding])
 
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the

--- a/lib/net.js
+++ b/lib/net.js
@@ -273,13 +273,14 @@ function writeAfterFIN(chunk, encoding, cb) {
 
   var er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  var self = this;
+
   // TODO: defer error events consistently everywhere, not just the cb
-  self.emit('error', er);
   if (util.isFunction(cb)) {
     process.nextTick(function() {
       cb(er);
     });
+  } else {
+    throw er;
   }
 }
 

--- a/test/simple/test-net-write-after-close.js
+++ b/test/simple/test-net-write-after-close.js
@@ -23,27 +23,27 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var gotError = false;
-var gotWriteCB = false;
-
-process.on('exit', function() {
-  assert(gotError);
-  assert(gotWriteCB);
-});
-
 var server = net.createServer(function(socket) {
   socket.resume();
 
-  socket.on('error', function(error) {
-    console.error('got error, closing server', error);
-    server.close();
-    gotError = true;
-  });
-
   setTimeout(function() {
     console.error('about to try to write');
+
+    var error;
+    try {
+      socket.write('test');
+    } catch (e) {
+      error = e;
+    }
+
+    assert(error);
+    console.error('about to try to write again');
+
     socket.write('test', function(e) {
-      gotWriteCB = true;
+      assert(e);
+
+      console.error('closing server');
+      server.close();
     });
   }, 250);
 });


### PR DESCRIPTION
`socket.write()` on a closed socket will either throw or pass an error to the callback.

see https://github.com/joyent/node/pull/7623#issuecomment-43895947
