### PR TITLE
child_process: accept `uid`/`gid` everywhere

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -491,6 +491,8 @@ See also: `child_process.exec()` and `child_process.fork()`
   * `timeout` {Number} (Default: 0)
   * `maxBuffer` {Number} (Default: `200*1024`)
   * `killSignal` {String} (Default: 'SIGTERM')
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
 * `callback` {Function} called with the output when process terminates
   * `error` {Error}
   * `stdout` {Buffer}
@@ -544,6 +546,8 @@ the child process is killed.
   * `timeout` {Number} (Default: 0)
   * `maxBuffer` {Number} (Default: 200\*1024)
   * `killSignal` {String} (Default: 'SIGTERM')
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
 * `callback` {Function} called with the output when process terminates
   * `error` {Error}
   * `stdout` {Buffer}
@@ -570,6 +574,8 @@ leaner than `child_process.exec`. It has the same options.
     piped to the parent, otherwise they will be inherited from the parent, see
     the "pipe" and "inherit" options for `spawn()`'s `stdio` for more details
     (default is false)
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
 * Return: ChildProcess object
 
 This is a special case of the `spawn()` functionality for spawning Node

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -128,6 +128,8 @@ values are `"rr"` and `"none"`.
     (Default=`process.argv.slice(2)`)
   * `silent` {Boolean} whether or not to send output to parent's stdio.
     (Default=`false`)
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
 
 After calling `.setupMaster()` (or `.fork()`) this settings object will contain
 the settings, including the default values.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -669,6 +669,8 @@ exports.execFile = function(file /* args, options, callback */) {
   var child = spawn(file, args, {
     cwd: options.cwd,
     env: options.env,
+    gid: options.gid,
+    uid: options.uid,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -285,7 +285,9 @@ function masterInit() {
     worker.process = fork(cluster.settings.exec, cluster.settings.args, {
       env: workerEnv,
       silent: cluster.settings.silent,
-      execArgv: createWorkerExecArgv(cluster.settings.execArgv, worker)
+      execArgv: createWorkerExecArgv(cluster.settings.execArgv, worker),
+      gid: cluster.settings.gid,
+      uid: cluster.settings.uid
     });
     worker.process.once('exit', function(exitCode, signalCode) {
       worker.suicide = !!worker.suicide;


### PR DESCRIPTION
Accept `uid`/`gid` option in every execute/spawn call (including
`cluster.fork`). Add documentation where needed.

fix #7881
