### PR TITLE
crypto: export externals to internal structs

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -105,6 +105,8 @@ class SecureContext : public BaseObject {
   static void LoadPKCS12(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetTicketKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetTicketKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CtxGetter(v8::Local<v8::String> property,
+                        const v8::PropertyCallbackInfo<v8::Value>& info);
 
   template <bool primary>
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -237,6 +239,8 @@ class SSLWrap {
                                      void* arg);
 #endif  // OPENSSL_NPN_NEGOTIATED
   static int TLSExtStatusCallback(SSL* s, void* arg);
+  static void SSLGetter(v8::Local<v8::String> property,
+                        const v8::PropertyCallbackInfo<v8::Value>& info);
 
   inline Environment* ssl_env() const {
     return env_;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -216,6 +216,21 @@ NODE_DEPRECATED("Use ThrowUVException(isolate)",
   return ThrowUVException(isolate, errorno, syscall, message, path);
 })
 
+inline void NODE_SET_EXTERNAL(v8::Handle<v8::ObjectTemplate> target,
+                              const char* key,
+                              v8::AccessorGetterCallback getter) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::String> prop = v8::String::NewFromUtf8(isolate, key);
+  target->SetAccessor(prop,
+                      getter,
+                      NULL,
+                      v8::Handle<v8::Value>(),
+                      v8::DEFAULT,
+                      static_cast<v8::PropertyAttribute>(v8::ReadOnly |
+                                                         v8::DontDelete));
+}
+
 }  // namespace node
 
 #endif  // SRC_NODE_INTERNALS_H_


### PR DESCRIPTION
Export External getters for a internal structs: SSL, SSL_CTX.

cc @tjfontaine , as discussed on nodeconf.
