### PR TITLE
stream: pause cancels pending resumes

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -63,6 +63,7 @@ function ReadableState(options, stream) {
   // actions that shouldn't happen until "later" should generally also
   // not happen before the first write call.
   this.sync = true;
+  this.paused = null;
 
   // whenever we return null, then we set a flag to say
   // that we're awaiting a 'readable' event emission.
@@ -709,6 +710,7 @@ Readable.prototype.resume = function() {
 };
 
 function resume(stream, state) {
+  state.paused = false;
   if (!state.resumeScheduled) {
     state.resumeScheduled = true;
     process.nextTick(function() {
@@ -718,6 +720,12 @@ function resume(stream, state) {
 }
 
 function resume_(stream, state) {
+  if (state.paused) {
+    state.resumeScheduled = false;
+
+    return;
+  }
+
   if (!state.reading) {
     debug('resume read 0');
     stream.read(0);
@@ -732,6 +740,7 @@ function resume_(stream, state) {
 
 Readable.prototype.pause = function() {
   debug('call pause flowing=%j', this._readableState.flowing);
+  this._readableState.paused = true;
   if (false !== this._readableState.flowing) {
     debug('pause');
     this._readableState.flowing = false;


### PR DESCRIPTION
In looking into fixing [this jenkins error](http://jenkins.nodejs.org/job/nodejs-master/DESTCPU=ia32,label=smartos/1298/tapTestReport/simple.tap-564/), I ran into a situation where v0.11 differs from v0.10 stream behavior:

``` bash
$  node -e 'setInterval(process.stdout.write.bind(process.stdout, "beep"), 100)' | node test/simple/test-stdin-pause-resume-sync.js
```

In v0.10, the above will eventually error out with EPIPE. In v0.11, it will hang forever (with `NODE_DEBUG=stream,net`, it produces [this output](https://gist.github.com/chrisdickinson/c29ba12b7f1a4fcc3539/)).

This fixes that change in behavior (and may have the side effect of fixing the jenkins bug, though I was unable to reproduce that bug on smartos itself). The problem was that `resume` defers its actual work with `process.nextTick`, between which time `pause` may be called. In the stdin case, `resume` triggers a `read`, which `readStart`'s the handle, and the process is kept open by a continuing `maybeReadMore` since the handle is open and data continues to flow in.
