### PR TITLE
udp: make it possible to receive empty udp packets

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -258,7 +258,8 @@ Socket.prototype.send = function(buffer,
   if (offset < 0)
     throw new RangeError('Offset should be >= 0');
 
-  if (offset >= buffer.length)
+  if ((length == 0 && offset > buffer.length) ||
+      (length > 0 && offset >= buffer.length))
     throw new RangeError('Offset into buffer too large');
 
   // Sending a zero-length datagram is kind of pointless but it _is_

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -309,7 +309,7 @@ Socket.prototype.send = function(buffer,
       self.emit('error', ex);
     }
     else if (self._handle) {
-      var req = { buffer: buffer };  // Keep reference alive.
+      var req = { buffer: buffer, length: length };  // Keep reference alive.
       if (callback) {
         req.callback = callback;
         req.oncomplete = afterSend;
@@ -333,7 +333,7 @@ Socket.prototype.send = function(buffer,
 
 
 function afterSend(err) {
-  this.callback(err ? errnoException(err, 'send') : null, this.buffer.length);
+  this.callback(err ? errnoException(err, 'send') : null, this.length);
 }
 
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -396,7 +396,7 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
                      const uv_buf_t* buf,
                      const struct sockaddr* addr,
                      unsigned int flags) {
-  if (nread == 0) {
+  if (nread == 0 && addr == NULL) {
     if (buf->base != NULL)
       free(buf->base);
     return;

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -268,7 +268,6 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   node::Utf8Value address(args[5]);
   const bool have_callback = args[6]->IsTrue();
 
-  assert(offset < Buffer::Length(buffer_obj));
   assert(length <= Buffer::Length(buffer_obj) - offset);
 
   SendWrap* req_wrap = new SendWrap(env, req_wrap_obj, have_callback);

--- a/test/simple/test-dgram-empty-packet.js
+++ b/test/simple/test-dgram-empty-packet.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+var fs = require('fs'),
+    dgram = require('dgram'),
+    callbacks = 0,
+    client,
+    timer;
+
+
+client = dgram.createSocket('udp4');
+
+client.bind(common.PORT);
+
+function callback() {
+  callbacks++;
+  if (callbacks == 2) {
+    clearTimeout(timer);
+    client.close();
+  } else if (callbacks > 2) {
+    throw "the callbacks should be called only two times";
+  }
+}
+
+client.on('message', function (buffer, bytes) {
+  callback();
+});
+
+client.send(new Buffer(1), 0, 0, common.PORT, "127.0.0.1", function (err, len) {
+  callback();
+});
+
+timer = setTimeout(function() {
+  throw new Error('Timeout');
+}, 200);

--- a/test/simple/test-dgram-send-callback-buffer-length.js
+++ b/test/simple/test-dgram-send-callback-buffer-length.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+var fs = require('fs'),
+    dgram = require('dgram'),
+    callbacks = 0,
+    client, timer, buf, len, offset;
+
+
+client = dgram.createSocket('udp4');
+
+buf = new Buffer(256);
+offset = 20;
+
+len = buf.length - offset;
+
+
+client.send(buf, offset, len, common.PORT, "127.0.0.1", function (err, bytes) {
+    assert.notEqual(bytes, buf.length);
+    assert.equal(bytes, buf.length - offset);
+    clearTimeout(timer);
+    client.close();
+});
+
+timer = setTimeout(function() {
+  throw new Error('Timeout');
+}, 200);

--- a/test/simple/test-dgram-send-empty-buffer.js
+++ b/test/simple/test-dgram-send-empty-buffer.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+var fs = require('fs'),
+    dgram = require('dgram'),
+    callbacks = 0,
+    client, timer, buf;
+
+
+client = dgram.createSocket('udp4');
+
+client.bind(common.PORT);
+
+client.on('message', function (buffer, bytes) {
+  clearTimeout(timer);
+  client.close();
+});
+
+buf = new Buffer(0);
+client.send(buf, 0, 0, common.PORT, "127.0.0.1", function (err, len) { });
+
+timer = setTimeout(function() {
+  throw new Error('Timeout');
+}, 200);


### PR DESCRIPTION
A udp packet can have 0 content.
In that case nread will be equal 0, but addr != NULL.
