### PR TITLE
http: avoid create extra hidden class

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -46,6 +46,8 @@ function IncomingMessage(socket) {
   this.socket = socket;
   this.connection = socket;
 
+  this.httpVersionMajor = null;
+  this.httpVersionMinor = null;
   this.httpVersion = null;
   this.complete = false;
   this.headers = {};
@@ -57,6 +59,7 @@ function IncomingMessage(socket) {
 
   this._pendings = [];
   this._pendingIndex = 0;
+  this.upgrade = null;
 
   // request (server) only
   this.url = '';


### PR DESCRIPTION
In `parserOnHeadersComplete` in _http_common.js will add `httpVersionMajor`, `httpVersionMinor` and `upgrade` three property. It will create extra hidden class.
