### PR TITLE
Enable override of checkServerIdentity in tls connections.

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -190,6 +190,10 @@ automatically set as a listener for the [secureConnection][] event.  The
     which is not authorized with the list of supplied CAs. This option only
     has an effect if `requestCert` is `true`. Default: `false`.
 
+  - `checkServerIdentity(servername, cert)`: Provide an override for checking
+    server's hostname against the certificate. Should return an error if verification
+    fails. Return `undefined` if passing.
+
   - `NPNProtocols`: An array or `Buffer` of possible NPN protocols. (Protocols
     should be ordered by their priority).
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -819,9 +819,13 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED,
-    ciphers: tls.DEFAULT_CIPHERS
+    ciphers: tls.DEFAULT_CIPHERS,
+    checkServerIdentity: tls.checkServerIdentity
   };
+
   options = util._extend(defaults, options || {});
+
+  assert(typeof options.checkServerIdentity === 'function');
 
   var hostname = options.servername ||
                  options.host ||
@@ -909,7 +913,7 @@ exports.connect = function(/* [port, host], options, cb */) {
       // Verify that server's identity matches it's certificate's names
       if (!verifyError) {
         var cert = result.getPeerCertificate();
-        verifyError = tls.checkServerIdentity(hostname, cert);
+        verifyError = options.checkServerIdentity(hostname, cert);
       }
 
       if (verifyError) {

--- a/test/simple/test-https-client-checkServerIdentity.js
+++ b/test/simple/test-https-client-checkServerIdentity.js
@@ -1,0 +1,85 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (!process.versions.openssl) {
+  console.error('Skipping because node compiled without OpenSSL.');
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+var https = require('https');
+var fs = require('fs');
+var path = require('path');
+
+var options = {
+  key: fs.readFileSync(path.join(common.fixturesDir, 'keys/agent3-key.pem')),
+  cert: fs.readFileSync(path.join(common.fixturesDir, 'keys/agent3-cert.pem'))
+};
+
+var reqCount = 0;
+
+var server = https.createServer(options, function(req, res) {
+  ++reqCount;
+  res.writeHead(200);
+  res.end();
+  req.resume();
+}).listen(common.PORT, function() {
+    authorized();
+});
+
+function authorized() {
+    var req = https.request({
+        port: common.PORT,
+        rejectUnauthorized: true,
+        ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))]
+    }, function(res) {
+        assert(false);
+    });
+    req.on('error', function(err) {
+        override();
+    });
+    req.end();
+}
+
+function override() {
+  var options = {
+    port: common.PORT,
+    rejectUnauthorized: true,
+    ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))],
+    checkServerIdentity: function (host, cert) {
+        return false;
+    }
+  };
+  options.agent = new https.Agent(options);
+  var req = https.request(options, function(res) {
+    assert(req.socket.authorized);
+    server.close();
+  });
+  req.on('error', function(err) {
+    throw err;
+  });
+  req.end();
+}
+
+process.on('exit', function() {
+  assert.equal(reqCount, 1);
+});

--- a/test/simple/test-https-client-checkServerIdentity.js
+++ b/test/simple/test-https-client-checkServerIdentity.js
@@ -37,27 +37,27 @@ var options = {
 
 var reqCount = 0;
 
-var server = https.createServer(options, function(req, res) {
+var server = https.createServer(options, function (req, res) {
   ++reqCount;
   res.writeHead(200);
   res.end();
   req.resume();
-}).listen(common.PORT, function() {
-    authorized();
+}).listen(common.PORT, function () {
+  authorized();
 });
 
 function authorized() {
-    var req = https.request({
-        port: common.PORT,
-        rejectUnauthorized: true,
-        ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))]
-    }, function(res) {
-        assert(false);
-    });
-    req.on('error', function(err) {
-        override();
-    });
-    req.end();
+  var req = https.request({
+    port: common.PORT,
+    rejectUnauthorized: true,
+    ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))]
+  }, function (res) {
+    assert(false);
+  });
+  req.on('error', function (err) {
+    override();
+  });
+  req.end();
 }
 
 function override() {
@@ -66,20 +66,20 @@ function override() {
     rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))],
     checkServerIdentity: function (host, cert) {
-        return false;
+      return false;
     }
   };
   options.agent = new https.Agent(options);
-  var req = https.request(options, function(res) {
+  var req = https.request(options, function (res) {
     assert(req.socket.authorized);
     server.close();
   });
-  req.on('error', function(err) {
+  req.on('error', function (err) {
     throw err;
   });
   req.end();
 }
 
-process.on('exit', function() {
+process.on('exit', function () {
   assert.equal(reqCount, 1);
 });


### PR DESCRIPTION
Currently TLS doesn't support overriding servername checks, only overriding all validation failures (`rejectUnauthorized:false`).

This change allows providing custom servername checks.

Reference to issue:
- http://stackoverflow.com/questions/14088787/hostname-ip-doesnt-match-certificates-altname
- http://stackoverflow.com/questions/22891228/encountering-hostname-ip-doesnt-match-certificates-altnames-on-heroku
- https://github.com/pkgcloud/pkgcloud/issues/174
- http://stackoverflow.com/questions/3048236/amazon-s3-https-ssl-is-it-possible

etc.
