### PR TITLE
build: linking CoreFoundation framework for OSX

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -306,6 +306,9 @@
           'defines': [ '__POSIX__' ],
         }],
         [ 'OS=="mac"', {
+          # linking Corefoundation is needed since certain OSX debugging tools
+          # like Instruments require it for some features 
+          'libraries': [ '-framework CoreFoundation' ],
           'defines!': [
             'PLATFORM="mac"',
           ],


### PR DESCRIPTION
Even though libuv has no link time dependencies, linking CoreFoundation for OSX
is needed for OSX debugging features to function properly.
### Without linking CoreFoundation

We get a warning about certain heap debugging features not working.

![screen shot 2014-08-06 at 2 04 45 pm](https://cloud.githubusercontent.com/assets/192891/3831583/06b41f38-1d95-11e4-990e-6a4241fe7fd6.png)
### Linking CoreFoundation

When we link CoreFoundation everything works just fine.

![screen shot 2014-08-06 at 2 05 49 pm](https://cloud.githubusercontent.com/assets/192891/3831588/10a3e3d4-1d95-11e4-8e32-2732972cb999.png)
