### PR TITLE
dns: throw if lookup() hostname is not string or null

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -105,8 +105,8 @@ exports.lookup = function lookup(hostname, options, callback) {
   var family = -1;
 
   // Parse arguments
-  if (typeof hostname !== 'string' && hostname !== null) {
-    throw TypeError('invalid arguments: hostname must be a string or null');
+  if (hostname && typeof hostname !== 'string') {
+    throw TypeError('invalid arguments: hostname must be a string or falsey');
   } else if (typeof options === 'function') {
     callback = options;
     family = 0;

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -105,7 +105,9 @@ exports.lookup = function lookup(hostname, options, callback) {
   var family = -1;
 
   // Parse arguments
-  if (typeof options === 'function') {
+  if (typeof hostname !== 'string' && hostname !== null) {
+    throw TypeError('invalid arguments: hostname must be a string or null');
+  } else if (typeof options === 'function') {
     callback = options;
     family = 0;
   } else if (typeof callback !== 'function') {

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -69,10 +69,46 @@ assert.throws(function() {
   return !(err instanceof TypeError);
 }, 'Unexpected error');
 
-// GH #8187
+// dns.lookup should accept falsey and string values
 assert.throws(function() {
   dns.lookup({}, noop);
-}, 'invalid arguments: hostname must be a string or null');
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup([], noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup(true, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup(1, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup(noop, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.doesNotThrow(function() {
+  dns.lookup('', noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(null, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(undefined, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(0, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(NaN, noop);
+});
 
 /*
  * Make sure that dns.lookup throws if hints does not represent a valid flag.

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -69,6 +69,11 @@ assert.throws(function() {
   return !(err instanceof TypeError);
 }, 'Unexpected error');
 
+// GH #8187
+assert.throws(function() {
+  dns.lookup({}, noop);
+}, 'invalid arguments: hostname must be a string or null');
+
 /*
  * Make sure that dns.lookup throws if hints does not represent a valid flag.
  * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:


### PR DESCRIPTION
Current behavior is C++ assertion failure. Closes #8187
