### PR TITLE
cluster: restore v0.10.x setupMaster() behaviour

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -214,13 +214,7 @@ function masterInit() {
   cluster.workers = {};
 
   var intercom = new EventEmitter;
-  var settings = {
-    args: process.argv.slice(2),
-    exec: process.argv[1],
-    execArgv: process.execArgv,
-    silent: false
-  };
-  cluster.settings = settings;
+  cluster.settings = {};
 
   // XXX(bnoordhuis) Fold cluster.schedulingPolicy into cluster.settings?
   var schedulingPolicy = {
@@ -247,6 +241,12 @@ function masterInit() {
   cluster.setupMaster = function(options) {
     if (initialized === true) return;
     initialized = true;
+    var settings = {
+      args: process.argv.slice(2),
+      exec: process.argv[1],
+      execArgv: process.execArgv,
+      silent: false
+    };
     settings = util._extend(settings, options || {});
     // Tell V8 to write profile data for each process to a separate file.
     // Without --logfile=v8-%p.log, everything ends up in a single, unusable
@@ -282,10 +282,10 @@ function masterInit() {
     var workerEnv = util._extend({}, process.env);
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + worker.id;
-    worker.process = fork(settings.exec, settings.args, {
+    worker.process = fork(cluster.settings.exec, cluster.settings.args, {
       env: workerEnv,
-      silent: settings.silent,
-      execArgv: createWorkerExecArgv(settings.execArgv, worker)
+      silent: cluster.settings.silent,
+      execArgv: createWorkerExecArgv(cluster.settings.execArgv, worker)
     });
     worker.process.once('exit', function(exitCode, signalCode) {
       worker.suicide = !!worker.suicide;

--- a/test/simple/test-cluster-setup-master-argv.js
+++ b/test/simple/test-cluster-setup-master-argv.js
@@ -1,0 +1,38 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+
+setTimeout(assert.fail.bind(assert, 'setup not emitted'), 1000).unref();
+
+cluster.on('setup', function() {
+  var clusterArgs = cluster.settings.args;
+  var realArgs = process.argv;
+  assert.equal(clusterArgs[clusterArgs.length - 1],
+               realArgs[realArgs.length - 1]);
+});
+
+assert(process.argv[process.argv.length - 1] !== 'OMG,OMG');
+process.argv.push('OMG,OMG');
+process.argv.push('OMG,OMG');
+cluster.setupMaster();


### PR DESCRIPTION
Fix for #7670 that restores previous behaviour and adds a regression test instead of changing cluster API.

In v0.10.x, `process.argv` and `process.execArgv` would only be
evaluated and copied into `cluster.settings` on the first call to
`cluster.setupMaster()` (either directly or via `cluster.fork()`),
allowing them to be modified as needed before initializing the
settings.

In 41b75ca the behaviour was changed so that these values are
initialized at the time of the first `require('cluster')`.

Fixes #7670.
