### PR TITLE
src: export additional startup functions

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -170,6 +170,22 @@ namespace node {
 NODE_EXTERN extern bool no_deprecation;
 
 NODE_EXTERN int Start(int argc, char *argv[]);
+NODE_EXTERN void Init(int* argc,
+                      const char** argv,
+                      int* exec_argc,
+                      const char*** exec_argv);
+
+class Environment;
+
+NODE_EXTERN Environment* CreateEnvironment(v8::Isolate* isolate,
+                                           v8::Handle<v8::Context> context,
+                                           int argc,
+                                           const char* const* argv,
+                                           int exec_argc,
+                                           const char* const* exec_argv);
+NODE_EXTERN void EmitBeforeExit(Environment* env);
+NODE_EXTERN int EmitExit(Environment* env);
+NODE_EXTERN void RunAtExit(Environment* env);
 
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(v8::Isolate::GetCurrent(),          \


### PR DESCRIPTION
This allows embedders enough control to initialize node, run the
event loop, and cleanly exit (including calling handlers).
