### PR TITLE
Cluster: fix shared handles on Windows

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1080,17 +1080,6 @@ var createServerHandle = exports._createServerHandle =
     return err;
   }
 
-  if (process.platform === 'win32') {
-    // On Windows, we always listen to the socket before sending it to
-    // the worker (see uv_tcp_duplicate_socket). So we better do it here
-    // so that we can handle any bind-time or listen-time errors early.
-    err = _listen(handle);
-    if (err) {
-      handle.close();
-      return err;
-    }
-  }
-
   return handle;
 };
 
@@ -1098,8 +1087,6 @@ var createServerHandle = exports._createServerHandle =
 Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   debug('listen2', address, port, addressType, backlog);
   var self = this;
-
-  var alreadyListening = false;
 
   // If there is not yet a handle, we need to create one and bind.
   // In the case of a server sent via IPC, we don't need to do this.
@@ -1113,7 +1100,6 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
       });
       return;
     }
-    alreadyListening = (process.platform === 'win32');
     self._handle = rval;
   } else {
     debug('_listen2: have a handle already');
@@ -1122,9 +1108,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   self._handle.onconnection = onconnection;
   self._handle.owner = self;
 
-  var err = 0;
-  if (!alreadyListening)
-    err = _listen(self._handle, backlog);
+  var err = _listen(self._handle, backlog);
 
   if (err) {
     var ex = errnoException(err, 'listen');


### PR DESCRIPTION
This is the Node side of the fix for Node's cluster module on Windows.
https://github.com/joyent/node/issues/7691

The other required part is
https://github.com/joyent/libuv/pull/1384

Windows and Unix return certain socket errors (i.e. EADDRINUSE) at
different times: bind on Windows, and listen on Unix.
In an effort to hide this difference, libuv on Windows stores such
errors in the bind_error field of uv_tcp_t, to defer raising it at
listen time.
This worked fine except for the case in which a socket is shared in
a Node cluster and a bind error occurs.

A previous attempt to fix this (
https://github.com/joyent/libuv/commit/d1e6be1460f555a1f8a4063d7642696aa7238769
https://github.com/joyent/node/commit/3da36fe00e5d85414031ae812e473f16629d8645
) was flawed becaused in an attempt to relay the error at the JS level
it caused the master to start accepting connections.

With this new approach, libuv itself is relaying the bind errors,
providing for a uniform behavior of uv_tcp_listen.
