### PR TITLE
lib: remove variables root and GLOBAL

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -421,7 +421,6 @@ Module.prototype._compile = function(content, filename) {
       sandbox.__dirname = dirname;
       sandbox.module = self;
       sandbox.global = sandbox;
-      sandbox.root = root;
 
       return runInNewContext(content, sandbox, { filename: filename });
     }

--- a/src/node.js
+++ b/src/node.js
@@ -165,8 +165,6 @@
   startup.globalVariables = function() {
     global.process = process;
     global.global = global;
-    global.GLOBAL = global;
-    global.root = global;
     global.Buffer = NativeModule.require('buffer').Buffer;
     process.domain = null;
     process._exiting = false;


### PR DESCRIPTION
There is no document and API use the root and GLOBAL variables. I think we can remove it from core.
