### PR TITLE
net: Add address & port info into listen error message

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1120,7 +1120,8 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   var err = _listen(self._handle, backlog);
 
   if (err) {
-    var ex = errnoException(err, 'listen');
+    var original = ', listen "' + address + ':' + port + '"';
+    var ex = errnoException(err, 'listen', original);
     self._handle.close();
     self._handle = null;
     process.nextTick(function() {


### PR DESCRIPTION
```
events.js:82
      throw er; // Unhandled 'error' event
            ^
Error: listen EADDRINUSE, listen "0.0.0.0:8000"
    at exports._errnoException (util.js:745:11)
    at Server._listen2 (net.js:1146:14)
    at listen (net.js:1168:10)
    at Server.listen (net.js:1243:5)
    at Function.app.listen (/usr/local/lib/node_modules/anywhere/node_modules/connect/lib/proto.js:229:24)
    at Object.<anonymous> (/usr/local/lib/node_modules/anywhere/bin/anywhere:63:5)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
```
