### PR TITLE
events: Fix typo in the removeListener comment

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -206,7 +206,7 @@ EventEmitter.prototype.once = function once(type, listener) {
   return this;
 };
 
-// emits a 'removeListener' event iff the listener was removed
+// emits a 'removeListener' event if the listener was removed
 EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
   var list, position, length, i;


### PR DESCRIPTION
line 209 reads

// emits a 'removeListener' event iff the listener was removed

should read

// emits a 'removeListener' event if the listener was removed
