### PR TITLE
Update fs.markdown to account for correct uses of fs.exists()

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -648,13 +648,10 @@ Then call the `callback` argument with either true or false.  Example:
       util.debug(exists ? "it's there" : "no passwd!");
     });
 
-`fs.exists()` is an anachronism and exists only for historical reasons.
-There should almost never be a reason to use it in your own code.
-
-In particular, checking if a file exists before opening it is an anti-pattern
-that leaves you vulnerable to race conditions: another process may remove the
-file between the calls to `fs.exists()` and `fs.open()`.  Just open the file
-and handle the error when it's not there.
+`fs.exists()` should not be used to check if a file exists before calling
+`fs.open()`. This introduces a race condition, since other processes may change
+the file's state between the two calls. Instead, user code should call `fs.open()`
+directly, and handle the error if the file is non-existent.
 
 ## fs.existsSync(path)
 


### PR DESCRIPTION
`fs.exists()` is not an anti-pattern in itself. It becomes an anti-pattern when used in a particular way. Checking the existence of a file is quite useful when, for example, checking filesystem based locks or status files (of course, _grabbing_ a lock is the same problem, and should use `fs.open()` directly), and the documentation shouldn't be so narrow in its assumptions.
