### PR TITLE
events: Added support for custom context

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -30,8 +30,8 @@ trace and exit the program.
 All EventEmitters emit the event `'newListener'` when new listeners are
 added and `'removeListener'` when a listener is removed.
 
-### emitter.addListener(event, listener)
-### emitter.on(event, listener)
+### emitter.addListener(event, listener, [context])
+### emitter.on(event, listener, [context])
 
 Adds a listener to the end of the listeners array for the specified event.
 
@@ -39,9 +39,15 @@ Adds a listener to the end of the listeners array for the specified event.
       console.log('someone connected!');
     });
 
-Returns emitter, so calls can be chained.
+Returns emitter, so calls can be chained. By default the context of the
+executed function is set to the object on which the event is emitted. This 
+can be overridden by specifying the context argument.
 
-### emitter.once(event, listener)
+    server.on('connection', function (stream) {
+      console.log(this); // foo
+    }, 'foo');
+
+### emitter.once(event, listener, [context])
 
 Adds a **one time** listener for the event. This listener is
 invoked only the next time the event is fired, after which
@@ -51,7 +57,13 @@ it is removed.
       console.log('Ah, we have our first user!');
     });
 
-Returns emitter, so calls can be chained.
+Returns emitter, so calls can be chained. By default the context of the
+executed function is is set to the object on which the event is emitted. 
+This can be overridden by specifying the context argument.
+
+    server.once('connection', function (stream) {
+      console.log(this); // foo
+    }, 'foo');
 
 ### emitter.removeListener(event, listener)
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -513,7 +513,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.removeListener('close', onclose);
     dest.removeListener('finish', onfinish);
     dest.removeListener('drain', ondrain);
-    dest.removeListener('error', onerror);
+    dest.removeListener('error', onerror.fn);
     dest.removeListener('unpipe', onunpipe);
     src.removeListener('end', onend);
     src.removeListener('end', cleanup);
@@ -543,17 +543,18 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
 
   // if the dest has an error, then stop piping into it.
   // however, don't suppress the throwing behavior for this.
-  function onerror(er) {
+  var onerror = new EE.Listener(function onerror(er) {
     debug('onerror', er);
     unpipe();
     dest.removeListener('error', onerror);
     if (EE.listenerCount(dest, 'error') === 0)
       dest.emit('error', er);
-  }
+  }, dest);
+
   // This is a brutally ugly hack to make sure that our error handler
   // is attached before any userland ones.  NEVER DO THIS.
   if (!dest._events || !dest._events.error)
-    dest.on('error', onerror);
+    dest._events.error = onerror;
   else if (Array.isArray(dest._events.error))
     dest._events.error.unshift(onerror);
   else

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,6 +24,11 @@
 var domain;
 var util = require('util');
 
+function Listener(fn, ctx) {
+  this.fn = fn;
+  this.ctx = ctx;
+}
+
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
@@ -31,6 +38,8 @@ module.exports = EventEmitter;
 EventEmitter.EventEmitter = EventEmitter;
 
 EventEmitter.usingDomains = false;
+
+EventEmitter.Listener = Listener;
 
 EventEmitter.prototype.domain = undefined;
 EventEmitter.prototype._events = undefined;
@@ -65,7 +74,7 @@ EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   return this;
 };
 
-EventEmitter.prototype.emit = function emit(type) {
+EventEmitter.prototype.emit = function emit(type, a1, a2) {
   var er, handler, len, args, i, listeners;
 
   if (!this._events)
@@ -91,23 +100,23 @@ EventEmitter.prototype.emit = function emit(type) {
 
   handler = this._events[type];
 
-  if (util.isUndefined(handler))
+  if (!handler)
     return false;
 
   if (this.domain && this !== process)
     this.domain.enter();
 
-  if (util.isFunction(handler)) {
+  if (typeof handler.fn === 'function') {
     switch (arguments.length) {
       // fast cases
       case 1:
-        handler.call(this);
+        handler.fn.call(handler.ctx);
         break;
       case 2:
-        handler.call(this, arguments[1]);
+        handler.fn.call(handler.ctx, a1);
         break;
       case 3:
-        handler.call(this, arguments[1], arguments[2]);
+        handler.fn.call(handler.ctx, a1, a2);
         break;
       // slower
       default:
@@ -115,9 +124,9 @@ EventEmitter.prototype.emit = function emit(type) {
         args = new Array(len - 1);
         for (i = 1; i < len; i++)
           args[i - 1] = arguments[i];
-        handler.apply(this, args);
+        handler.fn.apply(handler.ctx, args);
     }
-  } else if (util.isObject(handler)) {
+  } else {
     len = arguments.length;
     args = new Array(len - 1);
     for (i = 1; i < len; i++)
@@ -126,7 +135,7 @@ EventEmitter.prototype.emit = function emit(type) {
     listeners = handler.slice();
     len = listeners.length;
     for (i = 0; i < len; i++)
-      listeners[i].apply(this, args);
+      listeners[i].fn.apply(listeners[i].ctx, args);
   }
 
   if (this.domain && this !== process)
@@ -135,7 +144,8 @@ EventEmitter.prototype.emit = function emit(type) {
   return true;
 };
 
-EventEmitter.prototype.addListener = function addListener(type, listener) {
+EventEmitter.prototype.addListener =
+    function addListener(type, listener, context) {
   var m;
 
   if (!util.isFunction(listener))
@@ -144,17 +154,19 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
   if (!this._events)
     this._events = {};
 
+  listener = new Listener(listener, context || this);
+
   // To avoid recursion in the case that type === "newListener"! Before
   // adding it to the listeners, first emit "newListener".
   if (this._events.newListener)
     this.emit('newListener', type,
-              util.isFunction(listener.listener) ?
-              listener.listener : listener);
+              util.isFunction(listener.fn.listener) ?
+              listener.fn.listener : listener.fn);
 
   if (!this._events[type])
     // Optimize the case of one listener. Don't need the extra array object.
     this._events[type] = listener;
-  else if (util.isObject(this._events[type]))
+  else if (Array.isArray(this._events[type]))
     // If we've already got an array, just append.
     this._events[type].push(listener);
   else
@@ -162,7 +174,7 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
     this._events[type] = [this._events[type], listener];
 
   // Check for listener leak
-  if (util.isObject(this._events[type]) && !this._events[type].warned) {
+  if (Array.isArray(this._events[type]) && !this._events[type].warned) {
     var m;
     if (!util.isUndefined(this._maxListeners)) {
       m = this._maxListeners;
@@ -185,7 +197,8 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
 
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
-EventEmitter.prototype.once = function once(type, listener) {
+EventEmitter.prototype.once =
+    function once(type, listener, context) {
   if (!util.isFunction(listener))
     throw TypeError('listener must be a function');
 
@@ -196,7 +209,7 @@ EventEmitter.prototype.once = function once(type, listener) {
 
     if (!fired) {
       fired = true;
-      listener.apply(this, arguments);
+      listener.apply(context || this, arguments);
     }
   }
 
@@ -221,16 +234,17 @@ EventEmitter.prototype.removeListener =
   length = list.length;
   position = -1;
 
-  if (list === listener ||
-      (util.isFunction(list.listener) && list.listener === listener)) {
+  if (list.fn && (list.fn === listener ||
+      (util.isFunction(list.fn.listener) && list.fn.listener === listener))) {
     delete this._events[type];
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
 
-  } else if (util.isObject(list)) {
+  } else if (Array.isArray(list)) {
     for (i = length; i-- > 0;) {
-      if (list[i] === listener ||
-          (list[i].listener && list[i].listener === listener)) {
+      if (!list[i].fn) console.error(list[i]);
+      if (list[i].fn === listener ||
+          (list[i].fn.listener && list[i].fn.listener === listener)) {
         position = i;
         break;
       }
@@ -282,12 +296,12 @@ EventEmitter.prototype.removeAllListeners =
 
   listeners = this._events[type];
 
-  if (util.isFunction(listeners)) {
-    this.removeListener(type, listeners);
+  if (listeners && util.isFunction(listeners.fn)) {
+    this.removeListener(type, listeners.fn);
   } else if (Array.isArray(listeners)) {
     // LIFO order
     while (listeners.length)
-      this.removeListener(type, listeners[listeners.length - 1]);
+      this.removeListener(type, listeners[listeners.length - 1].fn);
   }
   delete this._events[type];
 
@@ -295,13 +309,17 @@ EventEmitter.prototype.removeAllListeners =
 };
 
 EventEmitter.prototype.listeners = function listeners(type) {
-  var ret;
-  if (!this._events || !this._events[type])
-    ret = [];
-  else if (util.isFunction(this._events[type]))
-    ret = [this._events[type]];
-  else
-    ret = this._events[type].slice();
+  var ret = [];
+
+  if (!this._events || !this._events[type]) return ret;
+
+  if (util.isFunction(this._events[type].fn))
+    ret = [this._events[type].fn];
+  else {
+    for (var i = 0, l = this._events[type].length; i < l; i++) {
+      ret.push(this._events[type][i].fn);
+    }
+  }
   return ret;
 };
 
@@ -309,7 +327,7 @@ EventEmitter.listenerCount = function(emitter, type) {
   var ret;
   if (!emitter._events || !emitter._events[type])
     ret = 0;
-  else if (util.isFunction(emitter._events[type]))
+  else if (util.isFunction(emitter._events[type].fn))
     ret = 1;
   else
     ret = emitter._events[type].length;

--- a/test/simple/test-event-emitter-context-once.js
+++ b/test/simple/test-event-emitter-context-once.js
@@ -1,4 +1,3 @@
-
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,38 +23,29 @@ var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 
-var EventEmitter = require('events').EventEmitter;
-var assert = require('assert');
+var e = new events.EventEmitter();
 
-var e = new EventEmitter;
-var fl;  // foo listeners
+var pattern = '';
+var emitted = 0;
+var ctx = 1345;
 
-fl = e.listeners('foo');
-assert(Array.isArray(fl));
-assert(fl.length === 0);
-assert.deepEqual(e._events, {});
+e.once('foo', function (foo) {
+  assert.equal(this, ctx);
+  assert.equal(foo, 'bar');
+  emitted++;
+}, ctx);
 
-e.on('foo', assert.fail);
-fl = e.listeners('foo');
-assert(e._events.foo.fn === assert.fail);
-assert(Array.isArray(fl));
-assert(fl.length === 1);
-assert(fl[0] === assert.fail);
+function bar() {
+  pattern += this;
+}
 
-e.listeners('bar');
-assert(!e._events.hasOwnProperty('bar'));
+e.once('foo', bar, 'bar');
+e.once('foo', bar, 'baz');
 
-e.on('foo', assert.ok);
-fl = e.listeners('foo');
+e.emit('foo', 'bar');
+e.emit('foo', 'bar');
 
-assert(Array.isArray(e._events.foo));
-assert(e._events.foo.length === 2);
-assert(e._events.foo[0].fn === assert.fail);
-assert(e._events.foo[1].fn === assert.ok);
-
-assert(Array.isArray(fl));
-assert(fl.length === 2);
-assert(fl[0] === assert.fail);
-assert(fl[1] === assert.ok);
-
-console.log('ok');
+process.on('exit', function() {
+  assert.equal(1, emitted);
+  assert.equal('barbaz', pattern);
+});

--- a/test/simple/test-event-emitter-context.js
+++ b/test/simple/test-event-emitter-context.js
@@ -1,4 +1,3 @@
-
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,38 +23,31 @@ var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 
-var EventEmitter = require('events').EventEmitter;
-var assert = require('assert');
+var e = new events.EventEmitter();
 
-var e = new EventEmitter;
-var fl;  // foo listeners
+var pattern = '';
+var emitted = 0;
+var ctx = 1345;
 
-fl = e.listeners('foo');
-assert(Array.isArray(fl));
-assert(fl.length === 0);
-assert.deepEqual(e._events, {});
+e.on('foo', function (foo) {
+  assert.equal(this, ctx);
+  assert.equal(foo, 'bar');
+  emitted++;
+}, ctx);
 
-e.on('foo', assert.fail);
-fl = e.listeners('foo');
-assert(e._events.foo.fn === assert.fail);
-assert(Array.isArray(fl));
-assert(fl.length === 1);
-assert(fl[0] === assert.fail);
+e.emit('foo', 'bar');
 
-e.listeners('bar');
-assert(!e._events.hasOwnProperty('bar'));
+function bar() {
+  pattern += this;
+}
 
-e.on('foo', assert.ok);
-fl = e.listeners('foo');
+e.on('bar', bar, 'foo');
+e.on('bar', bar, 'baz');
 
-assert(Array.isArray(e._events.foo));
-assert(e._events.foo.length === 2);
-assert(e._events.foo[0].fn === assert.fail);
-assert(e._events.foo[1].fn === assert.ok);
+e.emit('bar');
+e.emit('bar');
 
-assert(Array.isArray(fl));
-assert(fl.length === 2);
-assert(fl[0] === assert.fail);
-assert(fl[1] === assert.ok);
-
-console.log('ok');
+process.on('exit', function() {
+  assert.equal(1, emitted);
+  assert.equal(pattern, 'foobazfoobaz');
+});


### PR DESCRIPTION
The custom context argument allows you to specify with what context
your supplied event handler is executed. It defaults to the
EventEmitter class.

Fixes #8210
