### PR TITLE
gyp: do not let `v8dbg_` slip away on osx

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -21,7 +21,7 @@
       ['OS != "win"', {
         'v8_postmortem_support': 'true'
       }],
-      ['GENERATOR == "ninja"', {
+      ['GENERATOR == "ninja" or OS== "mac"', {
         'OBJ_DIR': '<(PRODUCT_DIR)/obj',
         'V8_BASE': '<(PRODUCT_DIR)/libv8_base.a',
       }, {

--- a/node.gyp
+++ b/node.gyp
@@ -271,6 +271,14 @@
             'PLATFORM="darwin"',
           ],
         }],
+        [ 'OS=="mac" and v8_postmortem_support=="true"', {
+          # Do not let `v8dbg_` symbols slip away
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(V8_BASE)',
+            ],
+          },
+        }],
         [ 'OS=="freebsd"', {
           'libraries': [
             '-lutil',


### PR DESCRIPTION
Pass `-force_load` to linker when linking to `libv8_base` to preserve
`v8dbg_` symbols, which are useful for debugging.

cc @tjfontaine
