### PR TITLE
bench: fix buffers/buffer-base64-encode benchmark

### DIFF
--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -28,9 +28,8 @@ function main(conf) {
   var b = Buffer(N);
   var s = '';
   for (var i = 0; i < 256; ++i) s += String.fromCharCode(i);
-
-  bench.start();
   for (var i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
+  bench.start();
   for (var i = 0; i < 32; ++i) b.toString('base64');
   bench.end(64);
 }


### PR DESCRIPTION
The test is supposed to measure the performance of the base64 encoder
so move the Buffer#write() calls out of the benchmark section.

The overhead of the calls isn't terrible (about 1-3%) but having
unrelated activity in a micro-benchmark is never a good idea.
