### PR TITLE
timers: fix timers with non-integer delay hanging.

### DIFF
--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -168,6 +168,7 @@ class TimerWrap : public HandleWrap {
   static Handle<Value> Now(const Arguments& args) {
     HandleScope scope;
 
+    uv_update_time(uv_default_loop());
     double now = static_cast<double>(uv_now(uv_default_loop()));
     return scope.Close(v8::Number::New(now));
   }

--- a/test/simple/test-timers-first-fire.js
+++ b/test/simple/test-timers-first-fire.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var TIMEOUT = 50;
+var last = process.hrtime();
+setTimeout(function() {
+  var hr = process.hrtime(last);
+  var ms = (hr[0] * 1e3) + (hr[1] / 1e6);
+  var delta = ms - TIMEOUT;
+  console.log('timer fired in', delta);
+  assert.ok(delta > 0, 'Timer fired early');
+}, TIMEOUT);


### PR DESCRIPTION
When backporting f8193ab into v0.10, a regression was introduced. Timers
with non-integer timeout could trigger a infinite recursion with 100%
cpu usage. This commit backports 93b0624 which fixes the regression.

After backporting f8193ab, instead of using Date.now(), timers would use
Timer.now() to determine if they had expired. However, Timer.now() is
based on loop->time, which is not updated when a timer's remaining time
is > 0 and < 1. Timers would thus never timeout if their remaining time
was at some point > 0 and < 1.

With this commit, Timer.now() updates loop->time itself, and timers
always timeout eventually.

Fixes #8065 and #8068.
