### PR TITLE
src: handle UV_EAGAIN in TryWrite

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -605,7 +605,7 @@ int StreamWrapCallbacks::TryWrite(uv_buf_t** bufs, size_t* count) {
   size_t vcount = *count;
 
   err = uv_try_write(wrap()->stream(), vbufs, vcount);
-  if (err == UV_ENOSYS)
+  if (err == UV_ENOSYS || err == UV_EAGAIN)
     return 0;
   if (err < 0)
     return err;


### PR DESCRIPTION
**Do NOT merge until latest libuv has been incorporated into node**

Adjust to a libuv change: we now return UV_EAGAIN in `uv_try_write` when the write cannot be completed immediately.

R=@indutny
