### PR TITLE
src: Pass the v8::Context to CreateEnvironment.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3527,13 +3527,13 @@ int EmitExit(Environment* env) {
 
 
 Environment* CreateEnvironment(Isolate* isolate,
+                               Handle<Context> context,
                                int argc,
                                const char* const* argv,
                                int exec_argc,
                                const char* const* exec_argv) {
   HandleScope handle_scope(isolate);
 
-  Local<Context> context = Context::New(isolate);
   Context::Scope context_scope(context);
   Environment* env = Environment::New(context);
 
@@ -3605,8 +3605,10 @@ int Start(int argc, char** argv) {
   V8::Initialize();
   {
     Locker locker(node_isolate);
-    Environment* env =
-        CreateEnvironment(node_isolate, argc, argv, exec_argc, exec_argv);
+    HandleScope handle_scope(node_isolate);
+    Local<Context> context = Context::New(node_isolate);
+    Environment* env = CreateEnvironment(
+        node_isolate, context, argc, argv, exec_argc, exec_argv);
     // Assign env to the debugger's context
     if (debugger_running) {
       HandleScope scope(env->isolate());


### PR DESCRIPTION
This allows callers to supply which context is used in the environment.

@indutny

I wrote the original "node embedding api", if you want to call it that, which is used to embed Node into Plask.  Basically there are a few parts of the startup process that Plask needs to be involved in, so there is where Start(), Init(), etc came from.  There have been a few changes in Node that broke some of the API, so I have a few patches coming here to bring Node back to an embeddable state.

Thanks
