### PR TITLE
buffer: readInt32 avoids readUInt32

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -730,11 +730,21 @@ Buffer.prototype.readInt16BE = function(offset, noAssert) {
 
 
 function readInt32(buffer, offset, isBigEndian) {
-  var val = readUInt32(buffer, offset, isBigEndian);
+  var val = 0;
 
-  if (!(val & 0x80000000))
-    return (val);
-  return (0xffffffff - val + 1) * -1;
+  if (isBigEndian) {
+    val = buffer[offset] << 24;
+    val |= buffer[offset + 1] << 16;
+    val |= buffer[offset + 2] << 8;
+    val |= buffer[offset + 3];
+  } else {
+    val = buffer[offset + 3] << 24;
+    val |= buffer[offset + 2] << 16;
+    val |= buffer[offset + 1] << 8;
+    val |= buffer[offset];
+  }
+
+  return val;
 }
 
 


### PR DESCRIPTION
Fixes GH #7809

Test: test/simple/test-readint.js
