### PR TITLE
Fix npm version in 0.10.29 ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -622,7 +622,7 @@
 
 * openssl: to 1.0.1h (CVE-2014-0224)
 
-* npm: upgrade to 1.4.10
+* npm: upgrade to 1.4.14
 
 * utf8: Prevent Node from sending invalid UTF-8 (Felix Geisendörfer)
   - *NOTE* this introduces a breaking change, previously you could construct


### PR DESCRIPTION
While 0.10.29 does contain 120f7cf, it also contains f051f31.

(I don't know if updating ChangeLog on master is the proper place to do it. I would recommend updating the blog as well.)
