### PR TITLE
net: remove writable, readable assign of handle

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1051,8 +1051,6 @@ var createServerHandle = exports._createServerHandle =
       return uv.UV_EINVAL;
     }
     handle.open(fd);
-    handle.readable = true;
-    handle.writable = true;
     assert(!address && !port);
   } else if (port === -1 && addressType === -1) {
     handle = createPipe();


### PR DESCRIPTION
The `readable` and `writable` properties of tcp handle object not be used anywhere.
