### PR TITLE
refactor normalizeArray, improve performance

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -25,17 +25,23 @@ var util = require('util');
 
 
 // resolves . and .. elements in a path array with directory names there
-// must be no slashes, empty elements, or device names (c:\) in the array
+// must be no slashes, or device names (c:\) in the array
 // (so also no leading and trailing slashes - it does not distinguish
 // relative and absolute paths)
 function normalizeArray(parts, allowAboveRoot) {
+  var nonEmptyParts = [];
+  for (var i = 0; i < parts.length; i++) {
+    var p = parts[i];
+    if (p && p !== '.') {
+      nonEmptyParts.push(p);
+    }
+  }
+  parts = nonEmptyParts;
+
   // if the path tries to go above the root, `up` ends up > 0
   var up = 0;
   for (var i = parts.length - 1; i >= 0; i--) {
-    var last = parts[i];
-    if (last === '.') {
-      parts.splice(i, 1);
-    } else if (last === '..') {
+    if (parts[i] === '..') {
       parts.splice(i, 1);
       up++;
     } else if (up) {
@@ -53,7 +59,6 @@ function normalizeArray(parts, allowAboveRoot) {
 
   return parts;
 }
-
 
 if (isWindows) {
   // Regex to split a windows path into three parts: [*, device, slash,
@@ -155,12 +160,7 @@ if (isWindows) {
     // fails)
 
     // Normalize the tail path
-
-    function f(p) {
-      return !!p;
-    }
-
-    resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/).filter(f),
+    resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/),
                                   !resolvedAbsolute).join('\\');
 
     return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
@@ -182,9 +182,7 @@ if (isWindows) {
     }
 
     // Normalize the tail path
-    tail = normalizeArray(tail.split(/[\\\/]+/).filter(function(p) {
-      return !!p;
-    }), !isAbsolute).join('\\');
+    tail = normalizeArray(tail.split(/[\\\/]+/), !isAbsolute).join('\\');
 
     if (!tail && !isAbsolute) {
       tail = '.';
@@ -337,9 +335,7 @@ if (isWindows) {
     // handle relative paths to be safe (might happen when process.cwd() fails)
 
     // Normalize the path
-    resolvedPath = normalizeArray(resolvedPath.split('/').filter(function(p) {
-      return !!p;
-    }), !resolvedAbsolute).join('/');
+    resolvedPath = normalizeArray(resolvedPath.split('/'), !resolvedAbsolute).join('/');
 
     return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
   };
@@ -349,16 +345,9 @@ if (isWindows) {
   exports.normalize = function(path) {
     var isAbsolute = exports.isAbsolute(path),
         trailingSlash = path[path.length - 1] === '/',
-        segments = path.split('/'),
-        nonEmptySegments = [];
 
-    // Normalize the path
-    for (var i = 0; i < segments.length; i++) {
-      if (segments[i]) {
-        nonEmptySegments.push(segments[i]);
-      }
-    }
-    path = normalizeArray(nonEmptySegments, !isAbsolute).join('/');
+    // normalize the path
+    path = normalizeArray(path.split('/'), !isAbsolute).join('/');
 
     if (!path && !isAbsolute) {
       path = '.';

--- a/lib/path.js
+++ b/lib/path.js
@@ -30,34 +30,45 @@ var util = require('util');
 // relative and absolute paths)
 function normalizeArray(parts, allowAboveRoot) {
   var nonEmptyParts = [];
+  var nonBack = true;
   for (var i = 0; i < parts.length; i++) {
     var p = parts[i];
     if (p && p !== '.') {
       nonEmptyParts.push(p);
     }
+    if (p === '..') {
+      nonBack = false;
+    }
   }
+
   parts = nonEmptyParts;
 
-  // if the path tries to go above the root, `up` ends up > 0
+  // if the path does not contain ..
+  if (nonBack) {
+    return parts;
+  }
+
+  // if the path tries to go ab ove the root, `up` ends up > 0
   var up = 0;
+  var res = [];
   for (var i = parts.length - 1; i >= 0; i--) {
     if (parts[i] === '..') {
-      parts.splice(i, 1);
       up++;
     } else if (up) {
-      parts.splice(i, 1);
       up--;
+    } else {
+      res.push(parts[i]);
     }
   }
 
   // if the path is allowed to go above the root, restore leading ..s
   if (allowAboveRoot) {
     for (; up--; up) {
-      parts.unshift('..');
+      res.push('..');
     }
   }
 
-  return parts;
+  return res.reverse();
 }
 
 if (isWindows) {
@@ -335,7 +346,8 @@ if (isWindows) {
     // handle relative paths to be safe (might happen when process.cwd() fails)
 
     // Normalize the path
-    resolvedPath = normalizeArray(resolvedPath.split('/'), !resolvedAbsolute).join('/');
+    resolvedPath = normalizeArray(resolvedPath.split('/'),
+                                  !resolvedAbsolute).join('/');
 
     return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
   };
@@ -344,7 +356,7 @@ if (isWindows) {
   // posix version
   exports.normalize = function(path) {
     var isAbsolute = exports.isAbsolute(path),
-        trailingSlash = path[path.length - 1] === '/',
+        trailingSlash = path[path.length - 1] === '/';
 
     // normalize the path
     path = normalizeArray(path.split('/'), !isAbsolute).join('/');


### PR DESCRIPTION
[test code](https://gist.github.com/dead-horse/ae3d6d34b6ec44d8d6ed)

before:

```
normalize simple path: 313ms
resolve simple path: 2098ms
normalize path contains .: 696ms
resolve path contains .: 2813ms
normalize path contains ..: 1043ms
resolve path contains ..: 3104ms
```

after:

```
normalize simple path: 307ms
resolve simple path: 860ms
normalize path contains .: 319ms
resolve path contains .: 926ms
normalize path contains ..: 457ms
resolve path contains ..: 1130ms
```
