### PR TITLE
fs: document `fd` option for `createReadStream` and `createWriteStream`.

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -745,6 +745,9 @@ Returns a new ReadStream object (See `Readable Stream`).
 the file instead of the entire file.  Both `start` and `end` are inclusive and
 start at 0. The `encoding` can be `'utf8'`, `'ascii'`, or `'base64'`.
 
+If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
+the specified file descriptor. This means that no `open` event will be emitted.
+
 If `autoClose` is false, then the file descriptor won't be closed, even if
 there's an error.  It is your responsibility to close it and make sure
 there's no file descriptor leak.  If `autoClose` is set to true (default
@@ -775,12 +778,18 @@ Returns a new WriteStream object (See `Writable Stream`).
 
     { flags: 'w',
       encoding: null,
+      fd: null,
       mode: 0666 }
 
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
 default mode `w`.
+
+Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the
+`path` argument and will use the specified file descriptor. This means that no
+`open` event will be emitted.
+
 
 ## Class: fs.WriteStream
 


### PR DESCRIPTION
I humbly submit this documentation with the hope that it'll satisfy issues #7707 and #7708
