### PR TITLE
net: add remoteFamily for socket

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -449,6 +449,10 @@ the socket is `ref`d calling `ref` again will have no effect.
 The string representation of the remote IP address. For example,
 `'74.125.127.100'` or `'2001:4860:a005::68'`.
 
+### socket.remoteFamily
+
+The string representation of the remote IP family. `'IPv4'` or `'IPv6'`.
+
 ### socket.remotePort
 
 The numeric representation of the remote port. For example,

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -90,7 +90,7 @@ This is achieved by randomly generating a key pair for key-agreement on every
 handshake (in contrary to the same key for all sessions). Methods implementing
 this technique, thus offering Perfect Forward Secrecy, are called "ephemeral".
 
-Currently two methods are commonly used to achieve Perfect Forward Secrecy (note 
+Currently two methods are commonly used to achieve Perfect Forward Secrecy (note
 the character "E" appended to the traditional abbreviations):
 
   * [DHE] - An ephemeral version of the Diffie Hellman key-agreement protocol.
@@ -339,7 +339,7 @@ Here is an example of a client of echo server as described previously:
       // These are necessary only if using the client certificate authentication
       key: fs.readFileSync('client-key.pem'),
       cert: fs.readFileSync('client-cert.pem'),
-    
+
       // This is necessary only if the server uses the self-signed certificate
       ca: [ fs.readFileSync('server-cert.pem') ]
     };
@@ -771,6 +771,10 @@ object with three properties, e.g.
 
 The string representation of the remote IP address. For example,
 `'74.125.127.100'` or `'2001:4860:a005::68'`.
+
+### tlsSocket.remoteFamily
+
+The string representation of the remote IP family. `'IPv4'` or `'IPv6'`.
 
 ### tlsSocket.remotePort
 

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -552,6 +552,9 @@ CleartextStream.prototype.__defineGetter__('remoteAddress', function() {
   return this.socket && this.socket.remoteAddress;
 });
 
+CleartextStream.prototype.__defineGetter__('remoteFamily', function() {
+  return this.socket && this.socket.remoteFamily;
+});
 
 CleartextStream.prototype.__defineGetter__('remotePort', function() {
   return this.socket && this.socket.remotePort;

--- a/lib/net.js
+++ b/lib/net.js
@@ -570,6 +570,9 @@ Socket.prototype.__defineGetter__('remoteAddress', function() {
   return this._getpeername().address;
 });
 
+Socket.prototype.__defineGetter__('remoteFamily', function() {
+  return this._getpeername().family;
+});
 
 Socket.prototype.__defineGetter__('remotePort', function() {
   return this._getpeername().port;

--- a/test/simple/test-net-during-close.js
+++ b/test/simple/test-net-during-close.js
@@ -35,6 +35,7 @@ server.listen(common.PORT, function() {
   // client is still attempting to connect
   assert.doesNotThrow(function() {
     client.remoteAddress;
+    client.remoteFamily;
     client.remotePort;
   });
   accessedProperties = true;

--- a/test/simple/test-net-remote-address-port.js
+++ b/test/simple/test-net-remote-address-port.js
@@ -29,6 +29,7 @@ var conns = 0, conns_closed = 0;
 var server = net.createServer(function(socket) {
   conns++;
   assert.equal('127.0.0.1', socket.remoteAddress);
+  assert.equal('IPv4', socket.remoteFamily);
   assert.ok(socket.remotePort);
   assert.notEqual(socket.remotePort, common.PORT);
   socket.on('end', function() {
@@ -42,11 +43,13 @@ server.listen(common.PORT, 'localhost', function() {
   var client2 = net.createConnection(common.PORT);
   client.on('connect', function() {
     assert.equal('127.0.0.1', client.remoteAddress);
+    assert.equal('IPv4', client.remoteFamily);
     assert.equal(common.PORT, client.remotePort);
     client.end();
   });
   client2.on('connect', function() {
     assert.equal('127.0.0.1', client2.remoteAddress);
+    assert.equal('IPv4', client.remoteFamily);
     assert.equal(common.PORT, client2.remotePort);
     client2.end();
   });


### PR DESCRIPTION
Add remoteFamily for the socket. Currently, can't get the client's IP family.
