### PR TITLE
tls: using %StringSplit to split `cert.subjectaltname`

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -122,12 +122,15 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   // Walk through altnames and generate lists of those names
   if (cert.subjectaltname) {
     cert.subjectaltname.split(/, /g).forEach(function(altname) {
-      if (/^DNS:/.test(altname)) {
-        dnsNames.push(altname.slice(4));
-      } else if (/^IP Address:/.test(altname)) {
-        ips.push(altname.slice(11));
-      } else if (/^URI:/.test(altname)) {
-        var uri = url.parse(altname.slice(4));
+      var option = altname.match(/^(DNS|IP Address|URI):(.*)$/);
+      if (!option)
+        return;
+      if (option[1] === 'DNS') {
+        dnsNames.push(option[2]);
+      } else if (option[1] === 'IP Address') {
+        ips.push(option[2]);
+      } else if (option[1] === 'URI') {
+        var uri = url.parse(option[2]);
         if (uri) uriNames.push(uri.hostname);
       }
     });


### PR DESCRIPTION
There are 2 changes in this patch:
- using `%StringSplit` not `StringSplitOnRegExp` in [v8/v8](https://github.com/v8/v8/blob/master/src/string.js#L588), the newer function seems to be faster.
- decreasing the times of comparing regular expression, and more readable for human.
