### PR TITLE
Update the header declaration of InitContextify to match the defintion.

### DIFF
--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -28,7 +28,9 @@
 
 namespace node {
 
-void InitContextify(v8::Handle<v8::Object> target);
+void InitContextify(v8::Handle<v8::Object> target,
+                    v8::Handle<v8::Value> unused,
+                    v8::Handle<v8::Context> context);
 
 }  // namespace node
 


### PR DESCRIPTION
The signature of the function was changed in
756b6222956b5d25b2e7db81f4e79033a3a4d20e, but the header was not updated.
