### PR TITLE
docs: add the 'deprecated status' highlight to already deprecated functions

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -66,7 +66,8 @@ added to the `'request'` event.
 
 ## http.createClient([port], [host])
 
-This function is **deprecated**; please use [http.request()][] instead.
+    Stability: 0 - Deprecated: use [http.request()][] instead.
+
 Constructs a new HTTP client. `port` and `host` refer to the server to be
 connected to.
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -253,7 +253,8 @@ with `child_process.fork()`.
 
 ### server.connections
 
-This function is **deprecated**; please use [server.getConnections()][] instead.
+    Stability: 0 - Deprecated: use [server.getConnections()][] instead.
+
 The number of concurrent connections on the server.
 
 This becomes `null` when sending a socket to a child with

--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -24,8 +24,7 @@ terminal.
 
 ## tty.setRawMode(mode)
 
-Deprecated. Use `tty.ReadStream#setRawMode()`
-(i.e. `process.stdin.setRawMode()`) instead.
+    Stability: 0 - Deprecated: use [rs.setRawMode()](#tty_rs_setrawmode_mode) instead.
 
 
 ## Class: ReadStream


### PR DESCRIPTION
The documentation index mentions the 'stability index' (http://nodejs.org/api/documentation.html) with different stages 0..5.
Some deprecated functions showed the 'Stability index: 0 - Deprecated' already and this commit adds the  
highlight to the missing ones.
