### PR TITLE
Fix issue with querystring on relative paths

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -132,7 +132,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = querystring.parse(this.search);
+          this.query = querystring.parse(this.search.substr(1));
         } else {
           this.query = this.search.substr(1);
         }

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -867,6 +867,20 @@ var parseTestsWithQueryString = {
     'search': '',
     'pathname': '/',
     'path': '/'
+  },
+  '/example?query=value':{
+    protocol: null,
+    slashes: null,
+    auth: null,
+    host: null,
+    port: null,
+    hostname: null,
+    hash: null,
+    search: '?query=value',
+    query: { query: 'value' },
+    pathname: '/example',
+    path: '/example?query=value',
+    href: '/example?query=value'
   }
 };
 for (var u in parseTestsWithQueryString) {


### PR DESCRIPTION
Fixes an issue that caused the first querystring to be parsed prepending a "?" in the first variable name on relative urls with no #fragment.

Example of the error: (Look the `query` property in the parsed url)

``` javascript
➜  node git:(master) node -v
v0.10.26
➜  node git:(master) node
> require('url').parse('/profile?access_token=1', true);
{ protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: '?access_token=1',
  query: { access_token: '1' },
  pathname: '/profile',
  path: '/profile?access_token=1',
  href: '/profile?access_token=1' }
```

``` javascript
➜  node git:(master) ./node -v
v0.13.0-pre
➜  node git:(master) ./node
> require('url').parse('/profile?access_token=1', true);
{ protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: '?access_token=1',
  query: { '?access_token': '1' },
  pathname: '/profile',
  path: '/profile?access_token=1',
  href: '/profile?access_token=1' }
```
