### PR TITLE
tls: fix to send TLS Alert before socket destroyed

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -473,6 +473,11 @@ void TLSCallbacks::ClearOut() {
     Local<Value> arg = GetSSLError(read, &err, NULL);
 
     if (!arg.IsEmpty()) {
+      // When TLS Alert are stored in wbio,
+      // it should be flushed to socket before destroyed.
+      if (BIO_pending(enc_out_) != 0)
+        EncOut();
+
       MakeCallback(env()->onerror_string(), 1, &arg);
     }
   }

--- a/test/simple/test-tls-alert.js
+++ b/test/simple/test-tls-alert.js
@@ -1,0 +1,63 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+
+if (!common.opensslCli) {
+  console.error('Skipping because node compiled without OpenSSL CLI.');
+  process.exit(0);
+}
+
+var assert = require('assert');
+var fs = require('fs');
+var tls = require('tls');
+var spawn = require('child_process').spawn;
+
+var success = false;
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var server = tls.Server({
+  secureProtocol: 'TLSv1_2_server_method',
+  key: loadPEM('agent2-key'),
+  cert:loadPEM('agent2-cert')
+}, null).listen(common.PORT, function() {
+  var args = ['s_client', '-quiet', '-tls1_1','-connect', '127.0.0.1:' + common.PORT];
+  var client = spawn(common.opensslCli, args);
+  var out = '';
+  client.stderr.setEncoding('utf8');
+  client.stderr.on('data', function(d) {
+    out += d;
+    if (/SSL alert number 70/.test(out)) {
+      success = true;
+      server.close();
+    }
+  });
+});
+process.on('exit', function() {
+  assert(success);
+});


### PR DESCRIPTION
When TLS Alert is occured in handshake, ClearOut only write it into wbio and does not flush to socket. TLS Alert should be written to socket with EncOut before socket is destroyed within its error callback.
After this patch, TLS Alert surly is sent from node server which is limited to accept TLS1.2 as below

```
$ openssl s_client -quiet -tls1_1  -connect localhost:443
140321003767456:error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:s3_pkt.c:1554:SSL alert number 70
140321003767456:error:1409E0E5:SSL routines:ssl3_write_bytes:ssl handshake failure:s3_pkt.c:658:
```
