### PR TITLE
Added support for options parameter in console.dir()

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -44,10 +44,21 @@ Same as `console.log` but prints to stderr.
 
 Same as `console.error`.
 
-## console.dir(obj)
+## console.dir(obj, [options])
 
 Uses `util.inspect` on `obj` and prints resulting string to stdout. This function
-bypasses any custom `inspect()` function on `obj`.
+bypasses any custom `inspect()` function on `obj`. An optional *options* object 
+may be passed that alters certain aspects of the formatted string:
+
+- `showHidden` - if `true` then the object's non-enumerable properties will be 
+shown too. Defaults to `false`.
+
+- `depth` - tells `inspect` how many times to recurse while formatting the
+object. This is useful for inspecting large complicated objects. Defaults to
+`2`. To make it recurse indefinitely pass `null`.
+
+- `colors` - if `true`, then the output will be styled with ANSI color codes.
+Defaults to `false`. Colors are customizable, see below.
 
 ## console.time(label)
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -66,12 +66,8 @@ Console.prototype.error = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object, options) {
-  if (typeof options === 'object' && options !== null) {
-    options.customInspect = false;
-  } else {
-    options = { customInspect: false };
-  }
-  this._stdout.write(util.inspect(object, options) + '\n');
+  this._stdout.write(util.inspect(object, 
+    util._extend({ customInspect : false }, options)) + '\n');
 };
 
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -65,8 +65,13 @@ Console.prototype.warn = function() {
 Console.prototype.error = Console.prototype.warn;
 
 
-Console.prototype.dir = function(object) {
-  this._stdout.write(util.inspect(object, { customInspect: false }) + '\n');
+Console.prototype.dir = function(object, options) {
+  if (typeof options === 'object' && options !== null) {
+    options.customInspect = false;
+  } else {
+    options = { customInspect: false };
+  }
+  this._stdout.write(util.inspect(object, options) + '\n');
 };
 
 

--- a/test/simple/test-console.js
+++ b/test/simple/test-console.js
@@ -50,6 +50,9 @@ console.log(custom_inspect);
 
 // test console.dir()
 console.dir(custom_inspect);
+console.dir(custom_inspect, { showHidden: false });
+console.dir({ foo : { bar : { baz : true } } }, { depth: 0 });
+console.dir({ foo : { bar : { baz : true } } }, { depth: 1 });
 
 // test console.trace()
 console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
@@ -63,6 +66,9 @@ assert.equal('foo bar hop\n', strings.shift());
 assert.equal("{ slashes: '\\\\\\\\' }\n", strings.shift());
 assert.equal('inspect\n', strings.shift());
 assert.equal("{ foo: 'bar', inspect: [Function] }\n", strings.shift());
+assert.equal("{ foo: 'bar', inspect: [Function] }\n", strings.shift());
+assert.notEqual(-1, strings.shift().indexOf('foo: [Object]'));
+assert.equal(-1, strings.shift().indexOf('baz'));
 assert.equal('Trace: This is a {"formatted":"trace"} 10 foo',
              strings.shift().split('\n').shift());
 


### PR DESCRIPTION
Solved issue: #5428. Now console.dir() accepts an optional parameter to define the maximum depth, colors and showHidden of the output.
