### PR TITLE
build: MSVC no warnings in `node` target

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -151,7 +151,9 @@
         ],
       },
     },
-    'msvs_disabled_warnings': [4351, 4355, 4800],
+    # 4267 - when passing an int64 as int, and truncation might happen (depends on linkage)
+    # 4244 - when passing an int64 as int, and truncation will happen
+    'msvs_disabled_warnings': [4351, 4355, 4800, 4267, 4244],
     'conditions': [
       ['OS == "win"', {
         'msvs_cygwin_shell': 0, # prevent actions from trying to use cygwin

--- a/node.gyp
+++ b/node.gyp
@@ -158,12 +158,22 @@
       'defines': [
         'NODE_WANT_INTERNALS=1',
         'ARCH="<(target_arch)"',
-        'PLATFORM="<(OS)"',
         'NODE_TAG="<(node_tag)"',
         'NODE_V8_OPTIONS="<(node_v8_options)"',
       ],
 
       'conditions': [
+        [ 'OS=="win"', {
+            'defines': [
+# we need to use node's preferred "win32" rather than gyp's preferred "win"
+              'PLATFORM="win32"'
+            ]
+          }, {
+            'defines': [
+              'PLATFORM="<(OS)"'
+            ]
+          }
+        ],
         [ 'node_use_openssl=="true"', {
           'defines': [ 'HAVE_OPENSSL=1' ],
           'sources': [
@@ -357,6 +367,9 @@
       'msvs_settings': {
         'VCLinkerTool': {
           'SubSystem': 1, # /subsystem:console
+        },
+        'VCCLCompilerTool':{
+          'WarnAsError': 'true',
         },
       },
     },

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -66,6 +66,9 @@ using v8::Value;
 
 #define THROW_BAD_ARGS TYPE_ERROR("Bad argument")
 
+#ifdef _MSC_VER
+  #pragma warning( disable: 4291 ) 
+#endif
 class FSReqWrap: public ReqWrap<uv_fs_t> {
  public:
   void* operator new(size_t size) { return new char[size]; }

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -122,6 +122,11 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
   OSVERSIONINFO info;
 
   info.dwOSVersionInfoSize = sizeof(info);
+#ifdef _MSC_VER
+  #pragma warning( disable: 4996 ) 
+  // `GetVersionEx` has been deprecated. It seems that it will only report the
+  // version this code is build for (so it can be mocked during build)
+#endif
   if (GetVersionEx(&info) == 0)
     return;
 

--- a/src/node_win32_etw_provider.h
+++ b/src/node_win32_etw_provider.h
@@ -92,8 +92,8 @@ INLINE bool NODE_NET_SOCKET_READ_ENABLED();
 INLINE bool NODE_NET_SOCKET_WRITE_ENABLED();
 INLINE bool NODE_V8SYMBOL_ENABLED();
 
-#define NODE_NET_SOCKET_READ(arg0, arg1)
-#define NODE_NET_SOCKET_WRITE(arg0, arg1)
+#define NODE_NET_SOCKET_READ(arg0, arg1, arg2, arg3, arg4)
+#define NODE_NET_SOCKET_WRITE(arg0, arg1, arg2, arg3, arg4)
 }  // namespace node
 
 #endif  // SRC_NODE_WIN32_ETW_PROVIDER_H_

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -183,7 +183,7 @@ size_t base64_decode(char* buf,
   const TypeName* srcEnd = src + srcLen;
 
   while (src < srcEnd && dst < dstEnd) {
-    int remaining = srcEnd - src;
+    size_t remaining = (srcEnd - src);
 
     while (unbase64(*src) < 0 && src < srcEnd)
       src++, remaining--;


### PR DESCRIPTION
Enable "Treat warnings as errors"

Removed/Silenced:
4005 - about redefinition of `PLATFORM` symbol
4996 - For the visible future I don't think we should be worried about the change in semantics of  `GetVersionEx`
4291 - for the `new` operator that has non side effects in FSReqWrap `void *node::FSReqWrap::operator new(size_t,char *)`
4267 - when passing an int64 as int, and truncation might happen (depends on linkage)
4244 - when passing an int64 as int, and truncation will happen

align macros between dtrace and ETW removes warnings:
NODE\SRC\NODE_DTRACE.CC(180) : warning C4002: too many actual parameters for macro 'NODE_NET_SOCKET_READ'
NODE\SRC\NODE_DTRACE.CC(196) : warning C4002: too many actual parameters for macro 'NODE_NET_SOCKET_WRITE'
