### PR TITLE
fs: close file if fstat() fails in readFile()

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -229,7 +229,12 @@ fs.readFile = function(path, options, callback_) {
     fd = fd_;
 
     fs.fstat(fd, function(er, st) {
-      if (er) return callback(er);
+      if (er) {
+        return fs.close(fd, function() {
+          callback(er);
+        });
+      }
+
       size = st.size;
       if (size === 0) {
         // the kernel lies about many files.


### PR DESCRIPTION
Currently, if `fstat()` fails in readFile(), the callback is invoked without closing the file. This commit closes the file before calling back.

Closes #7697
@piscisaureus
