### PR TITLE
fs: fix hasOwnProperty issue for readStream/writeStream options

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -54,6 +54,7 @@ var isWindows = process.platform === 'win32';
 var DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 var errnoException = util._errnoException;
 
+var hasOwnProperty = util._hasOwnProperty;
 
 function rethrow() {
   // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
@@ -1217,7 +1218,7 @@ fs.realpathSync = function realpathSync(p, cache) {
   // make p is absolute
   p = pathModule.resolve(p);
 
-  if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
+  if (cache && hasOwnProperty(cache, p)) {
     return cache[p];
   }
 
@@ -1269,7 +1270,7 @@ fs.realpathSync = function realpathSync(p, cache) {
     }
 
     var resolvedLink;
-    if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
+    if (cache && hasOwnProperty(cache, base)) {
       // some known symbolic link.  no need to stat again.
       resolvedLink = cache[base];
     } else {
@@ -1319,7 +1320,7 @@ fs.realpath = function realpath(p, cache, cb) {
   // make p is absolute
   p = pathModule.resolve(p);
 
-  if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
+  if (cache && hasOwnProperty(cache, p)) {
     return process.nextTick(cb.bind(null, null, cache[p]));
   }
 
@@ -1380,7 +1381,7 @@ fs.realpath = function realpath(p, cache, cb) {
       return process.nextTick(LOOP);
     }
 
-    if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
+    if (cache && hasOwnProperty(cache, base)) {
       // known symbolic link.  no need to stat again.
       return gotResolvedLink(cache[base]);
     }
@@ -1462,13 +1463,13 @@ function ReadStream(path, options) {
   Readable.call(this, options);
 
   this.path = path;
-  this.fd = options.hasOwnProperty('fd') ? options.fd : null;
-  this.flags = options.hasOwnProperty('flags') ? options.flags : 'r';
-  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+  this.fd = hasOwnProperty(options, 'fd') ? options.fd : null;
+  this.flags = hasOwnProperty(options, 'flags') ? options.flags : 'r';
+  this.mode = hasOwnProperty(options, 'mode') ? options.mode : 438; /*=0666*/
 
-  this.start = options.hasOwnProperty('start') ? options.start : undefined;
-  this.end = options.hasOwnProperty('end') ? options.end : undefined;
-  this.autoClose = options.hasOwnProperty('autoClose') ?
+  this.start = hasOwnProperty(options, 'start') ? options.start : undefined;
+  this.end = hasOwnProperty(options, 'end') ? options.end : undefined;
+  this.autoClose = hasOwnProperty(options, 'autoClose') ?
       options.autoClose : true;
   this.pos = undefined;
 
@@ -1630,11 +1631,11 @@ function WriteStream(path, options) {
   this.path = path;
   this.fd = null;
 
-  this.fd = options.hasOwnProperty('fd') ? options.fd : null;
-  this.flags = options.hasOwnProperty('flags') ? options.flags : 'w';
-  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+  this.fd = hasOwnProperty(options, 'fd') ? options.fd : null;
+  this.flags = hasOwnProperty(options, 'flags') ? options.flags : 'w';
+  this.mode = hasOwnProperty(options, 'mode') ? options.mode : 438; /*=0666*/
 
-  this.start = options.hasOwnProperty('start') ? options.start : undefined;
+  this.start = hasOwnProperty(options, 'start') ? options.start : undefined;
   this.pos = undefined;
   this.bytesWritten = 0;
 
@@ -1714,7 +1715,7 @@ function SyncWriteStream(fd, options) {
   this.fd = fd;
   this.writable = true;
   this.readable = false;
-  this.autoClose = options.hasOwnProperty('autoClose') ?
+  this.autoClose = hasOwnProperty(options, 'autoClose') ?
       options.autoClose : true;
 }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -30,10 +30,7 @@ var fs = NativeModule.require('fs');
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
 // See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
+var hasOwnProperty = util._hasOwnProperty;
 
 function Module(id, parent) {
   this.id = id;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -28,9 +28,7 @@ var util = require('util');
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
 // See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
+var hasOwnProperty = util._hasOwnProperty;
 
 
 function charCode(c) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -54,9 +54,7 @@ var debug = util.debuglog('repl');
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
 // See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
+var hasOwnProperty = util._hasOwnProperty;
 
 
 // hack for require.resolve("./relative") to work properly.

--- a/lib/util.js
+++ b/lib/util.js
@@ -652,7 +652,7 @@ exports._extend = function(origin, add) {
 function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
-
+exports._hasOwnProperty = hasOwnProperty;
 
 // Deprecated old stuff.
 

--- a/test/simple/test-fs-read-stream-options.js
+++ b/test/simple/test-fs-read-stream-options.js
@@ -1,0 +1,32 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var fs = require('fs');
+
+assert.doesNotThrow(function () {
+  var file = fs.createReadStream(__filename, {
+    encoding: 'utf8',
+    hasOwnProperty: function () {
+      return true;
+    }
+  });
+}, 'Should not throw error');

--- a/test/simple/test-fs-write-stream-options.js
+++ b/test/simple/test-fs-write-stream-options.js
@@ -1,0 +1,37 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var path = require('path'),
+    fs = require('fs');
+
+var file = path.join(common.tmpDir, 'write.txt');
+
+assert.doesNotThrow(function () {
+  fs.createWriteStream(file, {
+    encoding: 'utf8',
+    hasOwnProperty: function () {
+      return true;
+    }
+  });
+}, 'Should not throw error');


### PR DESCRIPTION
The hasOwnProperty that pass in make the createReadStream failed.

``` javascript
var reader = fs.createReadStream(__filename, {
  hasOwnProperty: function () {
    return true;
  }
});
```

Result: 

```
fs.js:434
  binding.open(pathModule._makeLong(path),
          ^
TypeError: flags must be an int
    at TypeError (native)
    at Object.fs.open (fs.js:434:11)
    at ReadStream.open (fs.js:1503:6)
    at new ReadStream (fs.js:1490:10)
    at Object.fs.createReadStream (fs.js:1444:10)
    at Object.<anonymous> (/Users/jacksontian/git/node_research/stream/readable.js:3:17)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
```
