### PR TITLE
repl: fix overwrite for this._prompt

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -49,6 +49,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   this._sawReturn = false;
+  this._defaultPrompt = '> ';
 
   EventEmitter.call(this);
 
@@ -82,7 +83,7 @@ function Interface(input, output, completer, terminal) {
     callback(null, completer(v));
   };
 
-  this.setPrompt('> ');
+  this.setDefaultPrompt();
 
   this.terminal = !!terminal;
 
@@ -163,6 +164,11 @@ Interface.prototype.setPrompt = function(prompt) {
   this._prompt = prompt;
 };
 
+Interface.prototype.setDefaultPrompt = function(prompt) {
+  if (!util.isUndefined(prompt))
+    this._defaultPrompt = prompt;
+  this._prompt = this._defaultPrompt;
+};
 
 Interface.prototype._setRawMode = function(mode) {
   if (util.isFunction(this.input.setRawMode)) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -193,7 +193,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     options.terminal
   ]);
 
-  self.setPrompt(!util.isUndefined(prompt) ? prompt : '> ');
+  self.setDefaultPrompt(prompt);
 
   this.commands = {};
   defineDefaultCommands(this);
@@ -389,16 +389,16 @@ REPLServer.prototype.resetContext = function() {
 };
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
-  var initial = this._prompt;
-  var prompt = initial;
+  var prompt = this._prompt;
   if (this.bufferedCommand.length) {
     prompt = '...';
     var levelInd = new Array(this.lines.level.length).join('..');
     prompt += levelInd + ' ';
+    this.setPrompt(prompt);
+  } else {
+    this.setDefaultPrompt();
   }
-  this.setPrompt(prompt);
   this.prompt(preserveCursor);
-  this.setPrompt(initial);
 };
 
 // A stream to push an array into a REPL

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -34,7 +34,8 @@ var net = require('net'),
                  'node repl, in your normal shell.\n' +
                  '(Press Control-D to exit.)\n',
     expect_npm = prompt_npm + prompt_unix,
-    server_tcp, server_unix, client_tcp, client_unix, timer;
+    server_tcp, server_unix, client_tcp, client_unix, timer,
+    repl_unix;
 
 
 // absolute path to test/fixtures/a.js
@@ -99,6 +100,7 @@ function error_test() {
     } else if (read_buffer.indexOf(prompt_multiline) !== -1) {
       // Check that you meant to send a multiline test
       assert.strictEqual(prompt_multiline, client_unix.expect);
+      assert.equal(repl_unix._prompt, prompt_multiline);
       read_buffer = '';
       if (client_unix.list && client_unix.list.length > 0) {
         send_expect(client_unix.list);
@@ -275,12 +277,13 @@ function unix_test() {
       socket.end();
     });
 
-    repl.start({
+    repl_unix = repl.start({
       prompt: prompt_unix,
       input: socket,
       output: socket,
       useGlobal: true
-    }).context.message = message;
+    });
+    repl_unix.context.message = message;
   });
 
   server_unix.on('listening', function() {


### PR DESCRIPTION
This patch https://github.com/joyent/node/commit/b5175003bca45e23bd20d9559096dafda3e0ad7c overwrites the this._prompt, it caused the bug:

``` sh
$ node
> function foo() {
...(space + backtrace/delete)
> 
```

`this._prompt` has been overwritten by https://github.com/joyent/node/commit/b5175003bca45e23bd20d9559096dafda3e0ad7c#diff-b13d72249263845d8e8341db0426f9d3R401

/cc @indutny
