### PR TITLE
repl: fix multi-line input

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -120,8 +120,11 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
         displayErrors: false
       });
     } catch (e) {
-      err = e;
       debug('parse error %j', code, e);
+      if (isRecoverableError(e))
+        err = new Recoverable(e);
+      else
+        err = e;
     }
 
     if (!err) {
@@ -294,7 +297,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
       // If error was SyntaxError and not JSON.parse error
       if (e) {
-        if (isRecoverableError(e)) {
+        if (e instanceof Recoverable) {
           // Start buffering data like that:
           // {
           // ...  x: 1
@@ -386,15 +389,16 @@ REPLServer.prototype.resetContext = function() {
 };
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
-  var prompt = this._prompt;
+  var initial = this._prompt;
+  var prompt = initial;
   if (this.bufferedCommand.length) {
     prompt = '...';
     var levelInd = new Array(this.lines.level.length).join('..');
     prompt += levelInd + ' ';
-  } else {
-    this.setPrompt(prompt);
   }
+  this.setPrompt(prompt);
   this.prompt(preserveCursor);
+  this.setPrompt(initial);
 };
 
 // A stream to push an array into a REPL
@@ -940,5 +944,10 @@ REPLServer.prototype.convertToContext = function(cmd) {
 function isRecoverableError(e) {
   return e &&
       e.name === 'SyntaxError' &&
-      /^Unexpected end of input/.test(e.message);
+      /^(Unexpected end of input|Unexpected token :)/.test(e.message);
 }
+
+function Recoverable(err) {
+  this.err = err;
+}
+inherits(Recoverable, SyntaxError);


### PR DESCRIPTION
The refactor in 3ae0b17c broke the multiline input's visual appearence.
While actually switching to this mode, the `...` prefix is not
displayed.

Additionally, account only SyntaxErrors that are happening at the parse
time, everything else should not be switching repl to the multiline
mode.

NOTE: We broke repl in a hard way, really. Let's fix it!
