### PR TITLE
lib: remove and restructure calls to isNaN()

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -218,7 +218,7 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return n === 0 ? 0 : 1;
 
-  if (isNaN(n) || n === null) {
+  if (n === null || isNaN(n)) {
     // only flow one buffer at a time
     if (state.flowing && state.buffer.length)
       return state.buffer[0].length;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -54,7 +54,7 @@ function replacer(key, value) {
   if (value === undefined) {
     return '' + value;
   }
-  if (typeof value === 'number' && (isNaN(value) || !isFinite(value))) {
+  if (typeof value === 'number' && !isFinite(value)) {
     return value.toString();
   }
   if (typeof value === 'function' || value instanceof RegExp) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -306,7 +306,7 @@ Socket.prototype.listen = function() {
 
 
 Socket.prototype.setTimeout = function(msecs, callback) {
-  if (msecs > 0 && !isNaN(msecs) && isFinite(msecs)) {
+  if (msecs > 0 && isFinite(msecs)) {
     timers.enroll(this, msecs);
     timers._unrefActive(this);
     if (callback) {


### PR DESCRIPTION
Switch condition order to check for `null` before calling `isNaN()`. Also remove two unnecessary calls to `isNaN()` that are already covered by calls to `isFinite()`. This commit targets v0.10, as opposed to #7891, which targets master (suggested by @bnoordhuis). Closes #7840.
