### PR TITLE
Remove forced --debug-force argument  #8159

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -288,9 +288,6 @@ function masterInit() {
       }
     }
 
-    if (!hasDebugArg)
-      execArgv = ['--debug-port=' + debugPort].concat(execArgv);
-
     return fork(cluster.settings.exec, cluster.settings.args, {
       env: workerEnv,
       silent: cluster.settings.silent,


### PR DESCRIPTION
If there is no debug argument, do nothing instead of adding the --debug-port option
