### PR TITLE
doc: document arguments for 'error' event on a stream

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -183,6 +183,8 @@ descriptor) has been closed. Not all streams will emit this.
 
 #### Event: 'error'
 
+* {Error Object}
+
 Emitted if there was an error receiving data.
 
 #### readable.read([size])
@@ -578,6 +580,8 @@ reader.unpipe(writer);
 ```
 
 #### Event: 'error'
+
+* {Error object}
 
 Emitted if there was an error when writing or piping data.
 


### PR DESCRIPTION
Fixes #6361.
