### PR TITLE
doc: set logical umask in process.umask example

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -683,7 +683,7 @@ Sets or reads the process's file mode creation mask. Child processes inherit
 the mask from the parent process. Returns the old mask if `mask` argument is
 given, otherwise returns the current mask.
 
-    var oldmask, newmask = 0644;
+    var oldmask, newmask = 0022;
 
     oldmask = process.umask(newmask);
     console.log('Changed umask from: ' + oldmask.toString(8) +


### PR DESCRIPTION
0644 seems to be the desired mode for new files (as it is a very
weird umask), and to achieve that the correct umask would be
0022.
