### PR TITLE
configure: generate a fully statically linked executable

### DIFF
--- a/configure
+++ b/configure
@@ -57,7 +57,8 @@ parser.add_option('--no-ifaddrs',
 parser.add_option("--fully-static",
     action="store_true",
     dest="fully_static",
-    help="Generate an executable without external dynamic libraries")
+    help="Generate an executable without external dynamic libraries. This "
+         "will not work on OSX when using default compilation environment")
 
 # deprecated
 parser.add_option('--openssl-includes',
@@ -658,6 +659,9 @@ def configure_openssl(o):
 def configure_fullystatic(o):
   if options.fully_static:
     o['libraries'] += ['-static']
+    if flavor == 'mac':
+      print("Generation of static executable will not work on OSX "
+            "when using default compilation environment")
 
 
 def configure_winsdk(o):

--- a/configure
+++ b/configure
@@ -54,6 +54,11 @@ parser.add_option('--no-ifaddrs',
     dest='no_ifaddrs',
     help='use on deprecated SunOS systems that do not support ifaddrs.h')
 
+parser.add_option("--fully-static",
+    action="store_true",
+    dest="fully_static",
+    help="Generate an executable without external dynamic libraries")
+
 # deprecated
 parser.add_option('--openssl-includes',
     action='store',
@@ -650,6 +655,11 @@ def configure_openssl(o):
       o['cflags'] += cflags.split()
 
 
+def configure_fullystatic(o):
+  if options.fully_static:
+    o['libraries'] += ['-static']
+
+
 def configure_winsdk(o):
   if flavor != 'win':
     return
@@ -697,6 +707,7 @@ configure_v8(output)
 configure_openssl(output)
 configure_winsdk(output)
 configure_icu(output)
+configure_fullystatic(output)
 
 # variables should be a root level element,
 # move everything else to target_defaults


### PR DESCRIPTION
Allow to create an executable with no external dynamic libraries, also the
ones from the system. This is somewhat dependent of the used C lib, for
example glibc has some internal dynamic libraries loaded by itself, but for
other ones like eglibc or dietlib, this would produce a true static linked
executable. This can be of interest for embebers or resource constraints
platforms, but the main reason for this is to allow to use a Javascript
file as Linux kernel 'init' on NodeOS.
