### PR TITLE
Allowing assert.deepEqual to check NaN values for equality

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -174,12 +174,17 @@ function _deepEqual(actual, expected) {
            actual.lastIndex === expected.lastIndex &&
            actual.ignoreCase === expected.ignoreCase;
 
-  // 7.4. Other pairs that do not both pass typeof value == 'object',
+  // 7.4 If the expected value is NaN, we need to perform this comparison
+  // using isNaN(), as the next case will not catch the condition.
+  } else if (util.isNumber(expected) && isNaN(expected)) {
+      return isNaN(actual);
+
+  // 7.5. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
   } else if (!util.isObject(actual) && !util.isObject(expected)) {
     return actual == expected;
 
-  // 7.5 For all other Object pairs, including Array objects, equivalence is
+  // 7.6 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified
   // with Object.prototype.hasOwnProperty.call), the same set of keys
   // (although not necessarily the same order), equivalent values for every

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -176,8 +176,8 @@ function _deepEqual(actual, expected) {
 
   // 7.4 If the expected value is NaN, we need to perform this comparison
   // using isNaN(), as the next case will not catch the condition.
-  } else if (util.isNumber(expected) && isNaN(expected)) {
-      return isNaN(actual);
+  } else if (Number.isNaN(expected)) {
+      return Number.isNaN(actual);
 
   // 7.5. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -98,14 +98,19 @@ re1.lastIndex = 3;
 assert.throws(makeBlock(a.deepEqual, re1, /a/));
 
 
-// 7.4
+// 7.4 
+assert.doesNotThrow(makeBlock(a.deepEqual, NaN, NaN));
+assert.throws(makeBlock(a.deepEqual, 1, NaN));
+
+
+// 7.5
 assert.doesNotThrow(makeBlock(a.deepEqual, 4, '4'), 'deepEqual == check');
 assert.doesNotThrow(makeBlock(a.deepEqual, true, 1), 'deepEqual == check');
 assert.throws(makeBlock(a.deepEqual, 4, '5'),
               a.AssertionError,
               'deepEqual == check');
 
-// 7.5
+// 7.6
 // having the same number of owned properties && the same set of keys
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4}, {a: 4}));
 assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '2'}, {a: 4, b: '2'}));


### PR DESCRIPTION
An Object may have NaN as one of its property values.  NaN doesn't compare directly to itself, so isNaN() must be used instead.
