### PR TITLE
src: fix Environment::GetCurrent() resource leak

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -991,8 +991,7 @@ void AfterGetNameInfo(uv_getnameinfo_t* req,
 
 
 static void IsIP(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   node::Utf8Value ip(args[0]);
   char address_buffer[sizeof(struct in6_addr)];
@@ -1061,8 +1060,8 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetNameInfo(const FunctionCallbackInfo<Value>& args) {
+  HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope handle_scope(env->isolate());
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());
@@ -1193,8 +1192,8 @@ static void SetServers(const FunctionCallbackInfo<Value>& args) {
 
 
 static void StrError(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   const char* errmsg = ares_strerror(args[0]->Int32Value());
   args.GetReturnValue().Set(OneByteString(env->isolate(), errmsg));
 }

--- a/src/env.h
+++ b/src/env.h
@@ -357,6 +357,9 @@ class Environment {
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };
 
+  // Environment::GetCurrent(Isolate*) calls Isolate::GetCurrentContext().
+  // Which returns a Local<Context>. So to prevent memory leaks all calls
+  // should be made within a {Escapable}HandleScope.
   static inline Environment* GetCurrent(v8::Isolate* isolate);
   static inline Environment* GetCurrent(v8::Local<v8::Context> context);
 

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -103,8 +103,8 @@ void FSEventWrap::New(const FunctionCallbackInfo<Value>& args) {
 
 
 void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
 
@@ -186,9 +186,6 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
 
 
 void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
 
   if (wrap == NULL || wrap->initialized_ == false)

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -44,9 +44,6 @@ extern QUEUE handle_wrap_queue;
 
 
 void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 
   if (wrap != NULL && wrap->handle__ != NULL) {
@@ -57,9 +54,6 @@ void HandleWrap::Ref(const FunctionCallbackInfo<Value>& args) {
 
 
 void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 
   if (wrap != NULL && wrap->handle__ != NULL) {
@@ -70,8 +64,8 @@ void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
 
 
 void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -683,16 +683,19 @@ const char *signo_string(int signo) {
 
 
 void ThrowError(v8::Isolate* isolate, const char* errmsg) {
+  HandleScope scope(isolate);
   Environment::GetCurrent(isolate)->ThrowError(errmsg);
 }
 
 
 void ThrowTypeError(v8::Isolate* isolate, const char* errmsg) {
+  HandleScope scope(isolate);
   Environment::GetCurrent(isolate)->ThrowTypeError(errmsg);
 }
 
 
 void ThrowRangeError(v8::Isolate* isolate, const char* errmsg) {
+  HandleScope scope(isolate);
   Environment::GetCurrent(isolate)->ThrowRangeError(errmsg);
 }
 
@@ -702,6 +705,7 @@ void ThrowErrnoException(v8::Isolate* isolate,
                          const char* syscall,
                          const char* message,
                          const char* path) {
+  HandleScope scope(isolate);
   Environment::GetCurrent(isolate)->ThrowErrnoException(errorno,
                                                         syscall,
                                                         message,
@@ -714,6 +718,7 @@ void ThrowUVException(v8::Isolate* isolate,
                       const char* syscall,
                       const char* message,
                       const char* path) {
+  HandleScope scope(isolate);
   Environment::GetCurrent(isolate)->ThrowErrnoException(errorno,
                                                         syscall,
                                                         message,
@@ -726,6 +731,7 @@ Local<Value> ErrnoException(Isolate* isolate,
                             const char *syscall,
                             const char *msg,
                             const char *path) {
+  EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
 
   Local<Value> e;
@@ -763,7 +769,7 @@ Local<Value> ErrnoException(Isolate* isolate,
     obj->Set(env->syscall_string(), OneByteString(env->isolate(), syscall));
   }
 
-  return e;
+  return handle_scope.Escape(e);
 }
 
 
@@ -773,6 +779,7 @@ Local<Value> UVException(Isolate* isolate,
                          const char *syscall,
                          const char *msg,
                          const char *path) {
+  EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
 
   if (!msg || !msg[0])
@@ -826,7 +833,7 @@ Local<Value> UVException(Isolate* isolate,
     obj->Set(env->syscall_string(), OneByteString(env->isolate(), syscall));
   }
 
-  return e;
+  return handle_scope.Escape(e);
 }
 
 
@@ -863,6 +870,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
                                   const char* syscall,
                                   const char* msg,
                                   const char* path) {
+  EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   Local<Value> e;
   bool must_free = false;
@@ -897,7 +905,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
   if (must_free)
     LocalFree((HLOCAL)msg);
 
-  return e;
+  return handle_scope.Escape(e);
 }
 #endif
 
@@ -929,13 +937,13 @@ void SetupAsyncListener(const FunctionCallbackInfo<Value>& args) {
 
 
 void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
   if (env->using_domains())
     return;
   env->set_using_domains(true);
 
-  HandleScope scope(env->isolate());
   Local<Object> process_object = env->process_object();
 
   Local<String> tick_callback_function_key = env->tick_domain_cb_string();
@@ -1550,8 +1558,8 @@ static void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
 // Non-static, friend of HandleWrap. Could have been a HandleWrap method but
 // implemented here for consistency with GetActiveRequests().
 void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Local<Array> ary = Array::New(env->isolate());
   QUEUE* q = NULL;
@@ -1580,8 +1588,8 @@ static void Abort(const FunctionCallbackInfo<Value>& args) {
 
 
 static void Chdir(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() != 1 || !args[0]->IsString()) {
     // FIXME(bnoordhuis) ThrowTypeError?
@@ -1597,8 +1605,8 @@ static void Chdir(const FunctionCallbackInfo<Value>& args) {
 
 
 static void Cwd(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 #ifdef _WIN32
   /* MAX_PATH is in characters, not bytes. Make sure we have enough headroom. */
   char buf[MAX_PATH * 4];
@@ -1621,8 +1629,8 @@ static void Cwd(const FunctionCallbackInfo<Value>& args) {
 
 
 static void Umask(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   uint32_t old;
 
   if (args.Length() < 1 || args[0]->IsUndefined()) {
@@ -1770,8 +1778,8 @@ static void GetGid(const FunctionCallbackInfo<Value>& args) {
 
 
 static void SetGid(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("setgid argument must be a number or a string");
@@ -1790,8 +1798,8 @@ static void SetGid(const FunctionCallbackInfo<Value>& args) {
 
 
 static void SetUid(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("setuid argument must be a number or a string");
@@ -1810,8 +1818,8 @@ static void SetUid(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetGroups(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int ngroups = getgroups(0, NULL);
 
@@ -1849,8 +1857,8 @@ static void GetGroups(const FunctionCallbackInfo<Value>& args) {
 
 
 static void SetGroups(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (!args[0]->IsArray()) {
     return env->ThrowTypeError("argument 1 must be an array");
@@ -1881,8 +1889,8 @@ static void SetGroups(const FunctionCallbackInfo<Value>& args) {
 
 
 static void InitGroups(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("argument 1 must be a number or a string");
@@ -1932,15 +1940,14 @@ static void InitGroups(const FunctionCallbackInfo<Value>& args) {
 
 
 void Exit(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
   exit(args[0]->IntegerValue());
 }
 
 
 static void Uptime(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   double uptime;
 
   uv_update_time(uv_default_loop());
@@ -1951,8 +1958,8 @@ static void Uptime(const FunctionCallbackInfo<Value>& args) {
 
 
 void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   size_t rss;
   int err = uv_resident_set_memory(&rss);
@@ -1979,8 +1986,8 @@ void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
 
 
 void Kill(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() != 2) {
     return env->ThrowError("Bad argument.");
@@ -2001,8 +2008,8 @@ void Kill(const FunctionCallbackInfo<Value>& args) {
 // and nanoseconds, to avoid any integer overflow possibility.
 // Pass in an Array from a previous hrtime() call to instead get a time diff.
 void Hrtime(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   uint64_t t = uv_hrtime();
 
@@ -2257,8 +2264,8 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
 
 static void ProcessTitleGetter(Local<String> property,
                                const PropertyCallbackInfo<Value>& info) {
+  HandleScope scope(info.GetIsolate());
   Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
   char buffer[512];
   uv_get_process_title(buffer, sizeof(buffer));
   info.GetReturnValue().Set(String::NewFromUtf8(env->isolate(), buffer));
@@ -2268,8 +2275,7 @@ static void ProcessTitleGetter(Local<String> property,
 static void ProcessTitleSetter(Local<String> property,
                                Local<Value> value,
                                const PropertyCallbackInfo<void>& info) {
-  Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(info.GetIsolate());
   node::Utf8Value title(value);
   // TODO(piscisaureus): protect with a lock
   uv_set_process_title(*title);
@@ -2278,8 +2284,8 @@ static void ProcessTitleSetter(Local<String> property,
 
 static void EnvGetter(Local<String> property,
                       const PropertyCallbackInfo<Value>& info) {
+  HandleScope scope(info.GetIsolate());
   Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
 #ifdef __POSIX__
   node::Utf8Value key(property);
   const char* val = getenv(*key);
@@ -2311,8 +2317,7 @@ static void EnvGetter(Local<String> property,
 static void EnvSetter(Local<String> property,
                       Local<Value> value,
                       const PropertyCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(info.GetIsolate());
 #ifdef __POSIX__
   node::Utf8Value key(property);
   node::Utf8Value val(value);
@@ -2333,8 +2338,7 @@ static void EnvSetter(Local<String> property,
 
 static void EnvQuery(Local<String> property,
                      const PropertyCallbackInfo<Integer>& info) {
-  Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(info.GetIsolate());
   int32_t rc = -1;  // Not found unless proven otherwise.
 #ifdef __POSIX__
   node::Utf8Value key(property);
@@ -2361,8 +2365,7 @@ static void EnvQuery(Local<String> property,
 
 static void EnvDeleter(Local<String> property,
                        const PropertyCallbackInfo<Boolean>& info) {
-  Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(info.GetIsolate());
   bool rc = true;
 #ifdef __POSIX__
   node::Utf8Value key(property);
@@ -2384,8 +2387,8 @@ static void EnvDeleter(Local<String> property,
 
 
 static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
+  HandleScope scope(info.GetIsolate());
   Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
 #ifdef __POSIX__
   int size = 0;
   while (environ[size])
@@ -2484,8 +2487,6 @@ static Handle<Object> GetFeatures(Environment* env) {
 
 static void DebugPortGetter(Local<String> property,
                             const PropertyCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
   info.GetReturnValue().Set(debug_port);
 }
 
@@ -2493,8 +2494,6 @@ static void DebugPortGetter(Local<String> property,
 static void DebugPortSetter(Local<String> property,
                             Local<Value> value,
                             const PropertyCallbackInfo<void>& info) {
-  Environment* env = Environment::GetCurrent(info.GetIsolate());
-  HandleScope scope(env->isolate());
   debug_port = value->NumberValue();
 }
 
@@ -2824,8 +2823,7 @@ static void SignalExit(int signo) {
 // when debugging the stream.Writable class or the process.nextTick
 // function, it is useful to bypass JavaScript entirely.
 static void RawDebug(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   assert(args.Length() == 1 && args[0]->IsString() &&
          "must be called with a single string");
@@ -3172,8 +3170,8 @@ static void RegisterSignalHandler(int signal,
 
 
 void DebugProcess(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() != 1) {
     return env->ThrowError("Invalid number of arguments.");
@@ -3261,8 +3259,8 @@ static int RegisterDebugSignalHandler() {
 
 static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  Environment* env = Environment::GetCurrent(isolate);
   HandleScope scope(isolate);
+  Environment* env = Environment::GetCurrent(isolate);
   DWORD pid;
   HANDLE process = NULL;
   HANDLE thread = NULL;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -165,8 +165,8 @@ Local<Object> New(Environment* env, size_t length) {
 
 
 Local<Object> New(Isolate* isolate, const char* data, size_t length) {
+  EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  EscapableHandleScope handle_scope(env->isolate());
   Local<Object> obj = Buffer::New(env, data, length);
   return handle_scope.Escape(obj);
 }
@@ -207,8 +207,8 @@ Local<Object> New(Isolate* isolate,
                   size_t length,
                   smalloc::FreeCallback callback,
                   void* hint) {
+  EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  EscapableHandleScope handle_scope(env->isolate());
   Local<Object> obj = Buffer::New(env, data, length, callback, hint);
   return handle_scope.Escape(obj);
 }
@@ -233,8 +233,8 @@ Local<Object> New(Environment* env,
 
 
 Local<Object> Use(Isolate* isolate, char* data, uint32_t length) {
+  EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  EscapableHandleScope handle_scope(env->isolate());
   Local<Object> obj = Buffer::Use(env, data, length);
   return handle_scope.Escape(obj);
 }
@@ -256,8 +256,8 @@ Local<Object> Use(Environment* env, char* data, uint32_t length) {
 
 template <encoding encoding>
 void StringSlice(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ARGS_THIS(args.This())
   SLICE_START_END(args[0], args[1], obj_length)
@@ -299,8 +299,8 @@ void Base64Slice(const FunctionCallbackInfo<Value>& args) {
 
 // bytesCopied = buffer.copy(target[, targetStart][, sourceStart][, sourceEnd]);
 void Copy(const FunctionCallbackInfo<Value> &args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Local<Object> target = args[0]->ToObject();
 
@@ -340,8 +340,8 @@ void Copy(const FunctionCallbackInfo<Value> &args) {
 
 // buffer.fill(value[, start][, end]);
 void Fill(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ARGS_THIS(args.This())
   SLICE_START_END(args[1], args[2], obj_length)
@@ -386,8 +386,8 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
 
 template <encoding encoding>
 void StringWrite(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ARGS_THIS(args.This())
 
@@ -468,6 +468,7 @@ static inline void Swizzle(char* start, unsigned int len) {
 
 template <typename T, enum Endianness endianness>
 void ReadFloatGeneric(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   bool doAssert = !args[1]->BooleanValue();
   size_t offset;
@@ -518,6 +519,7 @@ void ReadDoubleBE(const FunctionCallbackInfo<Value>& args) {
 
 template <typename T, enum Endianness endianness>
 uint32_t WriteFloatGeneric(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   bool doAssert = !args[2]->BooleanValue();
 
@@ -573,8 +575,8 @@ void WriteDoubleBE(const FunctionCallbackInfo<Value>& args) {
 
 
 void ByteLength(const FunctionCallbackInfo<Value> &args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (!args[0]->IsString())
     return env->ThrowTypeError("Argument must be a string");
@@ -622,8 +624,8 @@ void Compare(const FunctionCallbackInfo<Value> &args) {
 
 // pass Buffer object to load prototype methods
 void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   assert(args[0]->IsFunction());
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -250,8 +250,8 @@ class ContextifyContext {
 
 
   static void MakeContext(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
 
     if (!args[0]->IsObject()) {
       return env->ThrowTypeError("sandbox argument must be an object.");
@@ -281,8 +281,8 @@ class ContextifyContext {
 
 
   static void IsContext(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
 
     if (!args[0]->IsObject()) {
       env->ThrowTypeError("sandbox must be an object");
@@ -456,8 +456,8 @@ class ContextifyScript : public BaseObject {
 
   // args: code, [options]
   static void New(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
 
     if (!args.IsConstructCall()) {
       return env->ThrowError("Must call vm.Script as a constructor.");
@@ -518,8 +518,8 @@ class ContextifyScript : public BaseObject {
 
   // args: sandbox, [options]
   static void RunInContext(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
 
     // Assemble arguments
     TryCatch try_catch;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -428,8 +428,8 @@ static X509* LoadX509(Environment* env, Handle<Value> v) {
 
 
 void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
@@ -574,8 +574,8 @@ int SSL_CTX_use_certificate_chain(SSL_CTX* ctx,
 
 
 void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
@@ -606,8 +606,8 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
 
 void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
   bool newCAStore = false;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
@@ -636,8 +636,8 @@ void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   SecureContext* sc = Unwrap<SecureContext>(args.Holder());
 
@@ -852,8 +852,8 @@ void SecureContext::Close(const FunctionCallbackInfo<Value>& args) {
 
 // Takes .pfx or .p12 and password in string or buffer format
 void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   BIO* in = NULL;
   PKCS12* p12 = NULL;
@@ -1380,8 +1380,8 @@ void SSLWrap<Base>::GetPeerCertificate(
 
 template <class Base>
 void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Base* w = Unwrap<Base>(args.Holder());
 
@@ -1402,8 +1402,8 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
 
 template <class Base>
 void SSLWrap<Base>::SetSession(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Base* w = Unwrap<Base>(args.Holder());
 
@@ -2128,8 +2128,8 @@ int Connection::SelectSNIContextCallback_(SSL *s, int *ad, void* arg) {
 #endif
 
 void Connection::New(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1 || !args[0]->IsObject()) {
     env->ThrowError("First argument must be a tls module SecureContext");
@@ -2663,8 +2663,8 @@ bool CipherBase::GetAuthTag(char** out, unsigned int* out_len) const {
 
 
 void CipherBase::GetAuthTag(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope handle_scope(args.GetIsolate());
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
   CipherBase* cipher = Unwrap<CipherBase>(args.Holder());
 
   char* out = NULL;
@@ -2721,8 +2721,8 @@ bool CipherBase::SetAAD(const char* data, unsigned int len) {
 
 
 void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
+  HandleScope handle_scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope handle_scope(env->isolate());
 
   ASSERT_IS_BUFFER(args[0]);
 
@@ -2949,8 +2949,8 @@ bool Hmac::HmacUpdate(const char* data, int len) {
 
 
 void Hmac::HmacUpdate(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Hmac* hmac = Unwrap<Hmac>(args.Holder());
 
@@ -2996,8 +2996,8 @@ bool Hmac::HmacDigest(unsigned char** md_value, unsigned int* md_len) {
 
 
 void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Hmac* hmac = Unwrap<Hmac>(args.Holder());
 
@@ -3037,8 +3037,8 @@ void Hash::Initialize(Environment* env, v8::Handle<v8::Object> target) {
 
 
 void Hash::New(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() == 0 || !args[0]->IsString()) {
     return env->ThrowError("Must give hashtype string as argument");
@@ -3074,8 +3074,8 @@ bool Hash::HashUpdate(const char* data, int len) {
 
 
 void Hash::HashUpdate(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Hash* hash = Unwrap<Hash>(args.Holder());
 
@@ -3110,8 +3110,8 @@ void Hash::HashUpdate(const FunctionCallbackInfo<Value>& args) {
 
 
 void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Hash* hash = Unwrap<Hash>(args.Holder());
 
@@ -3238,8 +3238,8 @@ SignBase::Error Sign::SignUpdate(const char* data, int len) {
 
 
 void Sign::SignUpdate(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Sign* sign = Unwrap<Sign>(args.Holder());
 
@@ -3315,8 +3315,8 @@ SignBase::Error Sign::SignFinal(const char* key_pem,
 
 
 void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Sign* sign = Unwrap<Sign>(args.Holder());
 
@@ -3422,8 +3422,8 @@ SignBase::Error Verify::VerifyUpdate(const char* data, int len) {
 
 
 void Verify::VerifyUpdate(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Verify* verify = Unwrap<Verify>(args.Holder());
 
@@ -3530,8 +3530,8 @@ SignBase::Error Verify::VerifyFinal(const char* key_pem,
 
 
 void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Verify* verify = Unwrap<Verify>(args.Holder());
 
@@ -3663,8 +3663,8 @@ template <PublicKeyCipher::Operation operation,
           PublicKeyCipher::EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
           PublicKeyCipher::EVP_PKEY_cipher_t EVP_PKEY_cipher>
 void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ASSERT_IS_BUFFER(args[0]);
   char* kbuf = Buffer::Data(args[0]);
@@ -3862,8 +3862,8 @@ void DiffieHellman::New(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
@@ -3886,8 +3886,8 @@ void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
@@ -3905,8 +3905,8 @@ void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetGenerator(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
@@ -3924,8 +3924,8 @@ void DiffieHellman::GetGenerator(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
@@ -3948,8 +3948,8 @@ void DiffieHellman::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
@@ -3972,8 +3972,8 @@ void DiffieHellman::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   DiffieHellman* diffieHellman = Unwrap<DiffieHellman>(args.Holder());
 
@@ -4128,8 +4128,8 @@ void ECDH::Initialize(Environment* env, Handle<Object> target) {
 
 
 void ECDH::New(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   // TODO(indutny): Support raw curves?
   CHECK(args[0]->IsString());
@@ -4148,8 +4148,8 @@ void ECDH::New(const FunctionCallbackInfo<Value>& args) {
 
 
 void ECDH::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
@@ -4190,8 +4190,8 @@ EC_POINT* ECDH::BufferToPoint(char* data, size_t len) {
 
 
 void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ASSERT_IS_BUFFER(args[0]);
 
@@ -4220,8 +4220,8 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
 
 
 void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   // Conversion form
   CHECK_EQ(args.Length(), 1);
@@ -4259,8 +4259,8 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
@@ -4287,8 +4287,8 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
@@ -4307,8 +4307,8 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
 
 void ECDH::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
@@ -4471,8 +4471,8 @@ void EIO_PBKDF2After(uv_work_t* work_req, int status) {
 
 
 void PBKDF2(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   const EVP_MD* digest = NULL;
   const char* type_error = NULL;
@@ -4752,8 +4752,8 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
 
 
 void GetSSLCiphers(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   SSL_CTX* ctx = SSL_CTX_new(TLSv1_server_method());
   if (ctx == NULL) {
@@ -4808,8 +4808,8 @@ static void array_push_back(const TypeName* md,
 
 
 void GetCiphers(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   CipherPushContext ctx(env);
   EVP_CIPHER_do_all_sorted(array_push_back<EVP_CIPHER>, &ctx);
   args.GetReturnValue().Set(ctx.arr);
@@ -4817,8 +4817,8 @@ void GetCiphers(const FunctionCallbackInfo<Value>& args) {
 
 
 void GetHashes(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   CipherPushContext ctx(env);
   EVP_MD_do_all_sorted(array_push_back<EVP_MD>, &ctx);
   args.GetReturnValue().Set(ctx.arr);
@@ -4941,8 +4941,8 @@ const char* Certificate::ExportPublicKey(const char* data, int len) {
 
 
 void Certificate::ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Certificate* certificate = Unwrap<Certificate>(args.Holder());
 
@@ -4985,8 +4985,8 @@ const char* Certificate::ExportChallenge(const char* data, int len) {
 
 
 void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Certificate* crt = Unwrap<Certificate>(args.Holder());
 
@@ -5043,6 +5043,7 @@ void InitCryptoOnce() {
 
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   CHECK(args.Length() >= 2 && args[0]->IsString());
   unsigned int flags = args[1]->Uint32Value();

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -147,8 +147,8 @@ using v8::Value;
 void DTRACE_NET_SERVER_CONNECTION(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_NET_SERVER_CONNECTION_ENABLED())
     return;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   SLURP_CONNECTION(args[0], conn);
   NODE_NET_SERVER_CONNECTION(&conn, conn.remote, conn.port, conn.fd);
 }
@@ -157,8 +157,8 @@ void DTRACE_NET_SERVER_CONNECTION(const FunctionCallbackInfo<Value>& args) {
 void DTRACE_NET_STREAM_END(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_NET_STREAM_END_ENABLED())
     return;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   SLURP_CONNECTION(args[0], conn);
   NODE_NET_STREAM_END(&conn, conn.remote, conn.port, conn.fd);
 }
@@ -167,8 +167,8 @@ void DTRACE_NET_STREAM_END(const FunctionCallbackInfo<Value>& args) {
 void DTRACE_NET_SOCKET_READ(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_NET_SOCKET_READ_ENABLED())
     return;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   SLURP_CONNECTION(args[0], conn);
 
   if (!args[1]->IsNumber()) {
@@ -183,8 +183,8 @@ void DTRACE_NET_SOCKET_READ(const FunctionCallbackInfo<Value>& args) {
 void DTRACE_NET_SOCKET_WRITE(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_NET_SOCKET_WRITE_ENABLED())
     return;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   SLURP_CONNECTION(args[0], conn);
 
   if (!args[1]->IsNumber()) {
@@ -202,8 +202,8 @@ void DTRACE_HTTP_SERVER_REQUEST(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_HTTP_SERVER_REQUEST_ENABLED())
     return;
 
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   Local<Object> arg0 = Local<Object>::Cast(args[0]);
   Local<Object> headers;
 
@@ -233,8 +233,8 @@ void DTRACE_HTTP_SERVER_REQUEST(const FunctionCallbackInfo<Value>& args) {
 void DTRACE_HTTP_SERVER_RESPONSE(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_HTTP_SERVER_RESPONSE_ENABLED())
     return;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   SLURP_CONNECTION(args[0], conn);
   NODE_HTTP_SERVER_RESPONSE(&conn, conn.remote, conn.port, conn.fd);
 }
@@ -247,8 +247,8 @@ void DTRACE_HTTP_CLIENT_REQUEST(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_HTTP_CLIENT_REQUEST_ENABLED())
     return;
 
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   /*
    * For the method and URL, we're going to dig them out of the header.  This
@@ -283,8 +283,8 @@ void DTRACE_HTTP_CLIENT_REQUEST(const FunctionCallbackInfo<Value>& args) {
 void DTRACE_HTTP_CLIENT_RESPONSE(const FunctionCallbackInfo<Value>& args) {
   if (!NODE_HTTP_CLIENT_RESPONSE_ENABLED())
     return;
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   SLURP_CONNECTION_HTTP_CLIENT_RESPONSE(args[0], args[1], conn);
   NODE_HTTP_CLIENT_RESPONSE(&conn, conn.remote, conn.port, conn.fd);
 }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -307,8 +307,8 @@ struct fs_req_wrap {
 
 
 static void Close(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1 || !args[0]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -422,8 +422,8 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
 }
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1)
     return TYPE_ERROR("path required");
@@ -442,8 +442,8 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1)
     return TYPE_ERROR("path required");
@@ -462,8 +462,8 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void FStat(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1 || !args[0]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -481,8 +481,8 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Symlink(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -517,8 +517,8 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Link(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -541,8 +541,8 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void ReadLink(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1)
     return TYPE_ERROR("path required");
@@ -562,8 +562,8 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Rename(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -586,8 +586,8 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void FTruncate(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 2 || !args[0]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -606,8 +606,8 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1 || !args[0]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -623,8 +623,8 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Fsync(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1 || !args[0]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -640,8 +640,8 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Unlink(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1)
     return TYPE_ERROR("path required");
@@ -658,8 +658,8 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void RMDir(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1)
     return TYPE_ERROR("path required");
@@ -676,8 +676,8 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void MKDir(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -694,8 +694,8 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void ReadDir(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 1)
     return TYPE_ERROR("path required");
@@ -730,8 +730,8 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Open(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -770,8 +770,8 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
 // 4 position  if integer, position to write at in the file.
 //             if null, write from the current position
 static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   assert(args[0]->IsInt32());
   assert(Buffer::HasInstance(args[1]));
@@ -890,8 +890,8 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
  *
  */
 static void Read(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 2 || !args[0]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -944,8 +944,8 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
  * Wrapper for chmod(1) / EIO_CHMOD
  */
 static void Chmod(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -965,8 +965,8 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
  * Wrapper for fchmod(1) / EIO_FCHMOD
  */
 static void FChmod(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (args.Length() < 2 || !args[0]->IsInt32() || !args[1]->IsInt32()) {
     return THROW_BAD_ARGS;
@@ -986,8 +986,8 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
  * Wrapper for chown(1) / EIO_CHOWN
  */
 static void Chown(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -1019,8 +1019,8 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
  * Wrapper for fchown(1) / EIO_FCHOWN
  */
 static void FChown(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -1049,8 +1049,8 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
 
 
 static void UTimes(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -1078,8 +1078,8 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void FUTimes(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   int len = args.Length();
   if (len < 1)
@@ -1110,6 +1110,7 @@ void FSInitialize(const FunctionCallbackInfo<Value>& args) {
   Local<Function> stats_constructor = args[0].As<Function>();
   assert(stats_constructor->IsFunction());
 
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   env->set_fs_stats_constructor_function(stats_constructor);
 }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -437,8 +437,8 @@ class Parser : public BaseObject {
 
 
   static void Finish(const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
 
     Parser* parser = Unwrap<Parser>(args.Holder());
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -53,6 +53,7 @@ using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
+using v8::Isolate;
 using v8::Local;
 using v8::Number;
 using v8::Object;
@@ -61,16 +62,16 @@ using v8::Value;
 
 
 static void GetEndianness(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   const char* rval = IsBigEndian() ? "BE" : "LE";
   args.GetReturnValue().Set(OneByteString(env->isolate(), rval));
 }
 
 
 static void GetHostname(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   char buf[MAXHOSTNAMELEN + 1];
 
   if (gethostname(buf, sizeof(buf))) {
@@ -88,8 +89,8 @@ static void GetHostname(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetOSType(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   const char* rval;
 
 #ifdef __POSIX__
@@ -107,8 +108,8 @@ static void GetOSType(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   const char* rval;
 
 #ifdef __POSIX__
@@ -139,8 +140,8 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   uv_cpu_info_t* cpu_infos;
   int count, i;
 
@@ -180,28 +181,20 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetFreeMemory(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-  double amount = uv_get_free_memory();
-  if (amount < 0)
-    return;
-  args.GetReturnValue().Set(amount);
+  double amount = static_cast<double>(uv_get_free_memory());
+  if (amount >= 0)
+    args.GetReturnValue().Set(amount);
 }
 
 
 static void GetTotalMemory(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-  double amount = uv_get_total_memory();
-  if (amount < 0)
-    return;
-  args.GetReturnValue().Set(amount);
+  double amount = static_cast<double>(uv_get_total_memory());
+  if (amount >= 0)
+    args.GetReturnValue().Set(amount);
 }
 
 
 static void GetUptime(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   double uptime;
   int err = uv_uptime(&uptime);
   if (err == 0)
@@ -210,21 +203,21 @@ static void GetUptime(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetLoadAvg(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  Isolate* isolate = args.GetIsolate();
+  HandleScope scope(isolate);
   double loadavg[3];
   uv_loadavg(loadavg);
-  Local<Array> loads = Array::New(env->isolate(), 3);
-  loads->Set(0, Number::New(env->isolate(), loadavg[0]));
-  loads->Set(1, Number::New(env->isolate(), loadavg[1]));
-  loads->Set(2, Number::New(env->isolate(), loadavg[2]));
+  Local<Array> loads = Array::New(isolate, 3);
+  loads->Set(0, Number::New(isolate, loadavg[0]));
+  loads->Set(1, Number::New(isolate, loadavg[1]));
+  loads->Set(2, Number::New(isolate, loadavg[2]));
   args.GetReturnValue().Set(loads);
 }
 
 
 static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   uv_interface_address_t* interfaces;
   int count, i;
   char ip[INET6_ADDRSTRLEN];

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -109,8 +109,7 @@ void StatWatcher::New(const FunctionCallbackInfo<Value>& args) {
 
 void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   assert(args.Length() == 3);
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   StatWatcher* wrap = Unwrap<StatWatcher>(args.Holder());
   node::Utf8Value path(args[0]);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -128,8 +128,7 @@ class ZCtx : public AsyncWrap {
 
 
   static void Close(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
     ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
     ctx->Close();
   }
@@ -138,8 +137,7 @@ class ZCtx : public AsyncWrap {
   // write(flush, in, in_off, in_len, out, out_off, out_len)
   template <bool async>
   static void Write(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
     assert(args.Length() == 7);
 
     ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
@@ -223,8 +221,8 @@ class ZCtx : public AsyncWrap {
 
 
   static void AfterSync(ZCtx* ctx, const FunctionCallbackInfo<Value>& args) {
+    HandleScope scope(args.GetIsolate());
     Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     Local<Integer> avail_out = Integer::New(env->isolate(),
                                             ctx->strm_.avail_out);
     Local<Integer> avail_in = Integer::New(env->isolate(),
@@ -387,8 +385,7 @@ class ZCtx : public AsyncWrap {
 
   // just pull the ints out of the args and call the other Init
   static void Init(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
 
     assert((args.Length() == 4 || args.Length() == 5) &&
            "init(windowBits, level, memLevel, strategy, [dictionary])");
@@ -428,8 +425,7 @@ class ZCtx : public AsyncWrap {
   }
 
   static void Params(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
 
     assert(args.Length() == 2 && "params(level, strategy)");
 
@@ -439,8 +435,7 @@ class ZCtx : public AsyncWrap {
   }
 
   static void Reset(const FunctionCallbackInfo<Value> &args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
 
     ZCtx* ctx = Unwrap<ZCtx>(args.Holder());
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -146,8 +146,7 @@ PipeWrap::PipeWrap(Environment* env, Handle<Object> object, bool ipc)
 
 
 void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
@@ -159,8 +158,8 @@ void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
 
 #ifdef _WIN32
 void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
@@ -172,8 +171,7 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
 
 
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 
@@ -261,8 +259,8 @@ void PipeWrap::AfterConnect(uv_connect_t* req, int status) {
 
 
 void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -254,8 +254,6 @@ class ProcessWrap : public HandleWrap {
   }
 
   static void Kill(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     ProcessWrap* wrap = Unwrap<ProcessWrap>(args.Holder());
 
     int signal = args[0]->Int32Value();

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -86,8 +86,7 @@ class SignalWrap : public HandleWrap {
   }
 
   static void Start(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
     SignalWrap* wrap = Unwrap<SignalWrap>(args.Holder());
 
     int signum = args[0]->Int32Value();
@@ -96,8 +95,7 @@ class SignalWrap : public HandleWrap {
   }
 
   static void Stop(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
+    HandleScope scope(args.GetIsolate());
     SignalWrap* wrap = Unwrap<SignalWrap>(args.Holder());
 
     int err = uv_signal_stop(&wrap->handle_);

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -172,8 +172,8 @@ size_t ExternalArraySize(enum ExternalArrayType type) {
 
 // copyOnto(source, source_start, dest, dest_start, copy_length)
 void CopyOnto(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   if (!args[0]->IsObject())
     return env->ThrowTypeError("source must be an object");
@@ -249,9 +249,6 @@ void CopyOnto(const FunctionCallbackInfo<Value>& args) {
 // for internal use:
 //    dest._data = sliceOnto(source, dest, start, end);
 void SliceOnto(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   Local<Object> source = args[0].As<Object>();
   Local<Object> dest = args[1].As<Object>();
 
@@ -290,8 +287,8 @@ void SliceOnto(const FunctionCallbackInfo<Value>& args) {
 // for internal use:
 //    alloc(obj, n[, type]);
 void Alloc(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Local<Object> obj = args[0].As<Object>();
 
@@ -354,6 +351,7 @@ void Alloc(Environment* env,
 
 // for internal use: dispose(obj);
 void AllocDispose(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   AllocDispose(env, args[0].As<Object>());
 }
@@ -436,6 +434,7 @@ void Alloc(Environment* env,
 
 
 void HasExternalData(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   args.GetReturnValue().Set(args[0]->IsObject() &&
                             HasExternalData(env, args[0].As<Object>()));
@@ -448,8 +447,8 @@ bool HasExternalData(Environment* env, Local<Object> obj) {
 
 
 void AllocTruncate(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   Local<Object> obj = args[0].As<Object>();
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -70,8 +70,6 @@ StreamWrap::StreamWrap(Environment* env,
 
 void StreamWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 #if !defined(_WIN32)
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
   int fd = -1;
   if (wrap != NULL && wrap->stream() != NULL) {
@@ -90,9 +88,6 @@ void StreamWrap::UpdateWriteQueueSize() {
 }
 
 void StreamWrap::ReadStart(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   int err = uv_read_start(wrap->stream(), OnAlloc, OnRead);
@@ -102,9 +97,6 @@ void StreamWrap::ReadStart(const FunctionCallbackInfo<Value>& args) {
 
 
 void StreamWrap::ReadStop(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   int err = uv_read_stop(wrap->stream());
@@ -505,9 +497,6 @@ void StreamWrap::WriteBinaryString(const FunctionCallbackInfo<Value>& args) {
 }
 
 void StreamWrap::SetBlocking(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
   assert(args.Length() > 0);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -219,9 +219,6 @@ void TCPWrap::GetPeerName(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   int enable = static_cast<int>(args[0]->BooleanValue());
@@ -231,9 +228,6 @@ void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   int enable = args[0]->Int32Value();
@@ -246,8 +240,8 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
 
 #ifdef _WIN32
 void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
@@ -259,17 +253,14 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
-  int fd = static_cast<int>(args[0]->IntegerValue());
+  int fd = static_cast<int>(args[0]->Int32Value());
   uv_tcp_open(&wrap->handle_, fd);
 }
 
 
 void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
@@ -289,8 +280,7 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
 
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
@@ -310,9 +300,6 @@ void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   TCPWrap* wrap = Unwrap<TCPWrap>(args.Holder());
 
   int backlog = args[0]->Int32Value();

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -97,8 +97,6 @@ class TimerWrap : public HandleWrap {
   }
 
   static void Start(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int64_t timeout = args[0]->IntegerValue();
@@ -108,8 +106,6 @@ class TimerWrap : public HandleWrap {
   }
 
   static void Stop(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int err = uv_timer_stop(&wrap->handle_);
@@ -117,8 +113,6 @@ class TimerWrap : public HandleWrap {
   }
 
   static void Again(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int err = uv_timer_again(&wrap->handle_);
@@ -126,8 +120,6 @@ class TimerWrap : public HandleWrap {
   }
 
   static void SetRepeat(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int64_t repeat = args[0]->IntegerValue();
@@ -136,8 +128,6 @@ class TimerWrap : public HandleWrap {
   }
 
   static void GetRepeat(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args.GetIsolate());
-    HandleScope scope(env->isolate());
     TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
 
     int64_t repeat = uv_timer_get_repeat(&wrap->handle_);
@@ -147,7 +137,6 @@ class TimerWrap : public HandleWrap {
   static void OnTimeout(uv_timer_t* handle) {
     TimerWrap* wrap = static_cast<TimerWrap*>(handle->data);
     Environment* env = wrap->env();
-    HandleScope handle_scope(env->isolate());
     Context::Scope context_scope(env->context());
     wrap->MakeCallback(kOnTimeout, 0, NULL);
   }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -262,8 +262,8 @@ void TLSCallbacks::Receive(const FunctionCallbackInfo<Value>& args) {
 
 
 void TLSCallbacks::Start(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
@@ -671,8 +671,8 @@ int TLSCallbacks::DoShutdown(ShutdownWrap* req_wrap, uv_shutdown_cb cb) {
 
 
 void TLSCallbacks::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
@@ -703,9 +703,6 @@ void TLSCallbacks::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
 
 void TLSCallbacks::EnableSessionCallbacks(
     const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   wrap->enable_session_callbacks();
@@ -714,9 +711,6 @@ void TLSCallbacks::EnableSessionCallbacks(
 
 
 void TLSCallbacks::EnableHelloParser(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
   wrap->hello_parser_.Start(SSLWrap<TLSCallbacks>::OnClientHello,
@@ -733,8 +727,8 @@ void TLSCallbacks::OnClientHelloParseEnd(void* arg) {
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 void TLSCallbacks::GetServername(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 
@@ -749,8 +743,8 @@ void TLSCallbacks::GetServername(const FunctionCallbackInfo<Value>& args) {
 
 
 void TLSCallbacks::SetServername(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   TLSCallbacks* wrap = Unwrap<TLSCallbacks>(args.Holder());
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -99,8 +99,8 @@ uv_tty_t* TTYWrap::UVHandle() {
 
 
 void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   int fd = args[0]->Int32Value();
   assert(fd >= 0);
 
@@ -123,8 +123,6 @@ void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
 
 
 void TTYWrap::IsTTY(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   int fd = args[0]->Int32Value();
   assert(fd >= 0);
   bool rc = uv_guess_handle(fd) == UV_TTY;
@@ -133,8 +131,8 @@ void TTYWrap::IsTTY(const FunctionCallbackInfo<Value>& args) {
 
 
 void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
 
   TTYWrap* wrap = Unwrap<TTYWrap>(args.Holder());
   assert(args[0]->IsArray());
@@ -153,9 +151,6 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 
 
 void TTYWrap::SetRawMode(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
   TTYWrap* wrap = Unwrap<TTYWrap>(args.Holder());
 
   int err = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -137,8 +137,6 @@ void UDPWrap::New(const FunctionCallbackInfo<Value>& args) {
 
 void UDPWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 #if !defined(_WIN32)
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
   int fd = (wrap == NULL) ? -1 : wrap->handle_.io_watcher.fd;
   args.GetReturnValue().Set(fd);
@@ -147,9 +145,7 @@ void UDPWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
 
 
 void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
-
+  HandleScope scope(args.GetIsolate());
   UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   // bind(ip, port, flags)
@@ -213,8 +209,7 @@ X(SetMulticastLoopback, uv_udp_set_multicast_loop)
 
 void UDPWrap::SetMembership(const FunctionCallbackInfo<Value>& args,
                             uv_membership membership) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  HandleScope scope(args.GetIsolate());
   UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   assert(args.Length() == 2);
@@ -317,8 +312,6 @@ void UDPWrap::Send6(const FunctionCallbackInfo<Value>& args) {
 
 
 void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   int err = uv_udp_recv_start(&wrap->handle_, OnAlloc, OnRecv);
@@ -330,8 +323,6 @@ void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
 
 
 void UDPWrap::RecvStop(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
 
   int r = uv_udp_recv_stop(&wrap->handle_);

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -39,8 +39,8 @@ using v8::Value;
 
 
 void ErrName(const FunctionCallbackInfo<Value>& args) {
+  HandleScope scope(args.GetIsolate());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
   int err = args[0]->Int32Value();
   if (err >= 0)
     return env->ThrowError("err >= 0");


### PR DESCRIPTION
Environment::GetCurrent(Isolate_) makes a call to
Isolate::GetCurrentContext(), which returns a Local<Context>. Hence,
every call to GetCurrent(Isolate_) should be made within a HandleScope
or EscapableHandleScope.

Also removed excessive calls to GetCurrent().

/cc @bnoordhuis @indutny 
