### PR TITLE
tests: don't assume IPv4 only in remote addr tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -22,6 +22,7 @@
 var path = require('path');
 var fs = require('fs');
 var assert = require('assert');
+var os = require('os');
 
 exports.testDir = path.dirname(__filename);
 exports.fixturesDir = path.join(exports.testDir, 'fixtures');
@@ -45,6 +46,13 @@ if (process.platform === 'win32') {
   exports.faketimeCli = path.join(__dirname, "..", "tools", "faketime", "src",
     "faketime");
 }
+
+var ifaces = os.networkInterfaces();
+exports.hasIPv6 = Object.keys(ifaces).some(function(name) {
+  return /lo/.test(name) && ifaces[name].some(function(info) {
+    return info.family === 'IPv6';
+  });
+});
 
 var util = require('util');
 for (var i in util) exports[i] = util[i];

--- a/test/simple/test-dgram-bind-default-address.js
+++ b/test/simple/test-dgram-bind-default-address.js
@@ -29,6 +29,11 @@ dgram.createSocket('udp4').bind(common.PORT + 0, common.mustCall(function() {
   this.close();
 }));
 
+if (!common.hasIPv6) {
+  console.error('Skipping udp6 part of test, no IPv6 support');
+  return;
+}
+
 dgram.createSocket('udp6').bind(common.PORT + 1, common.mustCall(function() {
   assert.equal(this.address().port, common.PORT + 1);
   var address = this.address().address;

--- a/test/simple/test-net-connect-options-ipv6.js
+++ b/test/simple/test-net-connect-options-ipv6.js
@@ -24,6 +24,11 @@ var assert = require('assert');
 var net = require('net');
 var dns = require('dns');
 
+if (!common.hasIPv6) {
+  console.error('Skipping test, no IPv6 support');
+  return;
+}
+
 var serverGotEnd = false;
 var clientGotEnd = false;
 

--- a/test/simple/test-net-pingpong.js
+++ b/test/simple/test-net-pingpong.js
@@ -135,9 +135,13 @@ console.log(common.PIPE);
 pingPongTest(common.PIPE);
 pingPongTest(common.PORT);
 pingPongTest(common.PORT + 1, 'localhost');
-pingPongTest(common.PORT + 2, '::1');
+if (common.hasIPv6)
+  pingPongTest(common.PORT + 2, '::1');
 
 process.on('exit', function() {
-  assert.equal(4, tests_run);
+  if (common.hasIPv6)
+    assert.equal(4, tests_run);
+  else
+    assert.equal(3, tests_run);
   console.log('done');
 });

--- a/test/simple/test-net-remote-address-port.js
+++ b/test/simple/test-net-remote-address-port.js
@@ -26,10 +26,16 @@ var net = require('net');
 
 var conns = 0, conns_closed = 0;
 
+var remoteAddrCandidates = [ '127.0.0.1'];
+if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
+
+var remoteFamilyCandidates = ['IPv4'];
+if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
+
 var server = net.createServer(function(socket) {
   conns++;
-  assert.equal('127.0.0.1', socket.remoteAddress);
-  assert.equal('IPv4', socket.remoteFamily);
+  assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));
+  assert.notEqual(-1, remoteFamilyCandidates.indexOf(socket.remoteFamily));
   assert.ok(socket.remotePort);
   assert.notEqual(socket.remotePort, common.PORT);
   socket.on('end', function() {
@@ -42,14 +48,14 @@ server.listen(common.PORT, 'localhost', function() {
   var client = net.createConnection(common.PORT, 'localhost');
   var client2 = net.createConnection(common.PORT);
   client.on('connect', function() {
-    assert.equal('127.0.0.1', client.remoteAddress);
-    assert.equal('IPv4', client.remoteFamily);
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(client.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(client.remoteFamily));
     assert.equal(common.PORT, client.remotePort);
     client.end();
   });
   client2.on('connect', function() {
-    assert.equal('127.0.0.1', client2.remoteAddress);
-    assert.equal('IPv4', client2.remoteFamily);
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
     assert.equal(common.PORT, client2.remotePort);
     client2.end();
   });

--- a/test/simple/test-net-server-address.js
+++ b/test/simple/test-net-server-address.js
@@ -57,6 +57,11 @@ server_ipv6.listen(common.PORT, localhost_ipv6, function() {
   server_ipv6.close();
 });
 
+if (!common.hasIPv6) {
+  console.error('Skipping ipv6 part of test, no IPv6 support');
+  return;
+}
+
 // Test without hostname or ip
 var anycast_ipv6 = '::';
 var server1 = net.createServer();


### PR DESCRIPTION
Tests in test-net-remote-address-port.js assume that client and server
sockets always use IPv4. However, depending on the OS and the network
interfaces setup, this is not true. This change makes the test consider
that both IPv4 or IPv6 sockets are valid.

Tested on OS X, SmartOS, Ubuntu and Windows 7.

Fixes #8096.
