### PR TITLE
Console.debug()

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -63,6 +63,7 @@ Console.prototype.warn = function() {
 
 
 Console.prototype.error = Console.prototype.warn;
+Console.prototype.debug = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object) {

--- a/lib/console.js
+++ b/lib/console.js
@@ -54,6 +54,7 @@ Console.prototype.log = function() {
 };
 
 
+Console.prototype.debug = Console.prototype.log;
 Console.prototype.info = Console.prototype.log;
 
 
@@ -63,7 +64,6 @@ Console.prototype.warn = function() {
 
 
 Console.prototype.error = Console.prototype.warn;
-Console.prototype.debug = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object) {


### PR DESCRIPTION
Add support for Console.debug() function, as latest versions of Chrome & Firefox has. In a logical order, debug() has a lower priority than log(), although it's only intended for developers and it's not part of the normal output of the program, due to this I output it on stderr like warn() & error().
