### PR TITLE
timers: float delays can cause 100% cpu usage.

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -68,7 +68,7 @@ function insert(item, msecs) {
     L.init(list);
 
     lists[msecs] = list;
-    list.msecs = msecs;
+    list.msecs = Math.round(msecs);
     list.ontimeout = listOnTimeout;
   }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -53,6 +53,9 @@ function insert(item, msecs) {
   item._idleStart = Date.now();
   item._monotonicStartTime = Timer.now();
 
+  // fractional delay values are not allowed; (0, 1) range
+  // should be coerced to 1ms.
+  msecs = Math.ceil(msecs);
   item._idleTimeout = msecs;
 
   if (msecs < 0) return;
@@ -68,7 +71,7 @@ function insert(item, msecs) {
     L.init(list);
 
     lists[msecs] = list;
-    list.msecs = Math.round(msecs);
+    list.msecs = msecs;
     list.ontimeout = listOnTimeout;
   }
 

--- a/test/simple/test-timers-fractional-settimeout.js
+++ b/test/simple/test-timers-fractional-settimeout.js
@@ -1,0 +1,21 @@
+var times = 0;
+
+setInterval(function() {
+  process.stderr.write('.')
+}, 0);
+
+setTimeout(function() {
+  process.exit(times === 3 ? 0 : 1);
+}, 102);
+
+var a = setTimeout(function() {
+  ++times;
+}, 100.3);
+
+var b = setTimeout(function() {
+  ++times;
+}, 4.3);
+
+var c = setTimeout(function() {
+  ++times;
+}, 100);


### PR DESCRIPTION
The changes in befbbad switch all comparisons over to unsigned
integer comparisons, but in certain cases list.msecs will be fractional.
If this is the case, the timer will never be removed from the list.
This fixes the issue by casting msecs to an integer by rounding up
or down.

Fixes #8065.

---

I might need some advice on how best to test this. The below script will intermittently freeze and block the event loop, but I can't reliably trigger this behavior 100% of the time -- there is a small percentage of times where it'll run to completion.

``` javascript
setTimeout(function() {
  console.log('ummm')
}, 100.3)

setTimeout(function() {
  console.log('ERRRR')
}, 4.3)

setTimeout(function() {
  console.log('ok')
}, 100)
```
