### PR TITLE
Pipeline Errors - Forwarding errors down stream pipelines

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -647,6 +647,168 @@ Examples of Transform streams include:
 * [crypto streams][]
 
 
+### Common Stream Methods
+
+**All** streams have the following methods, be they Readable, Writable, Duplex,
+Transform, PassThrough, or classic.
+
+#### stream.addPipelineErrorHandler(handlerFunction)
+
+Adds an error handler to the stream. This is *distinct* from adding an 
+"error" listener: all errors that occur upstream of this handler will be forwarded
+to this handler. This handler fires before the streams are unpiped, and has the 
+option of preventing the default error handling behavior. The handlerFunction is
+provided a single argument, a [PipelineErrorEvent][] object that provides the original
+error object and the stream the error originated on.
+
+```javascript
+
+var A = createReadableSomehow();
+var B = createTransform();
+var C = createWritable();
+
+A.name = 'A';
+B.name = 'B';
+C.name = 'C';
+
+C.addPipelineErrorHandler(function(errorEvent) {
+  console.log(errorEvent.stream.name, errorEvent.error);
+
+  // prevent the stream from unpiping or exploding if there are
+  // no "error" listeners.
+  errorEvent.handleError();
+})
+
+A.pipe(B).pipe(C);
+
+A.emit('error', new Error('problem!'));   // logs, "A problem!"
+B.emit('error', new Error('problem!'));   // logs, "B problem!"
+C.emit('error', new Error('problem!'));   // logs, "C problem!"
+```
+
+If the error is not handled on the current turn of the event loop, the streams
+will be unpiped and if there are no error listeners on the stream that
+generated the error, the error will be thrown. For example:
+
+```javascript
+A.pipe(B).pipe(C).addPipelineErrorHandler(function (ev) {
+  console.log(ev.error.message);
+});
+
+A.emit('error', new Error('beep boop')); // logs "beep boop", and then the process crashes
+```
+
+Error events will propagate downward from the stream that emitted them. Handling
+the error event will also stop its propagation downstream.
+
+```javascript
+
+A.pipe(B).addPipelineErrorHandler(function (ev) {
+    console.log('B');
+  })
+  .pipe(C).addPipelineErrorHandler(function (ev) {
+    console.log('C');
+    ev.handleError();
+  })
+  .pipe(D).addPipelineErrorHandler(function (ev) {
+    console.log('D')
+  });
+
+A.emit('error', new Error('hello!')); // logs "B" and "C", but *not* "D"
+```
+
+#### stream.removePipelineErrorHandler(handlerFunction)
+
+Remove an error handler from a stream.
+
+```javascript
+
+var handler = function (ev) {
+  ev.handleError();
+};
+aStream.addPipelineErrorHandler(handler);
+aStream.removePipelineErrorHandler(handler);
+```
+
+#### stream.next()
+
+Returns an array of streams that this stream is piped to currently.
+
+```javascript
+A.pipe(B).pipe(C);
+A.next(); // [B]
+A.pipe(X);
+A.next(); // [B, X]
+```
+
+#### stream.prev()
+
+Returns an array of streams that are piping to this stream.
+
+```javascript
+A.pipe(B).pipe(C);
+C.prev(); // [B]
+X.pipe(C);
+C.prev(); // [B, X]
+```
+
+#### stream.nextAll()
+
+Returns an array of streams representing all downstream streams from this stream,
+with no cycles or duplicates, not including the current stream.
+
+```javascript
+A.pipe(B).pipe(C).pipe(D);
+A.pipe(X).pipe(Y);
+
+A.nextAll() // [B, C, D, X, Y]
+
+U.pipe(V).pipe(U);
+U.nextAll() // [V]
+```
+
+#### stream.prevAll()
+
+Returns an array of streams representing all upstream streams from this stream,
+with no cycles or duplicates, not including the current stream.
+
+```javascript
+A.pipe(B).pipe(C).pipe(D);
+X.pipe(Y).pipe(D);
+
+D.prevAll() // [C, B, A, Y, X]
+```
+
+### Class: PipelineErrorEvent
+
+This is the object that is provided to pipeline error handlers. It
+contains details about the error -- the original error object, as well
+as the stream the error was initially emitted on. Additionally, within
+an error event handler, it can be used to stop propagation of the error
+event and prevent the default unpiping behavior. Users should never need
+to instantiate this class themselves.
+
+```javascript
+
+fs.createReadStream('does/not/exist')
+  .pipe(http.request('http://localhost:8124'))
+  .addPipelineErrorHandler(function (errorEvent) {
+    errorEvent.error        // Error: ENOENT
+    errorEvent.stream       // fs.ReadStream
+    errorEvent.isHandled()  // 
+  })
+
+```
+
+#### errorEvent.isHandled()
+
+Returns a boolean value -- true if the error event is handled, and false if it
+is not.
+
+#### errorEvent.handleError()
+
+Prevents the error event from unpiping the streams, and stops the event from propagating downstream.
+
 ## API for Stream Implementors
 
 <!--type=misc-->

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -463,6 +463,9 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   var src = this;
   var state = this._readableState;
 
+  var nextIdx = src._nextStreams.push(dest) - 1;
+  var prevIdx = dest._prevStreams.push(dest) - 1;
+
   switch (state.pipesCount) {
     case 0:
       state.pipes = dest;
@@ -518,6 +521,16 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     src.removeListener('end', onend);
     src.removeListener('end', cleanup);
     src.removeListener('data', ondata);
+
+    if (nextIdx !== null) {
+      src._nextStreams.splice(nextIdx, 1);
+      nextIdx = null;
+    }
+
+    if (prevIdx !== null) {
+      dest._prevStreams.splice(prevIdx, 1);
+      prevIdx = null;
+    }
 
     // if the reader is waiting for a drain event from this
     // specific writer, then it would cause it to never start

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -463,6 +463,9 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   var src = this;
   var state = this._readableState;
 
+  src._nextStreams = src._nextStreams || [];
+  dest._prevStreams = dest._prevStreams || [];
+
   var nextIdx = src._nextStreams.push(dest) - 1;
   var prevIdx = dest._prevStreams.push(src) - 1;
 
@@ -557,7 +560,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // if the dest has an error, then stop piping into it.
   // however, don't suppress the throwing behavior for this.
   function onerror(er) {
-    var handled = {handled: false}
+    var handled = {handled: false};
     this.emit('_preError', er, handled);
 
     if (handled.handled) {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -464,7 +464,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   var state = this._readableState;
 
   var nextIdx = src._nextStreams.push(dest) - 1;
-  var prevIdx = dest._prevStreams.push(dest) - 1;
+  var prevIdx = dest._prevStreams.push(src) - 1;
 
   switch (state.pipesCount) {
     case 0:
@@ -557,6 +557,13 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // if the dest has an error, then stop piping into it.
   // however, don't suppress the throwing behavior for this.
   function onerror(er) {
+    var handled = {handled: false}
+    this.emit('_preError', er, handled);
+
+    if (handled.handled) {
+      return;
+    }
+
     debug('onerror', er);
     unpipe();
     dest.removeListener('error', onerror);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -144,6 +144,7 @@ Stream.prototype.addPipelineErrorHandler = function(fn) {
     stream.removeListener('error', _defaultPipelineErrorHandler);
     stream.removeListener('pipe', onpipe);
     stream.removeListener('unpipe', onunpipe);
+    installedMembership.delete(stream);
 
     if (!stream._errorHandlers) return;
     if (stream !== source) return;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -35,13 +35,16 @@ Stream.PassThrough = require('_stream_passthrough');
 // Backwards-compat with node 0.4.x
 Stream.Stream = Stream;
 
-
-
 // old-style streams.  Note that the pipe method (the only relevant
 // part of this class) is overridden in the Readable class.
 
 function Stream() {
   EE.call(this);
+
+  // note that we can't necessarily
+  // count on these attributes to be present
+  // on all streams -- some folk might subclass
+  // incorrectly.
   this._nextStreams = [];
   this._prevStreams = [];
   this._errorHandlers = [];
@@ -64,6 +67,8 @@ Stream.prototype.prevAll = function() {
 };
 
 Stream.prototype.removeErrorHandler = function(fn) {
+  if (!this._errorHandlers) return;
+
   for (var i = 0, len = this._errorHandlers.length; i < len; ++i) {
     if (this._errorHandlers[i].handler === fn) {
       this._errorHandlers[i].uninstall();
@@ -74,9 +79,13 @@ Stream.prototype.removeErrorHandler = function(fn) {
 };
 
 Stream.prototype.addErrorHandler = function(fn) {
+  if (!this._errorHandlers) {
+    this._errorHandlers = [];
+  }
+
   var isHandling = true;
   var installedOnStreams = [];
-  
+
   // Using a WeakSet + array pair to speed up
   // membership lookups. Could be accomplished
   // with just the array.
@@ -130,6 +139,8 @@ Stream.prototype.addErrorHandler = function(fn) {
     stream.removeListener('pipe', onpipe);
     stream.removeListener('unpipe', onunpipe);
 
+    if (!stream._errorHandlers) return;
+
     for (var i = 0, len = stream._errorHandlers.length; i < len; ++i) {
       if (stream._errorHandlers[i].handler === fn) {
         break;
@@ -147,14 +158,14 @@ Stream.prototype.addErrorHandler = function(fn) {
 };
 
 function defaultErrorHandler(err) {
-  var handled = {handled: false}
+  var handled = {handled: false};
   this.emit('_preError', err, handled);
 
   if (handled.handled) {
     return;
   }
 
-  if(EE.listenerCount(this, 'error') === 1) {
+  if (EE.listenerCount(this, 'error') === 1) {
     this.removeListener('error', defaultErrorHandler);
     this.emit('error', err);
   }
@@ -163,7 +174,8 @@ function defaultErrorHandler(err) {
 function maybePropagate(stream, error) {
   var errorEvent = error._errorEvent;
   var wasCreated = !errorEvent;
-  errorEvent = error._errorEvent = errorEvent || new PipelineErrorEvent(error, stream);
+  errorEvent = error._errorEvent = errorEvent ||
+      new PipelineErrorEvent(error, stream);
 
   if (wasCreated) {
     if (visit(stream)) {
@@ -176,16 +188,15 @@ function maybePropagate(stream, error) {
   return errorEvent.isHandled();
 
   function visit(xs, idx) {
-    if (!xs._errorHandlers.length) {
-      return;
-    }
+    if (!xs._errorHandlers) return;
+    if (!xs._errorHandlers.length) return;
 
     return xs._errorHandlers.some(function(handlerPair) {
 
       handlerPair.handler.call(xs, errorEvent);
 
       return errorEvent.isHandled();
-    })
+    });
   }
 }
 
@@ -216,6 +227,9 @@ function iterateStream(stream, attr) {
 
 Stream.prototype.pipe = function(dest, options) {
   var source = this;
+
+  source._nextStreams = source._nextStreams || [];
+  dest._prevStreams = dest._prevStreams || [];
 
   var nextIdx = source._nextStreams.push(dest) - 1;
   var prevIdx = dest._prevStreams.push(source) - 1;
@@ -263,7 +277,7 @@ Stream.prototype.pipe = function(dest, options) {
 
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
-    var handled = {handled: false}
+    var handled = {handled: false};
     this.emit('_preError', er, handled);
 
     if (handled.handled) {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -51,10 +51,16 @@ function Stream() {
 }
 
 Stream.prototype.next = function() {
+  if (!this._nextStreams) {
+    return [];
+  }
   return this._nextStreams.slice();
 };
 
 Stream.prototype.prev = function() {
+  if (!this._prevStreams) {
+    return [];
+  }
   return this._prevStreams.slice();
 };
 
@@ -215,6 +221,7 @@ function iterateStream(stream, attr) {
     visited.add(current);
     out.push(current);
     var children = attr in current ? current[attr] : [];
+    children = children || [];
 
     for (var i = children.length - 1; i > -1; --i) {
       stack.push(children[i]);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -41,10 +41,47 @@ Stream.Stream = Stream;
 
 function Stream() {
   EE.call(this);
+  this._nextStreams = [];
+  this._prevStreams = [];
+}
+
+Stream.prototype.nextAll = function() {
+  return iterateStream(this, '_nextStreams');
+};
+
+Stream.prototype.prevAll = function() {
+  return iterateStream(this, '_prevStreams');
+};
+
+function iterateStream(stream, attr) {
+  var visited = new WeakSet;
+  var current = this;
+  var stack = [this];
+  var out = [];
+
+  while (stack.length) {
+    current = stack.pop();
+
+    if (visited.has(current)) {
+      continue;
+    }
+
+    visited.add(current);
+    var children = attr in current ? current[attr] : [];
+
+    for (var i = children.length - 1; i > -1; --i) {
+      stack.push(children[i]);
+    }
+  }
+
+  return out;
 }
 
 Stream.prototype.pipe = function(dest, options) {
   var source = this;
+
+  var nextIdx = source._nextStreams.push(dest) - 1;
+  var prevIdx = dest._prevStreams.push(source) - 1;
 
   function ondata(chunk) {
     if (dest.writable) {
@@ -113,6 +150,16 @@ Stream.prototype.pipe = function(dest, options) {
     source.removeListener('close', cleanup);
 
     dest.removeListener('close', cleanup);
+
+    if (nextIdx !== null) {
+      source._nextStreams.splice(nextIdx, 1);
+      nextIdx = null;
+    }
+
+    if (prevIdx !== null) {
+      dest._prevStreams.splice(prevIdx, 1);
+      prevIdx = null;
+    }
   }
 
   source.on('end', cleanup);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -66,7 +66,7 @@ Stream.prototype.prevAll = function() {
   return iterateStream(this, '_prevStreams');
 };
 
-Stream.prototype.removeErrorHandler = function(fn) {
+Stream.prototype.removePipelineErrorHandler = function(fn) {
   if (!this._errorHandlers) return;
 
   for (var i = 0, len = this._errorHandlers.length; i < len; ++i) {
@@ -78,7 +78,7 @@ Stream.prototype.removeErrorHandler = function(fn) {
   }
 };
 
-Stream.prototype.addErrorHandler = function(fn) {
+Stream.prototype.addPipelineErrorHandler = function(fn) {
   if (!this._errorHandlers) {
     this._errorHandlers = [];
   }
@@ -95,10 +95,10 @@ Stream.prototype.addErrorHandler = function(fn) {
   install(this);
   this.prevAll().forEach(install);
 
-  this._errorHandlers.push({
+  var installedIdx = this._errorHandlers.push({
     handler: fn,
     uninstall: uninstallAll
-  });
+  }) - 1;
 
   return this;
 
@@ -114,19 +114,19 @@ Stream.prototype.addErrorHandler = function(fn) {
     stream.on('pipe', onpipe);
 
     if (EE.listenerCount(stream, 'error') === 0) {
-      stream.on('error', defaultErrorHandler);
+      stream.on('error', _defaultPipelineErrorHandler);
     }
   }
 
   function onpipe(newSrc) {
-    this.removeListener('error', defaultErrorHandler);
+    this.removeListener('error', _defaultPipelineErrorHandler);
     install(newSrc);
-    newSrc.prevAll(install);
+    newSrc.prevAll().forEach(install);
   }
 
   function onunpipe() {
     uninstallAll();
-    source.addErrorHandler(fn);
+    source.addPipelineErrorHandler(fn);
   }
 
   function onPreError(err, handled) {
@@ -135,29 +135,28 @@ Stream.prototype.addErrorHandler = function(fn) {
 
   function uninstall(stream) {
     stream.removeListener('_preError', onPreError);
-    stream.removeListener('error', defaultErrorHandler);
+    stream.removeListener('error', _defaultPipelineErrorHandler);
     stream.removeListener('pipe', onpipe);
     stream.removeListener('unpipe', onunpipe);
 
     if (!stream._errorHandlers) return;
+    if (stream !== source) return;
+    if (installedIdx === null) return;
 
-    for (var i = 0, len = stream._errorHandlers.length; i < len; ++i) {
-      if (stream._errorHandlers[i].handler === fn) {
-        break;
-      }
-    }
-
-    if (i === len) return;
-
-    stream._errorHandlers.splice(i, 1);
+    stream._errorHandlers.splice(installedIdx, 1);
+    installedIdx = null;
   }
 
   function uninstallAll() {
     installedOnStreams.forEach(uninstall);
+    installedOnStreams.length = 0;
   }
 };
 
-function defaultErrorHandler(err) {
+// the default pipeline error handler exists because
+// streams2+ do not add an error handler to Readables on ".pipe".
+// this catches any error that would otherwise be emitted.
+function _defaultPipelineErrorHandler(err) {
   var handled = {handled: false};
   this.emit('_preError', err, handled);
 
@@ -166,7 +165,7 @@ function defaultErrorHandler(err) {
   }
 
   if (EE.listenerCount(this, 'error') === 1) {
-    this.removeListener('error', defaultErrorHandler);
+    this.removeListener('error', _defaultPipelineErrorHandler);
     this.emit('error', err);
   }
 }

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -23,6 +23,7 @@ module.exports = Stream;
 
 var EE = require('events').EventEmitter;
 var util = require('util');
+var debug = util.debuglog('stream');
 
 util.inherits(Stream, EE);
 Stream.Readable = require('_stream_readable');
@@ -43,7 +44,16 @@ function Stream() {
   EE.call(this);
   this._nextStreams = [];
   this._prevStreams = [];
+  this._errorHandlers = [];
 }
+
+Stream.prototype.next = function() {
+  return this._nextStreams.slice();
+};
+
+Stream.prototype.prev = function() {
+  return this._prevStreams.slice();
+};
 
 Stream.prototype.nextAll = function() {
   return iterateStream(this, '_nextStreams');
@@ -53,10 +63,136 @@ Stream.prototype.prevAll = function() {
   return iterateStream(this, '_prevStreams');
 };
 
+Stream.prototype.removeErrorHandler = function(fn) {
+  for (var i = 0, len = this._errorHandlers.length; i < len; ++i) {
+    if (this._errorHandlers[i].handler === fn) {
+      this._errorHandlers[i].uninstall();
+
+      return;
+    }
+  }
+};
+
+Stream.prototype.addErrorHandler = function(fn) {
+  var isHandling = true;
+  var installedOnStreams = [];
+  
+  // Using a WeakSet + array pair to speed up
+  // membership lookups. Could be accomplished
+  // with just the array.
+  var installedMembership = new WeakSet;
+  var source = this;
+
+  install(this);
+  this.prevAll().forEach(install);
+
+  this._errorHandlers.push({
+    handler: fn,
+    uninstall: uninstallAll
+  });
+
+  return this;
+
+  function install(stream, idx, all) {
+    if (installedMembership.has(stream)) {
+      return;
+    }
+
+    installedOnStreams.push(stream);
+    installedMembership.add(stream);
+    stream.on('_preError', onPreError);
+    stream.on('unpipe', onunpipe);
+    stream.on('pipe', onpipe);
+
+    if (EE.listenerCount(stream, 'error') === 0) {
+      stream.on('error', defaultErrorHandler);
+    }
+  }
+
+  function onpipe(newSrc) {
+    this.removeListener('error', defaultErrorHandler);
+    install(newSrc);
+    newSrc.prevAll(install);
+  }
+
+  function onunpipe() {
+    uninstallAll();
+    source.addErrorHandler(fn);
+  }
+
+  function onPreError(err, handled) {
+    handled.handled = maybePropagate(this, err);
+  }
+
+  function uninstall(stream) {
+    stream.removeListener('_preError', onPreError);
+    stream.removeListener('error', defaultErrorHandler);
+    stream.removeListener('pipe', onpipe);
+    stream.removeListener('unpipe', onunpipe);
+
+    for (var i = 0, len = stream._errorHandlers.length; i < len; ++i) {
+      if (stream._errorHandlers[i].handler === fn) {
+        break;
+      }
+    }
+
+    if (i === len) return;
+
+    stream._errorHandlers.splice(i, 1);
+  }
+
+  function uninstallAll() {
+    installedOnStreams.forEach(uninstall);
+  }
+};
+
+function defaultErrorHandler(err) {
+  var handled = {handled: false}
+  this.emit('_preError', err, handled);
+
+  if (handled.handled) {
+    return;
+  }
+
+  if(EE.listenerCount(this, 'error') === 1) {
+    this.removeListener('error', defaultErrorHandler);
+    this.emit('error', err);
+  }
+}
+
+function maybePropagate(stream, error) {
+  var errorEvent = error._errorEvent;
+  var wasCreated = !errorEvent;
+  errorEvent = error._errorEvent = errorEvent || new PipelineErrorEvent(error, stream);
+
+  if (wasCreated) {
+    if (visit(stream)) {
+      return true;
+    }
+
+    return stream.nextAll().some(visit);
+  }
+
+  return errorEvent.isHandled();
+
+  function visit(xs, idx) {
+    if (!xs._errorHandlers.length) {
+      return;
+    }
+
+    return xs._errorHandlers.some(function(handlerPair) {
+
+      handlerPair.handler.call(xs, errorEvent);
+
+      return errorEvent.isHandled();
+    })
+  }
+}
+
 function iterateStream(stream, attr) {
   var visited = new WeakSet;
-  var current = this;
-  var stack = [this];
+  var current = stream;
+  var stack = [stream];
   var out = [];
 
   while (stack.length) {
@@ -67,6 +203,7 @@ function iterateStream(stream, attr) {
     }
 
     visited.add(current);
+    out.push(current);
     var children = attr in current ? current[attr] : [];
 
     for (var i = children.length - 1; i > -1; --i) {
@@ -74,7 +211,7 @@ function iterateStream(stream, attr) {
     }
   }
 
-  return out;
+  return out.slice(1);
 }
 
 Stream.prototype.pipe = function(dest, options) {
@@ -126,6 +263,13 @@ Stream.prototype.pipe = function(dest, options) {
 
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
+    var handled = {handled: false}
+    this.emit('_preError', er, handled);
+
+    if (handled.handled) {
+      return;
+    }
+
     cleanup();
     if (EE.listenerCount(this, 'error') === 0) {
       throw er; // Unhandled stream error in pipe.
@@ -171,4 +315,28 @@ Stream.prototype.pipe = function(dest, options) {
 
   // Allow for unix-like usage: A.pipe(B).pipe(C)
   return dest;
+};
+
+var pipelineErrorState = new WeakMap;
+
+function PipelineErrorEvent(err, sourceStream, unpipe) {
+  this.error = err;
+  this.stream = sourceStream;
+  pipelineErrorState.set(this, {
+    'isHandled': false
+  });
+}
+
+
+PipelineErrorEvent.prototype.handleError = function() {
+  debug('handleError', this.error);
+  pipelineErrorState.set(this, {
+    'isHandled': true
+  });
+};
+
+
+PipelineErrorEvent.prototype.isHandled = function() {
+  var state = pipelineErrorState.get(this) || {};
+  return Boolean(state.isHandled);
 };

--- a/test/simple/test-stream3-next-prev.js
+++ b/test/simple/test-stream3-next-prev.js
@@ -1,0 +1,367 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var assert = require('assert');
+var stream = require('stream');
+
+var fs = require('fs');
+var path = require('path');
+
+// utils
+function makeReadable() {
+  var r = new stream.Readable;
+
+  r._read = function() {
+    setTimeout(function() {
+      if(!r._readableState.ended) {
+        r.push('cool story');
+      }
+    });
+  };
+
+  r.end = function() {
+    r.push(null);
+  }
+
+  return r;
+}
+
+function makeWritable() {
+  var w = new stream.Writable;
+
+  w._write = function(chunk, enc, cb) {
+    this.bytesWritten = this.bytesWritten || 0;
+    this.bytesWritten += chunk.length;
+    setImmediate(cb);
+  };
+
+  return w;
+}
+
+function makeDuplex() {
+  var d = new stream.PassThrough;
+
+  d.end = function() {
+    stream.PassThrough.prototype.end.apply(d, arguments);
+    d.push(null);
+  }
+
+  return d;
+}
+
+function makeLegacy() {
+  var s = new stream.Stream;
+  
+  s.bytesWritten = 0;
+  s.write = function(chunk) {
+    s.bytesWritten += chunk.length;
+    setTimeout(function() {
+      s.emit('data', chunk); 
+    });
+  };
+  s.end = function() {
+    s.emit('end');
+  };
+
+  return s;
+}
+
+// borrowing node-tap look-alike
+var tests = [];
+var count = 0;
+
+function test(name, fn) {
+  count++;
+  tests.push([name, fn]);
+}
+
+function run() {
+  var next = tests.shift();
+  if (!next) {
+    return console.error('ok');
+  }
+
+  var name = next[0];
+  var fn = next[1];
+  console.log('# %s', name);
+
+  assert.end = function() {
+    --count;
+    run();
+  };
+
+  fn(assert);
+}
+
+// ensure all tests have run
+process.on("exit", function () {
+  assert.equal(count, 0);
+});
+
+process.nextTick(run);
+
+test('next()/prev() returns immediate destinations & sources', function(assert) {
+  var simpleTests = [
+    [makeReadable, makeWritable],
+    [makeDuplex, makeDuplex],
+    [makeReadable, makeLegacy],
+    [makeLegacy, makeWritable],
+    [makeDuplex, makeLegacy],
+    [makeLegacy, makeLegacy]
+  ]
+
+  simpleTests.forEach(function(testPair) {
+    var A = testPair[0]();
+    var B = testPair[1]();
+
+    A.pipe(B);
+    assert.deepEqual(A.next(), [B]);
+    assert.deepEqual(B.prev(), [A]);
+    A.end();
+  });
+
+  var complexForward = [
+    [makeReadable, [makeWritable, makeDuplex, makeLegacy]],
+    [makeDuplex, [makeWritable, makeDuplex, makeLegacy]],
+    [makeLegacy, [makeWritable, makeDuplex, makeLegacy]],
+  ];
+
+  complexForward.forEach(function(testPair) {
+    var A = testPair[0]();
+    var B = testPair[1].map(function(xs) {
+      return A.pipe(xs());
+    });
+
+    assert.deepEqual(A.next(), B);
+    B.forEach(function(xs) {
+      assert.deepEqual(xs.prev(), [A]);
+    });
+    A.end();
+  });
+
+  var complexBackward = [
+    [[makeReadable, makeDuplex, makeLegacy], makeWritable],
+    [[makeReadable, makeDuplex, makeLegacy], makeDuplex],
+    [[makeReadable, makeDuplex, makeLegacy], makeLegacy],
+  ];
+
+  complexBackward.forEach(function(testPair) {
+    var B = testPair[1]();
+    var A = testPair[0].map(function(xs) {
+      xs = xs();
+      xs.pipe(B);
+      return xs;
+    });
+
+    assert.deepEqual(B.prev(), A);
+    A.forEach(function(xs) {
+      assert.deepEqual(xs.next(), [B]);
+    });
+    A.forEach(function(xs) {
+      xs.end();
+    });
+  });
+
+  var longPipe = [
+    [makeReadable, makeDuplex, makeWritable],
+    [makeDuplex, makeDuplex, makeDuplex],
+    [makeReadable, makeDuplex, makeDuplex],
+    [makeDuplex, makeDuplex, makeWritable],
+    [makeLegacy, makeDuplex, makeWritable],
+    [makeReadable, makeDuplex, makeLegacy],
+    [makeReadable, makeLegacy, makeLegacy],
+    [makeLegacy, makeLegacy, makeWritable],
+    [makeLegacy, makeLegacy, makeLegacy],
+  ];
+
+  longPipe.forEach(function(testTriple) {
+    var A = testTriple[0]();
+    var B = testTriple[1]();
+    var C = testTriple[2]();
+
+    A.pipe(B).pipe(C);
+
+    assert.deepEqual(A.next(), [B]);
+    assert.deepEqual(C.prev(), [B]);
+    A.end();
+  });
+
+  assert.end();
+});
+
+test('nextAll()/prevAll() returns all destinations/sources of this stream', function(assert) {
+  var longPipe = [
+    [makeReadable, makeDuplex, makeWritable],
+    [makeDuplex, makeDuplex, makeDuplex],
+    [makeReadable, makeDuplex, makeDuplex],
+    [makeDuplex, makeDuplex, makeWritable],
+    [makeLegacy, makeDuplex, makeWritable],
+    [makeReadable, makeDuplex, makeLegacy],
+    [makeReadable, makeLegacy, makeLegacy],
+    [makeLegacy, makeLegacy, makeWritable],
+    [makeLegacy, makeLegacy, makeLegacy],
+  ];
+
+  longPipe.forEach(function(testTriple) {
+    var A = testTriple[0]();
+    var B = testTriple[1]();
+    var C = testTriple[2]();
+
+    A.pipe(B).pipe(C);
+
+    assert.deepEqual(A.nextAll(), [B, C]);
+    assert.deepEqual(C.prevAll(), [B, A]);
+    A.end();
+  });
+
+  var manyToMany = [
+    [[makeReadable, makeDuplex, makeLegacy], makeDuplex, [makeWritable, makeDuplex, makeLegacy]],
+    [[makeReadable, makeDuplex, makeLegacy], makeLegacy, [makeWritable, makeDuplex, makeLegacy]],
+  ];
+
+  manyToMany.forEach(function(testTriple) {
+    var B = testTriple[1]();
+    var A = testTriple[0].map(function(xs) {
+      xs = xs();
+      xs.pipe(B);
+      return xs;
+    });
+    var C = testTriple[2].map(function(xs) {
+      return B.pipe(xs());
+    });
+
+    A.forEach(function(stream) {
+      assert.deepEqual(stream.nextAll(), [B].concat(C));
+    });
+
+    assert.deepEqual(B.nextAll(), C);
+    assert.deepEqual(B.prevAll(), A);
+
+    C.forEach(function(stream) {
+      assert.deepEqual(stream.prevAll(), [B].concat(A));
+    });
+
+    A.forEach(function(xs) {
+      xs.end();
+    });
+  });
+
+  assert.end();
+});
+
+test('nextAll()/prevAll() returns all streams with no duplicates', function(assert) {
+  // A - B
+  //       \
+  //        D - E
+  //       /
+  // A - C
+  //
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeLegacy();
+  var D = makeDuplex();
+  var E = makeWritable();
+
+  A.pipe(B).pipe(D).pipe(E);
+  A.pipe(C).pipe(D);
+
+  assert.deepEqual(E.prevAll(), [D, B, A, C]);
+  A.end();
+
+  //       C - E
+  //      /
+  // A - B
+  //      \
+  //       D - E
+
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeLegacy();
+  var D = makeDuplex();
+  var E = makeWritable();
+
+  A.pipe(B).pipe(C).pipe(E);
+  B.pipe(D).pipe(E);
+  assert.deepEqual(A.nextAll(), [B, C, E, D]);
+  A.end();
+
+  assert.end();
+});
+
+test('nextAll()/prevAll() returns all streams with no cycles', function(assert) {
+  var A = makeLegacy();
+  var B = makeLegacy();
+
+  A.pipe(B).pipe(A);
+  assert.deepEqual(A.nextAll(), [B]);
+  assert.deepEqual(B.nextAll(), [A]);
+  assert.deepEqual(A.prevAll(), [B]);
+  assert.deepEqual(B.prevAll(), [A]);
+  A.end();
+
+  var A = makeDuplex();
+  var B = makeDuplex();
+
+  A.pipe(B).pipe(A);
+  assert.deepEqual(A.nextAll(), [B]);
+  assert.deepEqual(B.nextAll(), [A]);
+  assert.deepEqual(A.prevAll(), [B]);
+  assert.deepEqual(B.prevAll(), [A]);
+  A.end();
+
+  assert.end();
+});
+
+test('lifecycle: {next,prev}{All,}() responds to the removal of streams via end or unpipe', function(assert) {
+  //       C - E
+  //      /
+  // A - B
+  //      \
+  //       D - E
+  //
+  // then unpipe C from B
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeDuplex();
+  var D = makeDuplex();
+  var E = makeWritable();
+
+  A.pipe(B).pipe(C).pipe(E);
+  B.pipe(D).pipe(E);
+  assert.deepEqual(A.nextAll(), [B, C, E, D]);
+  assert.deepEqual(E.prevAll(), [C, B, A, D]);
+  assert.deepEqual(E.prev(), [C, D]);
+  assert.deepEqual(B.next(), [C, D]);
+  B.unpipe(C);
+  assert.deepEqual(B.next(), [D]);
+  assert.deepEqual(A.nextAll(), [B, D, E]);
+
+  // C is still piped to E!
+  assert.deepEqual(E.prevAll(), [C, D, B, A]);
+  assert.deepEqual(E.prev(), [C, D]);
+  C.unpipe(E);
+  assert.deepEqual(E.prevAll(), [D, B, A]);
+  assert.deepEqual(E.prev(), [D]);
+  A.end();
+
+  assert.end();
+});

--- a/test/simple/test-stream3-pipeline-error.js
+++ b/test/simple/test-stream3-pipeline-error.js
@@ -601,3 +601,24 @@ test('lifecycle: addErrorHandler / pipe / unpipe / error', function(assert) {
     assert.fail('should have thrown');
   }
 });
+
+test('multiple error handlers on a single stream', function(assert) {
+  var A = makeReadable();
+  var seen = 0;
+
+  A.addErrorHandler(countError);
+  A.addErrorHandler(countError);
+  A.addErrorHandler(function (ev) {
+    ev.handleError();
+  });
+  A.addErrorHandler(countError);
+  A.addErrorHandler(countError);
+
+  A.emit('error', new Error('wuh oh'));
+  assert.equal(seen, 2);
+  assert.end();
+
+  function countError() {
+    ++seen;
+  }
+});

--- a/test/simple/test-stream3-pipeline-error.js
+++ b/test/simple/test-stream3-pipeline-error.js
@@ -1,0 +1,603 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common.js');
+var assert = require('assert');
+var stream = require('stream');
+
+var fs = require('fs');
+var path = require('path');
+
+// utils
+function makeReadable() {
+  var r = new stream.Readable;
+
+  r._read = function() {
+    setTimeout(function() {
+      if(!r._readableState.ended) {
+        r.push('cool story');
+      }
+    });
+  };
+
+  r.end = function() {
+    r.push(null);
+  }
+
+  return r;
+}
+
+function makeWritable() {
+  var w = new stream.Writable;
+
+  w._write = function(chunk, enc, cb) {
+    this.bytesWritten = this.bytesWritten || 0;
+    this.bytesWritten += chunk.length;
+    setImmediate(cb);
+  };
+
+  return w;
+}
+
+function makeDuplex() {
+  var d = new stream.PassThrough;
+
+  d.end = function() {
+    stream.PassThrough.prototype.end.apply(d, arguments);
+    d.push(null);
+  }
+
+  return d;
+}
+
+function makeLegacy() {
+  var s = new stream.Stream;
+  
+  s.bytesWritten = 0;
+  s.write = function(chunk) {
+    s.bytesWritten += chunk.length;
+    setTimeout(function() {
+      s.emit('data', chunk); 
+    });
+  };
+  s.end = function() {
+    s.emit('end');
+  };
+
+  return s;
+}
+
+// borrowing node-tap look-alike
+var tests = [];
+var count = 0;
+
+function test(name, fn) {
+  count++;
+  tests.push([name, fn]);
+}
+
+function run() {
+  var next = tests.shift();
+  if (!next) {
+    return console.error('ok');
+  }
+
+  var name = next[0];
+  var fn = next[1];
+  console.log('# %s', name);
+
+  assert.end = function() {
+    --count;
+    run();
+  };
+
+  fn(assert);
+}
+
+// ensure all tests have run
+process.on("exit", function () {
+  assert.equal(count, 0);
+});
+
+process.nextTick(run);
+
+test('PipelineError has expected attributes', function(assert) {
+  var readable = new stream.Readable;
+  var error = new Error;
+  readable.addErrorHandler(function handler(ev) {
+    readable.removeErrorHandler(handler);
+    assert.strictEqual(ev.error, error);
+    assert.strictEqual(ev.stream, readable);
+    assert.end();
+  });
+
+  readable.emit('error', error);
+});
+
+test('handleError stops propagation', function(assert) {
+  // A -> B -> C
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeWritable();
+
+  // the error event should not crash the test.
+  A.on('error', Function());
+  B.on('error', Function());
+  C.on('error', Function());
+
+  A.pipe(B).pipe(C);
+
+  B.addErrorHandler(function(ev) {
+    ev.handleError();  
+  });
+
+  C.addErrorHandler(function(ev) {
+    assert.fail('should not have seen pipelineError');
+  });
+
+  A.emit('error', new Error('test pipelineError'));
+
+  A.push(null);
+  assert.end();
+});
+
+test('event handler does not prevent default behavior', function(assert) {
+  // A -> B -> C
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeWritable();
+  var seen = 0;
+  var err;
+
+  A.pipe(B).pipe(C);
+
+  A.addErrorHandler(onpipelineerror);
+  B.addErrorHandler(onpipelineerror);
+  C.addErrorHandler(onpipelineerror);
+
+  function onpipelineerror(ev) {
+    assert.ok(ev);
+    ++seen;
+  }
+
+  try {
+    A.emit('error', new Error('test pipelineError'));
+  } catch(e) {
+    err = e;
+  }
+
+  assert.ok(err);
+  assert.equal(seen, 3);
+  A.push(null);
+  assert.end();
+});
+
+test('propagation 1 - simple pipeline', function(assert) {
+  // A -> B -> C
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeWritable();
+
+  var visited = [];
+
+  A.pipe(B).pipe(C);
+  A.id = 'A'
+  B.id = 'B'
+  C.id = 'C'
+
+
+  A.addErrorHandler(countPipelineError);
+  B.addErrorHandler(countPipelineError);
+  C.addErrorHandler(countPipelineError);
+
+  var situations = [
+    [A, C, [A, B, C]],
+    [A, A, [A]],
+    [B, B, [B]],
+    [C, C, [C]],
+    [B, C, [B, C]],
+    [A, B, [A, B]],
+  ];
+  situations.forEach(examine);
+  A.push(null);
+  assert.end();
+
+  function examine(situation, idx) {
+    visited.length = 0;
+    situation[1].addErrorHandler(handlePipelineError);
+    try {
+      situation[0].emit('error', new Error('should not throw: ' + idx));
+    } finally {
+      situation[1].removeErrorHandler(handlePipelineError);
+    }
+    assert.deepEqual(
+        visited,
+        situation[2],
+        'expected ' + situation[2].map(toName).join('') + ', ' +
+        'got ' + visited.map(toName).join('')
+    )
+  }
+
+  function toName(stream) {
+    switch(stream) {
+      case A: return 'A'; break;
+      case B: return 'B'; break;
+      case C: return 'C'; break;
+    }
+  }
+
+  function countPipelineError(ev) {
+    visited.push(this);
+  }
+
+  function handlePipelineError(ev) {
+    ev.handleError();
+  }
+});
+
+test('propagation 2 - duplex pipeline', function(assert) {
+  // A -> B -> A
+  var A = makeDuplex();
+  var B = makeDuplex();
+  var C = makeDuplex();
+
+  var visited = [];
+  var err = new Error;
+
+  A.pipe(B).pipe(A);
+
+  A.addErrorHandler(countPipelineError);
+  B.addErrorHandler(countPipelineError);
+
+  // throws error / handles errors / propagation sequence
+  var situations = [
+    [A, A, [A]],
+    [A, B, [A, B]],
+    [B, B, [B]],
+    [B, A, [B, A]],
+  ];
+
+  situations.forEach(examine);
+  A.push(null);
+  assert.end();
+
+  function examine(situation, idx) {
+    visited.length = 0;
+    situation[1].addErrorHandler(handlePipelineError);
+    try {
+      situation[0].emit('error', new Error);
+    } finally {
+      situation[1].removeErrorHandler(handlePipelineError);
+    }
+    assert.deepEqual(
+        visited,
+        situation[2],
+        'expected ' + situation[2].map(toName).join('') + ', ' +
+        'got ' + visited.map(toName).join('')
+    )
+  }
+
+  function toName(stream) {
+    switch(stream) {
+      case A: return 'A'; break;
+      case B: return 'B'; break;
+    }
+  }
+
+  function countPipelineError(ev) {
+    visited.push(this);
+  }
+
+  function handlePipelineError(ev) {
+    ev.handleError();
+  }
+});
+
+test('propagation 3 - complex pipeline', function(assert) {
+  //        C -> D -> C
+  //       /
+  // A -> B    V -> W
+  //       \  /     | 
+  //        U       |
+  //          \     v 
+  //           X -> Y -> X -> Z
+
+  var A, B, C, D, U, V, W, X, Y, Z;
+
+  A = makeReadable();
+  B = makeDuplex();
+  C = makeDuplex();
+  D = makeDuplex();
+  U = makeDuplex();
+  V = makeDuplex();
+  W = makeDuplex();
+  X = makeDuplex();
+  Y = makeDuplex();
+  Z = makeWritable();
+
+  var visited = [];
+
+  [A, B, C, D, U, V, W, X, Y, Z].forEach(function(xs) {
+    xs.addErrorHandler(countPipelineError); 
+  });
+
+  A.pipe(B).pipe(C).pipe(D).pipe(C);
+  B.pipe(U).pipe(V).pipe(W).pipe(Y);
+  X.pipe(Y).pipe(X).pipe(Z);
+
+  // throws error / handles errors / propagation sequence
+  var situations = [
+    [A, Z, [A, B, C, D, U, V, W, Y, X, Z]],
+    [B, Z, [B, C, D, U, V, W, Y, X, Z]],
+    [U, W, [U, V, W]],
+    [U, Z, [U, V, W, Y, X, Z]],
+    [X, Z, [X, Y, Z]],
+    [C, D, [C, D]],
+  ];
+
+  situations.forEach(examine);
+  A.push(null);
+  assert.end();
+
+  function examine(situation, idx) {
+    visited.length = 0;
+    situation[1].addErrorHandler(handlePipelineError);
+    try {
+      situation[0].emit('error', new Error);
+    } finally {
+      situation[1].removeErrorHandler(handlePipelineError);
+    }
+    assert.deepEqual(
+        visited,
+        situation[2],
+        'expected ' + situation[2].map(toName).join('') + ', ' +
+        'got ' + visited.map(toName).join('')
+    )
+  }
+
+  function toName(stream) {
+    switch(stream) {
+      case A: return 'A'; break;
+      case B: return 'B'; break;
+      case C: return 'C'; break;
+      case D: return 'D'; break;
+      case U: return 'U'; break;
+      case V: return 'V'; break;
+      case W: return 'W'; break;
+      case X: return 'X'; break;
+      case Y: return 'Y'; break;
+      case Z: return 'Z'; break;
+    }
+  }
+
+  function countPipelineError(ev) {
+    visited.push(this);
+  }
+
+  function handlePipelineError(ev) {
+    ev.handleError();
+  }
+});
+
+test('pipelineError inside pipelineError works', function(assert) {
+  // A -> B -> C
+  // X -> Y
+  var A = makeReadable();
+  var B = makeDuplex();
+  var C = makeWritable();
+  
+  var X = makeReadable();
+  var Y = makeWritable();
+
+  var xyProblem = new Error('when you want Y, but ask for X');
+  var abProblem = new Error('what is the cat\'s rate of meows when given tuna vs chicken');
+  var seen = 0;
+
+  A.pipe(B).pipe(C);
+  X.pipe(Y);
+
+  // we're checking here that during the processing of one pipelineError,
+  // another distinct pipelineError can be emitted / handled separately.
+  C.addErrorHandler(function(ev) {
+    var error = ev.error;
+    var stream = ev.stream;
+    assert.strictEqual(error, abProblem);
+    assert.strictEqual(stream, A);
+    X.emit('error', xyProblem);
+    assert.ok(!ev.isHandled());
+    assert.strictEqual(error, ev.error);
+    assert.strictEqual(stream, ev.stream);
+    ev.handleError();
+  });
+
+  Y.addErrorHandler(function(ev) {
+    ++seen; 
+    assert.strictEqual(ev.stream, X);
+    assert.strictEqual(ev.error, xyProblem);
+  });
+
+
+  try {
+    A.emit('error', abProblem);
+  } catch(err) {
+    assert.strictEqual(err, xyProblem);
+    assert.strictEqual(seen, 1);
+    A.push(null);
+    X.push(null);
+    return assert.end();
+  }
+
+  assert.fail('expected thrown error');
+});
+
+test('single readableStream has pipelineError', function(assert) {
+  var readable = fs.createReadStream(path.join(__dirname, 'dne'));
+
+  // if this does not get handled the process will crash.
+  readable.addErrorHandler(function(ev) {
+    ev.handleError();
+    assert.end();
+  })
+});
+
+test('unpiped streams regain their own pipelineError machinery', function(assert) {
+  var A = makeReadable();
+  var B = makeDuplex();
+
+  A.pipe(B);
+
+  B.addErrorHandler(function(ev) {
+    ev.handleError();  
+  });
+
+  setTimeout(function() {
+    A.unpipe(B);
+    B.emit('error', new Error);
+    A.push(null);
+    assert.end();
+  }, 10);
+});
+
+test('legacy streams work with pipelineError', function(assert) {
+  var A = makeLegacy();
+  var B = makeLegacy();
+  var C = makeLegacy();
+
+  [A, B, C].forEach(function(xs) {
+    xs.name = toName(xs)
+  })
+
+  var visited = [];
+
+  A.pipe(B).pipe(C);
+
+  A.addErrorHandler(countPipelineError);
+  B.addErrorHandler(countPipelineError);
+  C.addErrorHandler(countPipelineError);
+
+  var situations = [
+    [A, C, [A, B, C]],
+    [A, B, [A, B]],
+    [A, A, [A]],
+    [B, C, [B, C]],
+    [B, B, [B]],
+    [C, C, [C]]
+  ];
+  situations.forEach(examine);
+  A.end();
+  assert.end();
+
+  function examine(situation, idx) {
+    visited.length = 0;
+    situation[1].addErrorHandler(handlePipelineError);
+    situation[0].emit('error', new Error('failed ' + idx));
+    situation[1].removeErrorHandler(handlePipelineError);
+    assert.deepEqual(
+        visited,
+        situation[2],
+        'expected ' + situation[2].map(toName).join('') + ', ' +
+        'got ' + visited.map(toName).join('')
+    )
+  }
+
+  function toName(stream) {
+    switch(stream) {
+      case A: return 'A'; break;
+      case B: return 'B'; break;
+      case C: return 'C'; break;
+    }
+  }
+
+  function countPipelineError(ev) {
+    visited.push(this);
+  }
+
+  function handlePipelineError(ev) {
+    ev.handleError();
+  }    
+});
+
+test('lifecycle: addErrorHandler / pipe / error', function(assert) {
+  var tests = [
+    [makeReadable, makeWritable],
+    [makeLegacy, makeWritable],
+    [makeReadable, makeLegacy],
+    [makeLegacy, makeLegacy],
+    [makeDuplex, makeDuplex],
+    [makeLegacy, makeDuplex],
+    [makeDuplex, makeLegacy]
+  ];
+
+  tests.forEach(evaluate);
+  assert.end();
+
+  function evaluate(testPair, idx) {
+    var A = testPair[0]();
+    var B = testPair[1]();
+
+    B.addErrorHandler(function(ev) {
+      ev.handleError();
+      assert.ok('saw error event');
+    });
+    A.pipe(B);
+    A.emit('error', new Error('should not be thrown'));
+    A.end();
+  }
+});
+
+test('lifecycle: addErrorHandler / pipe / unpipe / error', function(assert) {
+  // legacy streams don't have `.unpipe`, so are omitted here.
+  var tests = [
+    [makeReadable, makeWritable],
+    [makeReadable, makeLegacy],
+    [makeDuplex, makeDuplex],
+    [makeDuplex, makeLegacy]
+  ];
+
+  tests.forEach(evaluate);
+  assert.end();
+
+  function evaluate(testPair, idx) {
+    var A = testPair[0]();
+    var B = testPair[1]();
+    var C = makeReadable();
+
+    B.addErrorHandler(function(ev) {
+      ev.handleError();
+      assert.ok('saw error event');
+    });
+    A.pipe(B);
+    A.unpipe(B);
+
+    var err;
+
+    try {
+      err = new Error('should be thrown');
+      A.emit('error', err);
+    } catch(e) {
+      A.end();
+      assert.strictEqual(e, err);
+      return
+    }
+
+    assert.fail('should have thrown');
+  }
+});


### PR DESCRIPTION
**Note:** This is by way of proposal -- I'm opening this now in its current form to get more comments. In  particular, I have the following questions:

Would it be better to distinguish the error re-throwing behavior from the unpiping behavior? This would entail
splitting up `handleError` into `handleError` (to prevent re-throwing the error) and `preventDefault` (to prevent unpiping) -- or alternatively, should the presence of a pipelineError handler be enough to prevent the re-throwing of errors?

cc @phated @contra @tjfontaine @hayes @dominictarr @substack
# pipeline errors

Writing correct streaming programs is difficult. A single stream missing an
error handler in a pipeline has the ability to crash your entire program, often
with a cryptic error message. Even when an error listener is added, the stream
system has already unpiped by the time client code is called. This makes it
difficult to generically gather pipeline information on error events.
Finally, error events are not necessarily fatal to the pipeline, but the user
has no way to communicate this intent back to the stream subsystem -- any error
emitted _will_ destroy whatever pipeline it is emitted in, at present.
To reiterate: error handling in pipelines requires users to remember to add
error listeners to every constituent stream, does not allow users to prevent
undesired default behavior, and in the event of an error, does not give users
enough information to debug the situation.

The goals and constraints of this proposal are as follows:
- Make correct error handling easier to implement for end users.
- The solution must be polyfillable for older versions of node.
- The solution must work in browser (for browserify).
- Work with extant stream solutions (through, through2).
- Provide public methods into internal state for being able to traverse
  up and down pipelines.
- Implement the solution in terms of public methods, inasfar as possible.

To that end, this proposal adds six methods (in three pairs) to the Stream class.
- `stream.next()` and `stream.prev()`: Get an array of the set 
  of _immediate_ destination or source streams.
- `stream.nextAll()` and `stream.prevAll()`: Get an array of the 
  set of all destination or source streams, with no duplicates or cycles.
- `stream.addPipelineErrorHandler(fn)` and `stream.removePipelineErrorHandler(fn)`: 
  Add a pipeline error handler to a stream.
## User-facing API

``` javascript
var A = fs.createReadStream('input');
var B = new stream.PassThrough();
var C = fs.createWriteStream('output');

A.name = 'A';
B.name = 'B';
C.name = 'C';

C.addPipelineErrorHandler(function(ev) {
  console.log(ev.error.message, ev.stream.name);
  ev.handleError();
});

A.pipe(B).pipe(C);
A.emit('error', new Error('hello!')); // logs "hello!".
```

For example, in the above program, someone has maliciously injected an error
event into our stream pipeline. The error originates on `A`, but is handled at
`C`. The error handler indicates that the user wishes to manually handle this error
event and prevent the unpiping behavior with `ev.handleError()`. The original error
and the originating stream are available at `ev.error` and `ev.stream`, respectively.

The error event may only be marked "handled" on the same event loop turn as it was
emitted. Multiple pipeline error handlers may intercept an error -- it propagates downstream,
hitting handlers "A" then "B" then "C". Once an error event is "handled", it stops propagating
entirely. For complex pipelines -- where there may be cycles, or multiple branches, it propagates
down the "oldest" pipelines first, stopping when it hits duplicates. A few examples:

```
A - B - A     error at A, propagates to A, then B.
*

A - B - A     error at B, propagates to B, then A.
    *

A - B - C     error at A, propagates to A, B, then C.
*

A - B - C     error at B, propagates to B, then C.
    *

       C - D  error at A, propagates to A, B, C, D, X, then Y.
      /       NB: handlers on *either* branch have the opportunity
A - B         to "handle" the error and thus stop propagation.
*     \
       X - Y
```

A user may remove a handler by calling `stream.removePipelineErrorHandler(fn)` with the handler
function they originally provided.
## Implementation

The sequence of events during an error is as follows:
1. A.emit("error")
2. stream .pipe "error" handler (or `_defaultErrorHandler`).
3. Internal "_preError" event.
4. pipelineErrorHandlers for A, and all downstream streams (gathered with `nextAll`) until error is handled or streams exhausted.
5. if the error is handled, skip to step 8.
6. unpipe().
7. re-emit error if no other error handlers exist.
8. The rest of the "error" handlers on A.

In order to implement this sequence of events, the following modifications and
additions were made:
### Added `_nextStreams` and `_prevStreams` attributes to base Stream class

The stream constructor grew two new arrays -- `_nextStreams` and
`_prevStreams`. These are arrays tracking the next and previous streams, and
are managed internally by the `.pipe` method (both `Readable#pipe` and
`Stream#pipe` may affect these arrays. Since "correct" subclassing isn't
guaranteed (see crypto's `LazyTransform`), the attributes are [lazily](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/_stream_readable.js#L466-L467) [added](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L230-L231) 
by `*#pipe` if they are not present. These attributes are there to support 
the `{next,prev}{All,}()` methods. **`_nextStreams`** is a slight duplication
of information in the `Readable` case, but it is only ever represented by an
Array, while `_readableState.pipes` may be null, a single Stream, or an array
of Streams.
### Added `{next,prev}{All,}()` methods

To give users better tools to debug errors within streams, the `next()`,
`prev()`, `nextAll()`, and `prevAll()` methods were added to publicly expose
what was previously private or implicit state. `nextAll` and `prevAll` are implemented
in terms of `iterateStream(stream, attributeName)` ([here](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L61-L67) and [here](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L202-L225)), which does a (non-recursive) depth
first traversal of the `_nextStreams` (or `_prevStreams`) property. One potentially
controversial bit is the [use of a `WeakSet`](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L92) to ensure no duplicates are added to the
output -- this could be replaced with an array of "seen" streams in environments that
don't support `WeakSet`.
### Modified `onerror` in `{Readable,Stream}#pipe`

This is the primary change:

``` javascript
function onerror(er) {
  var handled = {handled: false};
  this.emit('_preError', er, handled);

  if (handled.handled) {
    return;
  }

  // ...
```

This has been added for [old streams](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L279-L284) as
well as [new streams](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/_stream_readable.js#L563-L568). The goal
was to keep all of the pipeline error event handling **out** of the pipe functions. Earlier attempts, where the pipelineError event was
emitted as a "normal" EE-style event, and the handling logic was embedded in `.pipe` became complicated _very_ quickly. There's bookkeeping
that needs to be done with regards to default error handlers, deciding which error handler needs to propagate the PipelineErrorEvent, etc.,
and I wanted to keep that as separate from `.pipe` as possible. In order to do this, I added an internal event -- `"_preError"` -- that emits
the error and an object that can be modified by listeners of `_preError` to indicate whether the error is handled or not.

One benefit of this approach is that the feature can be added piecemeal -- adding the navigational components can be one piece, adding `_preError`
can be another, and we can iterate on what the public API for `_preError` should be (if the current approach is deemed unsatisfactory).
### Added `_errorHandlers` attribute to base Stream class

This is pretty straightforward. Like `_{next,prev}Streams`, it's an attribute that's
lazily added if not present; otherwise it contains a list of `{handler, uninstall}` 
objects. `{add,remove}PipelineErrorHandler` manipulates this attribute.
### Added `addPipelineErrorEvent`

This is the [real meat](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L81-L154) of the change. It installs listeners onto the current
stream as well as all streams returned by `prevAll()`. Installation adds
listeners for `unpipe`, `pipe`, `_preError`, and, if there are no `error`
handlers present, `error` as well.

The `error` event handler is called `_defaultPipelineErrorHandler` ([here](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L156-L171)). Because streams2+
do not add an error event handler to Readable streams on `.pipe`, this ensures consistent
pipeline error behavior -- namely, that errors emitted on Readables are forwarded down the
pipeline.

Because upstream may change over time (after the initial
`addPipelineErrorHandler` call), a listener is added for `pipe` and
`unpipe`. [Once piped to](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L121-L125), a pipeline-error-handling stream will remove the
`_defaultPipelineErrorHandler`, and install the 3 to 4 listeners on the new
source and all of its ancestors. [If unpiped](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L127-L130), to keep things simple, the handler
simply uninstalls and reinstalls itself, re-propagating the error handlers out
appropriately.

Uninstallation involves [removing all installed listeners](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L137-L140), and [splicing out](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L142-L147) the
errorHandler from the list of error handlers if the stream is the source
stream. Since the streams installed are tracked by the `installedOnStreams`
array (deduplicated with the aid of a `WeakSet`), uninstallation is as simple as
calling `uninstall` on [each of the streams](https://github.com/chrisdickinson/node/blob/feature/adderrorhandler/lib/stream.js#L150-L153).
