### PR TITLE
http: fix http agent legacy support

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -131,12 +131,12 @@ Agent.prototype.getName = function(options) {
 };
 
 Agent.prototype.addRequest = function(req, options) {
-  // Legacy API: addRequest(req, host, port, path)
+  // Legacy API: addRequest(req, host, port, localAddress)
   if (typeof options === 'string') {
     options = {
       host: options,
       port: arguments[2],
-      path: arguments[3]
+      localAddress: arguments[3]
     };
   }
 


### PR DESCRIPTION
ClientRequest calls addRequest with 'localAddress' in V0.10,
(not 'path'). And getName looks for 'localAddress' in the
options object, so it is important to use the localAddress
as part of the key for  "socket" and "freeSocket" maps.

https://github.com/joyent/node/blob/v0.10/lib/http.js#L1416
