### PR TITLE
tls: fix performance issue

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -510,16 +510,11 @@ CryptoStream.prototype._read = function read(size) {
     if (this.ondata) {
       this.ondata(pool, start, start + bytesRead);
 
-      // Deceive streams2
-      var self = this;
+      // Force state.reading to set to false
+      this.push('');
 
-      setImmediate(function() {
-        // Force state.reading to set to false
-        self.push('');
-
-        // Try reading more, we most likely have some data
-        self.read(0);
-      });
+      // Try reading more, we most likely have some data
+      this.read(0);
     } else {
       this.push(pool.slice(start, start + bytesRead));
     }


### PR DESCRIPTION
tls: fix performance issue

See https://github.com/orangemocha/node-connection-drop

I have pinpointed the performance degradation to
https://github.com/joyent/node/commit/ac2263b77f3f346458d06fc019de27e24c63cee0

This change brings performance back to the original levels.
