### PR TITLE
Add require to the global object

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -168,6 +168,7 @@
     global.GLOBAL = global;
     global.root = global;
     global.Buffer = NativeModule.require('buffer').Buffer;
+    global.require = NativeModule.require;
     process.domain = null;
     process._exiting = false;
   };


### PR DESCRIPTION
Following codes are failed to run:

```
var x = new Function('return (' + 'function() {console.log(require)}' + ')')();
x();
```
