### PR TITLE
path: `resolve()` doesn't normalize drive letter on Windows

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -149,6 +149,11 @@ if (isWindows) {
     if (isUnc) {
       resolvedDevice = normalizeUNCRoot(resolvedDevice);
     }
+    // If `resolvedDevice` is a drive letter, we'll normalize to lower case.
+    if (resolvedDevice.charAt(1) === ':') {
+      resolvedDevice = resolvedDevice[0].toLowerCase() + resolvedDevice.substr(1);
+    }
+
 
     // At this point the path should be resolved to a full absolute path,
     // but handle relative paths to be safe (might happen when process.cwd()

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -324,6 +324,7 @@ if (isWindows) {
        [['.'], process.cwd()],
        [['//server/share', '..', 'relative\\'], '\\\\server\\share\\relative'],
        [['c:/', '//'], 'c:\\'],
+       [['C:/'], 'c:\\'],
        [['c:/', '//dir'], 'c:\\dir'],
        [['c:/', '//server/share'], '\\\\server\\share\\'],
        [['c:/', '//server//share'], '\\\\server\\share\\'],


### PR DESCRIPTION
Calling `resolve()` on Windows (in Node v0.11.0+) result in a path where drive
letter case isn't always lowercase (e.g. for a relative path like '.') while
`normalize()` always returns a path with a lower case drive letter.
This eventually breaks comparisons between results of `resolve()` and
`join()` (which relies on `normalize()`) for the same path.

Fixes joyent/node#7031 also resolves joyent/node#7806
