### PR TITLE
doc: fixed wording in child_process

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -290,7 +290,8 @@ child, and it is no longer possible to send messages.
 The 'disconnect' event will be emitted when there are no messages in the process
 of being received, most likely immediately.
 
-Note that you can also call `process.disconnect()` in the child process.
+Note that you can also call `process.disconnect()` in the child process when the
+child process has any open IPC channels with the parent (i.e `fork()`).
 
 ## child_process.spawn(command, [args], [options])
 


### PR DESCRIPTION
Attempted to make the child_process documentation regarding `process.disconnect()` more clear.

Fixes #7700
