### PR TITLE
cluster: enable error and message events using cluster.worker

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -459,6 +459,8 @@ function workerInit() {
         process.exit(0);
       }
     });
+    worker.process.on('error', worker.emit.bind(worker, 'error'));
+    worker.process.on('message', worker.emit.bind(worker, 'message'));
     process.on('internalMessage', internal(worker, onmessage));
     send({ act: 'online' });
     function onmessage(message, handle) {

--- a/test/simple/test-cluster-worker-init.js
+++ b/test/simple/test-cluster-worker-init.js
@@ -31,14 +31,15 @@ var msg = 'foo';
 
 if (cluster.isMaster) {
   var worker = cluster.fork();
-
-  setTimeout(function() {
+  var timer = setTimeout(function() {
     assert(false, 'message not received');
-  }, 100);
+  }, 1000);
+
+  timer.unref();
 
   worker.on('message', function(message) {
     assert(message, 'did not receive expected message');
-    process.exit(0);
+    worker.disconnect();
   });
 
   worker.on('online', function() {

--- a/test/simple/test-cluster-worker-init.js
+++ b/test/simple/test-cluster-worker-init.js
@@ -1,0 +1,52 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// test-cluster-worker-init.js
+// verifies that, when a child process is forked, the cluster.worker
+// object can receive messages as expected
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var msg = 'foo';
+
+if (cluster.isMaster) {
+  var worker = cluster.fork();
+
+  setTimeout(function() {
+    assert(false, 'message not received');
+  }, 100);
+
+  worker.on('message', function(message) {
+    assert(message, 'did not receive expected message');
+    process.exit(0);
+  });
+
+  worker.on('online', function() {
+    worker.send(msg);
+  });
+} else {
+  // GH #7998
+  cluster.worker.on('message', function(message) {
+    process.send(message === msg);
+  });
+}


### PR DESCRIPTION
Between 0.11.1 and 0.11.2, the `message` and `error` events stopped being usable via the `cluster.worker` object. This commit makes them usable again. Closes #7998.
