### PR TITLE
tests: do not hardcode service name in test-dns.

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -219,3 +219,58 @@ exports.checkSpawnSyncRet = function(ret) {
   assert.strictEqual(ret.status, 0);
   assert.strictEqual(ret.error, undefined);
 };
+
+var etcServicesFileName = path.join('/etc', 'services');
+if (process.platform === 'win32') {
+  etcServicesFileName = path.join(process.env.windir, 'System32', 'drivers',
+    'etc', 'services');
+}
+
+/*
+ * Returns a string that represents the service name associated
+ * to the service bound to port "port" and using protocol "protocol".
+ *
+ * If the service is not defined in the services file, it returns
+ * the port number as a string.
+ *
+ * Returns undefined if /etc/services (or its equivalent on non-UNIX
+ * platforms) can't be read.
+ */
+exports.getServiceName = function getServiceName(port, protocol) {
+  if (port == null) {
+    throw new Error("Missing port number");
+  }
+
+  if (typeof protocol !== 'string') {
+    throw new Error("Protocol must be a string");
+  }
+
+  /*
+   * By default, if a service can't be found in /etc/services,
+   * its name is considered to be its port number.
+   */
+  var serviceName = port.toString();
+
+  try {
+    /*
+     * I'm not a big fan of readFileSync, but reading /etc/services asynchronously
+     * here would require implementing a simple line parser, which seems overkill
+     * for a simple utility function that is not running concurrently with any
+     * other one.
+     */
+    var servicesContent = fs.readFileSync(etcServicesFileName,
+      { encoding: 'utf8'});
+    var regexp = util.format('^(\\w+)\\s+\\s%d/%s\\s', port, protocol);
+    var re = new RegExp(regexp, 'm');
+
+    var matches = re.exec(servicesContent);
+    if (matches && matches.length > 1) {
+      serviceName = matches[1];
+    }
+  } catch(e) {
+    console.error('Cannot read file: ', etcServicesFileName);
+    return undefined;
+  }
+
+  return serviceName;
+}

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -495,7 +495,23 @@ TEST(function test_lookupservice_ip_ipv4(done) {
   var req = dns.lookupService('127.0.0.1', 80, function(err, host, service) {
     if (err) throw err;
     assert.strictEqual(host, 'localhost');
-    assert.strictEqual(service, 'http');
+
+    /*
+     * Retrieve the actual HTTP service name as setup on the host currently
+     * running the test by reading it from /etc/services. This is not ideal,
+     * as the service name lookup could use another mechanism (e.g nscd), but
+     * it's already better than hardcoding it.
+     */
+    var httpServiceName = common.getServiceName(80, 'tcp');
+    if (!httpServiceName) {
+      /*
+       * Couldn't find service name, reverting to the most sensible default
+       * for port 80.
+       */
+      httpServiceName = 'http';
+    }
+
+    assert.strictEqual(service, httpServiceName);
 
     done();
   });
@@ -515,7 +531,23 @@ TEST(function test_lookupservice_ip_ipv6(done) {
      * that most sane platforms use either one of these two by default.
      */
     assert(host === 'localhost' || host === 'ip6-localhost');
-    assert.strictEqual(service, 'http');
+
+    /*
+     * Retrieve the actual HTTP service name as setup on the host currently
+     * running the test by reading it from /etc/services. This is not ideal,
+     * as the service name lookup could use another mechanism (e.g nscd), but
+     * it's already better than hardcoding it.
+     */
+    var httpServiceName = common.getServiceName(80, 'tcp');
+    if (!httpServiceName) {
+      /*
+       * Couldn't find service name, reverting to the most sensible default
+       * for port 80.
+       */
+      httpServiceName = 'http';
+    }
+
+    assert.strictEqual(service, httpServiceName);
 
     done();
   });


### PR DESCRIPTION
Instead of hard-coding http service name in test-dns, retrieve it from /etc/services. This is not ideal, but it's still better than hard-coding it.

I initially implemented it by reading from /etc/services asynchronously, but it lead to me writing line parsing code that seemed a bit overkill in this tiny utility module. I don't think it's worth it now, because we don't run tests concurrently. If you'd rather have me revert to this async behavior, I'll be happy to update the PR. 

Tested on OS X, Windows, Ubuntu and SmartOS.

Fixes #8047.
