### PR TITLE
Create less IO errors to improve efficiency of require

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -153,11 +153,14 @@ Only available on Mac OS X.
 
 Synchronous lchmod(2).
 
-## fs.stat(path, callback)
+## fs.stat(path, callback, [throwSafe])
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a [fs.Stats](#fs_class_fs_stats) object.  See the [fs.Stats](#fs_class_fs_stats)
 section below for more information.
+
+The throwSafe parameter if set to true prevents the error creation. If the call
+fails, the first parameter of the callback will be true.
 
 ## fs.lstat(path, callback)
 
@@ -172,9 +175,12 @@ Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a `fs.Stats` object. `fstat()` is identical to `stat()`, except that
 the file to be stat-ed is specified by the file descriptor `fd`.
 
-## fs.statSync(path)
+## fs.statSync(path, [throwSafe])
 
 Synchronous stat(2). Returns an instance of `fs.Stats`.
+
+The throwSafe parameter if set to true prevents the error creation. If the call
+fails, the first parameter of the callback will be true.
 
 ## fs.lstatSync(path)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -114,14 +114,16 @@ function assertEncoding(encoding) {
   }
 }
 
-function nullCheck(path, callback) {
+function nullCheck(path, callback, throwSafe) {
   if (('' + path).indexOf('\u0000') !== -1) {
-    var er = new Error('Path must be a string without null bytes.');
-    if (!callback)
-      throw er;
-    process.nextTick(function() {
-      callback(er);
-    });
+    if (!throwSafe) {
+      var er = new Error('Path must be a string without null bytes.');
+      if (!callback)
+        throw er;
+      process.nextTick(function() {
+        callback(er);
+      });
+    }
     return false;
   }
   return true;
@@ -162,21 +164,30 @@ fs.Stats.prototype.isSocket = function() {
 };
 
 fs.exists = function(path, callback) {
-  if (!nullCheck(path, cb)) return;
-  binding.stat(pathModule._makeLong(path), cb);
-  function cb(err, stats) {
-    if (callback) callback(err ? false : true);
+  if (!nullCheck(path, undefined, true)) {
+    process.nextTick(function() {
+      cb(true, false);
+    });
+    return;
+  }
+  binding.stat(pathModule._makeLong(path), cb, true);
+  function cb(err, result) {
+    if (callback) {
+      if (err) {
+        callback(false);
+      } else {
+        callback(!!result);
+      }
+    }
   }
 };
 
 fs.existsSync = function(path) {
-  try {
-    nullCheck(path);
-    binding.stat(pathModule._makeLong(path));
-    return true;
-  } catch (e) {
+  if (!nullCheck(path, undefined, true))
     return false;
-  }
+  if (!binding.stat(pathModule._makeLong(path), undefined, true))
+    return false;
+  return true;
 };
 
 fs.readFile = function(path, options, callback_) {
@@ -675,10 +686,17 @@ fs.lstat = function(path, callback) {
   binding.lstat(pathModule._makeLong(path), callback);
 };
 
-fs.stat = function(path, callback) {
+fs.stat = function(path, callback, throwSafe) {
   callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.stat(pathModule._makeLong(path), callback);
+  if (!nullCheck(path, callback, throwSafe)) {
+    if (throwSafe) {
+      process.nextTick(function() {
+        callback(true, false);
+      });
+    }
+    return;
+  }
+  binding.stat(pathModule._makeLong(path), callback, throwSafe);
 };
 
 fs.fstatSync = function(fd) {
@@ -690,9 +708,11 @@ fs.lstatSync = function(path) {
   return binding.lstat(pathModule._makeLong(path));
 };
 
-fs.statSync = function(path) {
-  nullCheck(path);
-  return binding.stat(pathModule._makeLong(path));
+fs.statSync = function(path, throwSafe) {
+  if (!nullCheck(path, undefined, throwSafe))
+    return false;
+
+  return binding.stat(pathModule._makeLong(path), undefined, throwSafe);
 };
 
 fs.readlink = function(path, callback) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -87,10 +87,8 @@ var debug = Module._debug;
 
 function statPath(path) {
   var fs = NativeModule.require('fs');
-  try {
-    return fs.statSync(path);
-  } catch (ex) {}
-  return false;
+
+  return fs.statSync(path, true);
 }
 
 // check if the directory is a package.json dir

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -27,6 +27,12 @@
 
 namespace node {
 
+struct node_fs_t {
+    uv_fs_t req;
+    int throwSafe;
+    void* data;
+};
+
 class File {
  public:
   static void Initialize(v8::Handle<v8::Object> target);

--- a/test/simple/test-fs-stat-sync.js
+++ b/test/simple/test-fs-stat-sync.js
@@ -1,0 +1,168 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var got_error = false;
+var success_count = 0;
+
+var stats;
+
+// statSync
+try {
+  stats = fs.statSync('.');
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  assert.ok(stats.mtime instanceof Date);
+  success_count++;
+}
+
+try {
+  stats = fs.statSync('.', true);
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  assert.ok(stats.mtime instanceof Date);
+  success_count++;
+}
+
+var errorCaught = false;
+try {
+  stats = fs.statSync('nonexisting_file');
+} catch (e) {
+  assert.ok(e instanceof Error);
+  success_count++;
+  errorCaught = true;
+}
+if (!errorCaught) {
+  got_error = true;
+}
+
+try {
+  stats = fs.statSync('nonexisting_file', true);
+} catch (e) {
+  got_error = true;
+}
+assert.equal(false, stats);
+success_count++;
+
+// lstatSync
+try {
+  stats = fs.lstatSync('.');
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  assert.ok(stats.mtime instanceof Date);
+  success_count++;
+}
+
+// fstatSync
+fs.open('.', 'r', undefined, function(err, fd) {
+  assert.ok(!err);
+  assert.ok(fd);
+
+  var stats;
+  try {
+    stats = fs.fstatSync(fd);
+  } catch (e) {
+    got_error = true;
+  }
+  if (!stats) {
+    got_error = true;
+  } else {
+    console.dir(stats);
+    assert.ok(stats.mtime instanceof Date);
+    success_count++;
+  }
+
+  assert(this === global);
+});
+
+// fstatSync
+fs.open('.', 'r', undefined, function(err, fd) {
+  var stats;
+  try {
+    stats = fs.fstatSync(fd);
+  } catch (err) {
+    got_error = true;
+  }
+  if (stats) {
+    console.dir(stats);
+    assert.ok(stats.mtime instanceof Date);
+    success_count++;
+  }
+  fs.close(fd);
+});
+
+console.log('stating: ' + __filename);
+try {
+  stats = fs.statSync(__filename);
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  success_count++;
+
+  console.log('isDirectory: ' + JSON.stringify(stats.isDirectory()));
+  assert.equal(false, stats.isDirectory());
+
+  console.log('isFile: ' + JSON.stringify(stats.isFile()));
+  assert.equal(true, stats.isFile());
+
+  console.log('isSocket: ' + JSON.stringify(stats.isSocket()));
+  assert.equal(false, stats.isSocket());
+
+  console.log('isBlockDevice: ' + JSON.stringify(stats.isBlockDevice()));
+  assert.equal(false, stats.isBlockDevice());
+
+  console.log('isCharacterDevice: ' + JSON.stringify(stats.isCharacterDevice()));
+  assert.equal(false, stats.isCharacterDevice());
+
+  console.log('isFIFO: ' + JSON.stringify(stats.isFIFO()));
+  assert.equal(false, stats.isFIFO());
+
+  console.log('isSymbolicLink: ' + JSON.stringify(stats.isSymbolicLink()));
+  assert.equal(false, stats.isSymbolicLink());
+
+  assert.ok(stats.mtime instanceof Date);
+}
+
+process.on('exit', function() {
+  assert.equal(8, success_count);
+  assert.equal(false, got_error);
+});

--- a/test/simple/test-fs-stat.js
+++ b/test/simple/test-fs-stat.js
@@ -36,6 +36,34 @@ fs.stat('.', function(err, stats) {
   assert(this === global);
 });
 
+fs.stat('.', function(err, stats) {
+  if (err) {
+    got_error = true;
+  } else {
+    console.dir(stats);
+    assert.ok(stats.mtime instanceof Date);
+    success_count++;
+  }
+  assert(this === global);
+}, true);
+
+fs.stat('nonexisting_file', function(err, stats) {
+  if (err) {
+    assert.ok(err instanceof Error);
+    success_count++;
+  } else {
+    got_error = true;
+  }
+  assert(this === global);
+});
+
+fs.stat('nonexisting_file', function(err, stats) {
+  assert.equal(true, err);
+  assert.equal(false, stats);
+  assert(this === global);
+  success_count++;
+}, true);
+
 fs.lstat('.', function(err, stats) {
   if (err) {
     got_error = true;
@@ -84,40 +112,39 @@ fs.open('.', 'r', undefined, function(err, fd) {
 });
 
 console.log('stating: ' + __filename);
-fs.stat(__filename, function(err, s) {
+fs.stat(__filename, function(err, stats) {
   if (err) {
     got_error = true;
   } else {
-    console.dir(s);
+    console.dir(stats);
     success_count++;
 
-    console.log('isDirectory: ' + JSON.stringify(s.isDirectory()));
-    assert.equal(false, s.isDirectory());
+    console.log('isDirectory: ' + JSON.stringify(stats.isDirectory()));
+    assert.equal(false, stats.isDirectory());
 
-    console.log('isFile: ' + JSON.stringify(s.isFile()));
-    assert.equal(true, s.isFile());
+    console.log('isFile: ' + JSON.stringify(stats.isFile()));
+    assert.equal(true, stats.isFile());
 
-    console.log('isSocket: ' + JSON.stringify(s.isSocket()));
-    assert.equal(false, s.isSocket());
+    console.log('isSocket: ' + JSON.stringify(stats.isSocket()));
+    assert.equal(false, stats.isSocket());
 
-    console.log('isBlockDevice: ' + JSON.stringify(s.isBlockDevice()));
-    assert.equal(false, s.isBlockDevice());
+    console.log('isBlockDevice: ' + JSON.stringify(stats.isBlockDevice()));
+    assert.equal(false, stats.isBlockDevice());
 
-    console.log('isCharacterDevice: ' + JSON.stringify(s.isCharacterDevice()));
-    assert.equal(false, s.isCharacterDevice());
+    console.log('isCharacterDevice: ' + JSON.stringify(stats.isCharacterDevice()));
+    assert.equal(false, stats.isCharacterDevice());
 
-    console.log('isFIFO: ' + JSON.stringify(s.isFIFO()));
-    assert.equal(false, s.isFIFO());
+    console.log('isFIFO: ' + JSON.stringify(stats.isFIFO()));
+    assert.equal(false, stats.isFIFO());
 
-    console.log('isSymbolicLink: ' + JSON.stringify(s.isSymbolicLink()));
-    assert.equal(false, s.isSymbolicLink());
+    console.log('isSymbolicLink: ' + JSON.stringify(stats.isSymbolicLink()));
+    assert.equal(false, stats.isSymbolicLink());
 
-    assert.ok(s.mtime instanceof Date);
+    assert.ok(stats.mtime instanceof Date);
   }
 });
 
 process.on('exit', function() {
-  assert.equal(5, success_count);
+  assert.equal(8, success_count);
   assert.equal(false, got_error);
 });
-


### PR DESCRIPTION
In some environment (especially when coffescript is involved) module.js
will spend a lot of time looking up nonexisting files. This is caused by the
lengthy error creation. Those errors are then immediately caught.

This change makes the lookup much faster, by avoiding the unnecessary error
creation.

module::statPath now uses the new second parameter of fs.statSync function of the
fs.js. There is a similar change for the fs.stat, adding the third parameter.
