### PR TITLE
doc: Fix typo in dns.resolveSrv docs

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -105,7 +105,7 @@ treated separately.
 The same as `dns.resolve()`, but only for service records (`SRV` records).
 `addresses` is an array of the SRV records available for `hostname`. Properties
 of SRV records are priority, weight, port, and name (e.g.,
-`[{'priority': 10, {'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]`).
+`[{'priority': 10, 'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]`).
 
 ## dns.resolveSoa(hostname, callback)
 


### PR DESCRIPTION
This typo confused me until I tried the code myself; certainly should be changed I think.
