### PR TITLE
dns: don't use AI_V4MAPPED unless IPv6 is explicitly specified

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -888,8 +888,10 @@ Socket.prototype.connect = function(options, cb) {
       hints: 0
     };
 
-    if (dnsopts.family !== 4 && dnsopts.family !== 6)
-      dnsopts.hints = dns.ADDRCONFIG | dns.V4MAPPED;
+    if (dnsopts.family === 6)
+      dnsopts.hints = dns.V4MAPPED;
+    else if (dnsopts.family !== 4)
+      dnsopts.hints = dns.ADDRCONFIG;
 
     debug('connect: find host ' + host);
     debug('connect: dns options ' + dnsopts);


### PR DESCRIPTION
`AI_V4MAPPED` is only applicable when using IPv6, so don't bother using it unless `AF_INET6` is specified.

@misterdjules if this still causes a problem, I can remove it from `lib/net.js` completely.
