### PR TITLE
http: fix bailout for writeHead

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -172,20 +172,19 @@ ServerResponse.prototype._implicitHeader = function() {
   this.writeHead(this.statusCode);
 };
 
-ServerResponse.prototype.writeHead = function(statusCode) {
-  var headers, headerIndex;
+ServerResponse.prototype.writeHead = function(statusCode, reasonPhrase, obj) {
+  var headers;
 
-  if (util.isString(arguments[1])) {
-    this.statusMessage = arguments[1];
-    headerIndex = 2;
+  // writeHead(statusCode, reasonPhrase[, headers])
+  if (util.isString(reasonPhrase)) {
+    this.statusMessage = reasonPhrase;
   } else {
+    // writeHead(statusCode, headers)
     this.statusMessage =
         this.statusMessage || STATUS_CODES[statusCode] || 'unknown';
-    headerIndex = 1;
+    obj = reasonPhrase;
   }
   this.statusCode = statusCode;
-
-  var obj = arguments[headerIndex];
 
   if (this._headers) {
     // Slow-case: when progressive API and header fields are passed.


### PR DESCRIPTION
When call `writeHead(statusCode)`(arguments.length is 1), the `util.isString(arguments[1])` out of bound. It's make the V8 optimize bailout.

Here is my test script: https://gist.github.com/JacksonTian/b5fa991185c739aa1aaf , but the code just test the `statusMessage` and `headers`.

```
writeHead1(statusCode) x 21,240,743 ops/sec ±3.62% (85 runs sampled)
writeHead2(statusCode) x 2,285,861 ops/sec ±14.70% (82 runs sampled)
writeHead1(statusCode, message) x 18,086,581 ops/sec ±1.58% (87 runs sampled)
writeHead2(statusCode, message) x 2,192,042 ops/sec ±1.51% (87 runs sampled)
writeHead1(statusCode, obj) x 16,861,389 ops/sec ±1.24% (91 runs sampled)
writeHead2(statusCode, obj) x 16,025,339 ops/sec ±5.33% (87 runs sampled)
writeHead1(statusCode, message, obj) x 17,747,071 ops/sec ±1.16% (83 runs sampled)
writeHead2(statusCode, message, obj) x 16,737,772 ops/sec ±1.85% (91 runs sampled)
```

In `writeHead1(statusCode)` case, about 9x faster.

The above result, `writeHead(statusCode)` and `writeHead(statusCode, message)` hit the bailout case.

Maybe this fix not graceful, please have a look.
