### PR TITLE
tests: fix internet/test-dns.js

### DIFF
--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -447,7 +447,14 @@ TEST(function test_lookupservice_ip_ipv4(done) {
 TEST(function test_lookupservice_ip_ipv6(done) {
   var req = dns.lookupService('::1', 80, function(err, host, service) {
     if (err) throw err;
-    assert.strictEqual(host, 'localhost');
+    /*
+     * On some systems, ::1 can be set to "localhost", on others it
+     * can be set to "ip6-localhost". There does not seem to be
+     * a consensus on that. Ultimately, it could be set to anything
+     * else just by changing /etc/hosts for instance, but it seems
+     * that most sane platforms use either one of these two by default.
+     */
+    assert(host === 'localhost' || host === 'ip6-localhost');
     assert.strictEqual(service, 'http');
 
     done();


### PR DESCRIPTION
internet/test-dns.js assumes that ::1 always resolves to "localhost" on
all platforms. This is not what happens in reality. Some platforms
resolve it to "ip6-localhost" too. There doesn't seem to be any consensus
on what's the right thing to do. However, most sane platforms will use
either one of these two values.
