### PR TITLE
node: remove extra deprecated function

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -241,12 +241,6 @@ enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
 enum encoding ParseEncoding(v8::Isolate* isolate,
                             v8::Handle<v8::Value> encoding_v,
                             enum encoding _default = BINARY);
-NODE_DEPRECATED("Use ParseEncoding(isolate, ...)",
-                inline enum encoding ParseEncoding(
-      v8::Handle<v8::Value> encoding_v,
-      enum encoding _default = BINARY) {
-  return ParseEncoding(v8::Isolate::GetCurrent(), encoding_v, _default);
-})
 
 NODE_EXTERN void FatalException(v8::Isolate* isolate,
                                 const v8::TryCatch& try_catch);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -836,7 +836,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
                                      string,
                                      const_cast<const char**>(&buf),
                                      &len)) {
-    enum encoding enc = ParseEncoding(args[3], UTF8);
+    enum encoding enc = ParseEncoding(env->isolate(), args[3], UTF8);
     len = StringBytes::StorageSize(env->isolate(), string, enc);
     buf = new char[len];
     // StorageSize may return too large a char, so correct the actual length

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -401,7 +401,8 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
 
     // String chunk
     Handle<String> string = chunk->ToString();
-    enum encoding encoding = ParseEncoding(chunks->Get(i * 2 + 1));
+    enum encoding encoding = ParseEncoding(env->isolate(),
+                                           chunks->Get(i * 2 + 1));
     size_t chunk_size;
     if (encoding == UTF8 && string->Length() > 65535)
       chunk_size = StringBytes::Size(env->isolate(), string, encoding);
@@ -444,7 +445,8 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
     size_t str_size = storage_size - offset;
 
     Handle<String> string = chunk->ToString();
-    enum encoding encoding = ParseEncoding(chunks->Get(i * 2 + 1));
+    enum encoding encoding = ParseEncoding(env->isolate(),
+                                           chunks->Get(i * 2 + 1));
     str_size = StringBytes::Write(env->isolate(),
                                   str_storage,
                                   str_size,


### PR DESCRIPTION
because of no `NODE_EXTERN` in this function, so we don't care about the backward compatible :p
