### PR TITLE
querystring: do not display separator for empty array stringify

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -128,9 +128,6 @@ var stringifyPrimitive = function(v) {
 QueryString.stringify = QueryString.encode = function(obj, sep, eq, options) {
   sep = sep || '&';
   eq = eq || '=';
-  if (util.isNull(obj)) {
-    obj = undefined;
-  }
 
   var encode = QueryString.escape;
   if (options && typeof options.encodeURIComponent === 'function') {
@@ -138,16 +135,23 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, options) {
   }
 
   if (util.isObject(obj)) {
-    return Object.keys(obj).map(function(k) {
+    var keys = Object.keys(obj);
+    var fields = [];
+
+    for (var i = 0, il = keys.length; i < il; ++i) {
+      var k = keys[i];
+      var v = obj[k];
       var ks = encode(stringifyPrimitive(k)) + eq;
-      if (util.isArray(obj[k])) {
-        return obj[k].map(function(v) {
-          return ks + encode(stringifyPrimitive(v));
-        }).join(sep);
+
+      if (util.isArray(v)) {
+        for (var j = 0, jl = v.length; j < jl; ++j) {
+          fields.push(ks + encode(stringifyPrimitive(v[j])));
+        }
       } else {
-        return ks + encode(stringifyPrimitive(obj[k]));
+        fields.push(ks + encode(stringifyPrimitive(v)));
       }
-    }).join(sep);
+    }
+    return fields.join(sep);
   }
   return '';
 };

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -138,15 +138,14 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, options) {
     var keys = Object.keys(obj);
     var fields = [];
 
-    for (var i = 0, il = keys.length; i < il; ++i) {
+    for (var i = 0; i < keys.length; i++) {
       var k = keys[i];
       var v = obj[k];
       var ks = encode(stringifyPrimitive(k)) + eq;
 
       if (util.isArray(v)) {
-        for (var j = 0, jl = v.length; j < jl; ++j) {
+        for (var j = 0; j < v.length; j++)
           fields.push(ks + encode(stringifyPrimitive(v[j])));
-        }
       } else {
         fields.push(ks + encode(stringifyPrimitive(v)));
       }

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -57,7 +57,9 @@ var qsTestCases = [
       valueOf: 'bar',
       __defineGetter__: 'baz' }],
   // See: https://github.com/joyent/node/issues/3058
-  ['foo&bar=baz', 'foo=&bar=baz', { foo: '', bar: 'baz' }]
+  ['foo&bar=baz', 'foo=&bar=baz', { foo: '', bar: 'baz' }],
+  [null, '', {}],
+  [undefined, '', {}]
 ];
 
 // [ wonkyQS, canonicalQS, obj ]

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -87,7 +87,8 @@ var qsWeirdObjects = [
   [{f: false, t: true}, 'f=false&t=true', {'f': 'false', 't': 'true'}],
   [{n: null}, 'n=', {'n': ''}],
   [{nan: NaN}, 'nan=', {'nan': ''}],
-  [{inf: Infinity}, 'inf=', {'inf': ''}]
+  [{inf: Infinity}, 'inf=', {'inf': ''}],
+  [{a: [], b: []}, '', {}]
 ];
 // }}}
 


### PR DESCRIPTION
Currently, stringification of an empty array outputs a single separator character. This commit causes an empty array to output the empty string. Also removed an unnecessary `if` statement. Related to #7971
