### PR TITLE
child_process: do not access stderr when stdio set to 'ignore'

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1323,10 +1323,10 @@ function checkExecSyncError(ret) {
     ret.error = null;
 
     if (!err) {
-      var cmd = ret.cmd ? ret.cmd : ret.args.join(' ');
-      err = new Error(util.format('Command failed: %s\n%s',
-                                  cmd,
-                                  ret.stderr.toString()));
+      var msg = 'Command failed: ' +
+                (ret.cmd ? ret.cmd : ret.args.join(' ')) +
+                (ret.stderr ? '\n' + ret.stderr.toString() : '');
+      err = new Error(msg);
     }
 
     util._extend(err, ret);

--- a/test/simple/test-child-process-execsync.js
+++ b/test/simple/test-child-process-execsync.js
@@ -96,3 +96,10 @@ assert.strictEqual(ret, msg + '\n', 'execFileSync encoding result should match')
 
   assert.strictEqual(response.toString().trim(), cwd);
 })();
+
+// Verify that stderr is not accessed when stdio = 'ignore' - GH #7966
+(function() {
+  assert.throws(function() {
+    execSync('exit -1', {stdio: 'ignore'});
+  }, /Command failed: exit -1/);
+})();


### PR DESCRIPTION
Currently, `checkExecSyncError()` attempts to access the contents of `stderr`. When `stdio` is set to `'ignore'`, this causes a crash. This commit adds a check on the access of `stderr`. Closes #7966.
