### PR TITLE
test: check return address family when detecting IPv6

### DIFF
--- a/test/simple/test-net-connect-options-ipv6.js
+++ b/test/simple/test-net-connect-options-ipv6.js
@@ -27,8 +27,8 @@ var dns = require('dns');
 var serverGotEnd = false;
 var clientGotEnd = false;
 
-dns.lookup('localhost', 6, function(err) {
-  if (err) {
+dns.lookup('localhost', 6, function(err, _, family) {
+  if (err || family !== 6) {
     console.error('Looks like IPv6 is not really supported');
     console.error(err);
     return;


### PR DESCRIPTION
According to our documentation:

> The callback has arguments (err, address, family). The address
> argument is a string representation of a IP v4 or v6 address. The
> family argument is either the integer 4 or 6 and denotes the family of
> address (not necessarily the value initially passed to lookup).

This fixes this test on CentOS 5.10.
