### PR TITLE
doc: process: Document process.mainModule

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -651,4 +651,16 @@ a diff reading, useful for benchmarks and measuring intervals:
       // benchmark took 1000000527 nanoseconds
     }, 1000);
 
+
+## process.mainModule
+
+Alternate way to retrieve
+[`require.main`](modules.html#modules_accessing_the_main_module).
+The difference is that if the main module changes at runtime, `require.main`
+might still refer to the original main module in modules that were required
+before the change occurred. Generally it's safe to assume that the two refer
+to the same module.
+
+As with `require.main`, it will be `undefined` if there was no entry script.
+
 [EventEmitter]: events.html#events_class_events_eventemitter


### PR DESCRIPTION
Instrumentation code might need to find out the entry point of the
process in a global context.
Documenting the existing process.mainModule to officially support this.

Fixes #7808
