### PR TITLE
Docs: add note on pre- & post- being available for run-scripts as well.

### DIFF
--- a/deps/npm/doc/misc/npm-scripts.md
+++ b/deps/npm/doc/misc/npm-scripts.md
@@ -34,7 +34,7 @@ following scripts:
   stop and start scripts if no `restart` script is provided.
 
 Additionally, arbitrary scripts can be run by doing
-`npm run-script <pkg> <stage>`.
+`npm run-script <pkg> <stage>`. *pre-* and *post-* commands with matching names would be ran for those as well (i.e.:'premyscript', 'myscript', 'postmyscript').
 
 ## NOTE: INSTALL SCRIPTS ARE AN ANTIPATTERN
 


### PR DESCRIPTION
After [learning something](http://sudodoki.name/til-prepost-are-for-everybody/) just thought it might be useful to put in documentation which might help some people make their flow easier and stop putting too much '&&' in their custom scripts.

This PR adds a note about the fact, that  if you script section looks like this:

```
{
  "scripts": {
    "premyscript": "echo \"Pre stuff\"",
    "myscript": "echo \"LOL MY SCRIPT\" ",
    "postmyscript":"echo \"Post stuff\""
  }
}
```

invoking `npm run myscript` would run `premyscript`, then `myscript` and `postmyscript` in the end.
