### PR TITLE
doc: console.trace takes a message format

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -62,9 +62,10 @@ Finish timer, record output. Example:
     }
     console.timeEnd('100-elements');
 
-## console.trace(label)
+## console.trace(message, [...])
 
-Print a stack trace to stderr of the current position.
+Print to stderr `'Trace :'`, followed by the formatted message and stack trace
+to the current position.
 
 ## console.assert(value, [message], [...])
 


### PR DESCRIPTION
Documentation claimed it accepted a single label argument, as time and
timeEnd do, which was incorrect.

Patch should be applied to master, too.
