### PR TITLE
src: expose libuv handle/req id on process object

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -58,6 +58,9 @@ inline AsyncWrap::AsyncWrap(Environment* env,
       async_flags_(NO_OPTIONS),
       provider_type_(provider),
       id_(env->NewUniqueId()) {
+  object->Set(env->id_string(),
+              v8::Number::New(env->isolate(), static_cast<double>(id())));
+
   if (!env->has_async_listener())
     return;
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -65,6 +65,8 @@ class AsyncWrap : public BaseObject {
 
   inline bool has_async_listener();
 
+  inline uint64_t id() const;
+
   inline uint32_t provider_type() const;
 
   // Only call these within a valid HandleScope.
@@ -79,6 +81,15 @@ class AsyncWrap : public BaseObject {
                                             v8::Handle<v8::Value>* argv);
 
  private:
+  struct ScopedExposeId {
+   public:
+    inline explicit ScopedExposeId(AsyncWrap* wrap);
+    inline ~ScopedExposeId();
+   private:
+    double* const uv_context_id_pointer_;
+    const double previous_value_;
+  };
+
   inline AsyncWrap();
 
   // TODO(trevnorris): BURN IN FIRE! Remove this as soon as a suitable
@@ -90,6 +101,7 @@ class AsyncWrap : public BaseObject {
 
   uint32_t async_flags_;
   uint32_t provider_type_;
+  const uint64_t id_;
 };
 
 }  // namespace node

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -230,6 +230,8 @@ inline Environment::Environment(v8::Local<v8::Context> context)
       using_smalloc_alloc_cb_(false),
       using_domains_(false),
       printed_error_(false),
+      unique_id_(0),
+      uv_context_id_(0),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());
@@ -252,6 +254,10 @@ inline Environment::~Environment() {
 
 inline void Environment::Dispose() {
   delete this;
+}
+
+inline uint64_t Environment::NewUniqueId() {
+  return ++unique_id_;
 }
 
 inline v8::Isolate* Environment::isolate() const {
@@ -342,6 +348,10 @@ inline bool Environment::printed_error() const {
 
 inline void Environment::set_printed_error(bool value) {
   printed_error_ = value;
+}
+
+inline double* Environment::uv_context_id_pointer() {
+  return &uv_context_id_;
 }
 
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {

--- a/src/env.h
+++ b/src/env.h
@@ -252,6 +252,7 @@ namespace node {
   V(domain_array, v8::Array)                                                  \
   V(fs_stats_constructor_function, v8::Function)                              \
   V(gc_info_callback_function, v8::Function)                                  \
+  V(handle_close_callback, v8::Function)                                      \
   V(module_load_list_array, v8::Array)                                        \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \
   V(process_object, v8::Object)                                               \

--- a/src/env.h
+++ b/src/env.h
@@ -79,6 +79,7 @@ namespace node {
   V(disposed_string, "_disposed")                                             \
   V(domain_string, "domain")                                                  \
   V(exchange_string, "exchange")                                              \
+  V(id_string, "id")                                                          \
   V(idle_string, "idle")                                                      \
   V(irq_string, "irq")                                                        \
   V(enter_string, "enter")                                                    \

--- a/src/env.h
+++ b/src/env.h
@@ -364,6 +364,8 @@ class Environment {
 
   void AssignToContext(v8::Local<v8::Context> context);
 
+  inline uint64_t NewUniqueId();
+
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
   inline bool has_async_listener() const;
@@ -398,6 +400,8 @@ class Environment {
 
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
+
+  inline double* uv_context_id_pointer();
 
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
@@ -460,6 +464,8 @@ class Environment {
   bool using_domains_;
   QUEUE gc_tracker_queue_;
   bool printed_error_;
+  uint64_t unique_id_;
+  double uv_context_id_;
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -114,6 +114,7 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   HandleWrap* wrap = static_cast<HandleWrap*>(handle->data);
   Environment* env = wrap->env();
   HandleScope scope(env->isolate());
+  Context::Scope context_scope(env->context());
 
   // The wrap object should still be there.
   assert(wrap->persistent().IsEmpty() == false);
@@ -121,8 +122,6 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   // But the handle pointer should be gone.
   assert(wrap->handle__ == NULL);
 
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
   Local<Object> object = wrap->object();
 
   if (wrap->flags_ & kCloseCallback) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -116,6 +116,7 @@ using v8::TryCatch;
 using v8::Uint32;
 using v8::V8;
 using v8::Value;
+using v8::kExternalFloat64Array;
 using v8::kExternalUnsignedIntArray;
 
 // FIXME(bnoordhuis) Make these per-context?
@@ -2591,6 +2592,13 @@ void SetupProcessObject(Environment* env,
   HandleScope scope(env->isolate());
 
   Local<Object> process = env->process_object();
+
+  // Node.js attaches a unique id to libuv handles and requests that is
+  // exposed to JS land as a single-element typed array-ish object.
+  Local<Object> uv_context_id_obj = Object::New(env->isolate());
+  uv_context_id_obj->SetIndexedPropertiesToExternalArrayData(
+      env->uv_context_id_pointer(), kExternalFloat64Array, 1);
+  READONLY_PROPERTY(process, "_uvContextId", uv_context_id_obj);
 
   process->SetAccessor(env->title_string(),
                        ProcessTitleGetter,

--- a/src/node.cc
+++ b/src/node.cc
@@ -2274,6 +2274,27 @@ static void ProcessTitleSetter(Local<String> property,
 }
 
 
+static void GetHandleCloseCallback(Local<String>,
+                                   const PropertyCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info.GetIsolate());
+  HandleScope scope(env->isolate());
+  Local<Function> handle_close_callback = env->handle_close_callback();
+  if (handle_close_callback.IsEmpty()) return;
+  info.GetReturnValue().Set(handle_close_callback);
+}
+
+
+
+static void SetHandleCloseCallback(Local<String>,
+                                   Local<Value> value,
+                                   const PropertyCallbackInfo<void>& info) {
+  Environment* env = Environment::GetCurrent(info.GetIsolate());
+  HandleScope scope(env->isolate());
+  env->set_handle_close_callback(
+      value->IsFunction() ? value.As<Function>() : Local<Function>());
+}
+
+
 static void EnvGetter(Local<String> property,
                       const PropertyCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info.GetIsolate());
@@ -2599,6 +2620,11 @@ void SetupProcessObject(Environment* env,
   uv_context_id_obj->SetIndexedPropertiesToExternalArrayData(
       env->uv_context_id_pointer(), kExternalFloat64Array, 1);
   READONLY_PROPERTY(process, "_uvContextId", uv_context_id_obj);
+
+  process->SetAccessor(
+      FIXED_ONE_BYTE_STRING(env->isolate(), "_uvHandleCloseCallback"),
+      GetHandleCloseCallback,
+      SetHandleCloseCallback);
 
   process->SetAccessor(env->title_string(),
                        ProcessTitleGetter,


### PR DESCRIPTION
Assign numeric identifiers to libuv handle and request wrappers and
expose them to JS land as process._uvContextId[0].  Provides an ersatz
"thread-local" state for tracking execution across asynchronous calls.

Future optimization: reuse identifiers so they keep fitting in a SMI?

R=@trevnorris?

This PR is a conversation starter.  The goal is to have a cheap way of tracking the flow of execution across callbacks for instrumentation purposes.
