### PR TITLE
_XOPEN_SOURCE breaks the events on OSX

### DIFF
--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -19,13 +19,15 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#if !defined(__DARWIN__) && !defined(__APPLE__)
 // O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 500.
-#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 500
+#if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE - 0L) < 500
 #undef _XOPEN_SOURCE
 #endif
 
 #if !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 500
+#endif
 #endif
 
 #include "node_constants.h"

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if !defined(__DARWIN__) && !defined(__APPLE__)
+#if defined(__sun)
 // O_NONBLOCK is not exported unless _XOPEN_SOURCE >= 500.
 #if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE - 0L) < 500
 #undef _XOPEN_SOURCE


### PR DESCRIPTION
OSX fcntl.h doesn't require _XOPEN_SOURCE -> _POSIX_C_SOURCE is defined for O_NONBLOCK. Defining _XOPEN_SOURCE on OSX breaks other events. 

See https://github.com/joyent/node/issues/7855
