### PR TITLE
Motify the lisntener on after emiting

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -91,8 +91,22 @@ EventEmitter.prototype.emit = function emit(type) {
 
   handler = this._events[type];
 
-  if (util.isUndefined(handler))
+  // if the event has not handler , 
+  //cache the handler for excuting when adding a handler to the event
+  if (util.isUndefined(handler)){
+  	var args = Array.prototype.slice.call(arguments, 1);
+  	if(!this._notOnEvents)
+  		this._notOnEvents = {};
+  	if(!this._notOnEvents[type])
+  		this._notOnEvents[type] = [];
+
+	this._notOnEvents[type].push(args);
+
     return false;
+  }
+
+  delete this._notOnEvents[type];
+    
 
   if (this.domain && this !== process)
     this.domain.enter();
@@ -128,6 +142,7 @@ EventEmitter.prototype.emit = function emit(type) {
     for (i = 0; i < len; i++)
       listeners[i].apply(this, args);
   }
+
 
   if (this.domain && this !== process)
     this.domain.exit();
@@ -178,6 +193,30 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
                     this._events[type].length);
       console.trace();
     }
+  }
+
+
+
+  if(this._notOnEvents&&this._notOnEvents[type]){
+  	var args = this._notOnEvents[type];
+  	args.forEach(function(arg){
+  		switch (arg.length) {
+	      // fast cases
+	      case 0:
+	        listener.call(this);
+	        break;
+	      case 1:
+	        listener.call(this, arg[0]);
+	        break;
+	      case 2:
+	        listener.call(this, arg[0], arg[1]);
+	        break;
+	      // slower
+	      default:
+	        listener.apply(this, arg);
+	    }
+  	});
+  	//delete this._notOnEvents[type];
   }
 
   return this;


### PR DESCRIPTION
this is a example:

``` javascript
function StreamLibrary() {
    this.emit('data', 'abc'); 
    this.emit('data', 'abcdef');         
}
StreamLibrary.prototype.__proto__ = EventEmitter.prototype;  
var stream = new StreamLibrary();
// the two listens can get 'abc' and 'abcdef'
stream.on('data', function(chunk) {
    console.log('Received: ' + chunk);
});
stream.on('data', function(chunk) {
    console.log('other: ' + chunk);
});
// the normal listen emit, that two lisntens will get 'finish'
stream.emit('data', 'finish');
// the listen can not get 'abc' 'abcdef' and 'finish' , but it can get 'zzz'
stream.on('data', function(chunk){
    console.log('finish: ' + chunk);
});
stream.emit('data', 'zzz');
```

I only modify the on(Function) and emit(Function) , if you think this hange has significance , i will do other work .
