### PR TITLE
Update path.js

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -269,7 +269,7 @@ if (isWindows) {
       }
 
       if (start > end) return [];
-      return arr.slice(start, end - start + 1);
+      return arr.slice(start, end + 1);
     }
 
     var toParts = trim(to.split('\\'));
@@ -413,7 +413,7 @@ if (isWindows) {
       }
 
       if (start > end) return [];
-      return arr.slice(start, end - start + 1);
+      return arr.slice(start, end + 1);
     }
 
     var fromParts = trim(from.split('/'));


### PR DESCRIPTION
Maybe I'm missing something, but seems to be a small inconsequent bug in internal function trim(arr). 2nd parameter of slice() is slice's end index (not included).
