### PR TITLE
test: assert cluster.disconnect is async

### DIFF
--- a/test/simple/test-cluster-disconnect-with-no-workers.js
+++ b/test/simple/test-cluster-disconnect-with-no-workers.js
@@ -31,3 +31,6 @@ process.on('exit', function() {
 cluster.disconnect(function() {
   disconnected = true;
 });
+
+// Assert that callback is not sometimes synchronous
+assert(!disconnected);


### PR DESCRIPTION
See joyent/node#8043, test passed on v0.11 already, but this makes the
test stronger.
