### PR TITLE
bugfix. path.isAbsolute (windows platform) should always return boolean

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -206,7 +206,7 @@ if (isWindows) {
   exports.isAbsolute = function(path) {
     var result = splitDeviceRe.exec(path),
         device = result[1] || '',
-        isUnc = device && device.charAt(1) !== ':';
+        isUnc = !!device && device.charAt(1) !== ':';
     // UNC paths are always absolute
     return !!result[2] || isUnc;
   };


### PR DESCRIPTION
### desc

bugfix, `require('path').isAbsolute()` should always return boolean.
### expect (on windows platform)

```
require('path').isAbsolute('directory/directory'); // return false 
```
### actual (on windows platform)

```
require('path').isAbsolute('directory/directory'); // return ""
```
