### PR TITLE
child_process: add type checking for "args" param

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -610,6 +610,10 @@ exports.execFile = function(file /* args, options, callback */) {
   if (Array.isArray(arguments[1])) {
     args = arguments[1];
     options = util._extend(options, arguments[2]);
+  } else if (arguments[1] && callback !== arguments[1]) {
+    throw new TypeError(
+        "Parameter 'args' must be an array, not a " + typeof arguments[1]
+    );
   } else {
     args = [];
     options = util._extend(options, arguments[1]);

--- a/test/simple/test-child-process-string-args.js
+++ b/test/simple/test-child-process-string-args.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+var common = require('../common');
+var assert = require('assert');
+var execFile = require('child_process').execFile;
+var err;
+
+// path + string does not work.
+try {
+  var c = execFile(process.execPath, 'string argument!');
+} catch(e) {
+  err = e;
+}
+assert.ok(err);
+assert.ok(err instanceof TypeError);
+
+// path + callback still works
+var c = execFile(process.execPath, function() {
+});
+
+c.kill('SIGINT');


### PR DESCRIPTION
This commit ensures that the "args" parameter is either:
1. Undefined or null (defaulting "args" to []).
2. The callback parameter (defaulting "args" to []).
3. An array.

All other values will throw a TypeError.

Fixes #8249.
