### PR TITLE
event: remove unused op in 99% case

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -296,7 +296,7 @@ EventEmitter.prototype.removeAllListeners =
 
 EventEmitter.prototype.listeners = function listeners(type) {
   var ret;
-  if (!this._events || !this._events[type])
+  if (!this._events[type])
     ret = [];
   else if (util.isFunction(this._events[type]))
     ret = [this._events[type]];
@@ -307,7 +307,7 @@ EventEmitter.prototype.listeners = function listeners(type) {
 
 EventEmitter.listenerCount = function(emitter, type) {
   var ret;
-  if (!emitter._events || !emitter._events[type])
+  if (!emitter._events[type])
     ret = 0;
   else if (util.isFunction(emitter._events[type]))
     ret = 1;


### PR DESCRIPTION
The `!this._events` will not be `true` in almost(99%) cases, 
The reason is, in many places of event.js itself, `{}` has been default value for `this._events`.
