### PR TITLE
tests: fix invalid hints flags dns test.

### DIFF
--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -69,8 +69,18 @@ assert.throws(function() {
   return !(err instanceof TypeError);
 }, 'Unexpected error');
 
+/*
+ * Make sure that dns.lookup throws if hints does not represent a valid flag.
+ * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:
+ * - it's different from dns.V4MAPPED and dns.ADDRCONFIG.
+ * - it's different from them bitwise ored.
+ * - it's different from 0.
+ * - it's an odd number different than 1, and thus is invalid, because
+ * flags are either === 1 or even.
+ */
 assert.throws(function() {
-  dns.lookup('www.google.com', { hints: 1 }, noop);
+  dns.lookup('www.google.com', { hints: (dns.V4MAPPED | dns.ADDRCONFIG) + 1 },
+    noop);
 });
 
 assert.throws(function() {


### PR DESCRIPTION
1 is actually a valid flag on SmartOS. More generally, hints flags'
values are defined by the underlying native flags, and these can have
different values on different systems.

Using (ADDRCONFIG | V4MAPPED) + 1 ensure that the flag will be invalid,
since it will always be different from ADDRCONFIG, V4MAPPED, ADDRCONFIG
| V4MAPPED,  0, 1 and any other combination of even flags.
