### PR TITLE
buffer: ignore case of encoding for all functions

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -192,7 +192,7 @@ Buffer.concat = function(list, length) {
 Buffer.byteLength = function(str, enc) {
   var ret;
   str = str + '';
-  switch (enc) {
+  switch ((enc + '').toLowerCase()) {
     case 'ascii':
     case 'binary':
     case 'raw':
@@ -232,7 +232,7 @@ Buffer.prototype.toString = function(encoding, start, end) {
   if (end <= start) return '';
 
   while (true) {
-    switch (encoding) {
+    switch (encoding.toLowerCase()) {
       case 'hex':
         return this.hexSlice(start, end);
 


### PR DESCRIPTION
Just be consistent for all functions in this behavior :p
