### PR TITLE
lib: improved forEach object performance

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1367,7 +1367,9 @@ Interface.prototype.setBreakpoint = function(script, line,
     // setBreakpoint('scriptname')
     if (script != +script && !this.client.scripts[script]) {
       var scripts = this.client.scripts;
-      Object.keys(scripts).forEach(function(id) {
+      var keys = Object.keys(scripts);
+      for (var v = 0; v < keys.length; v++) {
+        var id = keys[v];
         if (scripts[id] &&
             scripts[id].name &&
             scripts[id].name.indexOf(script) !== -1) {
@@ -1376,7 +1378,7 @@ Interface.prototype.setBreakpoint = function(script, line,
           }
           scriptId = id;
         }
-      });
+      }
     } else {
       scriptId = script;
     }

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -235,7 +235,9 @@ Agent.prototype.removeSocket = function(s, options) {
   if (s.destroyed)
     sets.push(this.freeSockets);
 
-  sets.forEach(function(sockets) {
+  for (var sk = 0; sk < sets.length; sk++) {
+    var sockets = sets[sk];
+
     if (sockets[name]) {
       var index = sockets[name].indexOf(s);
       if (index !== -1) {
@@ -245,7 +247,8 @@ Agent.prototype.removeSocket = function(s, options) {
           delete sockets[name];
       }
     }
-  });
+  }
+
   if (this.requests[name] && this.requests[name].length) {
     debug('removeSocket, have a request, make a socket');
     var req = this.requests[name][0];
@@ -256,13 +259,16 @@ Agent.prototype.removeSocket = function(s, options) {
 
 Agent.prototype.destroy = function() {
   var sets = [this.freeSockets, this.sockets];
-  sets.forEach(function(set) {
-    Object.keys(set).forEach(function(name) {
-      set[name].forEach(function(socket) {
-        socket.destroy();
-      });
-    });
-  });
+  for (var s = 0; s < sets.length; s++) {
+    var set = sets[s];
+    var keys = Object.keys(set);
+    for (var v = 0; v < keys.length; v++) {
+      var setName = set[keys[v]];
+      for (var n = 0; n < setName.length; n++) {
+        setName[n].destroy();
+      }
+    }
+  }
 };
 
 exports.globalAgent = new Agent();

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -31,10 +31,12 @@ var Writable = require('_stream_writable');
 
 util.inherits(Duplex, Readable);
 
-Object.keys(Writable.prototype).forEach(function(method) {
+var keys = Object.keys(Writable.prototype);
+for (var v = 0; v < keys.length; v++) {
+  var method = keys[v];
   if (!Duplex.prototype[method])
     Duplex.prototype[method] = Writable.prototype[method];
-});
+}
 
 function Duplex(options) {
   if (!(this instanceof Duplex))

--- a/lib/console.js
+++ b/lib/console.js
@@ -44,9 +44,11 @@ function Console(stdout, stderr) {
   Object.defineProperty(this, '_times', prop);
 
   // bind the prototype functions to this Console instance
-  Object.keys(Console.prototype).forEach(function(k) {
+  var keys = Object.keys(Console.prototype);
+  for (var v = 0; v < keys.length; v++) {
+    var k = keys[v];
     this[k] = this[k].bind(this);
-  }, this);
+  }
 }
 
 Console.prototype.log = function() {

--- a/lib/url.js
+++ b/lib/url.js
@@ -451,9 +451,11 @@ Url.prototype.resolveObject = function(relative) {
   }
 
   var result = new Url();
-  Object.keys(this).forEach(function(k) {
-    result[k] = this[k];
-  }, this);
+  var tkeys = Object.keys(this);
+  for (var tk = 0; tk < tkeys.length; tk++) {
+    var tkey = tkeys[tk];
+    result[tkey] = this[tkey];
+  }
 
   // hash is always overridden, no matter what.
   // even href="" will remove it.
@@ -468,10 +470,12 @@ Url.prototype.resolveObject = function(relative) {
   // hrefs like //foo/bar always cut to the protocol.
   if (relative.slashes && !relative.protocol) {
     // take everything except the protocol from relative
-    Object.keys(relative).forEach(function(k) {
-      if (k !== 'protocol')
-        result[k] = relative[k];
-    });
+    var rkeys = Object.keys(relative);
+    for (var rk = 0; rk < rkeys.length; rk++) {
+      var rkey = rkeys[rk];
+      if (rkey !== 'protocol')
+        result[rkey] = relative[rkey];
+    }
 
     //urlParse appends trailing / to urls like http://www.example.com
     if (slashedProtocol[result.protocol] &&
@@ -493,9 +497,11 @@ Url.prototype.resolveObject = function(relative) {
     // because that's known to be hostless.
     // anything else is assumed to be absolute.
     if (!slashedProtocol[relative.protocol]) {
-      Object.keys(relative).forEach(function(k) {
+      keys = Object.keys(relative);
+      for (v = 0; v < keys.length; v++) {
+        k = keys[v];
         result[k] = relative[k];
-      });
+      }
       result.href = result.format();
       return result;
     }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -47,9 +47,11 @@ binding.Z_MAX_LEVEL = 9;
 binding.Z_DEFAULT_LEVEL = binding.Z_DEFAULT_COMPRESSION;
 
 // expose all the zlib constants
-Object.keys(binding).forEach(function(k) {
-  if (k.match(/^Z/)) exports[k] = binding[k];
-});
+var bkeys = Object.keys(binding);
+for (var bk = 0; bk < bkeys.length; bk++) {
+  var bkey = bkeys[bk];
+  if (bkey.match(/^Z/)) exports[bkey] = binding[bkey];
+}
 
 // translation table for return codes.
 exports.codes = {
@@ -64,9 +66,11 @@ exports.codes = {
   Z_VERSION_ERROR: binding.Z_VERSION_ERROR
 };
 
-Object.keys(exports.codes).forEach(function(k) {
-  exports.codes[exports.codes[k]] = k;
-});
+var ckeys = Object.keys(exports.codes);
+for (var ck = 0; ck < ckeys.length; ck++) {
+  var ckey = ckeys[ck];
+  exports.codes[exports.codes[ckey]] = ckey;
+}
 
 exports.Deflate = Deflate;
 exports.Inflate = Inflate;


### PR DESCRIPTION
Trying to squeeze-out more performance out of the **object loops**. 

Based on [this perf test](http://jsperf.com/object-keys-foreach-vs-for-in-hasownproperty) I wrote 2 weeks ago. 

```
Object.keys forEach => 677,305 ops/sec
For Object.keys     => 1,356,592 ops/sec
```

It shows that the implemented code in this pull request is faster in most javascript engines than the previous implementation. Which is also true for google chrome's V8.

All test passing, Cheers 
