### PR TITLE
gyp: fix post-mortem in v0.11

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -24,7 +24,7 @@
         'os_posix': 1,
         'v8_postmortem_support': 'true'
       }],
-      ['GENERATOR == "ninja"', {
+      ['GENERATOR == "ninja" or OS== "mac"', {
         'OBJ_DIR': '<(PRODUCT_DIR)/obj',
         'V8_BASE': '<(PRODUCT_DIR)/libv8_base.<(target_arch).a',
       }, {

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -80,6 +80,16 @@ consts_misc = [
     { 'name': 'SmiShiftSize',           'value': 'kSmiShiftSize' },
     { 'name': 'PointerSizeLog2',        'value': 'kPointerSizeLog2' },
 
+    { 'name': 'OddballFalse',           'value': 'Oddball::kFalse' },
+    { 'name': 'OddballTrue',            'value': 'Oddball::kTrue' },
+    { 'name': 'OddballTheHole',         'value': 'Oddball::kTheHole' },
+    { 'name': 'OddballNull',            'value': 'Oddball::kNull' },
+    { 'name': 'OddballArgumentMarker',  'value': 'Oddball::kArgumentMarker' },
+    { 'name': 'OddballUndefined',       'value': 'Oddball::kUndefined' },
+    { 'name': 'OddballUninitialized',   'value': 'Oddball::kUninitialized' },
+    { 'name': 'OddballOther',           'value': 'Oddball::kOther' },
+    { 'name': 'OddballException',       'value': 'Oddball::kException' },
+
     { 'name': 'prop_idx_first',
         'value': 'DescriptorArray::kFirstIndex' },
     { 'name': 'prop_type_field',
@@ -88,6 +98,10 @@ consts_misc = [
         'value': 'INTERCEPTOR' },
     { 'name': 'prop_type_mask',
         'value': 'PropertyDetails::TypeField::kMask' },
+    { 'name': 'prop_index_mask',
+        'value': 'PropertyDetails::FieldIndexField::kMask' },
+    { 'name': 'prop_index_shift',
+        'value': 'PropertyDetails::FieldIndexField::kShift' },
 
     { 'name': 'prop_desc_key',
         'value': 'DescriptorArray::kDescriptorKey' },
@@ -97,6 +111,20 @@ consts_misc = [
         'value': 'DescriptorArray::kDescriptorValue' },
     { 'name': 'prop_desc_size',
         'value': 'DescriptorArray::kDescriptorSize' },
+
+    { 'name': 'bit_field2_elements_kind_mask',
+       'value': 'Map::kElementsKindMask' },
+    { 'name': 'bit_field2_elements_kind_shift',
+       'value': 'Map::kElementsKindShift' },
+    { 'name': 'bit_field3_dictionary_map_shift',
+        'value': 'Map::DictionaryMap::kShift' },
+
+    { 'name': 'elements_fast_holey_elements',
+        'value': 'FAST_HOLEY_ELEMENTS' },
+    { 'name': 'elements_fast_elements',
+        'value': 'FAST_ELEMENTS' },
+    { 'name': 'elements_dictionary_elements',
+        'value': 'DICTIONARY_ELEMENTS' },
 
     { 'name': 'off_fp_context',
         'value': 'StandardFrameConstants::kContextOffset' },
@@ -120,6 +148,16 @@ extras_accessors = [
     'Map, instance_attributes, int, kInstanceAttributesOffset',
     'Map, inobject_properties, int, kInObjectPropertiesOffset',
     'Map, instance_size, int, kInstanceSizeOffset',
+    'Map, bit_field, char, kBitFieldOffset',
+    'Map, bit_field2, char, kBitField2Offset',
+    'Map, bit_field3, SMI, kBitField3Offset',
+    'Map, prototype, Object, kPrototypeOffset',
+    'NameDictionaryShape, prefix_size, int, kPrefixSize',
+    'NameDictionaryShape, entry_size, int, kEntrySize',
+    'SeededNumberDictionaryShape, prefix_size, int, kPrefixSize',
+    'UnseededNumberDictionaryShape, prefix_size, int, kPrefixSize',
+    'NumberDictionaryShape, entry_size, int, kEntrySize',
+    'Oddball, kind_offset, int, kKindOffset',
     'HeapNumber, value, double, kValueOffset',
     'ConsString, first, String, kFirstOffset',
     'ConsString, second, String, kSecondOffset',
@@ -361,7 +399,7 @@ def parse_field(call):
                     'value': '%s::%s' % (klass, offset)
                 });
 
-        assert(kind == 'SMI_ACCESSORS');
+        assert(kind == 'SMI_ACCESSORS' or kind == 'ACCESSORS_TO_SMI');
         klass = args[0];
         field = args[1];
         offset = args[2];
@@ -385,7 +423,8 @@ def load_fields():
         # may span multiple lines and may contain nested parentheses.  We also
         # call parse_field() to pick apart the invocation.
         #
-        prefixes = [ 'ACCESSORS', 'ACCESSORS_GCSAFE', 'SMI_ACCESSORS' ];
+        prefixes = [ 'ACCESSORS', 'ACCESSORS_GCSAFE',
+                     'SMI_ACCESSORS', 'ACCESSORS_TO_SMI' ];
         current = '';
         opens = 0;
 

--- a/node.gyp
+++ b/node.gyp
@@ -261,6 +261,11 @@
         } ],
         [ 'v8_postmortem_support=="true"', {
           'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(V8_BASE)',
+            ],
+          },
         }],
         [ 'node_shared_v8=="false"', {
           'sources': [


### PR DESCRIPTION
Expose missing constants and keep symbols on OSX.
