### PR TITLE
events: Output the event that is leaking

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -173,9 +173,9 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
     if (m && m > 0 && this._events[type].length > m) {
       this._events[type].warned = true;
       console.error('(node) warning: possible EventEmitter memory ' +
-                    'leak detected. %d listeners added. ' +
+                    'leak detected. %d %s listeners added. ' +
                     'Use emitter.setMaxListeners() to increase limit.',
-                    this._events[type].length);
+                    this._events[type].length, type);
       console.trace();
     }
   }


### PR DESCRIPTION
This makes a bit easier to actually figure out which event is leaking. The console.trace() below it only useful when you're not adding event listeners asynchronously.
