### PR TITLE
configure: generate a fully statically linked executable

### DIFF
--- a/configure
+++ b/configure
@@ -54,6 +54,11 @@ parser.add_option('--no-ifaddrs',
     dest='no_ifaddrs',
     help='use on deprecated SunOS systems that do not support ifaddrs.h')
 
+parser.add_option("--fully-static",
+    action="store_true",
+    dest="fully_static",
+    help="Generate an executable without external dynamic libraries")
+
 # deprecated
 parser.add_option('--openssl-includes',
     action='store',
@@ -650,6 +655,11 @@ def configure_openssl(o):
       o['cflags'] += cflags.split()
 
 
+def configure_fullystatic(o):
+  if options.fully_static:
+    o['libraries'] += ['-static']
+
+
 def configure_winsdk(o):
   if flavor != 'win':
     return
@@ -697,6 +707,7 @@ configure_v8(output)
 configure_openssl(output)
 configure_winsdk(output)
 configure_icu(output)
+configure_fullystatic(output)
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/deps/openssl/openssl/apps/s_client.c
+++ b/deps/openssl/openssl/apps/s_client.c
@@ -178,6 +178,13 @@ typedef unsigned int u_int;
 #include <fcntl.h>
 #endif
 
+/* Use Windows API with STD_INPUT_HANDLE when checking for input?
+   Don't look at OPENSSL_SYS_MSDOS for this, since it is always defined if
+   OPENSSL_SYS_WINDOWS is defined */
+#if defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_WINCE) && defined(STD_INPUT_HANDLE)
+#define OPENSSL_USE_STD_INPUT_HANDLE
+#endif
+
 #undef PROG
 #define PROG	s_client_main
 
@@ -1606,10 +1613,10 @@ SSL_set_tlsext_status_ids(con, ids);
 					tv.tv_usec = 0;
 					i=select(width,(void *)&readfds,(void *)&writefds,
 						 NULL,&tv);
-#if defined(OPENSSL_SYS_WINCE) || defined(OPENSSL_SYS_MSDOS)
-					if(!i && (!_kbhit() || !read_tty) ) continue;
-#else
+#if defined(OPENSSL_USE_STD_INPUT_HANDLE)
 					if(!i && (!((_kbhit()) || (WAIT_OBJECT_0 == WaitForSingleObject(GetStdHandle(STD_INPUT_HANDLE), 0))) || !read_tty) ) continue;
+#else
+					if(!i && (!_kbhit() || !read_tty) ) continue;
 #endif
 				} else 	i=select(width,(void *)&readfds,(void *)&writefds,
 					 NULL,timeoutp);
@@ -1814,10 +1821,10 @@ printf("read=%d pending=%d peek=%d\n",k,SSL_pending(con),SSL_peek(con,zbuf,10240
 			}
 
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
-#if defined(OPENSSL_SYS_WINCE) || defined(OPENSSL_SYS_MSDOS)
-		else if (_kbhit())
-#else
+#if defined(OPENSSL_USE_STD_INPUT_HANDLE)
 		else if ((_kbhit()) || (WAIT_OBJECT_0 == WaitForSingleObject(GetStdHandle(STD_INPUT_HANDLE), 0)))
+#else
+		else if (_kbhit())
 #endif
 #elif defined (OPENSSL_SYS_NETWARE)
 		else if (_kbhit())

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -62,7 +62,9 @@ It can be constructed in a variety of ways.
 
 * `size` Number
 
-Allocates a new buffer of `size` octets.
+Allocates a new buffer of `size` octets. Note, `size` must be no more than
+[kMaxLength](smalloc.html#smalloc_smalloc_kmaxlength). Otherwise, a `RangeError`
+will be thrown here.
 
 ### new Buffer(array)
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -593,6 +593,22 @@ Exports the encoded public key from the supplied SPKAC.
 
 Exports the encoded challenge associated with the SPKAC.
 
+## crypto.publicEncrypt(public_key, buffer)
+
+Encrypts `buffer` with `public_key`. Only RSA is currently supported.
+
+## crypto.privateDecrypt(private_key, buffer)
+
+Decrypts `buffer` with `private_key`.
+
+`private_key` can be an object or a string. If `private_key` is a string, it is
+treated as the key with no passphrase.
+
+`private_key`:
+
+* `key` : A string holding the PEM encoded private key
+* `passphrase` : A string of passphrase for the private key
+
 ## crypto.DEFAULT_ENCODING
 
 The default encoding to use for functions that can take either strings

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -849,7 +849,7 @@ the client should send the request body.
 
 Flush the request headers.
 
-For effiency reasons, node.js normally buffers the request headers until you
+For efficiency reasons, node.js normally buffers the request headers until you
 call `request.end()` or write the first chunk of request data.  It then tries
 hard to pack the request headers and data into a single TCP packet.
 

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -971,7 +971,7 @@ function SourceWrapper(options) {
       self._source.readStop();
   };
 
-  // When the source ends, we push the EOF-signalling `null` chunk
+  // When the source ends, we push the EOF-signaling `null` chunk
   this._source.onend = function() {
     self.push(null);
   };

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -310,6 +310,24 @@ readable.on('data', function(chunk) {
 })
 ```
 
+#### readable.isPaused()
+
+* Return: `Boolean`
+
+This method returns whether or not the `readable` has been **explicitly**
+paused by client code (using `readable.pause()` without a corresponding
+`readable.resume()`).
+
+```javascript
+var readable = new stream.Readable
+
+readable.isPaused() // === false
+readable.pause()
+readable.isPaused() // === true
+readable.resume()
+readable.isPaused() // === false
+```
+
 #### readable.pipe(destination, [options])
 
 * `destination` {[Writable][] Stream} The destination for writing data

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -154,7 +154,7 @@ automatically set as a listener for the [secureConnection][] event.  The
     `RC4` is used as a fallback for clients that speak on older version of
     the TLS protocol.  `RC4` has in recent years come under suspicion and
     should be considered compromised for anything that is truly sensitive.
-    It is speculated that state-level actors posess the ability to break it.
+    It is speculated that state-level actors possess the ability to break it.
 
     **NOTE**: Previous revisions of this section suggested `AES256-SHA` as an
     acceptable cipher. Unfortunately, `AES256-SHA` is a CBC cipher and therefore
@@ -573,8 +573,9 @@ Typical flow:
 5. Client validates the response and either destroys socket or performs a
    handshake.
 
-NOTE: `issuer` could be null, if certficiate is self-signed or if issuer is not
-in the root certificates list. (You could provide an issuer via `ca` option.)
+NOTE: `issuer` could be null, if the certificate is self-signed or if the issuer
+is not in the root certificates list. (You could provide an issuer via `ca`
+option.)
 
 NOTE: adding this event listener will have an effect only on connections
 established after addition of event listener.

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -46,6 +46,8 @@ function IncomingMessage(socket) {
   this.socket = socket;
   this.connection = socket;
 
+  this.httpVersionMajor = null;
+  this.httpVersionMinor = null;
   this.httpVersion = null;
   this.complete = false;
   this.headers = {};
@@ -57,6 +59,7 @@ function IncomingMessage(socket) {
 
   this._pendings = [];
   this._pendingIndex = 0;
+  this.upgrade = null;
 
   // request (server) only
   this.url = '';

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -172,20 +172,19 @@ ServerResponse.prototype._implicitHeader = function() {
   this.writeHead(this.statusCode);
 };
 
-ServerResponse.prototype.writeHead = function(statusCode) {
-  var headers, headerIndex;
+ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
+  var headers;
 
-  if (util.isString(arguments[1])) {
-    this.statusMessage = arguments[1];
-    headerIndex = 2;
+  if (util.isString(reason)) {
+    // writeHead(statusCode, reasonPhrase[, headers])
+    this.statusMessage = reason;
   } else {
+    // writeHead(statusCode[, headers])
     this.statusMessage =
         this.statusMessage || STATUS_CODES[statusCode] || 'unknown';
-    headerIndex = 1;
+    obj = reason;
   }
   this.statusCode = statusCode;
-
-  var obj = arguments[headerIndex];
 
   if (this._headers) {
     // Slow-case: when progressive API and header fields are passed.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -131,6 +131,10 @@ Readable.prototype.unshift = function(chunk) {
   return readableAddChunk(this, state, chunk, '', true);
 };
 
+Readable.prototype.isPaused = function() {
+  return this._readableState.flowing === false;
+};
+
 function readableAddChunk(stream, state, chunk, encoding, addToFront) {
   var er = chunkInvalid(state, chunk);
   if (er) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -27,6 +27,7 @@ var crypto = require('crypto');
 var net = require('net');
 var tls = require('tls');
 var util = require('util');
+var listenerCount = require('events').listenerCount;
 var common = require('_tls_common');
 
 var Timer = process.binding('timer_wrap').Timer;
@@ -131,7 +132,7 @@ function requestOCSP(self, hello, ctx, cb) {
   if (ctx.context)
     ctx = ctx.context;
 
-  if (self.server.listeners('OCSPRequest').length === 0) {
+  if (listenerCount(self.server, 'OCSPRequest') === 0) {
     return cb(null);
   } else {
     self.server.emit('OCSPRequest',
@@ -311,9 +312,9 @@ TLSSocket.prototype._init = function(socket) {
     this.ssl.handshakes = 0;
 
     if (this.server &&
-        (this.server.listeners('resumeSession').length > 0 ||
-         this.server.listeners('newSession').length > 0 ||
-         this.server.listeners('OCSPRequest').length > 0)) {
+        (listenerCount(this.server, 'resumeSession') > 0 ||
+         listenerCount(this.server, 'newSession') > 0 ||
+         listenerCount(this.server, 'OCSPRequest') > 0)) {
       this.ssl.enableSessionCallbacks();
     }
   } else {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -355,6 +355,16 @@ Verify.prototype.verify = function(object, signature, sigEncoding) {
   return this._handle.verify(toBuf(object), toBuf(signature, sigEncoding));
 };
 
+exports.publicEncrypt = function(object, buffer) {
+  return binding.publicEncrypt(toBuf(object), buffer);
+};
+
+exports.privateDecrypt = function(options, buffer) {
+  var key = options.key || options;
+  var passphrase = options.passphrase || null;
+  return binding.privateDecrypt(toBuf(key), buffer, passphrase);
+};
+
 
 
 exports.createDiffieHellman = exports.DiffieHellman = DiffieHellman;

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -415,7 +415,7 @@ Socket.prototype.addMembership = function(multicastAddress,
 
   var err = this._handle.addMembership(multicastAddress, interfaceAddress);
   if (err) {
-    throw new errnoException(err, 'addMembership');
+    throw errnoException(err, 'addMembership');
   }
 };
 
@@ -430,7 +430,7 @@ Socket.prototype.dropMembership = function(multicastAddress,
 
   var err = this._handle.dropMembership(multicastAddress, interfaceAddress);
   if (err) {
-    throw new errnoException(err, 'dropMembership');
+    throw errnoException(err, 'dropMembership');
   }
 };
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -102,7 +102,7 @@ function onlookup(err, addresses) {
 // lookup(hostname, [options,] callback)
 exports.lookup = function lookup(hostname, options, callback) {
   var hints = 0;
-  var family = 0;
+  var family = -1;
 
   // Parse arguments
   if (typeof options === 'function') {
@@ -120,6 +120,8 @@ exports.lookup = function lookup(hostname, options, callback) {
         hints !== (exports.ADDRCONFIG | exports.V4MAPPED)) {
       throw new TypeError('invalid argument: hints must use valid flags');
     }
+  } else {
+    family = options >>> 0;
   }
 
   if (family !== 0 && family !== 4 && family !== 6)

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -105,7 +105,9 @@ exports.lookup = function lookup(hostname, options, callback) {
   var family = -1;
 
   // Parse arguments
-  if (typeof options === 'function') {
+  if (hostname && typeof hostname !== 'string') {
+    throw TypeError('invalid arguments: hostname must be a string or falsey');
+  } else if (typeof options === 'function') {
     callback = options;
     family = 0;
   } else if (typeof callback !== 'function') {

--- a/lib/net.js
+++ b/lib/net.js
@@ -970,7 +970,7 @@ function afterConnect(status, handle, req, readable, writable) {
 
     // start the first read, or get an immediate EOF.
     // this doesn't actually consume any bytes, because len=0.
-    if (readable)
+    if (readable && !self.isPaused())
       self.read(0);
 
   } else {

--- a/lib/url.js
+++ b/lib/url.js
@@ -132,7 +132,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = querystring.parse(this.search);
+          this.query = querystring.parse(this.search.substr(1));
         } else {
           this.query = this.search.substr(1);
         }

--- a/node.gyp
+++ b/node.gyp
@@ -191,7 +191,7 @@
                 ],
               },
               'conditions': [
-                ['OS=="linux"', {
+                ['OS in "linux freebsd"', {
                   'ldflags': [
                     '-Wl,--whole-archive <(PRODUCT_DIR)/libopenssl.a -Wl,--no-whole-archive',
                   ],
@@ -351,7 +351,7 @@
           ],
         }],
         [
-          'OS=="linux" and node_shared_v8=="false"', {
+          'OS in "linux freebsd" and node_shared_v8=="false"', {
             'ldflags': [
               '-Wl,--whole-archive <(V8_BASE) -Wl,--no-whole-archive',
             ],

--- a/node.gyp
+++ b/node.gyp
@@ -319,6 +319,9 @@
           'defines': [ '__POSIX__' ],
         }],
         [ 'OS=="mac"', {
+          # linking Corefoundation is needed since certain OSX debugging tools
+          # like Instruments require it for some features
+          'libraries': [ '-framework CoreFoundation' ],
           'defines!': [
             'PLATFORM="mac"',
           ],

--- a/src/env.h
+++ b/src/env.h
@@ -37,8 +37,8 @@
 // a nightmare so let's make the preprocessor generate them for us.
 //
 // Make sure that any macros defined here are undefined again at the bottom
-// of context-inl.h. The sole exception is NODE_CONTEXT_EMBEDDER_DATA_INDEX,
-// it may have been defined externally.
+// of context-inl.h. The exceptions are NODE_CONTEXT_EMBEDDER_DATA_INDEX
+// and NODE_ISOLATE_SLOT, they may have been defined externally.
 namespace node {
 
 // Pick an index that's hopefully out of the way when we're embedded inside
@@ -47,6 +47,14 @@ namespace node {
 // worst case we pay a one-time penalty for resizing the array.
 #ifndef NODE_CONTEXT_EMBEDDER_DATA_INDEX
 #define NODE_CONTEXT_EMBEDDER_DATA_INDEX 32
+#endif
+
+// The slot 0 and 1 had already been taken by "gin" and "blink" in Chrome,
+// and the size of isolate's slots is 4 by default, so using 3 should
+// hopefully make node work independently when embedded into other
+// application.
+#ifndef NODE_ISOLATE_SLOT
+#define NODE_ISOLATE_SLOT 3
 #endif
 
 // Strings are per-isolate primitives but Environment proxies them
@@ -430,7 +438,7 @@ class Environment {
 #undef V
 
  private:
-  static const int kIsolateSlot = 0;
+  static const int kIsolateSlot = NODE_ISOLATE_SLOT;
 
   class GCInfo;
   class IsolateData;

--- a/src/node.cc
+++ b/src/node.cc
@@ -3617,6 +3617,7 @@ int Start(int argc, char** argv) {
   V8::Initialize();
   {
     Locker locker(node_isolate);
+    Isolate::Scope isolate_scope(node_isolate);
     HandleScope handle_scope(node_isolate);
     Local<Context> context = Context::New(node_isolate);
     Environment* env = CreateEnvironment(

--- a/src/node.h
+++ b/src/node.h
@@ -232,8 +232,10 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
   v8::Handle<v8::Signature> s = v8::Signature::New(isolate, recv);
   v8::Local<v8::FunctionTemplate> t =
       v8::FunctionTemplate::New(isolate, callback, v8::Handle<v8::Value>(), s);
-  recv->PrototypeTemplate()->Set(v8::String::NewFromUtf8(isolate, name),
-                                 t->GetFunction());
+  v8::Local<v8::Function> fn = t->GetFunction();
+  recv->PrototypeTemplate()->Set(v8::String::NewFromUtf8(isolate, name), fn);
+  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
+  fn->SetName(fn_name);
 }
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 

--- a/src/node.js
+++ b/src/node.js
@@ -670,7 +670,7 @@
       if (isSignal(type)) {
         assert(signalWraps.hasOwnProperty(type));
 
-        if (EventEmitter.listenerCount(this, type) === 0) {
+        if (NativeModule.require('events').listenerCount(this, type) === 0) {
           signalWraps[type].close();
           delete signalWraps[type];
         }

--- a/src/node.js
+++ b/src/node.js
@@ -670,7 +670,7 @@
       if (isSignal(type)) {
         assert(signalWraps.hasOwnProperty(type));
 
-        if (this.listeners(type).length === 0) {
+        if (EventEmitter.listenerCount(this, type) === 0) {
           signalWraps[type].close();
           delete signalWraps[type];
         }

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -559,6 +559,35 @@ class Verify : public SignBase {
   }
 };
 
+class PublicKeyCipher {
+ public:
+  typedef int (*EVP_PKEY_cipher_init_t)(EVP_PKEY_CTX *ctx);
+  typedef int (*EVP_PKEY_cipher_t)(EVP_PKEY_CTX *ctx,
+                                   unsigned char *out, size_t *outlen,
+                                   const unsigned char *in, size_t inlen);
+
+  enum Operation {
+    kEncrypt,
+    kDecrypt
+  };
+
+  template <Operation operation,
+            EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
+            EVP_PKEY_cipher_t EVP_PKEY_cipher>
+  static bool Cipher(const char* key_pem,
+                     int key_pem_len,
+                     const char* passphrase,
+                     const unsigned char* data,
+                     int len,
+                     unsigned char** out,
+                     size_t* out_len);
+
+  template <Operation operation,
+            EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
+            EVP_PKEY_cipher_t EVP_PKEY_cipher>
+  static void Cipher(const v8::FunctionCallbackInfo<v8::Value>& args);
+};
+
 class DiffieHellman : public BaseObject {
  public:
   ~DiffieHellman() {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -836,7 +836,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
                                      string,
                                      const_cast<const char**>(&buf),
                                      &len)) {
-    enum encoding enc = ParseEncoding(args[3], UTF8);
+    enum encoding enc = ParseEncoding(env->isolate(), args[3], UTF8);
     len = StringBytes::StorageSize(env->isolate(), string, enc);
     buf = new char[len];
     // StorageSize may return too large a char, so correct the actual length

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -401,7 +401,8 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
 
     // String chunk
     Handle<String> string = chunk->ToString();
-    enum encoding encoding = ParseEncoding(chunks->Get(i * 2 + 1));
+    enum encoding encoding = ParseEncoding(env->isolate(),
+                                           chunks->Get(i * 2 + 1));
     size_t chunk_size;
     if (encoding == UTF8 && string->Length() > 65535)
       chunk_size = StringBytes::Size(env->isolate(), string, encoding);
@@ -444,7 +445,8 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
     size_t str_size = storage_size - offset;
 
     Handle<String> string = chunk->ToString();
-    enum encoding encoding = ParseEncoding(chunks->Get(i * 2 + 1));
+    enum encoding encoding = ParseEncoding(env->isolate(),
+                                           chunks->Get(i * 2 + 1));
     str_size = StringBytes::Write(env->isolate(),
                                   str_storage,
                                   str_size,

--- a/test/common.js
+++ b/test/common.js
@@ -22,6 +22,7 @@
 var path = require('path');
 var fs = require('fs');
 var assert = require('assert');
+var os = require('os');
 
 exports.testDir = path.dirname(__filename);
 exports.fixturesDir = path.join(exports.testDir, 'fixtures');
@@ -45,6 +46,13 @@ if (process.platform === 'win32') {
   exports.faketimeCli = path.join(__dirname, "..", "tools", "faketime", "src",
     "faketime");
 }
+
+var ifaces = os.networkInterfaces();
+exports.hasIPv6 = Object.keys(ifaces).some(function(name) {
+  return /lo/.test(name) && ifaces[name].some(function(info) {
+    return info.family === 'IPv6';
+  });
+});
 
 var util = require('util');
 for (var i in util) exports[i] = util[i];

--- a/test/common.js
+++ b/test/common.js
@@ -289,3 +289,12 @@ exports.getServiceName = function getServiceName(port, protocol) {
 
   return serviceName;
 }
+
+exports.isValidHostname = function(str) {
+  // See http://stackoverflow.com/a/3824105
+  var re = new RegExp(
+    '^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])' +
+    '(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$');
+
+  return !!str.match(re) && str.length <= 255;
+}

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -495,7 +495,23 @@ TEST(function test_lookupservice_ip_ipv4(done) {
   var req = dns.lookupService('127.0.0.1', 80, function(err, host, service) {
     if (err) throw err;
     assert.strictEqual(host, 'localhost');
-    assert.strictEqual(service, 'http');
+
+    /*
+     * Retrieve the actual HTTP service name as setup on the host currently
+     * running the test by reading it from /etc/services. This is not ideal,
+     * as the service name lookup could use another mechanism (e.g nscd), but
+     * it's already better than hardcoding it.
+     */
+    var httpServiceName = common.getServiceName(80, 'tcp');
+    if (!httpServiceName) {
+      /*
+       * Couldn't find service name, reverting to the most sensible default
+       * for port 80.
+       */
+      httpServiceName = 'http';
+    }
+
+    assert.strictEqual(service, httpServiceName);
 
     done();
   });
@@ -515,7 +531,23 @@ TEST(function test_lookupservice_ip_ipv6(done) {
      * that most sane platforms use either one of these two by default.
      */
     assert(host === 'localhost' || host === 'ip6-localhost');
-    assert.strictEqual(service, 'http');
+
+    /*
+     * Retrieve the actual HTTP service name as setup on the host currently
+     * running the test by reading it from /etc/services. This is not ideal,
+     * as the service name lookup could use another mechanism (e.g nscd), but
+     * it's already better than hardcoding it.
+     */
+    var httpServiceName = common.getServiceName(80, 'tcp');
+    if (!httpServiceName) {
+      /*
+       * Couldn't find service name, reverting to the most sensible default
+       * for port 80.
+       */
+      httpServiceName = 'http';
+    }
+
+    assert.strictEqual(service, httpServiceName);
 
     done();
   });

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -63,7 +63,6 @@ function checkWrap(req) {
   assert.ok(typeof req === 'object');
 }
 
-
 TEST(function test_resolve4(done) {
   var req = dns.resolve4('www.google.com', function(err, ips) {
     if (err) throw err;
@@ -354,7 +353,7 @@ TEST(function test_lookup_ipv4_explicit_object(done) {
 
 TEST(function test_lookup_ipv4_hint_addrconfig(done) {
   var req = dns.lookup('www.google.com', {
-    hint: dns.ADDRCONFIG
+    hints: dns.ADDRCONFIG
   }, function(err, ip, family) {
     if (err) throw err;
     assert.ok(net.isIPv4(ip));
@@ -411,8 +410,9 @@ TEST(function test_lookup_ipv6_explicit_object(done) {
 
 
 TEST(function test_lookup_ipv6_hint(done) {
-  var req = dns.lookup('ipv6.google.com', {
-    hint: dns.V4MAPPED
+  var req = dns.lookup('www.google.com', {
+    family: 6,
+    hints: dns.V4MAPPED
   }, function(err, ip, family) {
     if (err) throw err;
     assert.ok(net.isIPv6(ip));
@@ -494,7 +494,7 @@ TEST(function test_lookup_localhost_ipv4(done) {
 TEST(function test_lookupservice_ip_ipv4(done) {
   var req = dns.lookupService('127.0.0.1', 80, function(err, host, service) {
     if (err) throw err;
-    assert.strictEqual(host, 'localhost');
+    assert.ok(common.isValidHostname(host));
 
     /*
      * Retrieve the actual HTTP service name as setup on the host currently
@@ -523,14 +523,7 @@ TEST(function test_lookupservice_ip_ipv4(done) {
 TEST(function test_lookupservice_ip_ipv6(done) {
   var req = dns.lookupService('::1', 80, function(err, host, service) {
     if (err) throw err;
-    /*
-     * On some systems, ::1 can be set to "localhost", on others it
-     * can be set to "ip6-localhost". There does not seem to be
-     * a consensus on that. Ultimately, it could be set to anything
-     * else just by changing /etc/hosts for instance, but it seems
-     * that most sane platforms use either one of these two by default.
-     */
-    assert(host === 'localhost' || host === 'ip6-localhost');
+    assert.ok(common.isValidHostname(host));
 
     /*
      * Retrieve the actual HTTP service name as setup on the host currently

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -823,6 +823,40 @@ var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
 var bad_dh = crypto.createDiffieHellman(p, 'hex');
 assert.equal(bad_dh.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
 
+// Test RSA encryption/decryption
+(function() {
+  var input = 'I AM THE WALRUS';
+  var bufferToEncrypt = new Buffer(input);
+
+  var encryptedBuffer = crypto.publicEncrypt(rsaPubPem, bufferToEncrypt);
+
+  var decryptedBuffer = crypto.privateDecrypt(rsaKeyPem, encryptedBuffer);
+  assert.equal(input, decryptedBuffer.toString());
+
+  var decryptedBufferWithPassword = crypto.privateDecrypt({
+    key: rsaKeyPemEncrypted,
+    passphrase: 'password'
+  }, encryptedBuffer);
+  assert.equal(input, decryptedBufferWithPassword.toString());
+
+  encryptedBuffer = crypto.publicEncrypt(certPem, bufferToEncrypt);
+
+  decryptedBuffer = crypto.privateDecrypt(keyPem, encryptedBuffer);
+  assert.equal(input, decryptedBuffer.toString());
+
+  encryptedBuffer = crypto.publicEncrypt(keyPem, bufferToEncrypt);
+
+  decryptedBuffer = crypto.privateDecrypt(keyPem, encryptedBuffer);
+  assert.equal(input, decryptedBuffer.toString());
+
+  assert.throws(function() {
+    crypto.privateDecrypt({
+      key: rsaKeyPemEncrypted,
+      passphrase: 'wrong'
+    }, encryptedBuffer);
+  });
+})();
+
 // Test RSA key signing/verification
 var rsaSign = crypto.createSign('RSA-SHA1');
 var rsaVerify = crypto.createVerify('RSA-SHA1');

--- a/test/simple/test-dgram-bind-default-address.js
+++ b/test/simple/test-dgram-bind-default-address.js
@@ -29,6 +29,11 @@ dgram.createSocket('udp4').bind(common.PORT + 0, common.mustCall(function() {
   this.close();
 }));
 
+if (!common.hasIPv6) {
+  console.error('Skipping udp6 part of test, no IPv6 support');
+  return;
+}
+
 dgram.createSocket('udp6').bind(common.PORT + 1, common.mustCall(function() {
   assert.equal(this.address().port, common.PORT + 1);
   var address = this.address().address;

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -69,8 +69,18 @@ assert.throws(function() {
   return !(err instanceof TypeError);
 }, 'Unexpected error');
 
+/*
+ * Make sure that dns.lookup throws if hints does not represent a valid flag.
+ * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:
+ * - it's different from dns.V4MAPPED and dns.ADDRCONFIG.
+ * - it's different from them bitwise ored.
+ * - it's different from 0.
+ * - it's an odd number different than 1, and thus is invalid, because
+ * flags are either === 1 or even.
+ */
 assert.throws(function() {
-  dns.lookup('www.google.com', { hints: 1 }, noop);
+  dns.lookup('www.google.com', { hints: (dns.V4MAPPED | dns.ADDRCONFIG) + 1 },
+    noop);
 });
 
 assert.throws(function() {

--- a/test/simple/test-dns.js
+++ b/test/simple/test-dns.js
@@ -69,6 +69,47 @@ assert.throws(function() {
   return !(err instanceof TypeError);
 }, 'Unexpected error');
 
+// dns.lookup should accept falsey and string values
+assert.throws(function() {
+  dns.lookup({}, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup([], noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup(true, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup(1, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.throws(function() {
+  dns.lookup(noop, noop);
+}, 'invalid arguments: hostname must be a string or falsey');
+
+assert.doesNotThrow(function() {
+  dns.lookup('', noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(null, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(undefined, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(0, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup(NaN, noop);
+});
+
 /*
  * Make sure that dns.lookup throws if hints does not represent a valid flag.
  * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:

--- a/test/simple/test-net-connect-options-ipv6.js
+++ b/test/simple/test-net-connect-options-ipv6.js
@@ -24,6 +24,11 @@ var assert = require('assert');
 var net = require('net');
 var dns = require('dns');
 
+if (!common.hasIPv6) {
+  console.error('Skipping test, no IPv6 support');
+  return;
+}
+
 var serverGotEnd = false;
 var clientGotEnd = false;
 

--- a/test/simple/test-net-connect-paused-connection.js
+++ b/test/simple/test-net-connect-paused-connection.js
@@ -1,0 +1,35 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common');
+
+var net = require('net');
+
+net.createServer(function(conn) {
+  conn.unref();
+}).listen(8124).unref();
+
+net.connect(8124, 'localhost').pause();
+
+setTimeout(function() {
+  assert.fail('expected to exit');
+}, 1000).unref();

--- a/test/simple/test-net-pingpong.js
+++ b/test/simple/test-net-pingpong.js
@@ -135,9 +135,13 @@ console.log(common.PIPE);
 pingPongTest(common.PIPE);
 pingPongTest(common.PORT);
 pingPongTest(common.PORT + 1, 'localhost');
-pingPongTest(common.PORT + 2, '::1');
+if (common.hasIPv6)
+  pingPongTest(common.PORT + 2, '::1');
 
 process.on('exit', function() {
-  assert.equal(4, tests_run);
+  if (common.hasIPv6)
+    assert.equal(4, tests_run);
+  else
+    assert.equal(3, tests_run);
   console.log('done');
 });

--- a/test/simple/test-net-remote-address-port.js
+++ b/test/simple/test-net-remote-address-port.js
@@ -26,10 +26,16 @@ var net = require('net');
 
 var conns = 0, conns_closed = 0;
 
+var remoteAddrCandidates = [ '127.0.0.1'];
+if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
+
+var remoteFamilyCandidates = ['IPv4'];
+if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
+
 var server = net.createServer(function(socket) {
   conns++;
-  assert.equal('127.0.0.1', socket.remoteAddress);
-  assert.equal('IPv4', socket.remoteFamily);
+  assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));
+  assert.notEqual(-1, remoteFamilyCandidates.indexOf(socket.remoteFamily));
   assert.ok(socket.remotePort);
   assert.notEqual(socket.remotePort, common.PORT);
   socket.on('end', function() {
@@ -42,14 +48,14 @@ server.listen(common.PORT, 'localhost', function() {
   var client = net.createConnection(common.PORT, 'localhost');
   var client2 = net.createConnection(common.PORT);
   client.on('connect', function() {
-    assert.equal('127.0.0.1', client.remoteAddress);
-    assert.equal('IPv4', client.remoteFamily);
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(client.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(client.remoteFamily));
     assert.equal(common.PORT, client.remotePort);
     client.end();
   });
   client2.on('connect', function() {
-    assert.equal('127.0.0.1', client2.remoteAddress);
-    assert.equal('IPv4', client2.remoteFamily);
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
     assert.equal(common.PORT, client2.remotePort);
     client2.end();
   });

--- a/test/simple/test-net-server-address.js
+++ b/test/simple/test-net-server-address.js
@@ -57,6 +57,11 @@ server_ipv6.listen(common.PORT, localhost_ipv6, function() {
   server_ipv6.close();
 });
 
+if (!common.hasIPv6) {
+  console.error('Skipping ipv6 part of test, no IPv6 support');
+  return;
+}
+
 // Test without hostname or ip
 var anycast_ipv6 = '::';
 var server1 = net.createServer();

--- a/test/simple/test-process-kill-pid.js
+++ b/test/simple/test-process-kill-pid.js
@@ -55,6 +55,13 @@ assert.throws(function() { process.kill(+'not a number'); }, TypeError);
 assert.throws(function() { process.kill(1/0); }, TypeError);
 assert.throws(function() { process.kill(-1/0); }, TypeError);
 
+/* Sending SIGHUP is not supported on Windows */
+if (process.platform === 'win32') {
+  pass = true;
+  clearInterval(wait);
+  return;
+}
+
 process.once('SIGHUP', function() {
   process.once('SIGHUP', function() {
     pass = true;

--- a/test/simple/test-stream-ispaused.js
+++ b/test/simple/test-stream-ispaused.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var common = require('../common');
+
+var stream = require('stream');
+
+var readable = new stream.Readable;
+
+// _read is a noop, here.
+readable._read = Function();
+
+// default state of a stream is not "paused"
+assert.ok(!readable.isPaused());
+
+// make the stream start flowing...
+readable.on('data', Function());
+
+// still not paused.
+assert.ok(!readable.isPaused());
+
+readable.pause();
+assert.ok(readable.isPaused());
+readable.resume();
+assert.ok(!readable.isPaused());

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -867,6 +867,20 @@ var parseTestsWithQueryString = {
     'search': '',
     'pathname': '/',
     'path': '/'
+  },
+  '/example?query=value':{
+    protocol: null,
+    slashes: null,
+    auth: null,
+    host: null,
+    port: null,
+    hostname: null,
+    hash: null,
+    search: '?query=value',
+    query: { query: 'value' },
+    pathname: '/example',
+    path: '/example?query=value',
+    href: '/example?query=value'
   }
 };
 for (var u in parseTestsWithQueryString) {


### PR DESCRIPTION
Allow to create an executable with no external dynamic libraries, also the
ones from the system. This is somewhat dependent of the used C lib, for
example glibc has some internal dynamic libraries loaded by itself, but for
other ones like eglibc or dietlib, this would produce a true static linked
executable. This can be of interest for embebers or resource constraints
platforms, but the main reason for this is to allow to use a Javascript
file as Linux kernel 'init' on NodeOS.
