### PR TITLE
Create less IO errors to improve efficiency of require (forwardport of #8189)

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -168,11 +168,14 @@ Only available on Mac OS X.
 
 Synchronous lchmod(2).
 
-## fs.stat(path, callback)
+## fs.stat(path, callback, [throwSafe])
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a [fs.Stats](#fs_class_fs_stats) object.  See the [fs.Stats](#fs_class_fs_stats)
 section below for more information.
+
+Setting the throwSafe parameter to true prevents the error creation. If the call
+fails, the first parameter of the callback will be true.
 
 ## fs.lstat(path, callback)
 
@@ -187,9 +190,12 @@ Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a `fs.Stats` object. `fstat()` is identical to `stat()`, except that
 the file to be stat-ed is specified by the file descriptor `fd`.
 
-## fs.statSync(path)
+## fs.statSync(path, [throwSafe])
 
 Synchronous stat(2). Returns an instance of `fs.Stats`.
+
+Setting the throwSafe parameter to true prevents the error creation. If the call
+fails `fs.statSync` returns `false`.
 
 ## fs.lstatSync(path)
 

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -84,6 +84,12 @@ site, set the NODE_DEBUG environment variable:
         at Object.<anonymous> (/path/to/script.js:5:1)
         <etc.>
 
+## fs.CreateConfiguredFSObject(options)
+
+Creates and returns a new fs object with the specified options set. The valid options
+are:
+* `throwSafe` to prevent the error creation when the non-existent file is stat-ed
+
 
 ## fs.rename(oldPath, newPath, callback)
 
@@ -168,14 +174,15 @@ Only available on Mac OS X.
 
 Synchronous lchmod(2).
 
-## fs.stat(path, callback, [throwSafe])
+## fs.stat(path, callback)
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a [fs.Stats](#fs_class_fs_stats) object.  See the [fs.Stats](#fs_class_fs_stats)
 section below for more information.
 
-Setting the throwSafe parameter to true prevents the error creation. If the call
-fails, the first parameter of the callback will be true.
+Setting the throwSafe fs option to true (see [fs.CreateConfiguredFSObject](#fs_createconfiguredfsobject_options))
+prevents the error creation. If the call fails, the first parameter of the callback will be true.
+This does not prevent the errors when the path contains the null character.
 
 ## fs.lstat(path, callback)
 
@@ -190,12 +197,13 @@ Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a `fs.Stats` object. `fstat()` is identical to `stat()`, except that
 the file to be stat-ed is specified by the file descriptor `fd`.
 
-## fs.statSync(path, [throwSafe])
+## fs.statSync(path)
 
 Synchronous stat(2). Returns an instance of `fs.Stats`.
 
-Setting the throwSafe parameter to true prevents the error creation. If the call
-fails `fs.statSync` returns `false`.
+Setting the throwSafe fs option to true (see [fs.CreateConfiguredFSObject](#fs_createconfiguredfsobject_options))
+prevents the error creation. If the call fails `fs.statSync` returns `false`.
+This does not prevent the errors when the path contains the null character.
 
 ## fs.lstatSync(path)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -100,15 +100,16 @@ function assertEncoding(encoding) {
   }
 }
 
-function nullCheck(path, callback) {
+function nullCheck(path, callback, throwSafe) {
   if (('' + path).indexOf('\u0000') !== -1) {
+    if (throwSafe)
+      return false;
     var er = new Error('Path must be a string without null bytes.');
     if (!callback)
       throw er;
     process.nextTick(function() {
       callback(er);
     });
-    return false;
   }
   return true;
 }
@@ -181,21 +182,29 @@ fs.Stats.prototype.isSocket = function() {
 };
 
 fs.exists = function(path, callback) {
-  if (!nullCheck(path, cb)) return;
-  binding.stat(pathModule._makeLong(path), cb);
-  function cb(err, stats) {
-    if (callback) callback(err ? false : true);
+  if (!nullCheck(path, undefined, true)) {
+    process.nextTick(function() {
+      cb(true, false);
+    });
+    return;
+  }
+  binding.stat(pathModule._makeLong(path), cb, true);
+  function cb(err, result) {
+    if (callback) {
+      if (err)
+        callback(false);
+      else
+        callback(!!result);
+    }
   }
 };
 
 fs.existsSync = function(path) {
-  try {
-    nullCheck(path);
-    binding.stat(pathModule._makeLong(path));
-    return true;
-  } catch (e) {
+  if (!nullCheck(path, undefined, true))
     return false;
-  }
+  if (!binding.stat(pathModule._makeLong(path), undefined, true))
+    return false;
+  return true;
 };
 
 fs.readFile = function(path, options, callback_) {
@@ -701,10 +710,17 @@ fs.lstat = function(path, callback) {
   binding.lstat(pathModule._makeLong(path), callback);
 };
 
-fs.stat = function(path, callback) {
+fs.stat = function(path, callback, throwSafe) {
   callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.stat(pathModule._makeLong(path), callback);
+  if (!nullCheck(path, callback, throwSafe)) {
+    if (throwSafe) {
+      process.nextTick(function() {
+        callback(true, false);
+      });
+    }
+    return;
+  }
+  binding.stat(pathModule._makeLong(path), callback, throwSafe);
 };
 
 fs.fstatSync = function(fd) {
@@ -716,9 +732,11 @@ fs.lstatSync = function(path) {
   return binding.lstat(pathModule._makeLong(path));
 };
 
-fs.statSync = function(path) {
-  nullCheck(path);
-  return binding.stat(pathModule._makeLong(path));
+fs.statSync = function(path, throwSafe) {
+  if (!nullCheck(path, undefined, throwSafe))
+    return false;
+
+  return binding.stat(pathModule._makeLong(path), undefined, throwSafe);
 };
 
 fs.readlink = function(path, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -30,7 +30,6 @@ var pathModule = require('path');
 
 var binding = process.binding('fs');
 var constants = process.binding('constants');
-var fs = exports;
 var Stream = require('stream').Stream;
 var EventEmitter = require('events').EventEmitter;
 
@@ -54,1749 +53,1783 @@ var isWindows = process.platform === 'win32';
 var DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 var errnoException = util._errnoException;
 
+var CreateConfiguredFSObject = function(options) {
+  var fs = new Object();
 
-function rethrow() {
-  // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
-  // is fairly slow to generate.
-  if (DEBUG) {
-    var backtrace = new Error;
+  if (typeof options === 'undefined')
+    options = { throwSafe: false };
+
+  if (typeof options.throwSafe === 'undefined')
+    options.throwSafe = false;
+
+  Object.defineProperty(fs, 'options', {
+    enumerable: false,
+    writable: false,
+    value: options
+  });
+
+  function rethrow() {
+    // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
+    // is fairly slow to generate.
+    if (DEBUG) {
+      var backtrace = new Error;
+      return function(err) {
+        if (err) {
+          backtrace.stack = err.name + ': ' + err.message +
+                            backtrace.stack.substr(backtrace.name.length);
+          err = backtrace;
+          throw err;
+        }
+      };
+    }
+
     return function(err) {
       if (err) {
-        backtrace.stack = err.name + ': ' + err.message +
-                          backtrace.stack.substr(backtrace.name.length);
-        err = backtrace;
-        throw err;
+        throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
       }
     };
   }
 
-  return function(err) {
-    if (err) {
-      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
+  function maybeCallback(cb) {
+    return util.isFunction(cb) ? cb : rethrow();
+  }
+
+  // Ensure that callbacks run in the global context. Only use this function
+  // for callbacks that are passed to the binding layer, callbacks that are
+  // invoked from JS already run in the proper scope.
+  function makeCallback(cb) {
+    if (!util.isFunction(cb)) {
+      return rethrow();
     }
-  };
-}
 
-function maybeCallback(cb) {
-  return util.isFunction(cb) ? cb : rethrow();
-}
-
-// Ensure that callbacks run in the global context. Only use this function
-// for callbacks that are passed to the binding layer, callbacks that are
-// invoked from JS already run in the proper scope.
-function makeCallback(cb) {
-  if (!util.isFunction(cb)) {
-    return rethrow();
+    return function() {
+      return cb.apply(null, arguments);
+    };
   }
 
-  return function() {
-    return cb.apply(null, arguments);
-  };
-}
-
-function assertEncoding(encoding) {
-  if (encoding && !Buffer.isEncoding(encoding)) {
-    throw new Error('Unknown encoding: ' + encoding);
+  function assertEncoding(encoding) {
+    if (encoding && !Buffer.isEncoding(encoding)) {
+      throw new Error('Unknown encoding: ' + encoding);
+    }
   }
-}
 
-function nullCheck(path, callback, throwSafe) {
-  if (('' + path).indexOf('\u0000') !== -1) {
-    if (throwSafe)
+  function nullCheck(path, callback, throwSafe) {
+    if (typeof throwSafe === 'undefined')
+      throwSafe = fs.options.throwSafe;
+
+    if (('' + path).indexOf('\u0000') !== -1) {
+      if (throwSafe)
+        return false;
+      var er = new Error('Path must be a string without null bytes.');
+      if (!callback)
+        throw er;
+      process.nextTick(function() {
+        callback(er);
+      });
       return false;
-    var er = new Error('Path must be a string without null bytes.');
-    if (!callback)
-      throw er;
-    process.nextTick(function() {
-      callback(er);
-    });
-  }
-  return true;
-}
-
-// Static method to set the stats properties on a Stats object.
-fs.Stats = function(
-    dev,
-    mode,
-    nlink,
-    uid,
-    gid,
-    rdev,
-    blksize,
-    ino,
-    size,
-    blocks,
-    atim_msec,
-    mtim_msec,
-    ctim_msec,
-    birthtim_msec) {
-  this.dev = dev;
-  this.mode = mode;
-  this.nlink = nlink;
-  this.uid = uid;
-  this.gid = gid;
-  this.rdev = rdev;
-  this.blksize = blksize;
-  this.ino = ino;
-  this.size = size;
-  this.blocks = blocks;
-  this.atime = new Date(atim_msec);
-  this.mtime = new Date(mtim_msec);
-  this.ctime = new Date(ctim_msec);
-  this.birthtime = new Date(birthtim_msec);
-};
-
-// Create a C++ binding to the function which creates a Stats object.
-binding.FSInitialize(fs.Stats);
-
-fs.Stats.prototype._checkModeProperty = function(property) {
-  return ((this.mode & constants.S_IFMT) === property);
-};
-
-fs.Stats.prototype.isDirectory = function() {
-  return this._checkModeProperty(constants.S_IFDIR);
-};
-
-fs.Stats.prototype.isFile = function() {
-  return this._checkModeProperty(constants.S_IFREG);
-};
-
-fs.Stats.prototype.isBlockDevice = function() {
-  return this._checkModeProperty(constants.S_IFBLK);
-};
-
-fs.Stats.prototype.isCharacterDevice = function() {
-  return this._checkModeProperty(constants.S_IFCHR);
-};
-
-fs.Stats.prototype.isSymbolicLink = function() {
-  return this._checkModeProperty(constants.S_IFLNK);
-};
-
-fs.Stats.prototype.isFIFO = function() {
-  return this._checkModeProperty(constants.S_IFIFO);
-};
-
-fs.Stats.prototype.isSocket = function() {
-  return this._checkModeProperty(constants.S_IFSOCK);
-};
-
-fs.exists = function(path, callback) {
-  if (!nullCheck(path, undefined, true)) {
-    process.nextTick(function() {
-      cb(true, false);
-    });
-    return;
-  }
-  binding.stat(pathModule._makeLong(path), cb, true);
-  function cb(err, result) {
-    if (callback) {
-      if (err)
-        callback(false);
-      else
-        callback(!!result);
     }
-  }
-};
-
-fs.existsSync = function(path) {
-  if (!nullCheck(path, undefined, true))
-    return false;
-  if (!binding.stat(pathModule._makeLong(path), undefined, true))
-    return false;
-  return true;
-};
-
-fs.readFile = function(path, options, callback_) {
-  var callback = maybeCallback(arguments[arguments.length - 1]);
-
-  if (util.isFunction(options) || !options) {
-    options = { encoding: null, flag: 'r' };
-  } else if (util.isString(options)) {
-    options = { encoding: options, flag: 'r' };
-  } else if (!util.isObject(options)) {
-    throw new TypeError('Bad arguments');
+    return true;
   }
 
-  var encoding = options.encoding;
-  assertEncoding(encoding);
+  // Static method to set the stats properties on a Stats object.
+  fs.Stats = function(
+      dev,
+      mode,
+      nlink,
+      uid,
+      gid,
+      rdev,
+      blksize,
+      ino,
+      size,
+      blocks,
+      atim_msec,
+      mtim_msec,
+      ctim_msec,
+      birthtim_msec) {
+    this.dev = dev;
+    this.mode = mode;
+    this.nlink = nlink;
+    this.uid = uid;
+    this.gid = gid;
+    this.rdev = rdev;
+    this.blksize = blksize;
+    this.ino = ino;
+    this.size = size;
+    this.blocks = blocks;
+    this.atime = new Date(atim_msec);
+    this.mtime = new Date(mtim_msec);
+    this.ctime = new Date(ctim_msec);
+    this.birthtime = new Date(birthtim_msec);
+  };
 
-  // first, stat the file, so we know the size.
-  var size;
-  var buffer; // single buffer with file data
-  var buffers; // list for when size is unknown
-  var pos = 0;
-  var fd;
+  // Create a C++ binding to the function which creates a Stats object.
+  binding.FSInitialize(fs.Stats);
 
-  var flag = options.flag || 'r';
-  fs.open(path, flag, 438 /*=0666*/, function(er, fd_) {
-    if (er) return callback(er);
-    fd = fd_;
+  fs.Stats.prototype._checkModeProperty = function(property) {
+    return ((this.mode & constants.S_IFMT) === property);
+  };
 
-    fs.fstat(fd, function(er, st) {
-      if (er) {
-        return fs.close(fd, function() {
-          callback(er);
-        });
+  fs.Stats.prototype.isDirectory = function() {
+    return this._checkModeProperty(constants.S_IFDIR);
+  };
+
+  fs.Stats.prototype.isFile = function() {
+    return this._checkModeProperty(constants.S_IFREG);
+  };
+
+  fs.Stats.prototype.isBlockDevice = function() {
+    return this._checkModeProperty(constants.S_IFBLK);
+  };
+
+  fs.Stats.prototype.isCharacterDevice = function() {
+    return this._checkModeProperty(constants.S_IFCHR);
+  };
+
+  fs.Stats.prototype.isSymbolicLink = function() {
+    return this._checkModeProperty(constants.S_IFLNK);
+  };
+
+  fs.Stats.prototype.isFIFO = function() {
+    return this._checkModeProperty(constants.S_IFIFO);
+  };
+
+  fs.Stats.prototype.isSocket = function() {
+    return this._checkModeProperty(constants.S_IFSOCK);
+  };
+
+  fs.exists = function(path, callback) {
+    if (!nullCheck(path, undefined, true)) {
+      process.nextTick(function() {
+        callback(false);
+      });
+      return;
+    }
+    binding.stat(pathModule._makeLong(path), cb, true);
+    function cb(err, result) {
+      if (callback) {
+        if (err)
+          callback(false);
+        else
+          callback(!!result);
       }
+    }
+  };
 
-      size = st.size;
-      if (size === 0) {
-        // the kernel lies about many files.
-        // Go ahead and try to read some bytes.
-        buffers = [];
-        return read();
-      }
+  fs.existsSync = function(path) {
+    if (!nullCheck(path, undefined, true))
+      return false;
+    if (!binding.stat(pathModule._makeLong(path), undefined, true))
+      return false;
+    return true;
+  };
 
-      if (size > kMaxLength) {
-        var err = new RangeError('File size is greater than possible Buffer: ' +
-            '0x3FFFFFFF bytes');
-        return fs.close(fd, function() {
-          callback(err);
-        });
-      }
-      buffer = new Buffer(size);
-      read();
+  fs.readFile = function(path, options, callback_) {
+    var callback = maybeCallback(arguments[arguments.length - 1]);
+
+    if (util.isFunction(options) || !options) {
+      options = { encoding: null, flag: 'r' };
+    } else if (util.isString(options)) {
+      options = { encoding: options, flag: 'r' };
+    } else if (!util.isObject(options)) {
+      throw new TypeError('Bad arguments');
+    }
+
+    var encoding = options.encoding;
+    assertEncoding(encoding);
+
+    // first, stat the file, so we know the size.
+    var size;
+    var buffer; // single buffer with file data
+    var buffers; // list for when size is unknown
+    var pos = 0;
+    var fd;
+
+    var flag = options.flag || 'r';
+    fs.open(path, flag, 438 /*=0666*/, function(er, fd_) {
+      if (er) return callback(er);
+      fd = fd_;
+
+      fs.fstat(fd, function(er, st) {
+        if (er) {
+          return fs.close(fd, function() {
+            callback(er);
+          });
+        }
+
+        size = st.size;
+        if (size === 0) {
+          // the kernel lies about many files.
+          // Go ahead and try to read some bytes.
+          buffers = [];
+          return read();
+        }
+
+        if (size > kMaxLength) {
+          var err = new RangeError(
+              'File size is greater than possible Buffer: 0x3FFFFFFF bytes');
+          return fs.close(fd, function() {
+            callback(err);
+          });
+        }
+        buffer = new Buffer(size);
+        read();
+      });
     });
+
+    function read() {
+      if (size === 0) {
+        buffer = new Buffer(8192);
+        fs.read(fd, buffer, 0, 8192, -1, afterRead);
+      } else {
+        fs.read(fd, buffer, pos, size - pos, -1, afterRead);
+      }
+    }
+
+    function afterRead(er, bytesRead) {
+      if (er) {
+        return fs.close(fd, function(er2) {
+          return callback(er);
+        });
+      }
+
+      if (bytesRead === 0) {
+        return close();
+      }
+
+      pos += bytesRead;
+      if (size !== 0) {
+        if (pos === size) close();
+        else read();
+      } else {
+        // unknown size, just read until we don't get bytes.
+        buffers.push(buffer.slice(0, bytesRead));
+        read();
+      }
+    }
+
+    function close() {
+      fs.close(fd, function(er) {
+        if (size === 0) {
+          // collected the data into the buffers list.
+          buffer = Buffer.concat(buffers, pos);
+        } else if (pos < size) {
+          buffer = buffer.slice(0, pos);
+        }
+
+        if (encoding) buffer = buffer.toString(encoding);
+        return callback(er, buffer);
+      });
+    };
+  }
+
+  fs.readFileSync = function(path, options) {
+    if (!options) {
+      options = { encoding: null, flag: 'r' };
+    } else if (util.isString(options)) {
+      options = { encoding: options, flag: 'r' };
+    } else if (!util.isObject(options)) {
+      throw new TypeError('Bad arguments');
+    }
+
+    var encoding = options.encoding;
+    assertEncoding(encoding);
+
+    var flag = options.flag || 'r';
+    var fd = fs.openSync(path, flag, 438 /*=0666*/);
+
+    var size;
+    var threw = true;
+    try {
+      size = fs.fstatSync(fd).size;
+      threw = false;
+    } finally {
+      if (threw) fs.closeSync(fd);
+    }
+
+    var pos = 0;
+    var buffer; // single buffer with file data
+    var buffers; // list for when size is unknown
+
+    if (size === 0) {
+      buffers = [];
+    } else {
+      var threw = true;
+      try {
+        buffer = new Buffer(size);
+        threw = false;
+      } finally {
+        if (threw) fs.closeSync(fd);
+      }
+    }
+
+    var done = false;
+    while (!done) {
+      var threw = true;
+      try {
+        if (size !== 0) {
+          var bytesRead = fs.readSync(fd, buffer, pos, size - pos);
+        } else {
+          // the kernel lies about many files.
+          // Go ahead and try to read some bytes.
+          buffer = new Buffer(8192);
+          var bytesRead = fs.readSync(fd, buffer, 0, 8192);
+          if (bytesRead) {
+            buffers.push(buffer.slice(0, bytesRead));
+          }
+        }
+        threw = false;
+      } finally {
+        if (threw) fs.closeSync(fd);
+      }
+
+      pos += bytesRead;
+      done = (bytesRead === 0) || (size !== 0 && pos >= size);
+    }
+
+    fs.closeSync(fd);
+
+    if (size === 0) {
+      // data was collected into the buffers list.
+      buffer = Buffer.concat(buffers, pos);
+    } else if (pos < size) {
+      buffer = buffer.slice(0, pos);
+    }
+
+    if (encoding) buffer = buffer.toString(encoding);
+    return buffer;
+  };
+
+
+  // Used by binding.open and friends
+  function stringToFlags(flag) {
+    // Only mess with strings
+    if (!util.isString(flag)) {
+      return flag;
+    }
+
+    switch (flag) {
+      case 'r' : return O_RDONLY;
+      case 'rs' : // fall through
+      case 'sr' : return O_RDONLY | O_SYNC;
+      case 'r+' : return O_RDWR;
+      case 'rs+' : // fall through
+      case 'sr+' : return O_RDWR | O_SYNC;
+
+      case 'w' : return O_TRUNC | O_CREAT | O_WRONLY;
+      case 'wx' : // fall through
+      case 'xw' : return O_TRUNC | O_CREAT | O_WRONLY | O_EXCL;
+
+      case 'w+' : return O_TRUNC | O_CREAT | O_RDWR;
+      case 'wx+': // fall through
+      case 'xw+': return O_TRUNC | O_CREAT | O_RDWR | O_EXCL;
+
+      case 'a' : return O_APPEND | O_CREAT | O_WRONLY;
+      case 'ax' : // fall through
+      case 'xa' : return O_APPEND | O_CREAT | O_WRONLY | O_EXCL;
+
+      case 'a+' : return O_APPEND | O_CREAT | O_RDWR;
+      case 'ax+': // fall through
+      case 'xa+': return O_APPEND | O_CREAT | O_RDWR | O_EXCL;
+    }
+
+    throw new Error('Unknown file open flag: ' + flag);
+  }
+
+  // exported but hidden, only used by test/simple/test-fs-open-flags.js
+  Object.defineProperty(fs, '_stringToFlags', {
+    enumerable: false,
+    value: stringToFlags
   });
 
-  function read() {
-    if (size === 0) {
-      buffer = new Buffer(8192);
-      fs.read(fd, buffer, 0, 8192, -1, afterRead);
-    } else {
-      fs.read(fd, buffer, pos, size - pos, -1, afterRead);
-    }
+
+  // Yes, the follow could be easily DRYed up but I provide the explicit
+  // list to make the arguments clear.
+
+  fs.close = function(fd, callback) {
+    binding.close(fd, makeCallback(callback));
+  };
+
+  fs.closeSync = function(fd) {
+    return binding.close(fd);
+  };
+
+  function modeNum(m, def) {
+    if (util.isNumber(m))
+      return m;
+    if (util.isString(m))
+      return parseInt(m, 8);
+    if (def)
+      return modeNum(def);
+    return undefined;
   }
 
-  function afterRead(er, bytesRead) {
-    if (er) {
-      return fs.close(fd, function(er2) {
-        return callback(er);
-      });
-    }
+  fs.open = function(path, flags, mode, callback) {
+    callback = makeCallback(arguments[arguments.length - 1]);
+    mode = modeNum(mode, 438 /*=0666*/);
 
-    if (bytesRead === 0) {
-      return close();
-    }
+    if (!nullCheck(path, callback)) return;
+    binding.open(pathModule._makeLong(path),
+                 stringToFlags(flags),
+                 mode,
+                 callback);
+  };
 
-    pos += bytesRead;
-    if (size !== 0) {
-      if (pos === size) close();
-      else read();
-    } else {
-      // unknown size, just read until we don't get bytes.
-      buffers.push(buffer.slice(0, bytesRead));
-      read();
-    }
-  }
+  fs.openSync = function(path, flags, mode) {
+    mode = modeNum(mode, 438 /*=0666*/);
+    nullCheck(path);
+    return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
+  };
 
-  function close() {
-    fs.close(fd, function(er) {
-      if (size === 0) {
-        // collected the data into the buffers list.
-        buffer = Buffer.concat(buffers, pos);
-      } else if (pos < size) {
-        buffer = buffer.slice(0, pos);
-      }
+  fs.read = function(fd, buffer, offset, length, position, callback) {
+    if (!util.isBuffer(buffer)) {
+      // legacy string interface (fd, length, position, encoding, callback)
+      var cb = arguments[4],
+          encoding = arguments[3];
 
-      if (encoding) buffer = buffer.toString(encoding);
-      return callback(er, buffer);
-    });
-  }
-};
+      assertEncoding(encoding);
 
-fs.readFileSync = function(path, options) {
-  if (!options) {
-    options = { encoding: null, flag: 'r' };
-  } else if (util.isString(options)) {
-    options = { encoding: options, flag: 'r' };
-  } else if (!util.isObject(options)) {
-    throw new TypeError('Bad arguments');
-  }
+      position = arguments[2];
+      length = arguments[1];
+      buffer = new Buffer(length);
+      offset = 0;
 
-  var encoding = options.encoding;
-  assertEncoding(encoding);
+      callback = function(err, bytesRead) {
+        if (!cb) return;
 
-  var flag = options.flag || 'r';
-  var fd = fs.openSync(path, flag, 438 /*=0666*/);
+        var str = (bytesRead > 0) ?
+            buffer.toString(encoding, 0, bytesRead) : '';
 
-  var size;
-  var threw = true;
-  try {
-    size = fs.fstatSync(fd).size;
-    threw = false;
-  } finally {
-    if (threw) fs.closeSync(fd);
-  }
-
-  var pos = 0;
-  var buffer; // single buffer with file data
-  var buffers; // list for when size is unknown
-
-  if (size === 0) {
-    buffers = [];
-  } else {
-    var threw = true;
-    try {
-      buffer = new Buffer(size);
-      threw = false;
-    } finally {
-      if (threw) fs.closeSync(fd);
-    }
-  }
-
-  var done = false;
-  while (!done) {
-    var threw = true;
-    try {
-      if (size !== 0) {
-        var bytesRead = fs.readSync(fd, buffer, pos, size - pos);
-      } else {
-        // the kernel lies about many files.
-        // Go ahead and try to read some bytes.
-        buffer = new Buffer(8192);
-        var bytesRead = fs.readSync(fd, buffer, 0, 8192);
-        if (bytesRead) {
-          buffers.push(buffer.slice(0, bytesRead));
-        }
-      }
-      threw = false;
-    } finally {
-      if (threw) fs.closeSync(fd);
+        (cb)(err, str, bytesRead);
+      };
     }
 
-    pos += bytesRead;
-    done = (bytesRead === 0) || (size !== 0 && pos >= size);
-  }
-
-  fs.closeSync(fd);
-
-  if (size === 0) {
-    // data was collected into the buffers list.
-    buffer = Buffer.concat(buffers, pos);
-  } else if (pos < size) {
-    buffer = buffer.slice(0, pos);
-  }
-
-  if (encoding) buffer = buffer.toString(encoding);
-  return buffer;
-};
-
-
-// Used by binding.open and friends
-function stringToFlags(flag) {
-  // Only mess with strings
-  if (!util.isString(flag)) {
-    return flag;
-  }
-
-  switch (flag) {
-    case 'r' : return O_RDONLY;
-    case 'rs' : // fall through
-    case 'sr' : return O_RDONLY | O_SYNC;
-    case 'r+' : return O_RDWR;
-    case 'rs+' : // fall through
-    case 'sr+' : return O_RDWR | O_SYNC;
-
-    case 'w' : return O_TRUNC | O_CREAT | O_WRONLY;
-    case 'wx' : // fall through
-    case 'xw' : return O_TRUNC | O_CREAT | O_WRONLY | O_EXCL;
-
-    case 'w+' : return O_TRUNC | O_CREAT | O_RDWR;
-    case 'wx+': // fall through
-    case 'xw+': return O_TRUNC | O_CREAT | O_RDWR | O_EXCL;
-
-    case 'a' : return O_APPEND | O_CREAT | O_WRONLY;
-    case 'ax' : // fall through
-    case 'xa' : return O_APPEND | O_CREAT | O_WRONLY | O_EXCL;
-
-    case 'a+' : return O_APPEND | O_CREAT | O_RDWR;
-    case 'ax+': // fall through
-    case 'xa+': return O_APPEND | O_CREAT | O_RDWR | O_EXCL;
-  }
-
-  throw new Error('Unknown file open flag: ' + flag);
-}
-
-// exported but hidden, only used by test/simple/test-fs-open-flags.js
-Object.defineProperty(exports, '_stringToFlags', {
-  enumerable: false,
-  value: stringToFlags
-});
-
-
-// Yes, the follow could be easily DRYed up but I provide the explicit
-// list to make the arguments clear.
-
-fs.close = function(fd, callback) {
-  binding.close(fd, makeCallback(callback));
-};
-
-fs.closeSync = function(fd) {
-  return binding.close(fd);
-};
-
-function modeNum(m, def) {
-  if (util.isNumber(m))
-    return m;
-  if (util.isString(m))
-    return parseInt(m, 8);
-  if (def)
-    return modeNum(def);
-  return undefined;
-}
-
-fs.open = function(path, flags, mode, callback) {
-  callback = makeCallback(arguments[arguments.length - 1]);
-  mode = modeNum(mode, 438 /*=0666*/);
-
-  if (!nullCheck(path, callback)) return;
-  binding.open(pathModule._makeLong(path),
-               stringToFlags(flags),
-               mode,
-               callback);
-};
-
-fs.openSync = function(path, flags, mode) {
-  mode = modeNum(mode, 438 /*=0666*/);
-  nullCheck(path);
-  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
-};
-
-fs.read = function(fd, buffer, offset, length, position, callback) {
-  if (!util.isBuffer(buffer)) {
-    // legacy string interface (fd, length, position, encoding, callback)
-    var cb = arguments[4],
-        encoding = arguments[3];
-
-    assertEncoding(encoding);
-
-    position = arguments[2];
-    length = arguments[1];
-    buffer = new Buffer(length);
-    offset = 0;
-
-    callback = function(err, bytesRead) {
-      if (!cb) return;
-
-      var str = (bytesRead > 0) ? buffer.toString(encoding, 0, bytesRead) : '';
-
-      (cb)(err, str, bytesRead);
-    };
-  }
-
-  function wrapper(err, bytesRead) {
-    // Retain a reference to buffer so that it can't be GC'ed too soon.
-    callback && callback(err, bytesRead || 0, buffer);
-  }
-
-  binding.read(fd, buffer, offset, length, position, wrapper);
-};
-
-fs.readSync = function(fd, buffer, offset, length, position) {
-  var legacy = false;
-  if (!util.isBuffer(buffer)) {
-    // legacy string interface (fd, length, position, encoding, callback)
-    legacy = true;
-    var encoding = arguments[3];
-
-    assertEncoding(encoding);
-
-    position = arguments[2];
-    length = arguments[1];
-    buffer = new Buffer(length);
-
-    offset = 0;
-  }
-
-  var r = binding.read(fd, buffer, offset, length, position);
-  if (!legacy) {
-    return r;
-  }
-
-  var str = (r > 0) ? buffer.toString(encoding, 0, r) : '';
-  return [str, r];
-};
-
-// usage:
-//  fs.write(fd, buffer, offset, length[, position], callback);
-// OR
-//  fs.write(fd, string[, position[, encoding]], callback);
-fs.write = function(fd, buffer, offset, length, position, callback) {
-  if (util.isBuffer(buffer)) {
-    // if no position is passed then assume null
-    if (util.isFunction(position)) {
-      callback = position;
-      position = null;
-    }
-    callback = maybeCallback(callback);
-    var wrapper = function(err, written) {
+    function wrapper(err, bytesRead) {
       // Retain a reference to buffer so that it can't be GC'ed too soon.
+      callback && callback(err, bytesRead || 0, buffer);
+    }
+
+    binding.read(fd, buffer, offset, length, position, wrapper);
+  };
+
+  fs.readSync = function(fd, buffer, offset, length, position) {
+    var legacy = false;
+    if (!util.isBuffer(buffer)) {
+      // legacy string interface (fd, length, position, encoding, callback)
+      legacy = true;
+      var encoding = arguments[3];
+
+      assertEncoding(encoding);
+
+      position = arguments[2];
+      length = arguments[1];
+      buffer = new Buffer(length);
+
+      offset = 0;
+    }
+
+    var r = binding.read(fd, buffer, offset, length, position);
+    if (!legacy) {
+      return r;
+    }
+
+    var str = (r > 0) ? buffer.toString(encoding, 0, r) : '';
+    return [str, r];
+  };
+
+  // usage:
+  //  fs.write(fd, buffer, offset, length[, position], callback);
+  // OR
+  //  fs.write(fd, string[, position[, encoding]], callback);
+  fs.write = function(fd, buffer, offset, length, position, callback) {
+    if (util.isBuffer(buffer)) {
+      // if no position is passed then assume null
+      if (util.isFunction(position)) {
+        callback = position;
+        position = null;
+      }
+      callback = maybeCallback(callback);
+      var wrapper = function(err, written) {
+        // Retain a reference to buffer so that it can't be GC'ed too soon.
+        callback(err, written || 0, buffer);
+      };
+      return binding.writeBuffer(fd, buffer, offset, length, position, wrapper);
+    }
+
+    if (util.isString(buffer))
+      buffer += '';
+    if (!util.isFunction(position)) {
+      if (util.isFunction(offset)) {
+        position = offset;
+        offset = null;
+      } else {
+        position = length;
+      }
+      length = 'utf8';
+    }
+    callback = maybeCallback(position);
+    position = function(err, written) {
+      // retain reference to string in case it's external
       callback(err, written || 0, buffer);
     };
-    return binding.writeBuffer(fd, buffer, offset, length, position, wrapper);
-  }
-
-  if (util.isString(buffer))
-    buffer += '';
-  if (!util.isFunction(position)) {
-    if (util.isFunction(offset)) {
-      position = offset;
-      offset = null;
-    } else {
-      position = length;
-    }
-    length = 'utf8';
-  }
-  callback = maybeCallback(position);
-  position = function(err, written) {
-    // retain reference to string in case it's external
-    callback(err, written || 0, buffer);
+    return binding.writeString(fd, buffer, offset, length, position);
   };
-  return binding.writeString(fd, buffer, offset, length, position);
-};
 
-// usage:
-//  fs.writeSync(fd, buffer, offset, length[, position]);
-// OR
-//  fs.writeSync(fd, string[, position[, encoding]]);
-fs.writeSync = function(fd, buffer, offset, length, position) {
-  if (util.isBuffer(buffer)) {
-    if (util.isUndefined(position))
-      position = null;
-    return binding.writeBuffer(fd, buffer, offset, length, position);
-  }
-  if (!util.isString(buffer))
-    buffer += '';
-  if (util.isUndefined(offset))
-    offset = null;
-  return binding.writeString(fd, buffer, offset, length, position);
-};
-
-fs.rename = function(oldPath, newPath, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(oldPath, callback)) return;
-  if (!nullCheck(newPath, callback)) return;
-  binding.rename(pathModule._makeLong(oldPath),
-                 pathModule._makeLong(newPath),
-                 callback);
-};
-
-fs.renameSync = function(oldPath, newPath) {
-  nullCheck(oldPath);
-  nullCheck(newPath);
-  return binding.rename(pathModule._makeLong(oldPath),
-                        pathModule._makeLong(newPath));
-};
-
-fs.truncate = function(path, len, callback) {
-  if (util.isNumber(path)) {
-    // legacy
-    return fs.ftruncate(path, len, callback);
-  }
-  if (util.isFunction(len)) {
-    callback = len;
-    len = 0;
-  } else if (util.isUndefined(len)) {
-    len = 0;
-  }
-  callback = maybeCallback(callback);
-  fs.open(path, 'r+', function(er, fd) {
-    if (er) return callback(er);
-    binding.ftruncate(fd, len, function(er) {
-      fs.close(fd, function(er2) {
-        callback(er || er2);
-      });
-    });
-  });
-};
-
-fs.truncateSync = function(path, len) {
-  if (util.isNumber(path)) {
-    // legacy
-    return fs.ftruncateSync(path, len);
-  }
-  if (util.isUndefined(len)) {
-    len = 0;
-  }
-  // allow error to be thrown, but still close fd.
-  var fd = fs.openSync(path, 'r+');
-  try {
-    var ret = fs.ftruncateSync(fd, len);
-  } finally {
-    fs.closeSync(fd);
-  }
-  return ret;
-};
-
-fs.ftruncate = function(fd, len, callback) {
-  if (util.isFunction(len)) {
-    callback = len;
-    len = 0;
-  } else if (util.isUndefined(len)) {
-    len = 0;
-  }
-  binding.ftruncate(fd, len, makeCallback(callback));
-};
-
-fs.ftruncateSync = function(fd, len) {
-  if (util.isUndefined(len)) {
-    len = 0;
-  }
-  return binding.ftruncate(fd, len);
-};
-
-fs.rmdir = function(path, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.rmdir(pathModule._makeLong(path), callback);
-};
-
-fs.rmdirSync = function(path) {
-  nullCheck(path);
-  return binding.rmdir(pathModule._makeLong(path));
-};
-
-fs.fdatasync = function(fd, callback) {
-  binding.fdatasync(fd, makeCallback(callback));
-};
-
-fs.fdatasyncSync = function(fd) {
-  return binding.fdatasync(fd);
-};
-
-fs.fsync = function(fd, callback) {
-  binding.fsync(fd, makeCallback(callback));
-};
-
-fs.fsyncSync = function(fd) {
-  return binding.fsync(fd);
-};
-
-fs.mkdir = function(path, mode, callback) {
-  if (util.isFunction(mode)) callback = mode;
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.mkdir(pathModule._makeLong(path),
-                modeNum(mode, 511 /*=0777*/),
-                callback);
-};
-
-fs.mkdirSync = function(path, mode) {
-  nullCheck(path);
-  return binding.mkdir(pathModule._makeLong(path),
-                       modeNum(mode, 511 /*=0777*/));
-};
-
-fs.readdir = function(path, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.readdir(pathModule._makeLong(path), callback);
-};
-
-fs.readdirSync = function(path) {
-  nullCheck(path);
-  return binding.readdir(pathModule._makeLong(path));
-};
-
-fs.fstat = function(fd, callback) {
-  binding.fstat(fd, makeCallback(callback));
-};
-
-fs.lstat = function(path, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.lstat(pathModule._makeLong(path), callback);
-};
-
-fs.stat = function(path, callback, throwSafe) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback, throwSafe)) {
-    if (throwSafe) {
-      process.nextTick(function() {
-        callback(true, false);
-      });
+  // usage:
+  //  fs.writeSync(fd, buffer, offset, length[, position]);
+  // OR
+  //  fs.writeSync(fd, string[, position[, encoding]]);
+  fs.writeSync = function(fd, buffer, offset, length, position) {
+    if (util.isBuffer(buffer)) {
+      if (util.isUndefined(position))
+        position = null;
+      return binding.writeBuffer(fd, buffer, offset, length, position);
     }
-    return;
-  }
-  binding.stat(pathModule._makeLong(path), callback, throwSafe);
-};
+    if (!util.isString(buffer))
+      buffer += '';
+    if (util.isUndefined(offset))
+      offset = null;
+    return binding.writeString(fd, buffer, offset, length, position);
+  };
 
-fs.fstatSync = function(fd) {
-  return binding.fstat(fd);
-};
+  fs.rename = function(oldPath, newPath, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(oldPath, callback)) return;
+    if (!nullCheck(newPath, callback)) return;
+    binding.rename(pathModule._makeLong(oldPath),
+                   pathModule._makeLong(newPath),
+                   callback);
+  };
 
-fs.lstatSync = function(path) {
-  nullCheck(path);
-  return binding.lstat(pathModule._makeLong(path));
-};
+  fs.renameSync = function(oldPath, newPath) {
+    nullCheck(oldPath);
+    nullCheck(newPath);
+    return binding.rename(pathModule._makeLong(oldPath),
+                          pathModule._makeLong(newPath));
+  };
 
-fs.statSync = function(path, throwSafe) {
-  if (!nullCheck(path, undefined, throwSafe))
-    return false;
-
-  return binding.stat(pathModule._makeLong(path), undefined, throwSafe);
-};
-
-fs.readlink = function(path, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.readlink(pathModule._makeLong(path), callback);
-};
-
-fs.readlinkSync = function(path) {
-  nullCheck(path);
-  return binding.readlink(pathModule._makeLong(path));
-};
-
-function preprocessSymlinkDestination(path, type) {
-  if (!isWindows) {
-    // No preprocessing is needed on Unix.
-    return path;
-  } else if (type === 'junction') {
-    // Junctions paths need to be absolute and \\?\-prefixed.
-    return pathModule._makeLong(path);
-  } else {
-    // Windows symlinks don't tolerate forward slashes.
-    return ('' + path).replace(/\//g, '\\');
-  }
-}
-
-fs.symlink = function(destination, path, type_, callback) {
-  var type = (util.isString(type_) ? type_ : null);
-  var callback = makeCallback(arguments[arguments.length - 1]);
-
-  if (!nullCheck(destination, callback)) return;
-  if (!nullCheck(path, callback)) return;
-
-  binding.symlink(preprocessSymlinkDestination(destination, type),
-                  pathModule._makeLong(path),
-                  type,
-                  callback);
-};
-
-fs.symlinkSync = function(destination, path, type) {
-  type = (util.isString(type) ? type : null);
-
-  nullCheck(destination);
-  nullCheck(path);
-
-  return binding.symlink(preprocessSymlinkDestination(destination, type),
-                         pathModule._makeLong(path),
-                         type);
-};
-
-fs.link = function(srcpath, dstpath, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(srcpath, callback)) return;
-  if (!nullCheck(dstpath, callback)) return;
-
-  binding.link(pathModule._makeLong(srcpath),
-               pathModule._makeLong(dstpath),
-               callback);
-};
-
-fs.linkSync = function(srcpath, dstpath) {
-  nullCheck(srcpath);
-  nullCheck(dstpath);
-  return binding.link(pathModule._makeLong(srcpath),
-                      pathModule._makeLong(dstpath));
-};
-
-fs.unlink = function(path, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.unlink(pathModule._makeLong(path), callback);
-};
-
-fs.unlinkSync = function(path) {
-  nullCheck(path);
-  return binding.unlink(pathModule._makeLong(path));
-};
-
-fs.fchmod = function(fd, mode, callback) {
-  binding.fchmod(fd, modeNum(mode), makeCallback(callback));
-};
-
-fs.fchmodSync = function(fd, mode) {
-  return binding.fchmod(fd, modeNum(mode));
-};
-
-if (constants.hasOwnProperty('O_SYMLINK')) {
-  fs.lchmod = function(path, mode, callback) {
+  fs.truncate = function(path, len, callback) {
+    if (util.isNumber(path)) {
+      // legacy
+      return fs.ftruncate(path, len, callback);
+    }
+    if (util.isFunction(len)) {
+      callback = len;
+      len = 0;
+    } else if (util.isUndefined(len)) {
+      len = 0;
+    }
     callback = maybeCallback(callback);
-    fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
-      if (err) {
-        callback(err);
-        return;
-      }
-      // prefer to return the chmod error, if one occurs,
-      // but still try to close, and report closing errors if they occur.
-      fs.fchmod(fd, mode, function(err) {
-        fs.close(fd, function(err2) {
-          callback(err || err2);
+    fs.open(path, 'r+', function(er, fd) {
+      if (er) return callback(er);
+      binding.ftruncate(fd, len, function(er) {
+        fs.close(fd, function(er2) {
+          callback(er || er2);
         });
       });
     });
   };
 
-  fs.lchmodSync = function(path, mode) {
-    var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
-
-    // prefer to return the chmod error, if one occurs,
-    // but still try to close, and report closing errors if they occur.
-    var err, err2;
-    try {
-      var ret = fs.fchmodSync(fd, mode);
-    } catch (er) {
-      err = er;
+  fs.truncateSync = function(path, len) {
+    if (util.isNumber(path)) {
+      // legacy
+      return fs.ftruncateSync(path, len);
     }
+    if (util.isUndefined(len)) {
+      len = 0;
+    }
+    // allow error to be thrown, but still close fd.
+    var fd = fs.openSync(path, 'r+');
     try {
+      var ret = fs.ftruncateSync(fd, len);
+    } finally {
       fs.closeSync(fd);
-    } catch (er) {
-      err2 = er;
     }
-    if (err || err2) throw (err || err2);
     return ret;
   };
-}
 
+  fs.ftruncate = function(fd, len, callback) {
+    if (util.isFunction(len)) {
+      callback = len;
+      len = 0;
+    } else if (util.isUndefined(len)) {
+      len = 0;
+    }
+    binding.ftruncate(fd, len, makeCallback(callback));
+  };
 
-fs.chmod = function(path, mode, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.chmod(pathModule._makeLong(path),
-                modeNum(mode),
-                callback);
-};
+  fs.ftruncateSync = function(fd, len) {
+    if (util.isUndefined(len)) {
+      len = 0;
+    }
+    return binding.ftruncate(fd, len);
+  };
 
-fs.chmodSync = function(path, mode) {
-  nullCheck(path);
-  return binding.chmod(pathModule._makeLong(path), modeNum(mode));
-};
+  fs.rmdir = function(path, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.rmdir(pathModule._makeLong(path), callback);
+  };
 
-if (constants.hasOwnProperty('O_SYMLINK')) {
-  fs.lchown = function(path, uid, gid, callback) {
-    callback = maybeCallback(callback);
-    fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
-      if (err) {
-        callback(err);
-        return;
+  fs.rmdirSync = function(path) {
+    nullCheck(path);
+    return binding.rmdir(pathModule._makeLong(path));
+  };
+
+  fs.fdatasync = function(fd, callback) {
+    binding.fdatasync(fd, makeCallback(callback));
+  };
+
+  fs.fdatasyncSync = function(fd) {
+    return binding.fdatasync(fd);
+  };
+
+  fs.fsync = function(fd, callback) {
+    binding.fsync(fd, makeCallback(callback));
+  };
+
+  fs.fsyncSync = function(fd) {
+    return binding.fsync(fd);
+  };
+
+  fs.mkdir = function(path, mode, callback) {
+    if (util.isFunction(mode)) callback = mode;
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.mkdir(pathModule._makeLong(path),
+                  modeNum(mode, 511 /*=0777*/),
+                  callback);
+  };
+
+  fs.mkdirSync = function(path, mode) {
+    nullCheck(path);
+    return binding.mkdir(pathModule._makeLong(path),
+                         modeNum(mode, 511 /*=0777*/));
+  };
+
+  fs.readdir = function(path, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.readdir(pathModule._makeLong(path), callback);
+  };
+
+  fs.readdirSync = function(path) {
+    nullCheck(path);
+    return binding.readdir(pathModule._makeLong(path));
+  };
+
+  fs.fstat = function(fd, callback) {
+    binding.fstat(fd, makeCallback(callback));
+  };
+
+  fs.lstat = function(path, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.lstat(pathModule._makeLong(path), callback);
+  };
+
+  fs.stat = function(path, callback) {
+    var throwSafe = fs.options.throwSafe;
+
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) {
+      if (throwSafe) {
+        process.nextTick(function() {
+          callback(true, false);
+        });
       }
-      fs.fchown(fd, uid, gid, callback);
+      return;
+    }
+    binding.stat(pathModule._makeLong(path), callback, throwSafe);
+  };
+
+  fs.fstatSync = function(fd) {
+    return binding.fstat(fd);
+  };
+
+  fs.lstatSync = function(path) {
+    nullCheck(path);
+    return binding.lstat(pathModule._makeLong(path));
+  };
+
+  fs.statSync = function(path) {
+    var throwSafe = fs.options.throwSafe;
+
+    if (!nullCheck(path))
+      return false;
+
+    return binding.stat(pathModule._makeLong(path), undefined, throwSafe);
+  };
+
+  fs.readlink = function(path, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.readlink(pathModule._makeLong(path), callback);
+  };
+
+  fs.readlinkSync = function(path) {
+    nullCheck(path);
+    return binding.readlink(pathModule._makeLong(path));
+  };
+
+  function preprocessSymlinkDestination(path, type) {
+    if (!isWindows) {
+      // No preprocessing is needed on Unix.
+      return path;
+    } else if (type === 'junction') {
+      // Junctions paths need to be absolute and \\?\-prefixed.
+      return pathModule._makeLong(path);
+    } else {
+      // Windows symlinks don't tolerate forward slashes.
+      return ('' + path).replace(/\//g, '\\');
+    }
+  }
+
+  fs.symlink = function(destination, path, type_, callback) {
+    var type = (util.isString(type_) ? type_ : null);
+    var callback = makeCallback(arguments[arguments.length - 1]);
+
+    if (!nullCheck(destination, callback)) return;
+    if (!nullCheck(path, callback)) return;
+
+    binding.symlink(preprocessSymlinkDestination(destination, type),
+                    pathModule._makeLong(path),
+                    type,
+                    callback);
+  };
+
+  fs.symlinkSync = function(destination, path, type) {
+    type = (util.isString(type) ? type : null);
+
+    nullCheck(destination);
+    nullCheck(path);
+
+    return binding.symlink(preprocessSymlinkDestination(destination, type),
+                           pathModule._makeLong(path),
+                           type);
+  };
+
+  fs.link = function(srcpath, dstpath, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(srcpath, callback)) return;
+    if (!nullCheck(dstpath, callback)) return;
+
+    binding.link(pathModule._makeLong(srcpath),
+                 pathModule._makeLong(dstpath),
+                 callback);
+  };
+
+  fs.linkSync = function(srcpath, dstpath) {
+    nullCheck(srcpath);
+    nullCheck(dstpath);
+    return binding.link(pathModule._makeLong(srcpath),
+                        pathModule._makeLong(dstpath));
+  };
+
+  fs.unlink = function(path, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.unlink(pathModule._makeLong(path), callback);
+  };
+
+  fs.unlinkSync = function(path) {
+    nullCheck(path);
+    return binding.unlink(pathModule._makeLong(path));
+  };
+
+  fs.fchmod = function(fd, mode, callback) {
+    binding.fchmod(fd, modeNum(mode), makeCallback(callback));
+  };
+
+  fs.fchmodSync = function(fd, mode) {
+    return binding.fchmod(fd, modeNum(mode));
+  };
+
+  if (constants.hasOwnProperty('O_SYMLINK')) {
+    fs.lchmod = function(path, mode, callback) {
+      callback = maybeCallback(callback);
+      fs.open(path, constants.O_WRONLY | constants.O_SYMLINK,
+        function(err, fd) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        // prefer to return the chmod error, if one occurs,
+        // but still try to close, and report closing errors if they occur.
+        fs.fchmod(fd, mode, function(err) {
+          fs.close(fd, function(err2) {
+            callback(err || err2);
+          });
+        });
+      });
+    };
+
+    fs.lchmodSync = function(path, mode) {
+      var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
+
+      // prefer to return the chmod error, if one occurs,
+      // but still try to close, and report closing errors if they occur.
+      var err, err2;
+      try {
+        var ret = fs.fchmodSync(fd, mode);
+      } catch (er) {
+        err = er;
+      }
+      try {
+        fs.closeSync(fd);
+      } catch (er) {
+        err2 = er;
+      }
+      if (err || err2) throw (err || err2);
+      return ret;
+    };
+  }
+
+
+  fs.chmod = function(path, mode, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.chmod(pathModule._makeLong(path),
+                  modeNum(mode),
+                  callback);
+  };
+
+  fs.chmodSync = function(path, mode) {
+    nullCheck(path);
+    return binding.chmod(pathModule._makeLong(path), modeNum(mode));
+  };
+
+  if (constants.hasOwnProperty('O_SYMLINK')) {
+    fs.lchown = function(path, uid, gid, callback) {
+      callback = maybeCallback(callback);
+      fs.open(path, constants.O_WRONLY | constants.O_SYMLINK,
+        function(err, fd) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        fs.fchown(fd, uid, gid, callback);
+      });
+    };
+
+    fs.lchownSync = function(path, uid, gid) {
+      var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
+      return fs.fchownSync(fd, uid, gid);
+    };
+  }
+
+  fs.fchown = function(fd, uid, gid, callback) {
+    binding.fchown(fd, uid, gid, makeCallback(callback));
+  };
+
+  fs.fchownSync = function(fd, uid, gid) {
+    return binding.fchown(fd, uid, gid);
+  };
+
+  fs.chown = function(path, uid, gid, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.chown(pathModule._makeLong(path), uid, gid, callback);
+  };
+
+  fs.chownSync = function(path, uid, gid) {
+    nullCheck(path);
+    return binding.chown(pathModule._makeLong(path), uid, gid);
+  };
+
+  // converts Date or number to a fractional UNIX timestamp
+  function toUnixTimestamp(time) {
+    if (util.isNumber(time)) {
+      return time;
+    }
+    if (util.isDate(time)) {
+      // convert to 123.456 UNIX timestamp
+      return time.getTime() / 1000;
+    }
+    throw new Error('Cannot parse time: ' + time);
+  }
+
+  // exported for unit tests, not for public consumption
+  fs._toUnixTimestamp = toUnixTimestamp;
+
+  fs.utimes = function(path, atime, mtime, callback) {
+    callback = makeCallback(callback);
+    if (!nullCheck(path, callback)) return;
+    binding.utimes(pathModule._makeLong(path),
+                   toUnixTimestamp(atime),
+                   toUnixTimestamp(mtime),
+                   callback);
+  };
+
+  fs.utimesSync = function(path, atime, mtime) {
+    nullCheck(path);
+    atime = toUnixTimestamp(atime);
+    mtime = toUnixTimestamp(mtime);
+    binding.utimes(pathModule._makeLong(path), atime, mtime);
+  };
+
+  fs.futimes = function(fd, atime, mtime, callback) {
+    atime = toUnixTimestamp(atime);
+    mtime = toUnixTimestamp(mtime);
+    binding.futimes(fd, atime, mtime, makeCallback(callback));
+  };
+
+  fs.futimesSync = function(fd, atime, mtime) {
+    atime = toUnixTimestamp(atime);
+    mtime = toUnixTimestamp(mtime);
+    binding.futimes(fd, atime, mtime);
+  };
+
+  function writeAll(fd, buffer, offset, length, position, callback) {
+    callback = maybeCallback(arguments[arguments.length - 1]);
+
+    // write(fd, buffer, offset, length, position, callback)
+    fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
+      if (writeErr) {
+        fs.close(fd, function() {
+          if (callback) callback(writeErr);
+        });
+      } else {
+        if (written === length) {
+          fs.close(fd, callback);
+        } else {
+          offset += written;
+          length -= written;
+          position += written;
+          writeAll(fd, buffer, offset, length, position, callback);
+        }
+      }
+    });
+  }
+
+  fs.writeFile = function(path, data, options, callback) {
+    var callback = maybeCallback(arguments[arguments.length - 1]);
+
+    if (util.isFunction(options) || !options) {
+      options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
+    } else if (util.isString(options)) {
+      options = { encoding: options, mode: 438, flag: 'w' };
+    } else if (!util.isObject(options)) {
+      throw new TypeError('Bad arguments');
+    }
+
+    assertEncoding(options.encoding);
+
+    var flag = options.flag || 'w';
+    fs.open(path, flag, options.mode, function(openErr, fd) {
+      if (openErr) {
+        if (callback) callback(openErr);
+      } else {
+        var buffer = util.isBuffer(data) ? data : new Buffer('' + data,
+            options.encoding || 'utf8');
+        var position = /a/.test(flag) ? null : 0;
+        writeAll(fd, buffer, 0, buffer.length, position, callback);
+      }
     });
   };
 
-  fs.lchownSync = function(path, uid, gid) {
-    var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
-    return fs.fchownSync(fd, uid, gid);
-  };
-}
+  fs.writeFileSync = function(path, data, options) {
+    if (!options) {
+      options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
+    } else if (util.isString(options)) {
+      options = { encoding: options, mode: 438, flag: 'w' };
+    } else if (!util.isObject(options)) {
+      throw new TypeError('Bad arguments');
+    }
 
-fs.fchown = function(fd, uid, gid, callback) {
-  binding.fchown(fd, uid, gid, makeCallback(callback));
-};
+    assertEncoding(options.encoding);
 
-fs.fchownSync = function(fd, uid, gid) {
-  return binding.fchown(fd, uid, gid);
-};
-
-fs.chown = function(path, uid, gid, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.chown(pathModule._makeLong(path), uid, gid, callback);
-};
-
-fs.chownSync = function(path, uid, gid) {
-  nullCheck(path);
-  return binding.chown(pathModule._makeLong(path), uid, gid);
-};
-
-// converts Date or number to a fractional UNIX timestamp
-function toUnixTimestamp(time) {
-  if (util.isNumber(time)) {
-    return time;
-  }
-  if (util.isDate(time)) {
-    // convert to 123.456 UNIX timestamp
-    return time.getTime() / 1000;
-  }
-  throw new Error('Cannot parse time: ' + time);
-}
-
-// exported for unit tests, not for public consumption
-fs._toUnixTimestamp = toUnixTimestamp;
-
-fs.utimes = function(path, atime, mtime, callback) {
-  callback = makeCallback(callback);
-  if (!nullCheck(path, callback)) return;
-  binding.utimes(pathModule._makeLong(path),
-                 toUnixTimestamp(atime),
-                 toUnixTimestamp(mtime),
-                 callback);
-};
-
-fs.utimesSync = function(path, atime, mtime) {
-  nullCheck(path);
-  atime = toUnixTimestamp(atime);
-  mtime = toUnixTimestamp(mtime);
-  binding.utimes(pathModule._makeLong(path), atime, mtime);
-};
-
-fs.futimes = function(fd, atime, mtime, callback) {
-  atime = toUnixTimestamp(atime);
-  mtime = toUnixTimestamp(mtime);
-  binding.futimes(fd, atime, mtime, makeCallback(callback));
-};
-
-fs.futimesSync = function(fd, atime, mtime) {
-  atime = toUnixTimestamp(atime);
-  mtime = toUnixTimestamp(mtime);
-  binding.futimes(fd, atime, mtime);
-};
-
-function writeAll(fd, buffer, offset, length, position, callback) {
-  callback = maybeCallback(arguments[arguments.length - 1]);
-
-  // write(fd, buffer, offset, length, position, callback)
-  fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
-    if (writeErr) {
-      fs.close(fd, function() {
-        if (callback) callback(writeErr);
-      });
-    } else {
-      if (written === length) {
-        fs.close(fd, callback);
-      } else {
-        offset += written;
-        length -= written;
+    var flag = options.flag || 'w';
+    var fd = fs.openSync(path, flag, options.mode);
+    if (!util.isBuffer(data)) {
+      data = new Buffer('' + data, options.encoding || 'utf8');
+    }
+    var written = 0;
+    var length = data.length;
+    var position = /a/.test(flag) ? null : 0;
+    try {
+      while (written < length) {
+        written += fs.writeSync(fd, data, written, length - written, position);
         position += written;
-        writeAll(fd, buffer, offset, length, position, callback);
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+
+  fs.appendFile = function(path, data, options, callback_) {
+    var callback = maybeCallback(arguments[arguments.length - 1]);
+
+    if (util.isFunction(options) || !options) {
+      options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
+    } else if (util.isString(options)) {
+      options = { encoding: options, mode: 438, flag: 'a' };
+    } else if (!util.isObject(options)) {
+      throw new TypeError('Bad arguments');
+    }
+
+    if (!options.flag)
+      options = util._extend({ flag: 'a' }, options);
+    fs.writeFile(path, data, options, callback);
+  };
+
+  fs.appendFileSync = function(path, data, options) {
+    if (!options) {
+      options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
+    } else if (util.isString(options)) {
+      options = { encoding: options, mode: 438, flag: 'a' };
+    } else if (!util.isObject(options)) {
+      throw new TypeError('Bad arguments');
+    }
+    if (!options.flag)
+      options = util._extend({ flag: 'a' }, options);
+
+    fs.writeFileSync(path, data, options);
+  };
+
+  function FSWatcher() {
+    EventEmitter.call(this);
+
+    var self = this;
+    var FSEvent = process.binding('fs_event_wrap').FSEvent;
+    this._handle = new FSEvent();
+    this._handle.owner = this;
+
+    this._handle.onchange = function(status, event, filename) {
+      if (status < 0) {
+        self._handle.close();
+        self.emit('error', errnoException(status, 'watch'));
+      } else {
+        self.emit('change', event, filename);
+      }
+    };
+  }
+  util.inherits(FSWatcher, EventEmitter);
+
+  FSWatcher.prototype.start = function(filename, persistent, recursive) {
+    nullCheck(filename);
+    var err = this._handle.start(pathModule._makeLong(filename),
+                                 persistent,
+                                 recursive);
+    if (err) {
+      this._handle.close();
+      throw errnoException(err, 'watch');
+    }
+  };
+
+  FSWatcher.prototype.close = function() {
+    this._handle.close();
+  };
+
+  fs.watch = function(filename) {
+    nullCheck(filename);
+    var watcher;
+    var options;
+    var listener;
+
+    if (util.isObject(arguments[1])) {
+      options = arguments[1];
+      listener = arguments[2];
+    } else {
+      options = {};
+      listener = arguments[1];
+    }
+
+    if (util.isUndefined(options.persistent)) options.persistent = true;
+    if (util.isUndefined(options.recursive)) options.recursive = false;
+
+    watcher = new FSWatcher();
+    watcher.start(filename, options.persistent, options.recursive);
+
+    if (listener) {
+      watcher.addListener('change', listener);
+    }
+
+    return watcher;
+  };
+
+
+  // Stat Change Watchers
+
+  function StatWatcher() {
+    EventEmitter.call(this);
+
+    var self = this;
+    this._handle = new binding.StatWatcher();
+
+    // uv_fs_poll is a little more powerful than ev_stat but we curb it for
+    // the sake of backwards compatibility
+    var oldStatus = -1;
+
+    this._handle.onchange = function(current, previous, newStatus) {
+      if (oldStatus === -1 &&
+          newStatus === -1 &&
+          current.nlink === previous.nlink) return;
+
+      oldStatus = newStatus;
+      self.emit('change', current, previous);
+    };
+
+    this._handle.onstop = function() {
+      self.emit('stop');
+    };
+  }
+  util.inherits(StatWatcher, EventEmitter);
+
+
+  StatWatcher.prototype.start = function(filename, persistent, interval) {
+    nullCheck(filename);
+    this._handle.start(pathModule._makeLong(filename), persistent, interval);
+  };
+
+
+  StatWatcher.prototype.stop = function() {
+    this._handle.stop();
+  };
+
+
+  var statWatchers = {};
+  function inStatWatchers(filename) {
+    return Object.prototype.hasOwnProperty.call(statWatchers, filename) &&
+        statWatchers[filename];
+  }
+
+
+  fs.watchFile = function(filename) {
+    nullCheck(filename);
+    filename = pathModule.resolve(filename);
+    var stat;
+    var listener;
+
+    var options = {
+      // Poll interval in milliseconds. 5007 is what libev used to use. It's
+      // a little on the slow side but let's stick with it for now to keep
+      // behavioral changes to a minimum.
+      interval: 5007,
+      persistent: true
+    };
+
+    if (util.isObject(arguments[1])) {
+      options = util._extend(options, arguments[1]);
+      listener = arguments[2];
+    } else {
+      listener = arguments[1];
+    }
+
+    if (!listener) {
+      throw new Error('watchFile requires a listener function');
+    }
+
+    if (inStatWatchers(filename)) {
+      stat = statWatchers[filename];
+    } else {
+      stat = statWatchers[filename] = new StatWatcher();
+      stat.start(filename, options.persistent, options.interval);
+    }
+    stat.addListener('change', listener);
+    return stat;
+  };
+
+  fs.unwatchFile = function(filename, listener) {
+    nullCheck(filename);
+    filename = pathModule.resolve(filename);
+    if (!inStatWatchers(filename)) return;
+
+    var stat = statWatchers[filename];
+
+    if (util.isFunction(listener)) {
+      stat.removeListener('change', listener);
+    } else {
+      stat.removeAllListeners('change');
+    }
+
+    if (EventEmitter.listenerCount(stat, 'change') === 0) {
+      stat.stop();
+      statWatchers[filename] = undefined;
+    }
+  };
+
+  // Regexp that finds the next partion of a (partial) path
+  // result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
+  if (isWindows) {
+    var nextPartRe = /(.*?)(?:[\/\\]+|$)/g;
+  } else {
+    var nextPartRe = /(.*?)(?:[\/]+|$)/g;
+  }
+
+  // Regex to find the device root, including trailing slash. E.g. 'c:\\'.
+  if (isWindows) {
+    var splitRootRe = /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/;
+  } else {
+    var splitRootRe = /^[\/]*/;
+  }
+
+  fs.realpathSync = function realpathSync(p, cache) {
+    // make p is absolute
+    p = pathModule.resolve(p);
+
+    if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
+      return cache[p];
+    }
+
+    var original = p,
+        seenLinks = {},
+        knownHard = {};
+
+    // current character position in p
+    var pos;
+    // the partial path so far, including a trailing slash if any
+    var current;
+    // the partial path without a trailing slash
+    // (except when pointing at a root)
+    var base;
+    // the partial path scanned in the previous round, with slash
+    var previous;
+
+    start();
+
+    function start() {
+      // Skip over roots
+      var m = splitRootRe.exec(p);
+      pos = m[0].length;
+      current = m[0];
+      base = m[0];
+      previous = '';
+
+      // On windows, check that the root exists. On unix there is no need.
+      if (isWindows && !knownHard[base]) {
+        fs.lstatSync(base);
+        knownHard[base] = true;
       }
     }
-  });
-}
 
-fs.writeFile = function(path, data, options, callback) {
-  var callback = maybeCallback(arguments[arguments.length - 1]);
+    // walk down the path, swapping out linked pathparts for their real
+    // values
+    // NB: p.length changes.
+    while (pos < p.length) {
+      // find the next part
+      nextPartRe.lastIndex = pos;
+      var result = nextPartRe.exec(p);
+      previous = current;
+      current += result[0];
+      base = previous + result[1];
+      pos = nextPartRe.lastIndex;
 
-  if (util.isFunction(options) || !options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
-  } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'w' };
-  } else if (!util.isObject(options)) {
-    throw new TypeError('Bad arguments');
-  }
-
-  assertEncoding(options.encoding);
-
-  var flag = options.flag || 'w';
-  fs.open(path, flag, options.mode, function(openErr, fd) {
-    if (openErr) {
-      if (callback) callback(openErr);
-    } else {
-      var buffer = util.isBuffer(data) ? data : new Buffer('' + data,
-          options.encoding || 'utf8');
-      var position = /a/.test(flag) ? null : 0;
-      writeAll(fd, buffer, 0, buffer.length, position, callback);
-    }
-  });
-};
-
-fs.writeFileSync = function(path, data, options) {
-  if (!options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
-  } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'w' };
-  } else if (!util.isObject(options)) {
-    throw new TypeError('Bad arguments');
-  }
-
-  assertEncoding(options.encoding);
-
-  var flag = options.flag || 'w';
-  var fd = fs.openSync(path, flag, options.mode);
-  if (!util.isBuffer(data)) {
-    data = new Buffer('' + data, options.encoding || 'utf8');
-  }
-  var written = 0;
-  var length = data.length;
-  var position = /a/.test(flag) ? null : 0;
-  try {
-    while (written < length) {
-      written += fs.writeSync(fd, data, written, length - written, position);
-      position += written;
-    }
-  } finally {
-    fs.closeSync(fd);
-  }
-};
-
-fs.appendFile = function(path, data, options, callback_) {
-  var callback = maybeCallback(arguments[arguments.length - 1]);
-
-  if (util.isFunction(options) || !options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
-  } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'a' };
-  } else if (!util.isObject(options)) {
-    throw new TypeError('Bad arguments');
-  }
-
-  if (!options.flag)
-    options = util._extend({ flag: 'a' }, options);
-  fs.writeFile(path, data, options, callback);
-};
-
-fs.appendFileSync = function(path, data, options) {
-  if (!options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
-  } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'a' };
-  } else if (!util.isObject(options)) {
-    throw new TypeError('Bad arguments');
-  }
-  if (!options.flag)
-    options = util._extend({ flag: 'a' }, options);
-
-  fs.writeFileSync(path, data, options);
-};
-
-function FSWatcher() {
-  EventEmitter.call(this);
-
-  var self = this;
-  var FSEvent = process.binding('fs_event_wrap').FSEvent;
-  this._handle = new FSEvent();
-  this._handle.owner = this;
-
-  this._handle.onchange = function(status, event, filename) {
-    if (status < 0) {
-      self._handle.close();
-      self.emit('error', errnoException(status, 'watch'));
-    } else {
-      self.emit('change', event, filename);
-    }
-  };
-}
-util.inherits(FSWatcher, EventEmitter);
-
-FSWatcher.prototype.start = function(filename, persistent, recursive) {
-  nullCheck(filename);
-  var err = this._handle.start(pathModule._makeLong(filename),
-                               persistent,
-                               recursive);
-  if (err) {
-    this._handle.close();
-    throw errnoException(err, 'watch');
-  }
-};
-
-FSWatcher.prototype.close = function() {
-  this._handle.close();
-};
-
-fs.watch = function(filename) {
-  nullCheck(filename);
-  var watcher;
-  var options;
-  var listener;
-
-  if (util.isObject(arguments[1])) {
-    options = arguments[1];
-    listener = arguments[2];
-  } else {
-    options = {};
-    listener = arguments[1];
-  }
-
-  if (util.isUndefined(options.persistent)) options.persistent = true;
-  if (util.isUndefined(options.recursive)) options.recursive = false;
-
-  watcher = new FSWatcher();
-  watcher.start(filename, options.persistent, options.recursive);
-
-  if (listener) {
-    watcher.addListener('change', listener);
-  }
-
-  return watcher;
-};
-
-
-// Stat Change Watchers
-
-function StatWatcher() {
-  EventEmitter.call(this);
-
-  var self = this;
-  this._handle = new binding.StatWatcher();
-
-  // uv_fs_poll is a little more powerful than ev_stat but we curb it for
-  // the sake of backwards compatibility
-  var oldStatus = -1;
-
-  this._handle.onchange = function(current, previous, newStatus) {
-    if (oldStatus === -1 &&
-        newStatus === -1 &&
-        current.nlink === previous.nlink) return;
-
-    oldStatus = newStatus;
-    self.emit('change', current, previous);
-  };
-
-  this._handle.onstop = function() {
-    self.emit('stop');
-  };
-}
-util.inherits(StatWatcher, EventEmitter);
-
-
-StatWatcher.prototype.start = function(filename, persistent, interval) {
-  nullCheck(filename);
-  this._handle.start(pathModule._makeLong(filename), persistent, interval);
-};
-
-
-StatWatcher.prototype.stop = function() {
-  this._handle.stop();
-};
-
-
-var statWatchers = {};
-function inStatWatchers(filename) {
-  return Object.prototype.hasOwnProperty.call(statWatchers, filename) &&
-      statWatchers[filename];
-}
-
-
-fs.watchFile = function(filename) {
-  nullCheck(filename);
-  filename = pathModule.resolve(filename);
-  var stat;
-  var listener;
-
-  var options = {
-    // Poll interval in milliseconds. 5007 is what libev used to use. It's
-    // a little on the slow side but let's stick with it for now to keep
-    // behavioral changes to a minimum.
-    interval: 5007,
-    persistent: true
-  };
-
-  if (util.isObject(arguments[1])) {
-    options = util._extend(options, arguments[1]);
-    listener = arguments[2];
-  } else {
-    listener = arguments[1];
-  }
-
-  if (!listener) {
-    throw new Error('watchFile requires a listener function');
-  }
-
-  if (inStatWatchers(filename)) {
-    stat = statWatchers[filename];
-  } else {
-    stat = statWatchers[filename] = new StatWatcher();
-    stat.start(filename, options.persistent, options.interval);
-  }
-  stat.addListener('change', listener);
-  return stat;
-};
-
-fs.unwatchFile = function(filename, listener) {
-  nullCheck(filename);
-  filename = pathModule.resolve(filename);
-  if (!inStatWatchers(filename)) return;
-
-  var stat = statWatchers[filename];
-
-  if (util.isFunction(listener)) {
-    stat.removeListener('change', listener);
-  } else {
-    stat.removeAllListeners('change');
-  }
-
-  if (EventEmitter.listenerCount(stat, 'change') === 0) {
-    stat.stop();
-    statWatchers[filename] = undefined;
-  }
-};
-
-// Regexp that finds the next partion of a (partial) path
-// result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
-if (isWindows) {
-  var nextPartRe = /(.*?)(?:[\/\\]+|$)/g;
-} else {
-  var nextPartRe = /(.*?)(?:[\/]+|$)/g;
-}
-
-// Regex to find the device root, including trailing slash. E.g. 'c:\\'.
-if (isWindows) {
-  var splitRootRe = /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/;
-} else {
-  var splitRootRe = /^[\/]*/;
-}
-
-fs.realpathSync = function realpathSync(p, cache) {
-  // make p is absolute
-  p = pathModule.resolve(p);
-
-  if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
-    return cache[p];
-  }
-
-  var original = p,
-      seenLinks = {},
-      knownHard = {};
-
-  // current character position in p
-  var pos;
-  // the partial path so far, including a trailing slash if any
-  var current;
-  // the partial path without a trailing slash (except when pointing at a root)
-  var base;
-  // the partial path scanned in the previous round, with slash
-  var previous;
-
-  start();
-
-  function start() {
-    // Skip over roots
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
-
-    // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
-      fs.lstatSync(base);
-      knownHard[base] = true;
-    }
-  }
-
-  // walk down the path, swapping out linked pathparts for their real
-  // values
-  // NB: p.length changes.
-  while (pos < p.length) {
-    // find the next part
-    nextPartRe.lastIndex = pos;
-    var result = nextPartRe.exec(p);
-    previous = current;
-    current += result[0];
-    base = previous + result[1];
-    pos = nextPartRe.lastIndex;
-
-    // continue if not a symlink
-    if (knownHard[base] || (cache && cache[base] === base)) {
-      continue;
-    }
-
-    var resolvedLink;
-    if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
-      // some known symbolic link.  no need to stat again.
-      resolvedLink = cache[base];
-    } else {
-      var stat = fs.lstatSync(base);
-      if (!stat.isSymbolicLink()) {
-        knownHard[base] = true;
-        if (cache) cache[base] = base;
+      // continue if not a symlink
+      if (knownHard[base] || (cache && cache[base] === base)) {
         continue;
       }
 
-      // read the link if it wasn't read before
+      var resolvedLink;
+      if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
+        // some known symbolic link.  no need to stat again.
+        resolvedLink = cache[base];
+      } else {
+        var stat = fs.lstatSync(base);
+        if (!stat.isSymbolicLink()) {
+          knownHard[base] = true;
+          if (cache) cache[base] = base;
+          continue;
+        }
+
+        // read the link if it wasn't read before
+        // dev/ino always return 0 on windows, so skip the check.
+        var linkTarget = null;
+        if (!isWindows) {
+          var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+          if (seenLinks.hasOwnProperty(id)) {
+            linkTarget = seenLinks[id];
+          }
+        }
+        if (util.isNull(linkTarget)) {
+          fs.statSync(base);
+          linkTarget = fs.readlinkSync(base);
+        }
+        resolvedLink = pathModule.resolve(previous, linkTarget);
+        // track this, if given a cache.
+        if (cache) cache[base] = resolvedLink;
+        if (!isWindows) seenLinks[id] = linkTarget;
+      }
+
+      // resolve the link, then start over
+      p = pathModule.resolve(resolvedLink, p.slice(pos));
+      start();
+    }
+
+    if (cache) cache[original] = p;
+
+    return p;
+  };
+
+
+  fs.realpath = function realpath(p, cache, cb) {
+    if (!util.isFunction(cb)) {
+      cb = maybeCallback(cache);
+      cache = null;
+    }
+
+    // make p is absolute
+    p = pathModule.resolve(p);
+
+    if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
+      return process.nextTick(cb.bind(null, null, cache[p]));
+    }
+
+    var original = p,
+        seenLinks = {},
+        knownHard = {};
+
+    // current character position in p
+    var pos;
+    // the partial path so far, including a trailing slash if any
+    var current;
+    // the partial path without a trailing slash
+    // (except when pointing at a root)
+    var base;
+    // the partial path scanned in the previous round, with slash
+    var previous;
+
+    start();
+
+    function start() {
+      // Skip over roots
+      var m = splitRootRe.exec(p);
+      pos = m[0].length;
+      current = m[0];
+      base = m[0];
+      previous = '';
+
+      // On windows, check that the root exists. On unix there is no need.
+      if (isWindows && !knownHard[base]) {
+        fs.lstat(base, function(err) {
+          if (err) return cb(err);
+          knownHard[base] = true;
+          LOOP();
+        });
+      } else {
+        process.nextTick(LOOP);
+      }
+    }
+
+    // walk down the path, swapping out linked pathparts for their real
+    // values
+    function LOOP() {
+      // stop if scanned past end of path
+      if (pos >= p.length) {
+        if (cache) cache[original] = p;
+        return cb(null, p);
+      }
+
+      // find the next part
+      nextPartRe.lastIndex = pos;
+      var result = nextPartRe.exec(p);
+      previous = current;
+      current += result[0];
+      base = previous + result[1];
+      pos = nextPartRe.lastIndex;
+
+      // continue if not a symlink
+      if (knownHard[base] || (cache && cache[base] === base)) {
+        return process.nextTick(LOOP);
+      }
+
+      if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
+        // known symbolic link.  no need to stat again.
+        return gotResolvedLink(cache[base]);
+      }
+
+      return fs.lstat(base, gotStat);
+    }
+
+    function gotStat(err, stat) {
+      if (err) return cb(err);
+
+      // if not a symlink, skip to the next path part
+      if (!stat.isSymbolicLink()) {
+        knownHard[base] = true;
+        if (cache) cache[base] = base;
+        return process.nextTick(LOOP);
+      }
+
+      // stat & read the link if not read before
+      // call gotTarget as soon as the link target is known
       // dev/ino always return 0 on windows, so skip the check.
-      var linkTarget = null;
       if (!isWindows) {
         var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
         if (seenLinks.hasOwnProperty(id)) {
-          linkTarget = seenLinks[id];
+          return gotTarget(null, seenLinks[id], base);
         }
       }
-      if (util.isNull(linkTarget)) {
-        fs.statSync(base);
-        linkTarget = fs.readlinkSync(base);
-      }
-      resolvedLink = pathModule.resolve(previous, linkTarget);
-      // track this, if given a cache.
-      if (cache) cache[base] = resolvedLink;
-      if (!isWindows) seenLinks[id] = linkTarget;
-    }
-
-    // resolve the link, then start over
-    p = pathModule.resolve(resolvedLink, p.slice(pos));
-    start();
-  }
-
-  if (cache) cache[original] = p;
-
-  return p;
-};
-
-
-fs.realpath = function realpath(p, cache, cb) {
-  if (!util.isFunction(cb)) {
-    cb = maybeCallback(cache);
-    cache = null;
-  }
-
-  // make p is absolute
-  p = pathModule.resolve(p);
-
-  if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
-    return process.nextTick(cb.bind(null, null, cache[p]));
-  }
-
-  var original = p,
-      seenLinks = {},
-      knownHard = {};
-
-  // current character position in p
-  var pos;
-  // the partial path so far, including a trailing slash if any
-  var current;
-  // the partial path without a trailing slash (except when pointing at a root)
-  var base;
-  // the partial path scanned in the previous round, with slash
-  var previous;
-
-  start();
-
-  function start() {
-    // Skip over roots
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
-
-    // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
-      fs.lstat(base, function(err) {
+      fs.stat(base, function(err) {
         if (err) return cb(err);
-        knownHard[base] = true;
-        LOOP();
+
+        fs.readlink(base, function(err, target) {
+          if (!isWindows) seenLinks[id] = target;
+          gotTarget(err, target);
+        });
       });
-    } else {
-      process.nextTick(LOOP);
-    }
-  }
-
-  // walk down the path, swapping out linked pathparts for their real
-  // values
-  function LOOP() {
-    // stop if scanned past end of path
-    if (pos >= p.length) {
-      if (cache) cache[original] = p;
-      return cb(null, p);
     }
 
-    // find the next part
-    nextPartRe.lastIndex = pos;
-    var result = nextPartRe.exec(p);
-    previous = current;
-    current += result[0];
-    base = previous + result[1];
-    pos = nextPartRe.lastIndex;
-
-    // continue if not a symlink
-    if (knownHard[base] || (cache && cache[base] === base)) {
-      return process.nextTick(LOOP);
-    }
-
-    if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
-      // known symbolic link.  no need to stat again.
-      return gotResolvedLink(cache[base]);
-    }
-
-    return fs.lstat(base, gotStat);
-  }
-
-  function gotStat(err, stat) {
-    if (err) return cb(err);
-
-    // if not a symlink, skip to the next path part
-    if (!stat.isSymbolicLink()) {
-      knownHard[base] = true;
-      if (cache) cache[base] = base;
-      return process.nextTick(LOOP);
-    }
-
-    // stat & read the link if not read before
-    // call gotTarget as soon as the link target is known
-    // dev/ino always return 0 on windows, so skip the check.
-    if (!isWindows) {
-      var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
-      if (seenLinks.hasOwnProperty(id)) {
-        return gotTarget(null, seenLinks[id], base);
-      }
-    }
-    fs.stat(base, function(err) {
+    function gotTarget(err, target, base) {
       if (err) return cb(err);
 
-      fs.readlink(base, function(err, target) {
-        if (!isWindows) seenLinks[id] = target;
-        gotTarget(err, target);
-      });
-    });
+      var resolvedLink = pathModule.resolve(previous, target);
+      if (cache) cache[base] = resolvedLink;
+      gotResolvedLink(resolvedLink);
+    }
+
+    function gotResolvedLink(resolvedLink) {
+      // resolve the link, then start over
+      p = pathModule.resolve(resolvedLink, p.slice(pos));
+      start();
+    }
+  };
+
+
+
+  var pool;
+
+  function allocNewPool(poolSize) {
+    pool = new Buffer(poolSize);
+    pool.used = 0;
   }
 
-  function gotTarget(err, target, base) {
-    if (err) return cb(err);
-
-    var resolvedLink = pathModule.resolve(previous, target);
-    if (cache) cache[base] = resolvedLink;
-    gotResolvedLink(resolvedLink);
-  }
-
-  function gotResolvedLink(resolvedLink) {
-    // resolve the link, then start over
-    p = pathModule.resolve(resolvedLink, p.slice(pos));
-    start();
-  }
-};
 
 
-
-var pool;
-
-function allocNewPool(poolSize) {
-  pool = new Buffer(poolSize);
-  pool.used = 0;
-}
-
-
-
-fs.createReadStream = function(path, options) {
-  return new ReadStream(path, options);
-};
-
-util.inherits(ReadStream, Readable);
-fs.ReadStream = ReadStream;
-
-function ReadStream(path, options) {
-  if (!(this instanceof ReadStream))
+  fs.createReadStream = function(path, options) {
     return new ReadStream(path, options);
+  };
 
-  // a little bit bigger buffer and water marks by default
-  options = util._extend({
-    highWaterMark: 64 * 1024
-  }, options || {});
+  util.inherits(ReadStream, Readable);
+  fs.ReadStream = ReadStream;
 
-  Readable.call(this, options);
+  function ReadStream(path, options) {
+    if (!(this instanceof ReadStream))
+      return new ReadStream(path, options);
 
-  this.path = path;
-  this.fd = options.hasOwnProperty('fd') ? options.fd : null;
-  this.flags = options.hasOwnProperty('flags') ? options.flags : 'r';
-  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+    // a little bit bigger buffer and water marks by default
+    options = util._extend({
+      highWaterMark: 64 * 1024
+    }, options || {});
 
-  this.start = options.hasOwnProperty('start') ? options.start : undefined;
-  this.end = options.hasOwnProperty('end') ? options.end : undefined;
-  this.autoClose = options.hasOwnProperty('autoClose') ?
-      options.autoClose : true;
-  this.pos = undefined;
+    Readable.call(this, options);
 
-  if (!util.isUndefined(this.start)) {
-    if (!util.isNumber(this.start)) {
-      throw TypeError('start must be a Number');
-    }
-    if (util.isUndefined(this.end)) {
-      this.end = Infinity;
-    } else if (!util.isNumber(this.end)) {
-      throw TypeError('end must be a Number');
-    }
+    this.path = path;
+    this.fd = options.hasOwnProperty('fd') ? options.fd : null;
+    this.flags = options.hasOwnProperty('flags') ? options.flags : 'r';
+    this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
 
-    if (this.start > this.end) {
-      throw new Error('start must be <= end');
-    }
+    this.start = options.hasOwnProperty('start') ? options.start : undefined;
+    this.end = options.hasOwnProperty('end') ? options.end : undefined;
+    this.autoClose = options.hasOwnProperty('autoClose') ?
+        options.autoClose : true;
+    this.pos = undefined;
 
-    this.pos = this.start;
-  }
-
-  if (!util.isNumber(this.fd))
-    this.open();
-
-  this.on('end', function() {
-    if (this.autoClose) {
-      this.destroy();
-    }
-  });
-}
-
-fs.FileReadStream = fs.ReadStream; // support the legacy name
-
-ReadStream.prototype.open = function() {
-  var self = this;
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
-    if (er) {
-      if (self.autoClose) {
-        self.destroy();
+    if (!util.isUndefined(this.start)) {
+      if (!util.isNumber(this.start)) {
+        throw TypeError('start must be a Number');
       }
-      self.emit('error', er);
-      return;
+      if (util.isUndefined(this.end)) {
+        this.end = Infinity;
+      } else if (!util.isNumber(this.end)) {
+        throw TypeError('end must be a Number');
+      }
+
+      if (this.start > this.end) {
+        throw new Error('start must be <= end');
+      }
+
+      this.pos = this.start;
     }
 
-    self.fd = fd;
-    self.emit('open', fd);
-    // start the flow of data.
-    self.read();
-  });
-};
+    if (!util.isNumber(this.fd))
+      this.open();
 
-ReadStream.prototype._read = function(n) {
-  if (!util.isNumber(this.fd))
-    return this.once('open', function() {
-      this._read(n);
+    this.on('end', function() {
+      if (this.autoClose) {
+        this.destroy();
+      }
     });
-
-  if (this.destroyed)
-    return;
-
-  if (!pool || pool.length - pool.used < kMinPoolSpace) {
-    // discard the old pool.
-    pool = null;
-    allocNewPool(this._readableState.highWaterMark);
   }
 
-  // Grab another reference to the pool in the case that while we're
-  // in the thread pool another read() finishes up the pool, and
-  // allocates a new one.
-  var thisPool = pool;
-  var toRead = Math.min(pool.length - pool.used, n);
-  var start = pool.used;
+  fs.FileReadStream = fs.ReadStream; // support the legacy name
 
-  if (!util.isUndefined(this.pos))
-    toRead = Math.min(this.end - this.pos + 1, toRead);
-
-  // already read everything we were supposed to read!
-  // treat as EOF.
-  if (toRead <= 0)
-    return this.push(null);
-
-  // the actual read.
-  var self = this;
-  fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
-
-  // move the pool positions, and internal position for reading.
-  if (!util.isUndefined(this.pos))
-    this.pos += toRead;
-  pool.used += toRead;
-
-  function onread(er, bytesRead) {
-    if (er) {
-      if (self.autoClose) {
-        self.destroy();
-      }
-      self.emit('error', er);
-    } else {
-      var b = null;
-      if (bytesRead > 0)
-        b = thisPool.slice(start, start + bytesRead);
-
-      self.push(b);
-    }
-  }
-};
-
-
-ReadStream.prototype.destroy = function() {
-  if (this.destroyed)
-    return;
-  this.destroyed = true;
-
-  if (util.isNumber(this.fd))
-    this.close();
-};
-
-
-ReadStream.prototype.close = function(cb) {
-  var self = this;
-  if (cb)
-    this.once('close', cb);
-  if (this.closed || !util.isNumber(this.fd)) {
-    if (!util.isNumber(this.fd)) {
-      this.once('open', close);
-      return;
-    }
-    return process.nextTick(this.emit.bind(this, 'close'));
-  }
-  this.closed = true;
-  close();
-
-  function close(fd) {
-    fs.close(fd || self.fd, function(er) {
-      if (er)
+  ReadStream.prototype.open = function() {
+    var self = this;
+    fs.open(this.path, this.flags, this.mode, function(er, fd) {
+      if (er) {
+        if (self.autoClose) {
+          self.destroy();
+        }
         self.emit('error', er);
-      else
-        self.emit('close');
+        return;
+      }
+
+      self.fd = fd;
+      self.emit('open', fd);
+      // start the flow of data.
+      self.read();
     });
-    self.fd = null;
-  }
-};
+  };
 
+  ReadStream.prototype._read = function(n) {
+    if (!util.isNumber(this.fd))
+      return this.once('open', function() {
+        this._read(n);
+      });
 
-
-
-fs.createWriteStream = function(path, options) {
-  return new WriteStream(path, options);
-};
-
-util.inherits(WriteStream, Writable);
-fs.WriteStream = WriteStream;
-function WriteStream(path, options) {
-  if (!(this instanceof WriteStream))
-    return new WriteStream(path, options);
-
-  options = options || {};
-
-  Writable.call(this, options);
-
-  this.path = path;
-  this.fd = null;
-
-  this.fd = options.hasOwnProperty('fd') ? options.fd : null;
-  this.flags = options.hasOwnProperty('flags') ? options.flags : 'w';
-  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
-
-  this.start = options.hasOwnProperty('start') ? options.start : undefined;
-  this.pos = undefined;
-  this.bytesWritten = 0;
-
-  if (!util.isUndefined(this.start)) {
-    if (!util.isNumber(this.start)) {
-      throw TypeError('start must be a Number');
-    }
-    if (this.start < 0) {
-      throw new Error('start must be >= zero');
-    }
-
-    this.pos = this.start;
-  }
-
-  if (!util.isNumber(this.fd))
-    this.open();
-
-  // dispose on finish.
-  this.once('finish', this.close);
-}
-
-fs.FileWriteStream = fs.WriteStream; // support the legacy name
-
-
-WriteStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
-    if (er) {
-      this.destroy();
-      this.emit('error', er);
+    if (this.destroyed)
       return;
+
+    if (!pool || pool.length - pool.used < kMinPoolSpace) {
+      // discard the old pool.
+      pool = null;
+      allocNewPool(this._readableState.highWaterMark);
     }
+
+    // Grab another reference to the pool in the case that while we're
+    // in the thread pool another read() finishes up the pool, and
+    // allocates a new one.
+    var thisPool = pool;
+    var toRead = Math.min(pool.length - pool.used, n);
+    var start = pool.used;
+
+    if (!util.isUndefined(this.pos))
+      toRead = Math.min(this.end - this.pos + 1, toRead);
+
+    // already read everything we were supposed to read!
+    // treat as EOF.
+    if (toRead <= 0)
+      return this.push(null);
+
+    // the actual read.
+    var self = this;
+    fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
+
+    // move the pool positions, and internal position for reading.
+    if (!util.isUndefined(this.pos))
+      this.pos += toRead;
+    pool.used += toRead;
+
+    function onread(er, bytesRead) {
+      if (er) {
+        if (self.autoClose) {
+          self.destroy();
+        }
+        self.emit('error', er);
+      } else {
+        var b = null;
+        if (bytesRead > 0)
+          b = thisPool.slice(start, start + bytesRead);
+
+        self.push(b);
+      }
+    }
+  };
+
+
+  ReadStream.prototype.destroy = function() {
+    if (this.destroyed)
+      return;
+    this.destroyed = true;
+
+    if (util.isNumber(this.fd))
+      this.close();
+  };
+
+
+  ReadStream.prototype.close = function(cb) {
+    var self = this;
+    if (cb)
+      this.once('close', cb);
+    if (this.closed || !util.isNumber(this.fd)) {
+      if (!util.isNumber(this.fd)) {
+        this.once('open', close);
+        return;
+      }
+      return process.nextTick(this.emit.bind(this, 'close'));
+    }
+    this.closed = true;
+    close();
+
+    function close(fd) {
+      fs.close(fd || self.fd, function(er) {
+        if (er)
+          self.emit('error', er);
+        else
+          self.emit('close');
+      });
+      self.fd = null;
+    }
+  };
+
+
+
+
+  fs.createWriteStream = function(path, options) {
+    return new WriteStream(path, options);
+  };
+
+  util.inherits(WriteStream, Writable);
+  fs.WriteStream = WriteStream;
+  function WriteStream(path, options) {
+    if (!(this instanceof WriteStream))
+      return new WriteStream(path, options);
+
+    options = options || {};
+
+    Writable.call(this, options);
+
+    this.path = path;
+    this.fd = null;
+
+    this.fd = options.hasOwnProperty('fd') ? options.fd : null;
+    this.flags = options.hasOwnProperty('flags') ? options.flags : 'w';
+    this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+
+    this.start = options.hasOwnProperty('start') ? options.start : undefined;
+    this.pos = undefined;
+    this.bytesWritten = 0;
+
+    if (!util.isUndefined(this.start)) {
+      if (!util.isNumber(this.start)) {
+        throw TypeError('start must be a Number');
+      }
+      if (this.start < 0) {
+        throw new Error('start must be >= zero');
+      }
+
+      this.pos = this.start;
+    }
+
+    if (!util.isNumber(this.fd))
+      this.open();
+
+    // dispose on finish.
+    this.once('finish', this.close);
+  }
+
+  fs.FileWriteStream = fs.WriteStream; // support the legacy name
+
+
+  WriteStream.prototype.open = function() {
+    fs.open(this.path, this.flags, this.mode, function(er, fd) {
+      if (er) {
+        this.destroy();
+        this.emit('error', er);
+        return;
+      }
+
+      this.fd = fd;
+      this.emit('open', fd);
+    }.bind(this));
+  };
+
+
+  WriteStream.prototype._write = function(data, encoding, cb) {
+    if (!util.isBuffer(data))
+      return this.emit('error', new Error('Invalid data'));
+
+    if (!util.isNumber(this.fd))
+      return this.once('open', function() {
+        this._write(data, encoding, cb);
+      });
+
+    var self = this;
+    fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+      if (er) {
+        self.destroy();
+        return cb(er);
+      }
+      self.bytesWritten += bytes;
+      cb();
+    });
+
+    if (!util.isUndefined(this.pos))
+      this.pos += data.length;
+  };
+
+
+  WriteStream.prototype.destroy = ReadStream.prototype.destroy;
+  WriteStream.prototype.close = ReadStream.prototype.close;
+
+  // There is no shutdown() for files.
+  WriteStream.prototype.destroySoon = WriteStream.prototype.end;
+
+
+  // SyncWriteStream is internal. DO NOT USE.
+  // Temporary hack for process.stdout and process.stderr when piped to files.
+  function SyncWriteStream(fd, options) {
+    Stream.call(this);
+
+    options = options || {};
 
     this.fd = fd;
-    this.emit('open', fd);
-  }.bind(this));
-};
+    this.writable = true;
+    this.readable = false;
+    this.autoClose = options.hasOwnProperty('autoClose') ?
+        options.autoClose : true;
+  }
+
+  util.inherits(SyncWriteStream, Stream);
 
 
-WriteStream.prototype._write = function(data, encoding, cb) {
-  if (!util.isBuffer(data))
-    return this.emit('error', new Error('Invalid data'));
+  // Export
+  fs.SyncWriteStream = SyncWriteStream;
 
-  if (!util.isNumber(this.fd))
-    return this.once('open', function() {
-      this._write(data, encoding, cb);
-    });
 
-  var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
-    if (er) {
-      self.destroy();
-      return cb(er);
+  SyncWriteStream.prototype.write = function(data, arg1, arg2) {
+    var encoding, cb;
+
+    // parse arguments
+    if (arg1) {
+      if (util.isString(arg1)) {
+        encoding = arg1;
+        cb = arg2;
+      } else if (util.isFunction(arg1)) {
+        cb = arg1;
+      } else {
+        throw new Error('bad arg');
+      }
     }
-    self.bytesWritten += bytes;
-    cb();
-  });
+    assertEncoding(encoding);
 
-  if (!util.isUndefined(this.pos))
-    this.pos += data.length;
-};
-
-
-WriteStream.prototype.destroy = ReadStream.prototype.destroy;
-WriteStream.prototype.close = ReadStream.prototype.close;
-
-// There is no shutdown() for files.
-WriteStream.prototype.destroySoon = WriteStream.prototype.end;
-
-
-// SyncWriteStream is internal. DO NOT USE.
-// Temporary hack for process.stdout and process.stderr when piped to files.
-function SyncWriteStream(fd, options) {
-  Stream.call(this);
-
-  options = options || {};
-
-  this.fd = fd;
-  this.writable = true;
-  this.readable = false;
-  this.autoClose = options.hasOwnProperty('autoClose') ?
-      options.autoClose : true;
-}
-
-util.inherits(SyncWriteStream, Stream);
-
-
-// Export
-fs.SyncWriteStream = SyncWriteStream;
-
-
-SyncWriteStream.prototype.write = function(data, arg1, arg2) {
-  var encoding, cb;
-
-  // parse arguments
-  if (arg1) {
-    if (util.isString(arg1)) {
-      encoding = arg1;
-      cb = arg2;
-    } else if (util.isFunction(arg1)) {
-      cb = arg1;
-    } else {
-      throw new Error('bad arg');
+    // Change strings to buffers. SLOW
+    if (util.isString(data)) {
+      data = new Buffer(data, encoding);
     }
-  }
-  assertEncoding(encoding);
 
-  // Change strings to buffers. SLOW
-  if (util.isString(data)) {
-    data = new Buffer(data, encoding);
-  }
+    fs.writeSync(this.fd, data, 0, data.length);
 
-  fs.writeSync(this.fd, data, 0, data.length);
+    if (cb) {
+      process.nextTick(cb);
+    }
 
-  if (cb) {
-    process.nextTick(cb);
-  }
+    return true;
+  };
 
-  return true;
+
+  SyncWriteStream.prototype.end = function(data, arg1, arg2) {
+    if (data) {
+      this.write(data, arg1, arg2);
+    }
+    this.destroy();
+  };
+
+
+  SyncWriteStream.prototype.destroy = function() {
+    if (this.autoClose)
+      fs.closeSync(this.fd);
+    this.fd = null;
+    this.emit('close');
+    return true;
+  };
+
+  SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
+
+  return fs;
 };
 
-
-SyncWriteStream.prototype.end = function(data, arg1, arg2) {
-  if (data) {
-    this.write(data, arg1, arg2);
-  }
-  this.destroy();
-};
-
-
-SyncWriteStream.prototype.destroy = function() {
-  if (this.autoClose)
-    fs.closeSync(this.fd);
-  this.fd = null;
-  this.emit('close');
-  return true;
-};
-
-SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
+var defaultInstance = CreateConfiguredFSObject();
+module.exports = defaultInstance;
+module.exports.CreateConfiguredFSObject = CreateConfiguredFSObject;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -113,13 +113,15 @@ var CreateConfiguredFSObject = function(options) {
     }
   }
 
-  function nullCheck(path, callback, throwSafe) {
-    if (typeof throwSafe === 'undefined')
-      throwSafe = fs.options.throwSafe;
-
+  function simpleNullCheck(path) {
     if (('' + path).indexOf('\u0000') !== -1) {
-      if (throwSafe)
-        return false;
+      return false;
+    }
+    return true;
+  }
+
+  function nullCheck(path, callback) {
+    if (('' + path).indexOf('\u0000') !== -1) {
       var er = new Error('Path must be a string without null bytes.');
       if (!callback)
         throw er;
@@ -199,25 +201,20 @@ var CreateConfiguredFSObject = function(options) {
   };
 
   fs.exists = function(path, callback) {
-    if (!nullCheck(path, undefined, true)) {
-      process.nextTick(function() {
+    if (!simpleNullCheck(path)) {
+      process.nextTick(function () {
         callback(false);
       });
       return;
     }
     binding.stat(pathModule._makeLong(path), cb, true);
-    function cb(err, result) {
-      if (callback) {
-        if (err)
-          callback(false);
-        else
-          callback(!!result);
-      }
+    function cb(err, stats) {
+      if (callback) callback(err ? false : !!stats);
     }
   };
 
   fs.existsSync = function(path) {
-    if (!nullCheck(path, undefined, true))
+    if (!simpleNullCheck(path))
       return false;
     if (!binding.stat(pathModule._makeLong(path), undefined, true))
       return false;
@@ -732,14 +729,7 @@ var CreateConfiguredFSObject = function(options) {
     var throwSafe = fs.options.throwSafe;
 
     callback = makeCallback(callback);
-    if (!nullCheck(path, callback)) {
-      if (throwSafe) {
-        process.nextTick(function() {
-          callback(true, false);
-        });
-      }
-      return;
-    }
+    if (!nullCheck(path, callback)) return;
     binding.stat(pathModule._makeLong(path), callback, throwSafe);
   };
 
@@ -755,9 +745,7 @@ var CreateConfiguredFSObject = function(options) {
   fs.statSync = function(path) {
     var throwSafe = fs.options.throwSafe;
 
-    if (!nullCheck(path))
-      return false;
-
+    nullCheck(path);
     return binding.stat(pathModule._makeLong(path), undefined, throwSafe);
   };
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -81,10 +81,11 @@ var debug = Module._debug;
 //   -> a.<ext>
 //   -> a/index.<ext>
 
+var _fs = fs.CreateConfiguredFSObject({ throwSafe: true });
 function statPath(path) {
   var fs = NativeModule.require('fs');
 
-  return fs.statSync(path, true);
+  return _fs.statSync(path, true);
 }
 
 // check if the directory is a package.json dir

--- a/lib/module.js
+++ b/lib/module.js
@@ -82,10 +82,9 @@ var debug = Module._debug;
 //   -> a/index.<ext>
 
 function statPath(path) {
-  try {
-    return fs.statSync(path);
-  } catch (ex) {}
-  return false;
+  var fs = NativeModule.require('fs');
+
+  return fs.statSync(path, true);
 }
 
 // check if the directory is a package.json dir

--- a/lib/module.js
+++ b/lib/module.js
@@ -85,7 +85,11 @@ var _fs = fs.CreateConfiguredFSObject({ throwSafe: true });
 function statPath(path) {
   var fs = NativeModule.require('fs');
 
-  return _fs.statSync(path, true);
+  try {
+    return _fs.statSync(path, true);
+  } catch(err) {
+    return false;
+  }
 }
 
 // check if the directory is a package.json dir

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -66,13 +66,13 @@ using v8::Value;
 
 #define THROW_BAD_ARGS TYPE_ERROR("Bad argument")
 
-class FSReqWrap: public ReqWrap<uv_fs_t> {
+class FSReqWrap: public ReqWrap<node_fs_t> {
  public:
   void* operator new(size_t size) { return new char[size]; }
   void* operator new(size_t size, char* storage) { return storage; }
 
   FSReqWrap(Environment* env, const char* syscall, char* data = NULL)
-    : ReqWrap<uv_fs_t>(env, Object::New(env->isolate())),
+    : ReqWrap<node_fs_t>(env, Object::New(env->isolate())),
       syscall_(syscall),
       data_(data),
       dest_len_(0) {
@@ -115,8 +115,10 @@ static inline bool IsInt64(double x) {
 
 
 static void After(uv_fs_t *req) {
-  FSReqWrap* req_wrap = static_cast<FSReqWrap*>(req->data);
-  assert(&req_wrap->req_ == req);
+  node_fs_t* req_node = reinterpret_cast<node_fs_t*>(req);
+
+  FSReqWrap* req_wrap = static_cast<FSReqWrap*>(req_node->data);
+  assert(&req_wrap->req_.req == req);
   req_wrap->ReleaseEarly();  // Free memory that's no longer used now.
 
   Environment* env = req_wrap->env();
@@ -131,8 +133,12 @@ static void After(uv_fs_t *req) {
   Local<Value> argv[2];
 
   if (req->result < 0) {
-    // If the request doesn't have a path parameter set.
-    if (req->path == NULL) {
+    if (req_node->throwSafe == 1) {
+      argc = 2;
+      argv[0] = True(env->isolate());
+      argv[1] = False(env->isolate());
+    } else if (req->path == NULL) {
+      // If the request doesn't have a path parameter set.
       argv[0] = UVException(req->result, NULL, req_wrap->syscall());
     } else if ((req->result == UV_EEXIST ||
                 req->result == UV_ENOTEMPTY ||
@@ -235,7 +241,7 @@ static void After(uv_fs_t *req) {
 
   req_wrap->MakeCallback(env->oncomplete_string(), argc, argv);
 
-  uv_fs_req_cleanup(&req_wrap->req_);
+  uv_fs_req_cleanup(&req_wrap->req_.req);
   delete req_wrap;
 }
 
@@ -243,15 +249,15 @@ static void After(uv_fs_t *req) {
 // For async calls FSReqWrap is used.
 struct fs_req_wrap {
   fs_req_wrap() {}
-  ~fs_req_wrap() { uv_fs_req_cleanup(&req); }
+  ~fs_req_wrap() { uv_fs_req_cleanup(&req.req); }
   // Ensure that copy ctor and assignment operator are not used.
   fs_req_wrap(const fs_req_wrap& req);
   fs_req_wrap& operator=(const fs_req_wrap& req);
-  uv_fs_t req;
+  node_fs_t req;
 };
 
 
-#define ASYNC_DEST_CALL(func, callback, dest_path, ...)                       \
+#define ASYNC_DEST_CALL(func, callback, dest_path, throwSafeVal, ...)         \
   Environment* env = Environment::GetCurrent(args.GetIsolate());              \
   FSReqWrap* req_wrap;                                                        \
   char* dest_str = (dest_path);                                               \
@@ -264,31 +270,36 @@ struct fs_req_wrap {
            dest_str,                                                          \
            dest_len + 1);                                                     \
   }                                                                           \
+  req_wrap->req_.throwSafe = throwSafeVal;                                   \
   int err = uv_fs_ ## func(env->event_loop() ,                                \
-                           &req_wrap->req_,                                   \
+                           &req_wrap->req_.req,                               \
                            __VA_ARGS__,                                       \
                            After);                                            \
   req_wrap->object()->Set(env->oncomplete_string(), callback);                \
   req_wrap->Dispatched();                                                     \
   if (err < 0) {                                                              \
-    uv_fs_t* req = &req_wrap->req_;                                           \
+    uv_fs_t* req = &req_wrap->req_.req;                                       \
     req->result = err;                                                        \
     req->path = NULL;                                                         \
     After(req);                                                               \
   }                                                                           \
   args.GetReturnValue().Set(req_wrap->persistent());
 
-#define ASYNC_CALL(func, callback, ...)                                       \
-  ASYNC_DEST_CALL(func, callback, NULL, __VA_ARGS__)                          \
+#define ASYNC_CALL(func, callback, throwSafeVal, ...)                         \
+  ASYNC_DEST_CALL(func, callback, NULL, throwSafeVal, __VA_ARGS__)            \
 
-#define SYNC_DEST_CALL(func, path, dest, ...)                                 \
+#define SYNC_DEST_CALL(func, path, dest, throwSafeVal, ...)                   \
   fs_req_wrap req_wrap;                                                       \
+  req_wrap.req.throwSafe = throwSafeVal;                                     \
   int err = uv_fs_ ## func(env->event_loop(),                                 \
-                         &req_wrap.req,                                       \
+                         &req_wrap.req.req,                                   \
                          __VA_ARGS__,                                         \
                          NULL);                                               \
   if (err < 0) {                                                              \
-    if (dest != NULL &&                                                       \
+    if (req_wrap.req.throwSafe == 1) {                                       \
+      args.GetReturnValue().Set(False(env->isolate()));                       \
+      return;                                                                 \
+    } else if (dest != NULL &&                                                \
         (err == UV_EEXIST ||                                                  \
          err == UV_ENOTEMPTY ||                                               \
          err == UV_EPERM)) {                                                  \
@@ -298,10 +309,10 @@ struct fs_req_wrap {
     }                                                                         \
   }                                                                           \
 
-#define SYNC_CALL(func, path, ...)                                            \
-  SYNC_DEST_CALL(func, path, NULL, __VA_ARGS__)                               \
+#define SYNC_CALL(func, path, throwSafeVal, ...)                              \
+  SYNC_DEST_CALL(func, path, NULL, throwSafeVal, __VA_ARGS__)                 \
 
-#define SYNC_REQ req_wrap.req
+#define SYNC_REQ req_wrap.req.req
 
 #define SYNC_RESULT err
 
@@ -317,9 +328,9 @@ static void Close(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(close, args[1], fd)
+    ASYNC_CALL(close, args[1], 0, fd)
   } else {
-    SYNC_CALL(close, 0, fd)
+    SYNC_CALL(close, 0, 0, fd)
   }
 }
 
@@ -432,10 +443,15 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 
   node::Utf8Value path(args[0]);
 
+  int throwSafe = 0;
+  if (args[2]->IsTrue()) {
+    throwSafe = 1;
+  }
+
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(stat, args[1], *path)
+    ASYNC_CALL(stat, args[1], throwSafe, *path)
   } else {
-    SYNC_CALL(stat, *path, *path)
+    SYNC_CALL(stat, *path, throwSafe, *path)
     args.GetReturnValue().Set(
         BuildStatsObject(env, static_cast<const uv_stat_t*>(SYNC_REQ.ptr)));
   }
@@ -453,9 +469,9 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(lstat, args[1], *path)
+    ASYNC_CALL(lstat, args[1], 0, *path)
   } else {
-    SYNC_CALL(lstat, *path, *path)
+    SYNC_CALL(lstat, *path, 0, *path)
     args.GetReturnValue().Set(
         BuildStatsObject(env, static_cast<const uv_stat_t*>(SYNC_REQ.ptr)));
   }
@@ -472,9 +488,9 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(fstat, args[1], fd)
+    ASYNC_CALL(fstat, args[1], 0, fd)
   } else {
-    SYNC_CALL(fstat, 0, fd)
+    SYNC_CALL(fstat, 0, 0, fd)
     args.GetReturnValue().Set(
         BuildStatsObject(env, static_cast<const uv_stat_t*>(SYNC_REQ.ptr)));
   }
@@ -510,9 +526,9 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (args[3]->IsFunction()) {
-    ASYNC_DEST_CALL(symlink, args[3], *dest, *dest, *path, flags)
+    ASYNC_DEST_CALL(symlink, args[3], *dest, 0, *dest, *path, flags)
   } else {
-    SYNC_DEST_CALL(symlink, *path, *dest, *dest, *path, flags)
+    SYNC_DEST_CALL(symlink, *path, *dest, 0, *dest, *path, flags)
   }
 }
 
@@ -534,9 +550,9 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value new_path(args[1]);
 
   if (args[2]->IsFunction()) {
-    ASYNC_DEST_CALL(link, args[2], *new_path, *orig_path, *new_path)
+    ASYNC_DEST_CALL(link, args[2], *new_path, 0, *orig_path, *new_path)
   } else {
-    SYNC_DEST_CALL(link, *orig_path, *new_path, *orig_path, *new_path)
+    SYNC_DEST_CALL(link, *orig_path, *new_path, 0, *orig_path, *new_path)
   }
 }
 
@@ -552,9 +568,9 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(readlink, args[1], *path)
+    ASYNC_CALL(readlink, args[1], 0, *path)
   } else {
-    SYNC_CALL(readlink, *path, *path)
+    SYNC_CALL(readlink, *path, 0, *path)
     const char* link_path = static_cast<const char*>(SYNC_REQ.ptr);
     Local<String> rc = String::NewFromUtf8(env->isolate(), link_path);
     args.GetReturnValue().Set(rc);
@@ -579,9 +595,9 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value new_path(args[1]);
 
   if (args[2]->IsFunction()) {
-    ASYNC_DEST_CALL(rename, args[2], *new_path, *old_path, *new_path)
+    ASYNC_DEST_CALL(rename, args[2], *new_path, 0, *old_path, *new_path)
   } else {
-    SYNC_DEST_CALL(rename, *old_path, *new_path, *old_path, *new_path)
+    SYNC_DEST_CALL(rename, *old_path, *new_path, 0, *old_path, *new_path)
   }
 }
 
@@ -599,9 +615,9 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   int64_t len = GET_TRUNCATE_LENGTH(args[1]);
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(ftruncate, args[2], fd, len)
+    ASYNC_CALL(ftruncate, args[2], 0, fd, len)
   } else {
-    SYNC_CALL(ftruncate, 0, fd, len)
+    SYNC_CALL(ftruncate, 0, 0, fd, len)
   }
 }
 
@@ -616,9 +632,9 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(fdatasync, args[1], fd)
+    ASYNC_CALL(fdatasync, args[1], 0, fd)
   } else {
-    SYNC_CALL(fdatasync, 0, fd)
+    SYNC_CALL(fdatasync, 0, 0, fd)
   }
 }
 
@@ -633,9 +649,9 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(fsync, args[1], fd)
+    ASYNC_CALL(fsync, args[1], 0, fd)
   } else {
-    SYNC_CALL(fsync, 0, fd)
+    SYNC_CALL(fsync, 0, 0, fd)
   }
 }
 
@@ -651,9 +667,9 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(unlink, args[1], *path)
+    ASYNC_CALL(unlink, args[1], 0, *path)
   } else {
-    SYNC_CALL(unlink, *path, *path)
+    SYNC_CALL(unlink, *path, 0, *path)
   }
 }
 
@@ -669,9 +685,9 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(rmdir, args[1], *path)
+    ASYNC_CALL(rmdir, args[1], 0, *path)
   } else {
-    SYNC_CALL(rmdir, *path, *path)
+    SYNC_CALL(rmdir, *path, 0, *path)
   }
 }
 
@@ -687,9 +703,9 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(mkdir, args[2], *path, mode)
+    ASYNC_CALL(mkdir, args[2], 0, *path, mode)
   } else {
-    SYNC_CALL(mkdir, *path, *path, mode)
+    SYNC_CALL(mkdir, *path, 0, *path, mode)
   }
 }
 
@@ -705,9 +721,9 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(readdir, args[1], *path, 0 /*flags*/)
+    ASYNC_CALL(readdir, args[1], 0, *path, 0 /*flags*/)
   } else {
-    SYNC_CALL(readdir, *path, *path, 0 /*flags*/)
+    SYNC_CALL(readdir, *path, 0, *path, 0 /*flags*/)
 
     assert(SYNC_REQ.result >= 0);
     char* namebuf = static_cast<char*>(SYNC_REQ.ptr);
@@ -752,9 +768,9 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[2]->Int32Value());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(open, args[3], *path, flags, mode)
+    ASYNC_CALL(open, args[3], 0, *path, flags, mode)
   } else {
-    SYNC_CALL(open, *path, *path, flags, mode)
+    SYNC_CALL(open, *path, 0, *path, flags, mode)
     args.GetReturnValue().Set(SYNC_RESULT);
   }
 }
@@ -799,11 +815,11 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
   if (cb->IsFunction()) {
-    ASYNC_CALL(write, cb, fd, &uvbuf, 1, pos)
+    ASYNC_CALL(write, cb, 0, fd, &uvbuf, 1, pos)
     return;
   }
 
-  SYNC_CALL(write, NULL, fd, &uvbuf, 1, pos)
+  SYNC_CALL(write, NULL, 0, fd, &uvbuf, 1, pos)
   args.GetReturnValue().Set(SYNC_RESULT);
 }
 
@@ -850,15 +866,16 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
   if (!cb->IsFunction()) {
-    SYNC_CALL(write, NULL, fd, &uvbuf, 1, pos)
+    SYNC_CALL(write, NULL, 0, fd, &uvbuf, 1, pos)
     if (must_free)
       delete[] buf;
     return args.GetReturnValue().Set(SYNC_RESULT);
   }
 
   FSReqWrap* req_wrap = new FSReqWrap(env, "write", must_free ? buf : NULL);
+  req_wrap->req_.throwSafe = 0;
   int err = uv_fs_write(env->event_loop(),
-                        &req_wrap->req_,
+                        &req_wrap->req_.req,
                         fd,
                         &uvbuf,
                         1,
@@ -867,7 +884,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   req_wrap->object()->Set(env->oncomplete_string(), cb);
   req_wrap->Dispatched();
   if (err < 0) {
-    uv_fs_t* req = &req_wrap->req_;
+    uv_fs_t* req = &req_wrap->req_.req;
     req->result = err;
     req->path = NULL;
     After(req);
@@ -932,9 +949,9 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   cb = args[5];
 
   if (cb->IsFunction()) {
-    ASYNC_CALL(read, cb, fd, &uvbuf, 1, pos);
+    ASYNC_CALL(read, cb, 0, fd, &uvbuf, 1, pos);
   } else {
-    SYNC_CALL(read, 0, fd, &uvbuf, 1, pos)
+    SYNC_CALL(read, 0, 0, fd, &uvbuf, 1, pos)
     args.GetReturnValue().Set(SYNC_RESULT);
   }
 }
@@ -954,9 +971,9 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(chmod, args[2], *path, mode);
+    ASYNC_CALL(chmod, args[2], 0, *path, mode);
   } else {
-    SYNC_CALL(chmod, *path, *path, mode);
+    SYNC_CALL(chmod, *path, 0, *path, mode);
   }
 }
 
@@ -975,9 +992,9 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(fchmod, args[2], fd, mode);
+    ASYNC_CALL(fchmod, args[2], 0, fd, mode);
   } else {
-    SYNC_CALL(fchmod, 0, fd, mode);
+    SYNC_CALL(fchmod, 0, 0, fd, mode);
   }
 }
 
@@ -1008,9 +1025,9 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
   uv_gid_t gid = static_cast<uv_gid_t>(args[2]->Uint32Value());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(chown, args[3], *path, uid, gid);
+    ASYNC_CALL(chown, args[3], 0, *path, uid, gid);
   } else {
-    SYNC_CALL(chown, *path, *path, uid, gid);
+    SYNC_CALL(chown, *path, 0, *path, uid, gid);
   }
 }
 
@@ -1041,9 +1058,9 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
   uv_gid_t gid = static_cast<uv_gid_t>(args[2]->Uint32Value());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(fchown, args[3], fd, uid, gid);
+    ASYNC_CALL(fchown, args[3], 0, fd, uid, gid);
   } else {
-    SYNC_CALL(fchown, 0, fd, uid, gid);
+    SYNC_CALL(fchown, 0, 0, fd, uid, gid);
   }
 }
 
@@ -1071,9 +1088,9 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
   const double mtime = static_cast<double>(args[2]->NumberValue());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(utime, args[3], *path, atime, mtime);
+    ASYNC_CALL(utime, args[3], 0, *path, atime, mtime);
   } else {
-    SYNC_CALL(utime, *path, *path, atime, mtime);
+    SYNC_CALL(utime, *path, 0, *path, atime, mtime);
   }
 }
 
@@ -1100,9 +1117,9 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   const double mtime = static_cast<double>(args[2]->NumberValue());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(futime, args[3], fd, atime, mtime);
+    ASYNC_CALL(futime, args[3], 0, fd, atime, mtime);
   } else {
-    SYNC_CALL(futime, 0, fd, atime, mtime);
+    SYNC_CALL(futime, 0, 0, fd, atime, mtime);
   }
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -328,9 +328,9 @@ static void Close(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(close, args[1], 0, fd)
+    ASYNC_CALL(close, args[1], false, fd)
   } else {
-    SYNC_CALL(close, 0, 0, fd)
+    SYNC_CALL(close, 0, false, fd)
   }
 }
 
@@ -443,9 +443,9 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 
   node::Utf8Value path(args[0]);
 
-  int throw_safe = 0;
+  bool throw_safe = false;
   if (args[2]->IsTrue()) {
-    throw_safe = 1;
+    throw_safe = true;
   }
 
   if (args[1]->IsFunction()) {
@@ -469,9 +469,9 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(lstat, args[1], 0, *path)
+    ASYNC_CALL(lstat, args[1], false, *path)
   } else {
-    SYNC_CALL(lstat, *path, 0, *path)
+    SYNC_CALL(lstat, *path, false, *path)
     args.GetReturnValue().Set(
         BuildStatsObject(env, static_cast<const uv_stat_t*>(SYNC_REQ.ptr)));
   }
@@ -488,9 +488,9 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(fstat, args[1], 0, fd)
+    ASYNC_CALL(fstat, args[1], false, fd)
   } else {
-    SYNC_CALL(fstat, 0, 0, fd)
+    SYNC_CALL(fstat, 0, false, fd)
     args.GetReturnValue().Set(
         BuildStatsObject(env, static_cast<const uv_stat_t*>(SYNC_REQ.ptr)));
   }
@@ -526,9 +526,9 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (args[3]->IsFunction()) {
-    ASYNC_DEST_CALL(symlink, args[3], *dest, 0, *dest, *path, flags)
+    ASYNC_DEST_CALL(symlink, args[3], *dest, false, *dest, *path, flags)
   } else {
-    SYNC_DEST_CALL(symlink, *path, *dest, 0, *dest, *path, flags)
+    SYNC_DEST_CALL(symlink, *path, *dest, false, *dest, *path, flags)
   }
 }
 
@@ -568,9 +568,9 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(readlink, args[1], 0, *path)
+    ASYNC_CALL(readlink, args[1], false, *path)
   } else {
-    SYNC_CALL(readlink, *path, 0, *path)
+    SYNC_CALL(readlink, *path, false, *path)
     const char* link_path = static_cast<const char*>(SYNC_REQ.ptr);
     Local<String> rc = String::NewFromUtf8(env->isolate(), link_path);
     args.GetReturnValue().Set(rc);
@@ -615,9 +615,9 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   int64_t len = GET_TRUNCATE_LENGTH(args[1]);
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(ftruncate, args[2], 0, fd, len)
+    ASYNC_CALL(ftruncate, args[2], false, fd, len)
   } else {
-    SYNC_CALL(ftruncate, 0, 0, fd, len)
+    SYNC_CALL(ftruncate, 0, false, fd, len)
   }
 }
 
@@ -632,9 +632,9 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(fdatasync, args[1], 0, fd)
+    ASYNC_CALL(fdatasync, args[1], false, fd)
   } else {
-    SYNC_CALL(fdatasync, 0, 0, fd)
+    SYNC_CALL(fdatasync, 0, false, fd)
   }
 }
 
@@ -649,9 +649,9 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0]->Int32Value();
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(fsync, args[1], 0, fd)
+    ASYNC_CALL(fsync, args[1], false, fd)
   } else {
-    SYNC_CALL(fsync, 0, 0, fd)
+    SYNC_CALL(fsync, 0, false, fd)
   }
 }
 
@@ -667,9 +667,9 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(unlink, args[1], 0, *path)
+    ASYNC_CALL(unlink, args[1], false, *path)
   } else {
-    SYNC_CALL(unlink, *path, 0, *path)
+    SYNC_CALL(unlink, *path, false, *path)
   }
 }
 
@@ -685,9 +685,9 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(rmdir, args[1], 0, *path)
+    ASYNC_CALL(rmdir, args[1], false, *path)
   } else {
-    SYNC_CALL(rmdir, *path, 0, *path)
+    SYNC_CALL(rmdir, *path, false, *path)
   }
 }
 
@@ -703,9 +703,9 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(mkdir, args[2], 0, *path, mode)
+    ASYNC_CALL(mkdir, args[2], false, *path, mode)
   } else {
-    SYNC_CALL(mkdir, *path, 0, *path, mode)
+    SYNC_CALL(mkdir, *path, false, *path, mode)
   }
 }
 
@@ -721,9 +721,9 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value path(args[0]);
 
   if (args[1]->IsFunction()) {
-    ASYNC_CALL(readdir, args[1], 0, *path, 0 /*flags*/)
+    ASYNC_CALL(readdir, args[1], false, *path, 0 /*flags*/)
   } else {
-    SYNC_CALL(readdir, *path, 0, *path, 0 /*flags*/)
+    SYNC_CALL(readdir, *path, false, *path, 0 /*flags*/)
 
     assert(SYNC_REQ.result >= 0);
     char* namebuf = static_cast<char*>(SYNC_REQ.ptr);
@@ -768,9 +768,9 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[2]->Int32Value());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(open, args[3], 0, *path, flags, mode)
+    ASYNC_CALL(open, args[3], false, *path, flags, mode)
   } else {
-    SYNC_CALL(open, *path, 0, *path, flags, mode)
+    SYNC_CALL(open, *path, false, *path, flags, mode)
     args.GetReturnValue().Set(SYNC_RESULT);
   }
 }
@@ -815,11 +815,11 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
   if (cb->IsFunction()) {
-    ASYNC_CALL(write, cb, 0, fd, &uvbuf, 1, pos)
+    ASYNC_CALL(write, cb, false, fd, &uvbuf, 1, pos)
     return;
   }
 
-  SYNC_CALL(write, NULL, 0, fd, &uvbuf, 1, pos)
+  SYNC_CALL(write, NULL, false, fd, &uvbuf, 1, pos)
   args.GetReturnValue().Set(SYNC_RESULT);
 }
 
@@ -866,7 +866,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
   if (!cb->IsFunction()) {
-    SYNC_CALL(write, NULL, 0, fd, &uvbuf, 1, pos)
+    SYNC_CALL(write, NULL, false, fd, &uvbuf, 1, pos)
     if (must_free)
       delete[] buf;
     return args.GetReturnValue().Set(SYNC_RESULT);
@@ -949,9 +949,9 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   cb = args[5];
 
   if (cb->IsFunction()) {
-    ASYNC_CALL(read, cb, 0, fd, &uvbuf, 1, pos);
+    ASYNC_CALL(read, cb, false, fd, &uvbuf, 1, pos);
   } else {
-    SYNC_CALL(read, 0, 0, fd, &uvbuf, 1, pos)
+    SYNC_CALL(read, 0, false, fd, &uvbuf, 1, pos)
     args.GetReturnValue().Set(SYNC_RESULT);
   }
 }
@@ -971,9 +971,9 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(chmod, args[2], 0, *path, mode);
+    ASYNC_CALL(chmod, args[2], false, *path, mode);
   } else {
-    SYNC_CALL(chmod, *path, 0, *path, mode);
+    SYNC_CALL(chmod, *path, false, *path, mode);
   }
 }
 
@@ -992,9 +992,9 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
   int mode = static_cast<int>(args[1]->Int32Value());
 
   if (args[2]->IsFunction()) {
-    ASYNC_CALL(fchmod, args[2], 0, fd, mode);
+    ASYNC_CALL(fchmod, args[2], false, fd, mode);
   } else {
-    SYNC_CALL(fchmod, 0, 0, fd, mode);
+    SYNC_CALL(fchmod, 0, false, fd, mode);
   }
 }
 
@@ -1025,9 +1025,9 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
   uv_gid_t gid = static_cast<uv_gid_t>(args[2]->Uint32Value());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(chown, args[3], 0, *path, uid, gid);
+    ASYNC_CALL(chown, args[3], false, *path, uid, gid);
   } else {
-    SYNC_CALL(chown, *path, 0, *path, uid, gid);
+    SYNC_CALL(chown, *path, false, *path, uid, gid);
   }
 }
 
@@ -1058,9 +1058,9 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
   uv_gid_t gid = static_cast<uv_gid_t>(args[2]->Uint32Value());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(fchown, args[3], 0, fd, uid, gid);
+    ASYNC_CALL(fchown, args[3], false, fd, uid, gid);
   } else {
-    SYNC_CALL(fchown, 0, 0, fd, uid, gid);
+    SYNC_CALL(fchown, 0, false, fd, uid, gid);
   }
 }
 
@@ -1088,9 +1088,9 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
   const double mtime = static_cast<double>(args[2]->NumberValue());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(utime, args[3], 0, *path, atime, mtime);
+    ASYNC_CALL(utime, args[3], false, *path, atime, mtime);
   } else {
-    SYNC_CALL(utime, *path, 0, *path, atime, mtime);
+    SYNC_CALL(utime, *path, false, *path, atime, mtime);
   }
 }
 
@@ -1117,9 +1117,9 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   const double mtime = static_cast<double>(args[2]->NumberValue());
 
   if (args[3]->IsFunction()) {
-    ASYNC_CALL(futime, args[3], 0, fd, atime, mtime);
+    ASYNC_CALL(futime, args[3], false, fd, atime, mtime);
   } else {
-    SYNC_CALL(futime, 0, 0, fd, atime, mtime);
+    SYNC_CALL(futime, 0, false, fd, atime, mtime);
   }
 }
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -27,6 +27,12 @@
 
 namespace node {
 
+struct node_fs_t {
+    uv_fs_t req;
+    int throwSafe;
+    void* data;
+};
+
 void InitFs(v8::Handle<v8::Object> target);
 
 }  // namespace node

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -29,7 +29,7 @@ namespace node {
 
 struct node_fs_t {
     uv_fs_t req;
-    int throwSafe;
+    int throw_safe;
     void* data;
 };
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -29,7 +29,7 @@ namespace node {
 
 struct node_fs_t {
     uv_fs_t req;
-    int throw_safe;
+    bool throw_safe;
     void* data;
 };
 

--- a/test/simple/test-fs-stat-sync.js
+++ b/test/simple/test-fs-stat-sync.js
@@ -1,0 +1,168 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var got_error = false;
+var success_count = 0;
+
+var stats;
+
+// statSync
+try {
+  stats = fs.statSync('.');
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  assert.ok(stats.mtime instanceof Date);
+  success_count++;
+}
+
+try {
+  stats = fs.statSync('.', true);
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  assert.ok(stats.mtime instanceof Date);
+  success_count++;
+}
+
+var errorCaught = false;
+try {
+  stats = fs.statSync('nonexisting_file');
+} catch (e) {
+  assert.ok(e instanceof Error);
+  success_count++;
+  errorCaught = true;
+}
+if (!errorCaught) {
+  got_error = true;
+}
+
+try {
+  stats = fs.statSync('nonexisting_file', true);
+} catch (e) {
+  got_error = true;
+}
+assert.equal(false, stats);
+success_count++;
+
+// lstatSync
+try {
+  stats = fs.lstatSync('.');
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  assert.ok(stats.mtime instanceof Date);
+  success_count++;
+}
+
+// fstatSync
+fs.open('.', 'r', undefined, function(err, fd) {
+  assert.ok(!err);
+  assert.ok(fd);
+
+  var stats;
+  try {
+    stats = fs.fstatSync(fd);
+  } catch (e) {
+    got_error = true;
+  }
+  if (!stats) {
+    got_error = true;
+  } else {
+    console.dir(stats);
+    assert.ok(stats.mtime instanceof Date);
+    success_count++;
+  }
+
+  assert(this === global);
+});
+
+// fstatSync
+fs.open('.', 'r', undefined, function(err, fd) {
+  var stats;
+  try {
+    stats = fs.fstatSync(fd);
+  } catch (err) {
+    got_error = true;
+  }
+  if (stats) {
+    console.dir(stats);
+    assert.ok(stats.mtime instanceof Date);
+    success_count++;
+  }
+  fs.close(fd);
+});
+
+console.log('stating: ' + __filename);
+try {
+  stats = fs.statSync(__filename);
+} catch (e) {
+  got_error = true;
+}
+if (!stats) {
+  got_error = true;
+} else {
+  console.dir(stats);
+  success_count++;
+
+  console.log('isDirectory: ' + JSON.stringify(stats.isDirectory()));
+  assert.equal(false, stats.isDirectory());
+
+  console.log('isFile: ' + JSON.stringify(stats.isFile()));
+  assert.equal(true, stats.isFile());
+
+  console.log('isSocket: ' + JSON.stringify(stats.isSocket()));
+  assert.equal(false, stats.isSocket());
+
+  console.log('isBlockDevice: ' + JSON.stringify(stats.isBlockDevice()));
+  assert.equal(false, stats.isBlockDevice());
+
+  console.log('isCharacterDevice: ' + JSON.stringify(stats.isCharacterDevice()));
+  assert.equal(false, stats.isCharacterDevice());
+
+  console.log('isFIFO: ' + JSON.stringify(stats.isFIFO()));
+  assert.equal(false, stats.isFIFO());
+
+  console.log('isSymbolicLink: ' + JSON.stringify(stats.isSymbolicLink()));
+  assert.equal(false, stats.isSymbolicLink());
+
+  assert.ok(stats.mtime instanceof Date);
+}
+
+process.on('exit', function() {
+  assert.equal(8, success_count);
+  assert.equal(false, got_error);
+});

--- a/test/simple/test-fs-stat-sync.js
+++ b/test/simple/test-fs-stat-sync.js
@@ -22,6 +22,7 @@
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
+var throwSafeFs = fs.CreateConfiguredFSObject({ throwSafe: true });
 var got_error = false;
 var success_count = 0;
 
@@ -42,7 +43,7 @@ if (!stats) {
 }
 
 try {
-  stats = fs.statSync('.', true);
+  stats = throwSafeFs.statSync('.');
 } catch (e) {
   got_error = true;
 }
@@ -67,7 +68,7 @@ if (!errorCaught) {
 }
 
 try {
-  stats = fs.statSync('nonexisting_file', true);
+  stats = throwSafeFs.statSync('nonexisting_file');
 } catch (e) {
   got_error = true;
 }
@@ -106,8 +107,6 @@ fs.open('.', 'r', undefined, function(err, fd) {
     assert.ok(stats.mtime instanceof Date);
     success_count++;
   }
-
-  assert(this === global);
 });
 
 // fstatSync

--- a/test/simple/test-fs-stat.js
+++ b/test/simple/test-fs-stat.js
@@ -22,6 +22,7 @@
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
+var throwSafeFs = fs.CreateConfiguredFSObject({ throwSafe: true });
 var got_error = false;
 var success_count = 0;
 
@@ -33,7 +34,6 @@ fs.stat('.', function(err, stats) {
     assert.ok(stats.mtime instanceof Date);
     success_count++;
   }
-  assert(this === global);
 });
 
 fs.stat('.', function(err, stats) {
@@ -48,15 +48,13 @@ fs.stat('nonexisting_file', function(err, stats) {
   } else {
     got_error = true;
   }
-  assert(this === global);
 });
 
-fs.stat('nonexisting_file', function(err, stats) {
+throwSafeFs.stat('nonexisting_file', function(err, stats) {
   assert.equal(true, err);
   assert.equal(false, stats);
-  assert(this === global);
   success_count++;
-}, true);
+});
 
 fs.lstat('.', function(err, stats) {
   if (err) {
@@ -66,7 +64,6 @@ fs.lstat('.', function(err, stats) {
     assert.ok(stats.mtime instanceof Date);
     success_count++;
   }
-  assert(this === global);
 });
 
 // fstat
@@ -83,10 +80,8 @@ fs.open('.', 'r', undefined, function(err, fd) {
       success_count++;
       fs.close(fd);
     }
-    assert(this === global);
   });
 
-  assert(this === global);
 });
 
 // fstatSync

--- a/test/simple/test-fs-stat.js
+++ b/test/simple/test-fs-stat.js
@@ -41,6 +41,23 @@ fs.stat('.', function(err, stats) {
   assert.ok(stats.hasOwnProperty('blocks'));
 });
 
+fs.stat('nonexisting_file', function(err, stats) {
+  if (err) {
+    assert.ok(err instanceof Error);
+    success_count++;
+  } else {
+    got_error = true;
+  }
+  assert(this === global);
+});
+
+fs.stat('nonexisting_file', function(err, stats) {
+  assert.equal(true, err);
+  assert.equal(false, stats);
+  assert(this === global);
+  success_count++;
+}, true);
+
 fs.lstat('.', function(err, stats) {
   if (err) {
     got_error = true;
@@ -89,40 +106,39 @@ fs.open('.', 'r', undefined, function(err, fd) {
 });
 
 console.log('stating: ' + __filename);
-fs.stat(__filename, function(err, s) {
+fs.stat(__filename, function(err, stats) {
   if (err) {
     got_error = true;
   } else {
-    console.dir(s);
+    console.dir(stats);
     success_count++;
 
-    console.log('isDirectory: ' + JSON.stringify(s.isDirectory()));
-    assert.equal(false, s.isDirectory());
+    console.log('isDirectory: ' + JSON.stringify(stats.isDirectory()));
+    assert.equal(false, stats.isDirectory());
 
-    console.log('isFile: ' + JSON.stringify(s.isFile()));
-    assert.equal(true, s.isFile());
+    console.log('isFile: ' + JSON.stringify(stats.isFile()));
+    assert.equal(true, stats.isFile());
 
-    console.log('isSocket: ' + JSON.stringify(s.isSocket()));
-    assert.equal(false, s.isSocket());
+    console.log('isSocket: ' + JSON.stringify(stats.isSocket()));
+    assert.equal(false, stats.isSocket());
 
-    console.log('isBlockDevice: ' + JSON.stringify(s.isBlockDevice()));
-    assert.equal(false, s.isBlockDevice());
+    console.log('isBlockDevice: ' + JSON.stringify(stats.isBlockDevice()));
+    assert.equal(false, stats.isBlockDevice());
 
-    console.log('isCharacterDevice: ' + JSON.stringify(s.isCharacterDevice()));
-    assert.equal(false, s.isCharacterDevice());
+    console.log('isCharacterDevice: ' + JSON.stringify(stats.isCharacterDevice()));
+    assert.equal(false, stats.isCharacterDevice());
 
-    console.log('isFIFO: ' + JSON.stringify(s.isFIFO()));
-    assert.equal(false, s.isFIFO());
+    console.log('isFIFO: ' + JSON.stringify(stats.isFIFO()));
+    assert.equal(false, stats.isFIFO());
 
-    console.log('isSymbolicLink: ' + JSON.stringify(s.isSymbolicLink()));
-    assert.equal(false, s.isSymbolicLink());
+    console.log('isSymbolicLink: ' + JSON.stringify(stats.isSymbolicLink()));
+    assert.equal(false, stats.isSymbolicLink());
 
-    assert.ok(s.mtime instanceof Date);
+    assert.ok(stats.mtime instanceof Date);
   }
 });
 
 process.on('exit', function() {
-  assert.equal(5, success_count);
+  assert.equal(7, success_count);
   assert.equal(false, got_error);
 });
-


### PR DESCRIPTION
In some environment (especially when coffescript is involved) module.js
will spend a lot of time looking up nonexisting files. This is caused by the
lengthy error creation. Those errors are then immediately caught.

This change makes the lookup much faster, by avoiding the unnecessary error
creation.

module::statPath now uses the new second parameter of fs.statSync function of the
fs.js. There is a similar change for the fs.stat, adding the third parameter.

This is the forwardport of https://github.com/joyent/node/pull/8189
