### PR TITLE
bugfix: path.isAbsolute() should always return boolean.

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -206,7 +206,7 @@ if (isWindows) {
   exports.isAbsolute = function(path) {
     var result = splitDeviceRe.exec(path),
         device = result[1] || '',
-        isUnc = device && device.charAt(1) !== ':';
+        isUnc = !!device && device.charAt(1) !== ':';
     // UNC paths are always absolute
     return !!result[2] || isUnc;
   };


### PR DESCRIPTION
In windows version, path.isAbsolute is return '' on failed case.
this patch is fix this issue, so that it will return false on failed case.

on windows version: 
- before: `path.isAbsolute('directory/directory'); // return ''`
- now: `path.isAbsolute('directory/directory'); // return false`
