### PR TITLE
doc: document _transform callback takes 2 arguments

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1130,7 +1130,7 @@ initialized.
 * `encoding` {String} If the chunk is a string, then this is the
   encoding type.  (Ignore if `decodeStrings` chunk is a buffer.)
 * `callback` {Function} Call this function (optionally with an error
-  argument) when you are done processing the supplied chunk.
+  argument and data) when you are done processing the supplied chunk.
 
 Note: **This function MUST NOT be called directly.**  It should be
 implemented by child classes, and called by the internal Transform
@@ -1150,7 +1150,20 @@ as a result of this chunk.
 
 Call the callback function only when the current chunk is completely
 consumed.  Note that there may or may not be output as a result of any
-particular input chunk.
+particular input chunk. If you supply as the second argument to the
+it will be passed to push method, in other words the following are
+equivalent:
+
+```javascript
+transform.prototype._transform = function (data, encoding, callback) {
+  this.push(data);
+  callback();
+}
+
+transform.prototype._transform = function (data, encoding, callback) {
+  callback(null, data);
+}
+```
 
 This method is prefixed with an underscore because it is internal to
 the class that defines it, and should not be called directly by user


### PR DESCRIPTION
Expands the paragraph in the transform stream
implementation docs about the callback that is passed
to the _transform method to include details about how
two arguments may be passed, error and data.  A code
example is also included.
