### PR TITLE
doc: fix console.assert docs, message is a format

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -66,10 +66,10 @@ Finish timer, record output. Example:
 
 Print a stack trace to stderr of the current position.
 
-## console.assert(expression, [message])
+## console.assert(value, [message], [...])
 
-Same as [assert.ok()][] where if the `expression` evaluates as `false` throw an
-AssertionError with `message`.
+Similar to [assert.ok()][], but the error message is formatted as
+`util.format(message...)`.
 
 [assert.ok()]: assert.html#assert_assert_value_message_assert_ok_value_message
 [util.format()]: util.html#util_util_format_format


### PR DESCRIPTION
Documentation for console.assert incorrectly described message as a
single message, but it is a format.
