### PR TITLE
fd leak in ReadStream.destroy()

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1588,9 +1588,7 @@ ReadStream.prototype.destroy = function() {
   if (this.destroyed)
     return;
   this.destroyed = true;
-
-  if (util.isNumber(this.fd))
-    this.close();
+  this.close();
 };
 
 


### PR DESCRIPTION
defensive programming is bad sometimes :)

this leaks:

``` js
setInterval(function() {
  var x = require('fs').createReadStream('/etc/passwd');
  x.destroy();
}, 1000);
```

this doesn't:

``` js
setInterval(function() {
  var x = require('fs').createReadStream('/etc/passwd');
  x.close();
}, 1000);
```

all details are here somewhere: https://github.com/visionmedia/send/issues/55

I wonder how do I write tests for those...
