### PR TITLE
stream: only end reading on null, not undefined

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -139,7 +139,7 @@ function readableAddChunk(stream, state, chunk, encoding, addToFront) {
   var er = chunkInvalid(state, chunk);
   if (er) {
     stream.emit('error', er);
-  } else if (util.isNullOrUndefined(chunk)) {
+  } else if (chunk === null) {
     state.reading = false;
     if (!state.ended)
       onEofChunk(stream, state);

--- a/test/simple/test-stream2-readable-non-empty-end.js
+++ b/test/simple/test-stream2-readable-non-empty-end.js
@@ -35,7 +35,7 @@ var n = 0;
 test._read = function(size) {
   var chunk = chunks[n++];
   setTimeout(function() {
-    test.push(chunk);
+    test.push(chunk === undefined ? null : chunk);
   });
 };
 


### PR DESCRIPTION
The [Stream documentation for .push](http://nodejs.org/api/stream.html#stream_readable_push_chunk_encoding)
explicitly states multiple times that null is a special cased value
that indicates the end of a stream. It is confusing and undocumented
that undefined _also_ ends the stream, even though in object mode
there is a distinct and important difference.

The docs for Object-Mode also explicitly mention null as the _only_
special cased value, making no mention of undefined.
