### PR TITLE
Ensure handle still open before emitting listening, fixes #7834

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1136,7 +1136,10 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   this._connectionKey = addressType + ':' + address + ':' + port;
 
   process.nextTick(function() {
-    self.emit('listening');
+    // ensure handle hasn't closed
+    if (self._handle) {
+      self.emit('listening');
+    }
   });
 };
 

--- a/test/simple/test-net-listen-close-server.js
+++ b/test/simple/test-net-listen-close-server.js
@@ -1,0 +1,36 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var gotError = false;
+
+var server = net.createServer(function(socket) {
+});
+server.listen(common.PORT, function() {
+  assert(false);
+});
+server.on('error', function(error) {
+  common.debug(error);
+  assert(false);
+});
+server.close();


### PR DESCRIPTION
Fixes #7834.

``` js
net.createServer()
  .on('listening', console.log.bind(console, 'listening'))
  .listen()
  .close();
```

/cc @indutny 
