### PR TITLE
child_process: copy spawnSync() cwd option to proper buffer

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -726,7 +726,7 @@ int SyncProcessRunner::ParseOptions(Local<Value> js_value) {
 
   Local<Value> js_cwd = js_options->Get(env()->cwd_string());
   if (IsSet(js_cwd)) {
-    r = CopyJsString(js_cwd, &uv_process_options_.cwd);
+    r = CopyJsString(js_cwd, &cwd_buffer_);
     if (r < 0)
       return r;
     uv_process_options_.cwd = cwd_buffer_;

--- a/test/simple/test-child-process-execsync.js
+++ b/test/simple/test-child-process-execsync.js
@@ -80,3 +80,19 @@ assert.deepEqual(ret, msgBuf);
 ret = execFileSync(process.execPath, args, { encoding: 'utf8' });
 
 assert.strictEqual(ret, msg + '\n', 'execFileSync encoding result should match');
+
+// Verify that the cwd option works - GH #7824
+(function() {
+  var response;
+  var cwd;
+
+  if (process.platform === 'win32') {
+    cwd = 'c:\\';
+    response = execSync('echo %cd%', {cwd: cwd});
+  } else {
+    cwd = '/';
+    response = execSync('pwd', {cwd: cwd});
+  }
+
+  assert.strictEqual(response.toString().trim(), cwd);
+})();

--- a/test/simple/test-child-process-spawnsync.js
+++ b/test/simple/test-child-process-spawnsync.js
@@ -46,3 +46,19 @@ assert.strictEqual(stop[0], 1, 'sleep should not take longer or less than 1 seco
 // Error test when command does not exist
 var ret_err = spawnSync('command_does_not_exist');
 assert.strictEqual(ret_err.error.code, 'ENOENT');
+
+// Verify that the cwd option works - GH #7824
+(function() {
+  var response;
+  var cwd;
+
+  if (process.platform === 'win32') {
+    cwd = 'c:\\';
+    response = spawnSync('cmd.exe', ['/c', 'cd'], {cwd: cwd});
+  } else {
+    cwd = '/';
+    response = spawnSync('pwd', [], {cwd: cwd});
+  }
+
+  assert.strictEqual(response.stdout.toString().trim(), cwd);
+})();


### PR DESCRIPTION
The `spawnSync()` `cwd` option was being copied to the incorrect location. This PR copies to the correct location. Closes #7824
