### PR TITLE
dns: fix support for passing a number as second lookup() arg

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -102,7 +102,7 @@ function onlookup(err, addresses) {
 // lookup(hostname, [options,] callback)
 exports.lookup = function lookup(hostname, options, callback) {
   var hints = 0;
-  var family = 0;
+  var family = -1;
 
   // Parse arguments
   if (typeof options === 'function') {
@@ -120,6 +120,8 @@ exports.lookup = function lookup(hostname, options, callback) {
         hints !== (exports.ADDRCONFIG | exports.V4MAPPED)) {
       throw new TypeError('invalid argument: hints must use valid flags');
     }
+  } else {
+    family = options >>> 0;
   }
 
   if (family !== 0 && family !== 4 && family !== 6)


### PR DESCRIPTION
This was a regression in e643fe4. @trevnorris this addresses the comment in https://github.com/joyent/node/commit/e643fe4c4b79f2683914c6435f7166fc6be9f1a7#commitcomment-7305948. I added back the removed `else` branch. I also initialized `family` to a value that will not pass validation on line 127.
