### PR TITLE
dns: introduce lookupService function

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -49,6 +49,17 @@ the hostname does not exist but also when the lookup fails in other ways
 such as no available file descriptors.
 
 
+# dns.lookupService(address, port, callback)
+
+Resolves the given address and port into a hostname and service using
+`getnameinfo`.
+
+The callback has arguments `(err, hostname, service)`. The `hostname` and
+`service` arguments are strings (e.g. `'localhost'` and `'http'` respectively).
+
+On error, `err` is an `Error` object, where `err.code` is the error code.
+
+
 ## dns.resolve(hostname, [rrtype], callback)
 
 Resolves a hostname (e.g. `'google.com'`) into an array of the record types

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -144,6 +144,38 @@ exports.lookup = function(hostname, family, callback) {
 };
 
 
+function onlookupservice(err, host, service) {
+  if (err)
+    return this.callback(errnoException(err, 'getnameinfo', this.host));
+
+  this.callback(null, host, service);
+}
+
+
+// lookupService(address, port, callback)
+exports.lookupService = function(host, port, callback) {
+  if (arguments.length !== 3)
+    throw new Error('invalid arguments');
+
+  if (cares.isIP(host) === 0)
+    throw new TypeError('host needs to be a valid IP address');
+
+  callback = makeAsync(callback);
+
+  var req = {
+    callback: callback,
+    host: host,
+    port: port,
+    oncomplete: onlookupservice
+  };
+  var err = cares.getnameinfo(req, host, port);
+  if (err) throw errnoException(err, 'getnameinfo', host);
+
+  callback.immediately = true;
+  return req;
+};
+
+
 function onresolve(err, result) {
   if (err)
     this.callback(errnoException(err, this.bindingName, this.hostname));

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -53,7 +53,8 @@ class AsyncWrap : public BaseObject {
     PROVIDER_TLSWRAP            = 1 << 14,
     PROVIDER_TTYWRAP            = 1 << 15,
     PROVIDER_UDPWRAP            = 1 << 16,
-    PROVIDER_ZLIB               = 1 << 17
+    PROVIDER_ZLIB               = 1 << 17,
+    PROVIDER_GETNAMEINFOREQWRAP = 1 << 18
   };
 
   inline AsyncWrap(Environment* env,

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -431,6 +431,44 @@ TEST(function test_lookup_localhost_ipv4(done) {
 });
 
 
+TEST(function test_lookupservice_ip_ipv4(done) {
+  var req = dns.lookupService('127.0.0.1', 80, function(err, host, service) {
+    if (err) throw err;
+    assert.strictEqual(host, 'localhost');
+    assert.strictEqual(service, 'http');
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+
+TEST(function test_lookupservice_ip_ipv6(done) {
+  var req = dns.lookupService('::1', 80, function(err, host, service) {
+    if (err) throw err;
+    assert.strictEqual(host, 'localhost');
+    assert.strictEqual(service, 'http');
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+
+TEST(function test_lookupservice_invalid(done) {
+  var req = dns.lookupService('1.2.3.4', 80, function(err, host, service) {
+    assert(err instanceof Error);
+    assert.strictEqual(err.code, 'ENOTFOUND');
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+
 TEST(function test_reverse_failure(done) {
   var req = dns.reverse('0.0.0.0', function(err) {
     assert(err instanceof Error);


### PR DESCRIPTION
Uses getnameinfo to resolve an address an port into a hostname and
service.

NOTE: latest libuv needs to be pulled into node before merging this.

Does what it says on the tin. I'm not thrilled about the `lookupService` name, suggestions are welcome :-)

Suggested reviewer: @indutny, but all feedback is of course welcome!
