### PR TITLE
lib, src: add vm.runInDebugContext()

### DIFF
--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -134,6 +134,20 @@ Note that running untrusted code is a tricky business requiring great care.
 a separate process.
 
 
+## vm.runInDebugContext(code)
+
+`vm.runInDebugContext` compiles and executes `code` inside the V8 debug context.
+The primary use case is to get access to the V8 debug object:
+
+    var Debug = vm.runInDebugContext('Debug');
+    Debug.scripts().forEach(function(script) { console.log(script.name); });
+
+Note that the debug context and object are intrinsically tied to V8's debugger
+implementation and may change (or even get removed) without prior warning.
+
+The debug object can also be exposed with the `--expose_debug_as=` switch.
+
+
 ## Class: Script
 
 A class for holding precompiled scripts, and running them in specific sandboxes.

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -55,6 +55,10 @@ exports.createContext = function(sandbox) {
   return sandbox;
 };
 
+exports.runInDebugContext = function(code) {
+  return binding.runInDebugContext(code);
+};
+
 exports.runInContext = function(code, contextifiedSandbox, options) {
   var script = new Script(code, options);
   return script.runInContext(contextifiedSandbox, options);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -28,6 +28,7 @@
 #include "env-inl.h"
 #include "util.h"
 #include "util-inl.h"
+#include "v8-debug.h"
 
 namespace node {
 
@@ -35,6 +36,7 @@ using v8::AccessType;
 using v8::Array;
 using v8::Boolean;
 using v8::Context;
+using v8::Debug;
 using v8::EscapableHandleScope;
 using v8::External;
 using v8::Function;
@@ -244,8 +246,22 @@ class ContextifyContext {
     function_template->InstanceTemplate()->SetInternalFieldCount(1);
     env->set_script_data_constructor_function(function_template->GetFunction());
 
+    NODE_SET_METHOD(target, "runInDebugContext", RunInDebugContext);
     NODE_SET_METHOD(target, "makeContext", MakeContext);
     NODE_SET_METHOD(target, "isContext", IsContext);
+  }
+
+
+  static void RunInDebugContext(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
+    Local<String> script_source(args[0]->ToString());
+    if (script_source.IsEmpty())
+      return;  // Exception pending.
+    Context::Scope context_scope(Debug::GetDebugContext());
+    Local<Script> script = Script::Compile(script_source);
+    if (script.IsEmpty())
+      return;  // Exception pending.
+    args.GetReturnValue().Set(script->Run());
   }
 
 

--- a/test/simple/test-vm-debug-context.js
+++ b/test/simple/test-vm-debug-context.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var vm = require('vm');
+
+assert.throws(function() {
+  vm.runInDebugContext('*');
+}, /SyntaxError/);
+
+assert.throws(function() {
+  vm.runInDebugContext({ toString: assert.fail });
+}, /AssertionError/);
+
+assert.throws(function() {
+  vm.runInDebugContext('throw URIError("BAM")');
+}, /URIError/);
+
+assert.throws(function() {
+  vm.runInDebugContext('(function(f) { f(f) })(function(f) { f(f) })');
+}, /RangeError/);
+
+assert.equal(typeof(vm.runInDebugContext('this')), 'object');
+assert.equal(typeof(vm.runInDebugContext('Debug')), 'object');
+
+assert.strictEqual(vm.runInDebugContext(), undefined);
+assert.strictEqual(vm.runInDebugContext(0), 0);
+assert.strictEqual(vm.runInDebugContext(null), null);
+assert.strictEqual(vm.runInDebugContext(undefined), undefined);


### PR DESCRIPTION
Compiles and executes source code in V8's debugger context.  Provides
a programmatic way to get access to the debug object by executing:

```
var Debug = vm.runInDebugContext('Debug');
```

Fixes #7886.
