### PR TITLE
dns: support passing integer as option to lookup()

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -110,6 +110,9 @@ exports.lookup = function lookup(hostname, options, callback) {
     family = 0;
   } else if (typeof callback !== 'function') {
     throw TypeError('invalid arguments: callback must be passed');
+  } else if (util.isNumber(options)) {
+    hints = 0;
+    family = options >>> 0;
   } else if (util.isObject(options)) {
     hints = options.hints >>> 0;
     family = options.family >>> 0;

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -114,3 +114,18 @@ assert.doesNotThrow(function() {
     hints: dns.ADDRCONFIG | dns.V4MAPPED
   }, noop);
 });
+
+// test passing a number as family works
+dns.lookup('www.google.com', 6, function(err, addr, family) {
+  if (err) {
+    console.error('Looks like IPv6 is not really supported');
+    console.error(err);
+    return;
+  }
+
+  dns.lookup('www.google.com', { family: 6 }, function (err, _addr, _family) {
+    assert.ifError(err);
+    assert.equal(addr, _addr);
+    assert.equal(family, _family);
+  });
+});


### PR DESCRIPTION
Node 0.10 behaviour, has since been replaced by an options argument but
the ability to pass an integer, even though it's mentioned in the docs,
is not supported and some tests still use integer-arg for dns.lookup()
