### PR TITLE
src: Add function name for internal.byteLength and compare

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -671,12 +671,15 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> internal = args[1].As<Object>();
 
-  internal->Set(env->byte_length_string(),
-                FunctionTemplate::New(
-                    env->isolate(), ByteLength)->GetFunction());
-  internal->Set(env->compare_string(),
-                FunctionTemplate::New(
-                    env->isolate(), Compare)->GetFunction());
+  Local<Function> byte_length = FunctionTemplate::New(
+                    env->isolate(), ByteLength)->GetFunction();
+  byte_length->SetName(env->byte_length_string());
+  internal->Set(env->byte_length_string(), byte_length);
+
+  Local<Function> compare = FunctionTemplate::New(
+                    env->isolate(), Compare)->GetFunction();
+  compare->SetName(env->compare_string());
+  internal->Set(env->compare_string(), compare);
 }
 
 


### PR DESCRIPTION
In profile view, the internal.byteLength is `(anonymous function)`.

![2014-08-25 8 56 50](https://cloud.githubusercontent.com/assets/327019/4030001/854e842a-2c57-11e4-90e6-a061a704019d.png)
