### PR TITLE
lib: remove and restructure calls to isNaN()

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -228,7 +228,7 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return n === 0 ? 0 : 1;
 
-  if (isNaN(n) || util.isNull(n)) {
+  if (n === null || isNaN(n)) {
     // only flow one buffer at a time
     if (state.flowing && state.buffer.length)
       return state.buffer[0].length;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -60,7 +60,7 @@ function replacer(key, value) {
   if (util.isUndefined(value)) {
     return '' + value;
   }
-  if (util.isNumber(value) && (isNaN(value) || !isFinite(value))) {
+  if (util.isNumber(value) && !isFinite(value)) {
     return value.toString();
   }
   if (util.isFunction(value) || util.isRegExp(value)) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -305,7 +305,7 @@ Socket.prototype.listen = function() {
 
 
 Socket.prototype.setTimeout = function(msecs, callback) {
-  if (msecs > 0 && !isNaN(msecs) && isFinite(msecs)) {
+  if (msecs > 0 && isFinite(msecs)) {
     timers.enroll(this, msecs);
     timers._unrefActive(this);
     if (callback) {


### PR DESCRIPTION
In #7840, @bnoordhuis pointed out a simple optimization surrounding a call to `isNaN()`. This commit implements that optimization. It also removes two unnecessary calls to `isNaN()` that are already covered by calls to `isFinite()`. Closes #7840.

@trevnorris

As a side note, there appear to be two tests that are failing in master.
