### PR TITLE
doc: Tell that net.connect is a shorthand for net.Socket

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -53,8 +53,11 @@ Use `nc` to connect to a UNIX domain socket server:
 ## net.connect(options, [connectionListener])
 ## net.createConnection(options, [connectionListener])
 
-Constructs a new socket object and opens the socket to the given location.
+A factory method, which constructs a new ['net.Socket'](#net_class_net_socket)
+object and opens the socket to the given location.
 When the socket is established, the ['connect'][] event will be emitted.
+
+Has the same events as ['net.Socket'](#net_class_net_socket).
 
 For TCP sockets, `options` argument should be an object which specifies:
 
@@ -106,12 +109,18 @@ Creates a TCP connection to `port` on `host`. If `host` is omitted,
 The `connectListener` parameter will be added as an listener for the
 ['connect'][] event.
 
+A factory method for ['net.Socket'](#net_class_net_socket), so you can look
+at the event for that method.
+
 ## net.connect(path, [connectListener])
 ## net.createConnection(path, [connectListener])
 
 Creates unix socket connection to `path`.
 The `connectListener` parameter will be added as an listener for the
 ['connect'][] event.
+
+A factory method for ['net.Socket'](#net_class_net_socket), so you can look
+at the event for that method.
 
 ## Class: net.Server
 


### PR DESCRIPTION
I is not clear from the documentation that `net.connect` is a shorthand function for `net.Socket`, and therefore it can be diffucult to see what is the difference and what you should use, when there in reality is really no difference.

This commit makes it clearer that `net.connect` function is using `net.Socket`, so you should look at that function.
