### PR TITLE
module: normalize path when computing cache key.

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -276,8 +276,9 @@ Module._load = function(request, parent, isMain) {
   }
 
   var filename = Module._resolveFilename(request, parent);
+  var cacheKey = path.normalize(filename);
 
-  var cachedModule = Module._cache[filename];
+  var cachedModule = Module._cache[cacheKey];
   if (cachedModule) {
     return cachedModule.exports;
   }
@@ -302,7 +303,7 @@ Module._load = function(request, parent, isMain) {
     module.id = '.';
   }
 
-  Module._cache[filename] = module;
+  Module._cache[cacheKey] = module;
 
   var hadException = true;
 
@@ -311,7 +312,7 @@ Module._load = function(request, parent, isMain) {
     hadException = false;
   } finally {
     if (hadException) {
-      delete Module._cache[filename];
+      delete Module._cache[cacheKey];
     }
   }
 

--- a/test/simple/test-module-multiple-loading.js
+++ b/test/simple/test-module-multiple-loading.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * This test ensures that even when required with different file paths that
+ * all resolve to the same path, a given module is loaded only once.
+ */
+var assert = require('assert');
+
+// Track how many times the module is loaded
+if (global.nbTimesLoaded === undefined) {
+    global.nbTimesLoaded = 1;
+} else {
+    global.nbTimesLoaded += 1;
+}
+
+var path = require('path');
+
+/*
+ * Build a path such as /path/to/module/../module/module.js and load
+ * the module again.
+ */
+var moduleFilename = path.basename(__filename);
+var moduleDir = path.dirname(__filename);
+var moduleDirComponents = moduleDir.split(path.sep);
+var moduleParentDirName = moduleDirComponents[moduleDirComponents.length - 1];
+var complexFilename = path.join(moduleDir, '..',
+                                moduleParentDirName,
+                                moduleFilename);
+require(complexFilename);
+
+/*
+ * Load the module again, this time with the same filename.
+ */
+require(__filename);
+
+/*
+ * Load the module again after applying join, which normalizes the filename.
+ * On windows, it changes the drive letter to lower case and thus changes the
+ * filename passed to it.
+ */
+require(path.join(__filename));
+
+assert(global.nbTimesLoaded === 1);


### PR DESCRIPTION
When adding a new module to the cache, and also when querying the cache,
normalize the path so that modules don't get loaded more than once when:
- They are referenced by the same file name but with different case for
  the drive letter on Windows.
- They are referenced by two different paths that point to the same
  file.

Tested on Windows, Ubuntu 12.04, MacOS X and SmartOS.

Fixes #7031.
