### PR TITLE
fs: fix fs.readFileSync fd leak when get RangeError

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -328,7 +328,13 @@ fs.readFileSync = function(path, options) {
   if (size === 0) {
     buffers = [];
   } else {
-    buffer = new Buffer(size);
+    var threw = true;
+    try {
+      buffer = new Buffer(size);
+      threw = false;
+    } finally {
+      if (threw) fs.closeSync(fd);
+    }
   }
 
   var done = false;


### PR DESCRIPTION
The `new Buffer(size)` will throw RangeError when size grater than 1GB. Need close the fd here.
