### PR TITLE
gyp: do not remove unused openssl syms on osx

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -155,6 +155,19 @@
                 # For tests
                 './deps/openssl/openssl.gyp:openssl-cli',
               ],
+              # Do not let unused OpenSSL symbols to slip away
+              'xcode_settings': {
+                'OTHER_LDFLAGS': [
+                  '-Wl,-force_load,<(PRODUCT_DIR)/libopenssl.a',
+                ],
+              },
+              'conditions': [
+                ['OS=="linux"', {
+                  'ldflags': [
+                    '-Wl,--whole-archive <(PRODUCT_DIR)/libopenssl.a -Wl,--no-whole-archive',
+                  ],
+                }],
+              ],
             }]]
         }, {
           'defines': [ 'HAVE_OPENSSL=0' ]


### PR DESCRIPTION
fix #8026

@tjfontaine: I suggest landing it before next v0.10 release
