### PR TITLE
http: OPTIONS shouldn't default to chunked encoding

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -119,6 +119,7 @@ function ClientRequest(options, cb) {
   if (method === 'GET' ||
       method === 'HEAD' ||
       method === 'DELETE' ||
+      method === 'OPTIONS' ||
       method === 'CONNECT') {
     self.useChunkedEncodingByDefault = false;
   } else {

--- a/test/simple/test-http-client-default-headers-exist.js
+++ b/test/simple/test-http-client-default-headers-exist.js
@@ -27,6 +27,7 @@ var expectedHeaders = {
   'DELETE': ['host', 'connection'],
   'GET': ['host', 'connection'],
   'HEAD': ['host', 'connection'],
+  'OPTIONS': ['host', 'connection'],
   'POST': ['host', 'connection', 'transfer-encoding'],
   'PUT': ['host', 'connection', 'transfer-encoding']
 };


### PR DESCRIPTION
OPTIONS requests have an optional request body, but Node's http client currently adds a `Transfer-Encoding: chunked` header to all OPTIONS requests. This header indicates that a request body is present even if there is no request body. This subsequently confuses some servers and causes requests to fail.

This same issue cropped up for [DELETE requests](https://github.com/joyent/node/issues/6185), and this patch simply applies that same fix for OPTIONS requests.

For a concrete example of the current behavior's impact, using node-http-proxy in conjunction with a Varnish backend server will break the OPTIONS requests from CORS preflight requests. This is because CORS preflight OPTIONS requests don't have a body and Varnish doesn't like `Transfer-Encoding: chunked` accompanied by an empty body.

And finally, just from [the spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2) indicating the request body is optional (and currently undefined) for OPTIONS requests:

> If the OPTIONS request includes an entity-body (as indicated by the presence of Content-Length or Transfer-Encoding), then the media type MUST be indicated by a Content-Type field. Although this specification does not define any use for such a body, future extensions to HTTP might use the OPTIONS body to make more detailed queries on the server. A server that does not support such an extension MAY discard the request body.
