### PR TITLE
path: fix slice OOB in trim

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -269,7 +269,7 @@ if (isWindows) {
       }
 
       if (start > end) return [];
-      return arr.slice(start, end - start + 1);
+      return arr.slice(start, end + 1);
     }
 
     var toParts = trim(to.split('\\'));
@@ -413,7 +413,7 @@ if (isWindows) {
       }
 
       if (start > end) return [];
-      return arr.slice(start, end - start + 1);
+      return arr.slice(start, end + 1);
     }
 
     var fromParts = trim(from.split('/'));


### PR DESCRIPTION
internal function trim(arr). 2nd parameter of slice() should be slice's end index (not included). Because of function normalize() (called before trim()), "start" is always zero so the bug -for now- has no effect, but its a bug waiting to happen.
