### PR TITLE
dns: send `lookup` c-ares errors to callback

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -133,13 +133,13 @@ exports.lookup = function(hostname, family, callback) {
     oncomplete: onlookup
   };
 
-  callback.immediately = true;
   var err = cares.getaddrinfo(req, hostname, family);
   if (err) {
     callback(errnoException(err, 'getaddrinfo', hostname));
     return {};
   }
 
+  callback.immediately = true;
   return req;
 };
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -132,10 +132,14 @@ exports.lookup = function(hostname, family, callback) {
     hostname: hostname,
     oncomplete: onlookup
   };
-  var err = cares.getaddrinfo(req, hostname, family);
-  if (err) throw errnoException(err, 'getaddrinfo', hostname);
 
   callback.immediately = true;
+  var err = cares.getaddrinfo(req, hostname, family);
+  if (err) {
+    callback(errnoException(err, 'getaddrinfo', hostname));
+    return {};
+  }
+
   return req;
 };
 

--- a/test/simple/test-dns-lookup-cb-error.js
+++ b/test/simple/test-dns-lookup-cb-error.js
@@ -31,7 +31,14 @@ cares.getaddrinfo = function() {
 };
 
 assert.doesNotThrow(function() {
+  var tickValue = 0;
+
   dns.lookup('example.com', function(error, result, addressType) {
+    assert.equal(tickValue, 1);
     assert.equal(error.code, 'ENOENT');
   });
+
+  // Make sure that the error callback is called
+  // on next tick.
+  tickValue = 1;
 });

--- a/test/simple/test-dns-lookup-cb-error.js
+++ b/test/simple/test-dns-lookup-cb-error.js
@@ -1,0 +1,37 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cares = process.binding('cares_wrap');
+
+var dns = require('dns');
+
+// Stub `getaddrinfo` to *always* error.
+cares.getaddrinfo = function() {
+  return process.binding('uv').UV_ENOENT;
+};
+
+assert.doesNotThrow(function() {
+  dns.lookup('example.com', function(error, result, addressType) {
+    assert.equal(error.code, 'ENOENT');
+  });
+});


### PR DESCRIPTION
Calling `dns.lookup` with arguments that generate an error from c-ares
previously sent those errors back to the callback. This commit restores
that behavior.

Fixes joyent/node#7731.
