### PR TITLE
events: use emitter.listeners for listenerCount

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -306,12 +306,5 @@ EventEmitter.prototype.listeners = function listeners(type) {
 };
 
 EventEmitter.listenerCount = function(emitter, type) {
-  var ret;
-  if (!emitter._events || !emitter._events[type])
-    ret = 0;
-  else if (util.isFunction(emitter._events[type]))
-    ret = 1;
-  else
-    ret = emitter._events[type].length;
-  return ret;
+  return emitter.listeners(type).length;
 };


### PR DESCRIPTION
Call `emitter.listeners(type).length` directly will simplify `EventEmitter.listenerCount(emitter, type)`.

```
EventEmitter.prototype.listeners = function listeners(type) {
  var ret;
  if (!this._events || !this._events[type])
    ret = [];
  else if (util.isFunction(this._events[type]))
    ret = [this._events[type]];
  else
    ret = this._events[type].slice();
  return ret;
};
```

```
EventEmitter.listenerCount = function(emitter, type) {
  var ret;
  if (!emitter._events || !emitter._events[type])
    ret = 0;
  else if (util.isFunction(emitter._events[type]))
    ret = 1;
  else
    ret = emitter._events[type].length;
  return ret;
};
```

```
jacksontian node_research $ node count.js 
EventEmitter.listenerCount x 6,859,500 ops/sec ±1.67% (88 runs sampled)
emitter.listeners(type).length x 5,783,443 ops/sec ±1.74% (89 runs sampled)
Fastest is EventEmitter.listenerCount
```

wtf.
