### PR TITLE
Fix issue 4055, querystring.unescape override

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -105,7 +105,11 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
 
 
 QueryString.unescape = function(s, decodeSpaces) {
-  return QueryString.unescapeBuffer(s, decodeSpaces).toString();
+  try {
+    return decodeURIComponent(s);
+  } catch (e) {
+    return QueryString.unescapeBuffer(s, decodeSpaces).toString();
+  }
 };
 
 
@@ -193,13 +197,8 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
       vstr = '';
     }
 
-    try {
-      k = decodeURIComponent(kstr);
-      v = decodeURIComponent(vstr);
-    } catch (e) {
-      k = QueryString.unescape(kstr, true);
-      v = QueryString.unescape(vstr, true);
-    }
+    k = QueryString.unescape(kstr, true);
+    v = QueryString.unescape(vstr, true);
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -229,3 +229,11 @@ assert.equal(0xeb, b[16]);
 assert.equal(0xd8, b[17]);
 assert.equal(0xa2, b[18]);
 assert.equal(0xe6, b[19]);
+
+// test overriding .unescape
+var prevUnescape = qs.unescape;
+qs.unescape = function (str) {
+  return str.replace(/o/g, '_');
+};
+assert.deepEqual(qs.parse('foo=bor'), {f__: 'b_r'});
+qs.unescape = prevUnescape;


### PR DESCRIPTION
Documentation states that `querystring.unescape` may be overridden to replace unescaper during parsing. However, the function was only being used as a fallback for when the native decoder throws (on a malformed URL). This patch moves the call to the native function and the try/catch around it into querystring.unescape then has the parser always invoke it, so that an override will always be used.
