### PR TITLE
buffer: fix abort while passing incorrect this in slice

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -419,6 +419,11 @@ Buffer.prototype.toJSON = function() {
 // TODO(trevnorris): currently works like Array.prototype.slice(), which
 // doesn't follow the new standard for throwing on out of range indexes.
 Buffer.prototype.slice = function(start, end) {
+
+  if (!Buffer.isBuffer(this)) {
+    throw new TypeError('`this` must be a Buffer when slicing');
+  }
+
   var len = this.length;
   start = ~~start;
   end = util.isUndefined(end) ? len : ~~end;

--- a/test/simple/test-buffer-slice.js
+++ b/test/simple/test-buffer-slice.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+assert.throws(function() {
+  var b = new Buffer(10);
+  b.slice.call(null, [0, 5]);
+});
+
+assert.throws(function() {
+  var b = new Buffer(10);
+  b.slice.call(10, [0, 5]);
+});
+
+assert.throws(function() {
+  var b = new Buffer(10);
+  b.slice.call({}, [0, 5]);
+});
+
+assert.throws(function() {
+  var b = new Buffer(10);
+  b.slice.call([], [0, 5]);
+});
+
+var b = new Buffer(10);
+var c = b.slice.call(b, [0, 5]);
+console.log("ok");


### PR DESCRIPTION
Reproduce code:

``` js
var b = new Buffer(512);
var c = 'foo';
b.slice.apply(c, [0, 128]);
```

The node process aborted at https://github.com/joyent/node/blob/master/src/smalloc.cc#L258 and prints:

``` sh
Assertion failed: (source->HasIndexedPropertiesInExternalArrayData()), function SliceOnto, file ../src/smalloc.cc, line 312.
Abort trap: 6
```

We should protect this by doing a check for `buf.slice`, and the reproduced version is 0.11.13.
