### PR TITLE
tls: throw an error, but a string

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -738,7 +738,7 @@ Server.prototype.setOptions = function(options) {
 // SNI Contexts High-Level API
 Server.prototype.addContext = function(servername, context) {
   if (!servername) {
-    throw 'Servername is required parameter for Server.addContext';
+    throw new Error('Servername is required parameter for Server.addContext');
   }
 
   var re = new RegExp('^' +


### PR DESCRIPTION
We should throw an Error object, but a string.
