### PR TITLE
src: fix _XOPEN_SOURCE for FreeBSD ipv6 structs

### DIFF
--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -21,7 +21,7 @@
 
 // O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 600.
 #if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600
-#undef _XOPEN_SOURCE
+# undef _XOPEN_SOURCE
 #endif
 
 #if !defined(_XOPEN_SOURCE)

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -19,15 +19,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 500.
-#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 500
+// O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 600.
+#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600
 #undef _XOPEN_SOURCE
 #endif
 
-#if defined(__FreeBSD__)
+#if !defined(_XOPEN_SOURCE)
 # define _XOPEN_SOURCE 600
-#elif !defined(_XOPEN_SOURCE)
-# define _XOPEN_SOURCE 500
 #endif
 
 #include "node_constants.h"

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -24,8 +24,10 @@
 #undef _XOPEN_SOURCE
 #endif
 
-#if !defined(_XOPEN_SOURCE)
-#define _XOPEN_SOURCE 500
+#if defined(__FreeBSD__)
+# define _XOPEN_SOURCE 600
+#elif !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 500
 #endif
 
 #include "node_constants.h"
@@ -35,7 +37,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #if !defined(_MSC_VER)
-#include <unistd.h>
+# include <unistd.h>
 #endif
 #include <signal.h>
 #include <sys/types.h>

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -19,15 +19,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 500.
-#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 500
-#undef _XOPEN_SOURCE
+// O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 600.
+#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600
+# undef _XOPEN_SOURCE
 #endif
 
-#if defined(__FreeBSD__)
+#if !defined(_XOPEN_SOURCE)
 # define _XOPEN_SOURCE 600
-#elif !defined(_XOPEN_SOURCE)
-# define _XOPEN_SOURCE 500
 #endif
 
 #include "node_constants.h"


### PR DESCRIPTION
The constant must be at least 600 to include the ipv6 structs definitions,
it raises a compilation error on FreeBSD 10. The check of the platform
is made on header before uv.h declaration.
