### PR TITLE
windows-debug: DebugProcess

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2871,7 +2871,7 @@ static Handle<Value> DebugProcess(const Arguments& args) {
     CloseHandle(mapping);
   }
 
-  return Undefined();
+  return rv;
 }
 #endif // _WIN32
 


### PR DESCRIPTION
DebugProcess doesn't return thrown exceptions
