### PR TITLE
net: Improve Socket.prototype.write()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -606,7 +606,7 @@ Socket.prototype.__defineGetter__('localPort', function() {
 Socket.prototype.write = function(chunk, encoding, cb) {
   if (!util.isString(chunk) && !util.isBuffer(chunk))
     throw new TypeError('invalid data');
-  return stream.Duplex.prototype.write.apply(this, arguments);
+  return stream.Duplex.prototype.write.call(this, chunk, encoding, cb);
 };
 
 


### PR DESCRIPTION
In `http` and `net` module `.write()` is very important, any speed-up is benefit.
