### PR TITLE
cluster: disconnect should not be synchronous

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -533,8 +533,10 @@ cluster.disconnect = function(callback) {
     worker.disconnect();
   });
 
-  // in case there weren't any workers
-  progress.check();
+  process.nextTick(function() {
+    // in case there weren't any workers
+    progress.check();
+  });
 };
 
 // Internal function. Called from src/node.js when worker process starts.

--- a/test/simple/test-cluster-disconnect-with-no-workers.js
+++ b/test/simple/test-cluster-disconnect-with-no-workers.js
@@ -1,0 +1,36 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var cluster = require('cluster');
+
+var disconnected;
+
+process.on('exit', function() {
+  assert(disconnected);
+});
+
+cluster.disconnect(function() {
+  disconnected = true;
+});
+
+// Assert that callback is not sometimes synchronous
+assert(!disconnected);


### PR DESCRIPTION
Callbacks in node are usually asynchronous, and should never be
sometimes synchronous, and sometimes asynchronous.

Test is backported from 6f40abe

and enhanced to assert the non-synchronicity of the callback.

This is a reopen of https://github.com/joyent/node/pull/8043, but targetted against v0.10 branch, as it should have been.
