### PR TITLE
lib/url.js: Add support for RFC 3490 separators

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -278,18 +278,11 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     }
 
     if (!ipv6Hostname) {
-      // IDNA Support: Returns a puny coded representation of "domain".
-      // It only converts the part of the domain name that
-      // has non ASCII characters. I.e. it dosent matter if
-      // you call it with a domain that already is in ASCII.
-      var domainArray = this.hostname.split('.');
-      var newOut = [];
-      for (var i = 0; i < domainArray.length; ++i) {
-        var s = domainArray[i];
-        newOut.push(s.match(/[^A-Za-z0-9_-]/) ?
-            'xn--' + punycode.encode(s) : s);
-      }
-      this.hostname = newOut.join('.');
+      // IDNA Support: Returns a punycoded representation of "domain".
+      // It only converts parts of the domain name that
+      // have non-ASCII characters, i.e. it doesn't matter if
+      // you call it with a domain that already is ASCII-only.
+      this.hostname = punycode.toASCII(this.hostname);
     }
 
     var p = this.port ? ':' + this.port : '';


### PR DESCRIPTION
There is no need to split the host by hand in `url.js` – Punycode.js takes care of it anyway. This not only simplifies the code, but also adds support for RFC 3490 separators (i.e. not just U+002E, but U+3002, U+FF0E, and U+FF61 as well).

Closes #6055.
