### PR TITLE
http: avoid use 'binary' encoding in 'res.end()'

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -129,7 +129,7 @@ OutgoingMessage.prototype._send = function(data, encoding, callback) {
       data = this._header + data;
     } else {
       this.output.unshift(this._header);
-      this.outputEncodings.unshift('binary');
+      this.outputEncodings.unshift('utf8');
       this.outputCallbacks.unshift(null);
     }
     this._headerSent = true;
@@ -446,7 +446,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
             conn.uncork();
         });
       }
-      this._send(len.toString(16), 'binary', null);
+      this._send(len.toString(16), 'utf8', null);
       this._send(crlf_buf, null, null);
       this._send(chunk, encoding, null);
       ret = this._send(crlf_buf, null, callback);
@@ -529,10 +529,10 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   }
 
   if (this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n', 'binary', finish);
+    ret = this._send('0\r\n' + this._trailer + '\r\n', 'utf8', finish);
   } else {
     // Force a flush, HACK.
-    ret = this._send('', 'binary', finish);
+    ret = this._send('', 'utf8', finish);
   }
 
   if (this.connection && data)


### PR DESCRIPTION
Use `binary` will cause `new Buffer()`. It makes `response.end()` slow.

In my test case, `res.end('hello world!');` 47% faster than `res.write('hello world!');res.end();`

Trace these calls, `res.end(data)` use `writev()` path, res.end() use `writeBuffer()` path.

Because use `binary` encoding, the final path is：

```
handle.writeBuffer(req, new Buffer(data, encoding));
```

The `new Buffer()` make it slowly. So change encoding from `binary` to `utf8` to avoid string -> buffer conversion. This patch make my hello world test case speed up 70%.

Test case and benchmark result are here: https://gist.github.com/JacksonTian/382a1ed51e5992fd5e70 
