### PR TITLE
gyp: use --export-dynamic on FreeBSD

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -235,6 +235,11 @@
       }],
       ['OS=="freebsd" and node_use_dtrace=="true"', {
         'libraries': [ '-lelf' ],
+      }],
+      ['OS=="freebsd"', {
+        'ldflags': [
+          '-Wl,--export-dynamic',
+        ],
       }]
     ],
   }


### PR DESCRIPTION
Should help addons use OpenSSL functions.

---

Appears to be helpful for bud, and I thought it should be as helpful for node.js too. cc @tjfontaine 
