### PR TITLE
src: use v8::String::kInternalizedString for property names

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -304,7 +304,7 @@ class QueryWrap : public AsyncWrap {
     switch (status) {
 #define V(code)                                                               \
       case ARES_ ## code:                                                     \
-        arg = FIXED_ONE_BYTE_STRING(env()->isolate(), #code);                 \
+        arg = FIXED_ONE_BYTE_NORMAL_STRING(env()->isolate(), #code);          \
         break;
       V(ENODATA)
       V(EFORMERR)
@@ -332,7 +332,8 @@ class QueryWrap : public AsyncWrap {
       V(ECANCELLED)
 #undef V
       default:
-        arg = FIXED_ONE_BYTE_STRING(env()->isolate(), "UNKNOWN_ARES_ERROR");
+        arg = FIXED_ONE_BYTE_NORMAL_STRING(env()->isolate(),
+                                           "UNKNOWN_ARES_ERROR");
         break;
     }
     MakeCallback(env()->oncomplete_string(), 1, &arg);

--- a/src/node.cc
+++ b/src/node.cc
@@ -733,16 +733,19 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<String> message = OneByteString(env->isolate(), msg);
 
   Local<String> cons1 =
-      String::Concat(estring, FIXED_ONE_BYTE_STRING(env->isolate(), ", "));
+      String::Concat(estring,
+                     FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), ", "));
   Local<String> cons2 = String::Concat(cons1, message);
 
   if (path) {
     Local<String> cons3 =
-        String::Concat(cons2, FIXED_ONE_BYTE_STRING(env->isolate(), " '"));
+        String::Concat(cons2,
+                       FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), " '"));
     Local<String> cons4 =
         String::Concat(cons3, String::NewFromUtf8(env->isolate(), path));
     Local<String> cons5 =
-        String::Concat(cons4, FIXED_ONE_BYTE_STRING(env->isolate(), "'"));
+        String::Concat(cons4,
+                       FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), "'"));
     e = Exception::Error(cons5);
   } else {
     e = Exception::Error(cons2);
@@ -778,7 +781,8 @@ Local<Value> UVException(Isolate* isolate,
   Local<String> estring = OneByteString(env->isolate(), uv_err_name(errorno));
   Local<String> message = OneByteString(env->isolate(), msg);
   Local<String> cons1 =
-      String::Concat(estring, FIXED_ONE_BYTE_STRING(env->isolate(), ", "));
+      String::Concat(estring,
+                     FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), ", "));
   Local<String> cons2 = String::Concat(cons1, message);
 
   Local<Value> e;
@@ -788,8 +792,9 @@ Local<Value> UVException(Isolate* isolate,
   if (path) {
 #ifdef _WIN32
     if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
-      path_str = String::Concat(FIXED_ONE_BYTE_STRING(env->isolate(), "\\\\"),
-                                String::NewFromUtf8(env->isolate(), path + 8));
+      path_str =
+        String::Concat(FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), "\\\\"),
+                       String::NewFromUtf8(env->isolate(), path + 8));
     } else if (strncmp(path, "\\\\?\\", 4) == 0) {
       path_str = String::NewFromUtf8(env->isolate(), path + 4);
     } else {
@@ -800,11 +805,13 @@ Local<Value> UVException(Isolate* isolate,
 #endif
 
     Local<String> cons3 =
-        String::Concat(cons2, FIXED_ONE_BYTE_STRING(env->isolate(), " '"));
+        String::Concat(cons2,
+                       FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), " '"));
     Local<String> cons4 =
         String::Concat(cons3, path_str);
     Local<String> cons5 =
-        String::Concat(cons4, FIXED_ONE_BYTE_STRING(env->isolate(), "'"));
+        String::Concat(cons4,
+                       FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), "'"));
     e = Exception::Error(cons5);
   } else {
     e = Exception::Error(cons2);
@@ -866,11 +873,14 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
   if (path) {
     Local<String> cons1 =
-        String::Concat(message, FIXED_ONE_BYTE_STRING(isolate, " '"));
+        String::Concat(message,
+                       FIXED_ONE_BYTE_NORMAL_STRING(isolate, " '"));
     Local<String> cons2 =
-        String::Concat(cons1, String::NewFromUtf8(isolate, path));
+        String::Concat(cons1,
+                       FIXED_ONE_BYTE_NORMAL_STRING(isolate, path));
     Local<String> cons3 =
-        String::Concat(cons2, FIXED_ONE_BYTE_STRING(isolate, "'"));
+        String::Concat(cons2,
+                       FIXED_ONE_BYTE_NORMAL_STRING(isolate, "'"));
     e = Exception::Error(cons3);
   } else {
     e = Exception::Error(message);
@@ -1182,7 +1192,8 @@ Handle<Value> MakeCallback(Environment* env,
                            const char* method,
                            int argc,
                            Handle<Value> argv[]) {
-  Local<String> method_string = OneByteString(env->isolate(), method);
+  Local<String> method_string = OneByteInternalizedString(env->isolate(),
+                                                          method);
   return MakeCallback(env, recv, method_string, argc, argv);
 }
 
@@ -2563,7 +2574,7 @@ void StopProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
 
 #define READONLY_PROPERTY(obj, str, var)                                      \
   do {                                                                        \
-    obj->Set(OneByteString(env->isolate(), str), var, v8::ReadOnly);          \
+    obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), str), var, v8::ReadOnly);  \
   } while (0)
 
 
@@ -2583,7 +2594,7 @@ void SetupProcessObject(Environment* env,
   // process.version
   READONLY_PROPERTY(process,
                     "version",
-                    FIXED_ONE_BYTE_STRING(env->isolate(), NODE_VERSION));
+                    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), NODE_VERSION));
 
   // process.moduleLoadList
   READONLY_PROPERTY(process,
@@ -2599,7 +2610,8 @@ void SetupProcessObject(Environment* env,
                                      NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR);
   READONLY_PROPERTY(versions,
                     "http_parser",
-                    FIXED_ONE_BYTE_STRING(env->isolate(), http_parser_version));
+                    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(),
+                                                 http_parser_version));
 
   // +1 to get rid of the leading 'v'
   READONLY_PROPERTY(versions,
@@ -2613,13 +2625,13 @@ void SetupProcessObject(Environment* env,
                     OneByteString(env->isolate(), uv_version_string()));
   READONLY_PROPERTY(versions,
                     "zlib",
-                    FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION));
+                    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), ZLIB_VERSION));
 
   const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);
   READONLY_PROPERTY(
       versions,
       "modules",
-      FIXED_ONE_BYTE_STRING(env->isolate(), node_modules_version));
+      FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), node_modules_version));
 
 #if HAVE_OPENSSL
   // Stupid code to slice out the version string.
@@ -2645,12 +2657,13 @@ void SetupProcessObject(Environment* env,
 #endif
 
   // process.arch
-  READONLY_PROPERTY(process, "arch", OneByteString(env->isolate(), ARCH));
+  READONLY_PROPERTY(process, "arch",
+                    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), ARCH));
 
   // process.platform
   READONLY_PROPERTY(process,
                     "platform",
-                    OneByteString(env->isolate(), PLATFORM));
+                    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), PLATFORM));
 
   // process.argv
   Local<Array> arguments = Array::New(env->isolate(), argc);
@@ -2834,7 +2847,8 @@ void Load(Environment* env) {
   // are not safe to ignore.
   try_catch.SetVerbose(false);
 
-  Local<String> script_name = FIXED_ONE_BYTE_STRING(env->isolate(), "node.js");
+  Local<String> script_name =
+      FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), "node.js");
   Local<Value> f_value = ExecuteString(env, MainSource(env), script_name);
   if (try_catch.HasCaught())  {
     ReportException(env, try_catch);
@@ -3093,9 +3107,10 @@ static void EnableDebug(Isolate* isolate, bool wait_connect) {
   Context::Scope context_scope(env->context());
   Local<Object> message = Object::New(env->isolate());
   message->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "cmd"),
-               FIXED_ONE_BYTE_STRING(env->isolate(), "NODE_DEBUG_ENABLED"));
+               FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(),
+                                            "NODE_DEBUG_ENABLED"));
   Local<Value> argv[] = {
-    FIXED_ONE_BYTE_STRING(env->isolate(), "internalMessage"),
+    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), "internalMessage"),
     message
   };
   MakeCallback(env, env->process_object(), "emit", ARRAY_SIZE(argv), argv);
@@ -3486,7 +3501,7 @@ void EmitBeforeExit(Environment* env) {
   Local<Object> process_object = env->process_object();
   Local<String> exit_code = FIXED_ONE_BYTE_STRING(env->isolate(), "exitCode");
   Local<Value> args[] = {
-    FIXED_ONE_BYTE_STRING(env->isolate(), "beforeExit"),
+    FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), "beforeExit"),
     process_object->Get(exit_code)->ToInteger()
   };
   MakeCallback(env, process_object, "emit", ARRAY_SIZE(args), args);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -166,7 +166,7 @@ class ContextifyContext {
         // which doesn't faithfully capture the full range of configurations
         // that can be done using Object.defineProperty.
         if (clone_property_method.IsEmpty()) {
-          Local<String> code = FIXED_ONE_BYTE_STRING(env()->isolate(),
+          Local<String> code = FIXED_ONE_BYTE_NORMAL_STRING(env()->isolate(),
               "(function cloneProperty(source, key, target) {\n"
               "  if (key === 'Proxy') return;\n"
               "  try {\n"
@@ -178,7 +178,7 @@ class ContextifyContext {
               "  }\n"
               "})");
 
-          Local<String> fname = FIXED_ONE_BYTE_STRING(env()->isolate(),
+          Local<String> fname = FIXED_ONE_BYTE_NORMAL_STRING(env()->isolate(),
               "binding:script");
           Local<Script> script = Script::Compile(code, fname);
           clone_property_method = Local<Function>::Cast(script->Run());
@@ -607,7 +607,8 @@ class ContextifyScript : public BaseObject {
   static Local<String> GetFilenameArg(const FunctionCallbackInfo<Value>& args,
                                       const int i) {
     Local<String> defaultFilename =
-        FIXED_ONE_BYTE_STRING(args.GetIsolate(), "evalmachine.<anonymous>");
+        FIXED_ONE_BYTE_NORMAL_STRING(args.GetIsolate(),
+                                     "evalmachine.<anonymous>");
 
     if (args[i]->IsUndefined()) {
       return defaultFilename;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -781,8 +781,9 @@ void SecureContext::SetSessionIdContext(
 
   bio = BIO_new(BIO_s_mem());
   if (bio == NULL) {
-    message = FIXED_ONE_BYTE_STRING(args.GetIsolate(),
-                                    "SSL_CTX_set_session_id_context error");
+    message =
+        FIXED_ONE_BYTE_NORMAL_STRING(args.GetIsolate(),
+                                     "SSL_CTX_set_session_id_context error");
   } else {
     ERR_print_errors(bio);
     BIO_get_mem_ptr(bio, &mem);

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -84,7 +84,7 @@ using v8::Value;
     return env->ThrowError( \
       "expected object for " #obj " to contain integer member " #member); \
   } \
-  *valp = obj->Get(OneByteString(env->isolate(), #member)) \
+  *valp = obj->Get(FIXED_ONE_BYTE_STRING(env->isolate(), #member)) \
       ->ToInteger()->Value();
 
 #define SLURP_OBJECT(obj, member, valp) \
@@ -92,7 +92,8 @@ using v8::Value;
     return env->ThrowError( \
       "expected object for " #obj " to contain object member " #member); \
   } \
-  *valp = Local<Object>::Cast(obj->Get(OneByteString(env->isolate(), #member)));
+  *valp = Local<Object>::Cast( \
+      obj->Get(FIXED_ONE_BYTE_STRING(env->isolate(), #member)));
 
 #define SLURP_CONNECTION(arg, conn) \
   if (!(arg)->IsObject()) { \

--- a/src/node_javascript.cc
+++ b/src/node_javascript.cc
@@ -39,7 +39,7 @@ using v8::Object;
 using v8::String;
 
 Handle<String> MainSource(Environment* env) {
-  return OneByteString(env->isolate(), node_native, sizeof(node_native) - 1);
+  return FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), node_native);
 }
 
 void DefineJavaScript(Environment* env, Handle<Object> target) {

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -245,7 +245,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   }
 
   for (i = 0; i < count; i++) {
-    name = OneByteString(env->isolate(), interfaces[i].name);
+    name = OneByteInternalizedString(env->isolate(), interfaces[i].name);
     if (ret->Has(name)) {
       ifarr = Local<Array>::Cast(ret->Get(name));
     } else {
@@ -280,7 +280,8 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
     o->Set(env->address_string(), OneByteString(env->isolate(), ip));
     o->Set(env->netmask_string(), OneByteString(env->isolate(), netmask));
     o->Set(env->family_string(), family);
-    o->Set(env->mac_string(), FIXED_ONE_BYTE_STRING(env->isolate(), mac));
+    o->Set(env->mac_string(),
+           FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), mac));
 
     if (interfaces[i].address.address4.sin_family == AF_INET6) {
       uint32_t scopeid = interfaces[i].address.address6.sin6_scope_id;

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -666,7 +666,7 @@ void InitZlib(Handle<Object> target,
   NODE_DEFINE_CONSTANT(target, UNZIP);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ZLIB_VERSION"),
-              FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION));
+              FIXED_ONE_BYTE_NORMAL_STRING(env->isolate(), ZLIB_VERSION));
 }
 
 }  // namespace node

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -419,8 +419,7 @@ Local<Value> TLSCallbacks::GetSSLError(int status, int* err, const char** msg) {
 
         const char* buf = PrintErrors();
 
-        Local<String> message =
-            OneByteString(env()->isolate(), buf, strlen(buf));
+        Local<String> message = OneByteString(env()->isolate(), buf);
         Local<Value> exception = Exception::Error(message);
 
         if (msg != NULL) {

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -115,7 +115,7 @@ void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
     abort();
   }
 
-  args.GetReturnValue().Set(OneByteString(env->isolate(), type));
+  args.GetReturnValue().Set(OneByteInternalizedString(env->isolate(), type));
 }
 
 

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -62,6 +62,15 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                     length);
 }
 
+inline v8::Local<v8::String> OneByteInternalizedString(v8::Isolate* isolate,
+                                                       const char* data,
+                                                       int length) {
+  return v8::String::NewFromOneByte(isolate,
+                                    reinterpret_cast<const uint8_t*>(data),
+                                    v8::String::kInternalizedString,
+                                    length);
+}
+
 inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            const signed char* data,
                                            int length) {
@@ -71,12 +80,31 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                     length);
 }
 
+inline v8::Local<v8::String> OneByteInternalizedString(v8::Isolate* isolate,
+                                                       const signed char* data,
+                                                       int length) {
+  return v8::String::NewFromOneByte(isolate,
+                                    reinterpret_cast<const uint8_t*>(data),
+                                    v8::String::kInternalizedString,
+                                    length);
+}
+
 inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            const unsigned char* data,
                                            int length) {
   return v8::String::NewFromOneByte(isolate,
                                     reinterpret_cast<const uint8_t*>(data),
                                     v8::String::kNormalString,
+                                    length);
+}
+
+inline
+v8::Local<v8::String> OneByteInternalizedString(v8::Isolate* isolate,
+                                                const unsigned char* data,
+                                                int length) {
+  return v8::String::NewFromOneByte(isolate,
+                                    reinterpret_cast<const uint8_t*>(data),
+                                    v8::String::kInternalizedString,
                                     length);
 }
 


### PR DESCRIPTION
Just in case you don't trust me on this, Chromium is doing this too (see [`v8AtomicString`](https://chromium.googlesource.com/chromium/blink/+/1cf6f54cef305d9b7ca3dffd0e85f24899553c94/Source/bindings/v8/V8Binding.h#210) and [`V8DOMConfiguration::installCallbacks`](https://chromium.googlesource.com/chromium/blink/+/1cf6f54cef305d9b7ca3dffd0e85f24899553c94/Source/bindings/v8/V8DOMConfiguration.cpp#88) for an example).

Before this patch:

```
lu-kanghao-no-macbook-pro-2:node kennyluck$ ./out/Release/node -p 'process.memoryUsage()'
{ rss: 13684736, heapTotal: 6295040, heapUsed: 2545200 }
lu-kanghao-no-macbook-pro-2:node kennyluck$ ./out/Release/node -p 'process.memoryUsage()'
{ rss: 13324288, heapTotal: 6295040, heapUsed: 2545200 }
lu-kanghao-no-macbook-pro-2:node kennyluck$ ./out/Release/node -p 'process.memoryUsage()'
{ rss: 13291520, heapTotal: 6295040, heapUsed: 2545200 }
```

After this patch:

```
lu-kanghao-no-macbook-pro-2:node kennyluck$ ./out/Release/node -p 'process.memoryUsage()'
{ rss: 13660160, heapTotal: 6295040, heapUsed: 2540208 }
lu-kanghao-no-macbook-pro-2:node kennyluck$ ./out/Release/node -p 'process.memoryUsage()'
{ rss: 13271040, heapTotal: 6295040, heapUsed: 2540208 }
lu-kanghao-no-macbook-pro-2:node kennyluck$ ./out/Release/node -p 'process.memoryUsage()'
{ rss: 13262848, heapTotal: 6295040, heapUsed: 2540208 }
```

So that's about 5k of memory reduction (yeah I know that's small, but let's do our best). Having to do character-by-character comparison during `Get()`/`Set()` seems bad, too.

This is a partial revert of @bnoordhuis f674b09. I agree that we should probably move some of these to module-scope `Persistent`s, but that'll make this patch huge. I'll just go with this one for now.

Who's the right person to review patches like this (V8 API use)? I am likely to send some more later.
