### PR TITLE
tls: Server should honor previous "timeout" listeners

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -635,6 +635,8 @@ function Server(/* [options], listener */) {
     });
 
     socket.on('secure', function() {
+      // enable normal socket timeout after handshake
+      socket.setTimeout(self.timeout || 0);
       if (socket._requestCert) {
         var verifyError = socket.ssl.verifyError();
         if (verifyError) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -636,7 +636,7 @@ function Server(/* [options], listener */) {
 
     socket.on('secure', function() {
       // enable normal socket timeout after handshake
-      socket.setTimeout(self.timeout || 0);
+      socket.setTimeout(self.timeout | 0);
       if (socket._requestCert) {
         var verifyError = socket.ssl.verifyError();
         if (verifyError) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -636,7 +636,7 @@ function Server(/* [options], listener */) {
 
     socket.on('secure', function() {
       // enable normal socket timeout after handshake
-      socket.setTimeout(self.timeout | 0);
+      socket.setTimeout(self.timeout >>> 0);
       if (socket._requestCert) {
         var verifyError = socket.ssl.verifyError();
         if (verifyError) {

--- a/test/simple/test-https-timeout-server-3.js
+++ b/test/simple/test-https-timeout-server-3.js
@@ -36,7 +36,6 @@ var options = {
 var server = https.createServer(options, assert.fail);
 
 server.setTimeout(50, function() {
-  cleartext.destroy();
   server.close();
 });
 

--- a/test/simple/test-https-timeout-server-3.js
+++ b/test/simple/test-https-timeout-server-3.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) process.exit();
+
+var common = require('../common');
+var assert = require('assert');
+var https = require('https');
+var net = require('net');
+var tls = require('tls');
+var fs = require('fs');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var server = https.createServer(options, assert.fail);
+
+server.setTimeout(50, function() {
+  cleartext.destroy();
+  server.close();
+});
+
+server.listen(common.PORT, function() {
+  tls.connect({
+    host: '127.0.0.1',
+    port: common.PORT,
+    rejectUnauthorized: false
+  });
+});


### PR DESCRIPTION
This fixes #7764 and allows HTTPS servers to follow the same socket timeout behavior as HTTP servers.
