### PR TITLE
src: remove Environment::GetCurrentChecked()

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -207,23 +207,6 @@ inline Environment* Environment::GetCurrent(v8::Local<v8::Context> context) {
       context->GetAlignedPointerFromEmbedderData(kContextEmbedderDataIndex));
 }
 
-inline Environment* Environment::GetCurrentChecked(v8::Isolate* isolate) {
-  if (isolate == NULL) {
-    return NULL;
-  } else {
-    return GetCurrentChecked(isolate->GetCurrentContext());
-  }
-}
-
-inline Environment* Environment::GetCurrentChecked(
-    v8::Local<v8::Context> context) {
-  if (context.IsEmpty()) {
-    return NULL;
-  } else {
-    return GetCurrent(context);
-  }
-}
-
 inline Environment::Environment(v8::Local<v8::Context> context)
     : isolate_(context->GetIsolate()),
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate())),

--- a/src/env.h
+++ b/src/env.h
@@ -351,8 +351,6 @@ class Environment {
 
   static inline Environment* GetCurrent(v8::Isolate* isolate);
   static inline Environment* GetCurrent(v8::Local<v8::Context> context);
-  static inline Environment* GetCurrentChecked(v8::Isolate* isolate);
-  static inline Environment* GetCurrentChecked(v8::Local<v8::Context> context);
 
   // See CreateEnvironment() in src/node.cc.
   static inline Environment* New(v8::Local<v8::Context> context);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3099,9 +3099,12 @@ static void EnableDebug(Isolate* isolate, bool wait_connect) {
   fprintf(stderr, "Debugger listening on port %d\n", debug_port);
   fflush(stderr);
 
-  Environment* env = Environment::GetCurrentChecked(isolate);
-  if (env == NULL)
+  if (isolate == NULL)
     return;  // Still starting up.
+  Local<Context> context = isolate->GetCurrentContext();
+  if (context.IsEmpty())
+    return;  // Still starting up.
+  Environment* env = Environment::GetCurrent(context);
 
   // Assign environment to the debugger's context
   env->AssignToContext(v8::Debug::GetDebugContext());
@@ -3620,7 +3623,7 @@ int Start(int argc, char** argv) {
       env->AssignToContext(v8::Debug::GetDebugContext());
     }
     // This Context::Scope is here so EnableDebug() can look up the current
-    // environment with Environment::GetCurrentChecked().
+    // environment with Environment::GetCurrent().
     // TODO(bnoordhuis) Reorder the debugger initialization logic so it can
     // be removed.
     {


### PR DESCRIPTION
There is only one call site that uses it and that can do the checks
itself.  Removes ~15 lines of code.
