### PR TITLE
fs: Add DuplexStream and fs.createDuplexStream

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -797,6 +797,45 @@ Emitted when the WriteStream's file is opened.
 The number of bytes written so far. Does not include data that is still queued
 for writing.
 
+
+## fs.createDuplexStream(path, [options])
+
+Returns a new DuplexStream object (See `Duplex Stream`).
+
+`options` is an object with the following defaults:
+
+    { flags: 'r+',
+      encoding: null,
+      fd: null,
+      mode: 0666,
+      autoClose: true
+    }
+
+For more information on `options`, see `ReadStream` and `WriteStream`.
+Note that replacing a file rather than modifying it may require a `flags`
+mode of `w+` rather than the default mode `r+`.
+
+Note that if `autoClose` is set to false, the `fd` used by `DuplexStream`
+will still be closed if `end` is called.
+
+## Class: fs.DuplexStream
+
+`DuplexStream` is a [Duplex Stream](stream.html#stream_class_stream_duplex).
+It is built using parasitic inheritance from the the above ReadStream and
+WriteStream classes. 
+
+### Event: 'open'
+
+* `fd` {Integer} file descriptor used by the ReadStream.
+
+Emitted when the DuplexStream's file is opened.
+
+### file.bytesWritten
+
+The number of bytes written so far. Does not include data that is still queued
+for writing.
+
+
 ## Class: fs.FSWatcher
 
 Objects returned from `fs.watch()` are of this type.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -36,6 +36,7 @@ var EventEmitter = require('events').EventEmitter;
 
 var Readable = Stream.Readable;
 var Writable = Stream.Writable;
+var Duplex = Stream.Duplex;
 
 var kMinPoolSpace = 128;
 var kMaxLength = require('smalloc').kMaxLength;
@@ -1467,7 +1468,7 @@ function ReadStream(path, options) {
   this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
 
   this.start = options.hasOwnProperty('start') ? options.start : undefined;
-  this.end = options.hasOwnProperty('end') ? options.end : undefined;
+  this._end = options.hasOwnProperty('end') ? options.end : undefined;
   this.autoClose = options.hasOwnProperty('autoClose') ?
       options.autoClose : true;
   this.pos = undefined;
@@ -1476,15 +1477,20 @@ function ReadStream(path, options) {
     if (!util.isNumber(this.start)) {
       throw TypeError('start must be a Number');
     }
-    if (util.isUndefined(this.end)) {
-      this.end = Infinity;
-    } else if (!util.isNumber(this.end)) {
+    if (util.isUndefined(this._end)) {
+      this._end = Infinity;
+    } else if (!util.isNumber(this._end)) {
       throw TypeError('end must be a Number');
     }
 
-    if (this.start > this.end) {
+    if (this.start > this._end) {
       throw new Error('start must be <= end');
     }
+
+    if (this.start < 0) {
+      throw new Error('start must be >= zero');
+    }
+
 
     this.pos = this.start;
   }
@@ -1542,7 +1548,7 @@ ReadStream.prototype._read = function(n) {
   var start = pool.used;
 
   if (!util.isUndefined(this.pos))
-    toRead = Math.min(this.end - this.pos + 1, toRead);
+    toRead = Math.min(this._end - this.pos + 1, toRead);
 
   // already read everything we were supposed to read!
   // treat as EOF.
@@ -1703,6 +1709,102 @@ WriteStream.prototype.close = ReadStream.prototype.close;
 // There is no shutdown() for files.
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 
+
+
+
+fs.createDuplexStream = function(path, options) {
+  return new DuplexStream(path, options);
+};
+
+util.inherits(DuplexStream, Duplex);
+fs.DuplexStream = DuplexStream;
+function DuplexStream(path, options) {
+  if (!(this instanceof DuplexStream))
+    return new DuplexStream(path, options);
+
+  // a little bit bigger buffer and water marks by default
+  options = util._extend({
+    highWaterMark: 64 * 1024
+  }, options || {});
+
+  Duplex.call(this, options);
+
+  this.path = path;
+
+  this.fd = options.hasOwnProperty('fd') ? options.fd : null;
+  this.flags = options.hasOwnProperty('flags') ? options.flags : 'r+';
+  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+
+  this.start = options.hasOwnProperty('start') ? options.start : undefined;
+  this._end = options.hasOwnProperty('end') ? options.end : undefined;
+  this.autoClose = options.hasOwnProperty('autoClose') ?
+      options.autoClose : true;
+  this.pos = undefined;
+  this.bytesWritten = 0;
+
+  if (!util.isUndefined(this.start)) {
+    if (!util.isNumber(this.start)) {
+      throw TypeError('start must be a Number');
+    }
+
+    if (util.isUndefined(this._end)) {
+      this._end = Infinity;
+    } else if (!util.isNumber(this._end)) {
+      throw TypeError('end must be a Number');
+    }
+
+    if (this.start > this._end) {
+      throw new Error('start must be <= end');
+    }
+
+    if (this.start < 0) {
+      throw new Error('start must be >= zero');
+    }
+
+    this.pos = this.start;
+  }
+
+  if (!util.isNumber(this.fd))
+    this.open();
+
+  // dispose on finish.
+  this.once('finish', this.close);
+
+  this.once('end', function() {
+    if (this.autoClose) {
+      this.destroy();
+    }
+  });
+}
+
+fs.FileDuplexStream = DuplexStream;
+
+
+DuplexStream.prototype.open = function() {
+  var self = this;
+  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+    if (er) {
+      if (self.autoClose) {
+        self.destroy();
+      }
+      self.emit('error', er);
+      return;
+    }
+
+    self.fd = fd;
+    self.emit('open', fd);
+    // start the flow of data.
+    self.read();
+  });
+};
+
+DuplexStream.prototype._read = ReadStream.prototype._read;
+DuplexStream.prototype._write = WriteStream.prototype._write;
+DuplexStream.prototype.destroy = ReadStream.prototype.destroy;
+DuplexStream.prototype.close = ReadStream.prototype.close;
+
+// There is no shutdown() for files.
+DuplexStream.prototype.destroySoon = WriteStream.prototype.end;
 
 // SyncWriteStream is internal. DO NOT USE.
 // Temporary hack for process.stdout and process.stderr when piped to files.

--- a/test/simple/test-fs-duplex-stream-change-open.js
+++ b/test/simple/test-fs-duplex-stream-change-open.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var path = require('path'),
+    fs = require('fs'),
+    Duplex = require('stream').Duplex;
+
+var file = path.join(common.tmpDir, 'write.txt');
+
+var stream = fs.DuplexStream(file, { flags : 'w+' }),
+    _fs_close = fs.close,
+    _fs_open = fs.open;
+
+// change the fs.open with an identical function after the DuplexStream
+// has pushed it onto its internal action queue, but before it's
+// returned.  This simulates AOP-style extension of the fs lib.
+fs.open = function() {
+  return _fs_open.apply(fs, arguments);
+};
+
+fs.close = function(fd) {
+  assert.ok(fd, 'fs.close must not be called with an undefined fd.');
+  fs.close = _fs_close;
+  fs.open = _fs_open;
+}
+
+stream.write('foo');
+stream.end();
+
+process.on('exit', function() {
+  assert.equal(fs.open, _fs_open);
+});

--- a/test/simple/test-fs-duplex-stream-end.js
+++ b/test/simple/test-fs-duplex-stream-end.js
@@ -1,0 +1,42 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var fs = require('fs');
+
+(function() {
+  var file = path.join(common.tmpDir, 'write-end-test0.txt');
+  var stream = fs.createDuplexStream(file, { flags: 'w+' });
+  stream.end();
+  stream.on('close', common.mustCall(function() { }));
+})();
+
+(function() {
+  var file = path.join(common.tmpDir, 'write-end-test1.txt');
+  var stream = fs.createDuplexStream(file, { flags: 'w+' });
+  stream.end('a\n', 'utf8');
+  stream.on('close', common.mustCall(function() {
+    var content = fs.readFileSync(file, 'utf8');
+    assert.equal(content, 'a\n');
+  }));
+})();

--- a/test/simple/test-fs-duplex-stream-read-err.js
+++ b/test/simple/test-fs-duplex-stream-read-err.js
@@ -1,0 +1,63 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+
+var stream = fs.createDuplexStream(__filename, {
+  bufferSize: 64
+});
+var err = new Error('BAM');
+
+stream.on('error', common.mustCall(function errorHandler(err_) {
+  console.error('error event');
+  process.nextTick(function() {
+    assert.equal(stream.fd, null);
+    assert.equal(err_, err);
+  });
+}));
+
+fs.close = common.mustCall(function(fd_, cb) {
+  assert.equal(fd_, stream.fd);
+  process.nextTick(cb);
+});
+
+var read = fs.read;
+fs.read = function() {
+  // first time is ok.
+  read.apply(fs, arguments);
+  // then it breaks
+  fs.read = function() {
+    var cb = arguments[arguments.length - 1];
+    process.nextTick(function() {
+      cb(err);
+    });
+    // and should not be called again!
+    fs.read = function() {
+      throw new Error('BOOM!');
+    };
+  };
+};
+
+stream.on('data', function(buf) {
+  stream.on('data', assert.fail);  // no more 'data' events should follow
+});

--- a/test/simple/test-fs-duplex-stream-read-fd.js
+++ b/test/simple/test-fs-duplex-stream-read-fd.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var fs = require('fs');
+var assert = require('assert');
+var path = require('path');
+
+var common = require('../common');
+
+var file = path.join(common.tmpDir, '/duplex_stream_fd_test.txt');
+var input = 'hello world';
+var output = '';
+var fd, stream;
+
+fs.writeFileSync(file, input);
+fd = fs.openSync(file, 'r');
+
+stream = fs.createDuplexStream(null, { fd: fd, encoding: 'utf8' });
+stream.on('data', function(data) {
+  output += data;
+});
+
+process.on('exit', function() {
+  fs.unlinkSync(file);
+  assert.equal(output, input);
+});

--- a/test/simple/test-fs-duplex-stream-resume.js
+++ b/test/simple/test-fs-duplex-stream-resume.js
@@ -1,0 +1,51 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var fs = require('fs');
+var path = require('path');
+
+var file = path.join(common.fixturesDir, 'x.txt');
+var data = '';
+var first = true;
+
+var stream = fs.createDuplexStream(file);
+stream.setEncoding('utf8');
+stream.on('data', function(chunk) {
+  data += chunk;
+  if (first) {
+    first = false;
+    stream.resume();
+  }
+});
+  
+process.nextTick(function() {
+  stream.pause();
+  setTimeout(function() {
+    stream.resume();
+  }, 100);
+});
+
+process.on('exit', function() {
+  assert.equal(data, 'xyz\n');
+});

--- a/test/simple/test-fs-duplex-stream-write-err.js
+++ b/test/simple/test-fs-duplex-stream-write-err.js
@@ -1,0 +1,72 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+
+var stream = fs.createDuplexStream(common.tmpDir + '/out', {
+  highWaterMark: 10,
+  flags : 'w+'
+});
+var err = new Error('BAM');
+
+var write = fs.write;
+var writeCalls = 0;
+fs.write = function() {
+  switch (writeCalls++) {
+    case 0:
+      console.error('first write');
+      // first time is ok.
+      return write.apply(fs, arguments);
+    case 1:
+      // then it breaks
+      console.error('second write');
+      var cb = arguments[arguments.length - 1];
+      return process.nextTick(function() {
+        cb(err);
+      });
+    default:
+      // and should not be called again!
+      throw new Error('BOOM!');
+  }
+};
+
+fs.close = common.mustCall(function(fd_, cb) {
+  console.error('fs.close', fd_, stream.fd);
+  assert.equal(fd_, stream.fd);
+  process.nextTick(cb);
+});
+
+stream.on('error', common.mustCall(function(err_) {
+  console.error('error handler');
+  assert.equal(stream.fd, null);
+  assert.equal(err_, err);
+}));
+
+
+stream.write(new Buffer(256), function() {
+  console.error('first cb');
+  stream.write(new Buffer(256), common.mustCall(function(err_) {
+    console.error('second cb');
+    assert.equal(err_, err);
+  }));
+});

--- a/test/simple/test-fs-duplex-stream.js
+++ b/test/simple/test-fs-duplex-stream.js
@@ -1,0 +1,221 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+var common = require('../common');
+var assert = require('assert');
+
+// TODO Improved this test. test_ca.pem is too small. A proper test would
+// great a large utf8 (with multibyte chars) file and stream it in,
+// performing sanity checks throughout.
+
+var path = require('path');
+var fs = require('fs');
+var fn = path.join(common.fixturesDir, 'elipses.txt');
+var rangeFile = path.join(common.fixturesDir, 'x.txt');
+
+var callbacks = { open: 0, end: 0, close: 0 };
+
+var paused = false;
+
+var file = fs.DuplexStream(fn);
+
+file.on('open', function(fd) {
+  file.length = 0;
+  callbacks.open++;
+  assert.equal('number', typeof fd);
+  assert.ok(file.readable);
+
+  // GH-535
+  file.pause();
+  file.resume();
+  file.pause();
+  file.resume();
+});
+
+file.on('data', function(data) {
+  assert.ok(data instanceof Buffer);
+  assert.ok(!paused);
+  file.length += data.length;
+
+  paused = true;
+  file.pause();
+
+  setTimeout(function() {
+    paused = false;
+    file.resume();
+  }, 10);
+});
+
+
+file.on('end', function(chunk) {
+  callbacks.end++;
+});
+
+
+file.on('close', function() {
+  callbacks.close++;
+
+  //assert.equal(fs.readFileSync(fn), fileContent);
+});
+
+var file3 = fs.createDuplexStream(fn, {encoding: 'utf8'});
+file3.length = 0;
+file3.on('data', function(data) {
+  assert.equal('string', typeof(data));
+  file3.length += data.length;
+
+  for (var i = 0; i < data.length; i++) {
+    // http://www.fileformat.info/info/unicode/char/2026/index.htm
+    assert.equal('\u2026', data[i]);
+  }
+});
+
+file3.on('close', function() {
+  callbacks.close++;
+});
+
+process.on('exit', function() {
+  assert.equal(1, callbacks.open);
+  assert.equal(1, callbacks.end);
+  assert.equal(2, callbacks.close);
+  assert.equal(30000, file.length);
+  assert.equal(10000, file3.length);
+  console.error('ok');
+});
+
+var file4 = fs.createDuplexStream(rangeFile, {bufferSize: 1, start: 1, end: 2});
+var contentRead = '';
+file4.on('data', function(data) {
+  contentRead += data.toString('utf-8');
+});
+file4.on('end', function(data) {
+  assert.equal(contentRead, 'yz');
+});
+
+var file5 = fs.createDuplexStream(rangeFile, {bufferSize: 1, start: 1});
+file5.data = '';
+file5.on('data', function(data) {
+  file5.data += data.toString('utf-8');
+});
+file5.on('end', function() {
+  assert.equal(file5.data, 'yz\n');
+});
+
+// https://github.com/joyent/node/issues/2320
+var file6 = fs.createDuplexStream(rangeFile, {bufferSize: 1.23, start: 1});
+file6.data = '';
+file6.on('data', function(data) {
+  file6.data += data.toString('utf-8');
+});
+file6.on('end', function() {
+  assert.equal(file6.data, 'yz\n');
+});
+
+assert.throws(function() {
+  fs.createDuplexStream(rangeFile, {start: 10, end: 2});
+}, /start must be <= end/);
+
+var stream = fs.createDuplexStream(rangeFile, { start: 0, end: 0 });
+stream.data = '';
+
+stream.on('data', function(chunk) {
+  stream.data += chunk;
+});
+
+stream.on('end', function() {
+  assert.equal('x', stream.data);
+});
+
+// pause and then resume immediately.
+var pauseRes = fs.createDuplexStream(rangeFile);
+pauseRes.pause();
+pauseRes.resume();
+
+var file7 = fs.createDuplexStream(rangeFile, {autoClose: false });
+file7.on('data', function() {});
+file7.on('end', function() {
+  process.nextTick(function() {
+    assert(!file7.closed);
+    assert(!file7.destroyed);
+    file7Next();
+  });
+});
+
+function file7Next(){
+  // This will tell us if the fd is usable again or not.
+  file7 = fs.createDuplexStream(null, {fd: file7.fd, start: 0 });
+  file7.data = '';
+  file7.on('data', function(data) {
+    file7.data += data;
+  });
+  file7.on('end', function(err) {
+    assert.equal(file7.data, 'xyz\n');
+  });
+}
+
+// Just to make sure autoClose won't close the stream because of error.
+var file8 = fs.createDuplexStream(null, {fd: 13337, autoClose: false });
+file8.on('data', function() {});
+file8.on('error', common.mustCall(function() {}));
+
+// Make sure stream is destroyed when file does not exist.
+var file9 = fs.createDuplexStream('/path/to/file/that/does/not/exist');
+file9.on('data', function() {});
+file9.on('error', common.mustCall(function() {}));
+
+process.on('exit', function() {
+  assert(file7.closed);
+  assert(file7.destroyed);
+
+  assert(!file8.closed);
+  assert(!file8.destroyed);
+  assert(file8.fd);
+
+  assert(!file9.closed);
+  assert(file9.destroyed);
+});
+
+
+var file10 = path.join(common.tmpDir, 'write.txt');
+
+(function() {
+  var stream = fs.DuplexStream(file10, { flags : 'w+' }),
+      _fs_close = fs.close;
+
+  fs.close = function(fd) {
+    assert.ok(fd, 'fs.close must not be called without an undefined fd.');
+    fs.close = _fs_close;
+  }
+  stream.destroy();
+})();
+
+(function() {
+  var stream = fs.createDuplexStream(file10, { flags: 'w+' });
+
+  stream.on('drain', function() {
+    assert.fail('\'drain\' event must not be emitted before ' +
+                'stream.write() has been called at least once.');
+  });
+  stream.destroy();
+})();


### PR DESCRIPTION
This adds a `DuplexStream` and matching `createDuplexStream` function to the fs module. Similar to how `Duplex` uses parasitic inheritance from the `Writable` class, I've implemented this by inheriting prototypically from `Duplex` and parasitically from `ReadStream` and `WriteStream`.

Please note that I had to modify slightly the `ReadStream` class to make this work. The only modification necessary was to prefix the `end` member (undocumented and used in a private context), so it is now `_end`. This prevents this field from clashing with the `end` method specified by the `Duplex` stream.
