### PR TITLE
lib, src: don't make http parser handles weak

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -257,7 +257,7 @@ function socketCloseListener() {
 
   if (parser) {
     parser.finish();
-    freeParser(parser, req);
+    freeParser(parser, req, socket);
   }
 }
 
@@ -276,7 +276,7 @@ function socketErrorListener(err) {
 
   if (parser) {
     parser.finish();
-    freeParser(parser, req);
+    freeParser(parser, req, socket);
   }
   socket.destroy();
 }
@@ -294,7 +294,7 @@ function socketOnEnd() {
   }
   if (parser) {
     parser.finish();
-    freeParser(parser, req);
+    freeParser(parser, req, socket);
   }
   socket.destroy();
 }
@@ -309,7 +309,7 @@ function socketOnData(d) {
   var ret = parser.execute(d);
   if (ret instanceof Error) {
     debug('parse error');
-    freeParser(parser, req);
+    freeParser(parser, req, socket);
     socket.destroy();
     req.emit('error', ret);
     req.socket._hadError = true;
@@ -344,7 +344,7 @@ function socketOnData(d) {
       // Got Upgrade header or CONNECT method, but have no handler.
       socket.destroy();
     }
-    freeParser(parser, req);
+    freeParser(parser, req, socket);
   } else if (parser.incoming && parser.incoming.complete &&
              // When the status code is 100 (Continue), the server will
              // send a final response after this client sends a request
@@ -352,7 +352,7 @@ function socketOnData(d) {
              parser.incoming.statusCode !== 100) {
     socket.removeListener('data', socketOnData);
     socket.removeListener('end', socketOnEnd);
-    freeParser(parser, req);
+    freeParser(parser, req, socket);
   }
 }
 

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -200,7 +200,8 @@ function freeParser(parser, req) {
       parser.socket.parser = null;
     parser.socket = null;
     parser.incoming = null;
-    parsers.free(parser);
+    if (parsers.free(parser) === false)
+      parser.close();
     parser = null;
   }
   if (req) {

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -192,7 +192,7 @@ exports.parsers = parsers;
 // up by doing `parser.data = {}`, which should
 // be done in FreeList.free.  `parsers.free(parser)`
 // should be all that is needed.
-function freeParser(parser, req) {
+function freeParser(parser, req, socket) {
   if (parser) {
     parser._headers = [];
     parser.onIncoming = null;
@@ -206,6 +206,9 @@ function freeParser(parser, req) {
   }
   if (req) {
     req.parser = null;
+  }
+  if (socket) {
+    socket.parser = null;
   }
 }
 exports.freeParser = freeParser;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -286,8 +286,9 @@ function connectionListener(socket) {
   function serverSocketCloseListener() {
     debug('server socket close');
     // mark this parser as reusable
-    if (this.parser)
-      freeParser(this.parser);
+    if (this.parser) {
+      freeParser(this.parser, null, this);
+    }
 
     abortIncoming();
   }
@@ -354,7 +355,8 @@ function connectionListener(socket) {
       socket.removeListener('end', socketOnEnd);
       socket.removeListener('close', serverSocketCloseListener);
       parser.finish();
-      freeParser(parser, req);
+      freeParser(parser, req, null);
+      parser = null;
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
       if (EventEmitter.listenerCount(self, eventName) > 0) {

--- a/lib/freelist.js
+++ b/lib/freelist.js
@@ -39,5 +39,7 @@ exports.FreeList.prototype.free = function(obj) {
   //debug("free " + this.name + " " + this.list.length);
   if (this.list.length < this.max) {
     this.list.push(obj);
+    return true;
   }
+  return false;
 };

--- a/lib/http.js
+++ b/lib/http.js
@@ -28,7 +28,6 @@ exports.IncomingMessage = require('_http_incoming').IncomingMessage;
 
 var common = require('_http_common');
 exports.METHODS = util._extend([], common.methods).sort();
-exports.parsers = common.parsers;
 
 
 exports.OutgoingMessage = require('_http_outgoing').OutgoingMessage;

--- a/src/base-object.h
+++ b/src/base-object.h
@@ -32,10 +32,15 @@ class BaseObject {
   BaseObject(Environment* env, v8::Local<v8::Object> handle);
   ~BaseObject();
 
-  // Returns the wrapped object.  Illegal to call in your destructor.
+  // Returns the wrapped object.  Returns an empty handle when
+  // persistent.IsEmpty() is true.
   inline v8::Local<v8::Object> object();
 
-  // Parent class is responsible to Dispose.
+  // The parent class is responsible for calling .Reset() on destruction
+  // when the persistent handle is strong because there is no way for
+  // BaseObject to know when the handle goes out of scope.
+  // Weak handles have been reset by the time the destructor runs but
+  // calling .Reset() again is harmless.
   inline v8::Persistent<v8::Object>& persistent();
 
   inline Environment* env() const;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -373,8 +373,8 @@ class Parser : public BaseObject {
 
   // var bytesParsed = parser->execute(buffer);
   static void Execute(const FunctionCallbackInfo<Value>& args) {
+    HandleScope handle_scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
 
     Parser* parser = Unwrap<Parser>(args.Holder());
     assert(parser->current_buffer_.IsEmpty());

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -107,6 +107,10 @@ void Wrap(v8::Local<v8::Object> object, TypeName* pointer) {
   object->SetAlignedPointerInInternalField(0, pointer);
 }
 
+void ClearWrap(v8::Local<v8::Object> object) {
+  Wrap<void>(object, NULL);
+}
+
 template <typename TypeName>
 TypeName* Unwrap(v8::Local<v8::Object> object) {
   assert(!object.IsEmpty());

--- a/src/util.h
+++ b/src/util.h
@@ -112,6 +112,8 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
 
 inline void Wrap(v8::Local<v8::Object> object, void* pointer);
 
+inline void ClearWrap(v8::Local<v8::Object> object);
+
 template <typename TypeName>
 inline TypeName* Unwrap(v8::Local<v8::Object> object);
 


### PR DESCRIPTION
Weak handles put strain on the garbage collector and the parser handle
doesn't need to be weak in the first place.  This change should improve
GC times on busy servers a little.
