### PR TITLE
http: initialization of request options

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -140,6 +140,17 @@ Agent.prototype.addRequest = function(req, options) {
     };
   }
 
+  options = util._extend({}, options);
+  options = util._extend(options, this.options);
+
+  options.servername = options.host;
+  if (req) {
+    var hostHeader = req.getHeader('host');
+    if (hostHeader) {
+      options.servername = hostHeader.replace(/:.*$/, '');
+    }
+  }
+
   var name = this.getName(options);
   if (!this.sockets[name]) {
     this.sockets[name] = [];
@@ -176,17 +187,6 @@ Agent.prototype.addRequest = function(req, options) {
 
 Agent.prototype.createSocket = function(req, options) {
   var self = this;
-  options = util._extend({}, options);
-  options = util._extend(options, self.options);
-
-  options.servername = options.host;
-  if (req) {
-    var hostHeader = req.getHeader('host');
-    if (hostHeader) {
-      options.servername = hostHeader.replace(/:.*$/, '');
-    }
-  }
-
   var name = self.getName(options);
 
   debug('createConnection', name, options);


### PR DESCRIPTION
Documentation of http.Agent (https://github.com/joyent/node/blob/master/doc/api/http.markdown#new-agentoptions)
doesn't say you can use properties of the options object of the "request" method in the options object of the Agent "constructor" to configure default request options.

But the code is allowing when it extends the "options" object of requests with the "this.options" of the Agent in the "createSocket" method. And the documentation of "https.request"(https://github.com/joyent/node/blob/master/doc/api/https.markdown#httpsrequestoptions-callback) shows an example of creating a custom instance of "https.Agent" using SSL default request options such as _key_ or _cert_. 

The problem extending or modifying the request options object in the "createSocket" method is that "addRequest" method can end up calling the "getName" method with different data to those used by "createSocket" method. There are some lines in the code that calls "getName" and it's important to always use the same data in options object to make sure that the created key to access "sockets" or "freeSockets" maps is always the same, to reuse and release the sockets correctly.

If you create an "https.Agent" using an option object with for example a default "rejectUnauthorized" configuration, the name created by "getName" will be different the first time called by "addRequest" and the second time called by "createSocket" method.

``` js
    var options = {
        rejectUnauthorized: false
    };
    options.agent = new https.Agent(options);
```

Moving the initialization to 'addRequest' solves the problem.
