### PR TITLE
fs: add fs.fstatExistsSync

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -191,6 +191,11 @@ the file to be stat-ed is specified by the file descriptor `fd`.
 
 Synchronous stat(2). Returns an instance of `fs.Stats`.
 
+## fs.fstatExistsSync(path)
+
+Synchronous stat(2). Returns an instance of `fs.Stats`. This function does not
+throw and returns false if the given path does not exist.
+
 ## fs.lstatSync(path)
 
 Synchronous lstat(2). Returns an instance of `fs.Stats`.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -695,6 +695,15 @@ fs.fstat = function(fd, callback) {
   binding.fstat(fd, makeCallback(callback));
 };
 
+fs.fstatExistsSync = function(path) {
+  nullCheck(path);
+  try {
+    return binding.stat(pathModule._makeLong(path));
+  } catch (e) {
+    return false;
+  }
+};
+
 fs.lstat = function(path, callback) {
   callback = makeCallback(callback);
   if (!nullCheck(path, callback)) return;

--- a/test/simple/test-fs-stat-exists-sync.js
+++ b/test/simple/test-fs-stat-exists-sync.js
@@ -1,0 +1,34 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var common = require('../common.js');
+var assert = require('assert');
+var fs = require('fs');
+
+assert.ok(!fs.fstatExistsSync('does-not-exist'), 'returns false if file does not exists');
+
+var stats = fs.fstatExistsSync(common.fixturesDir + '/a1.js');
+assert.ok(stats.mtime instanceof Date, 'returns stats for file that does exists');
+
+assert.throws(function() {
+  fs.fstatExistsSync('\u0000');
+}, /null bytes/);


### PR DESCRIPTION
I talked with @tjfontaine on that at lxjs and nodeconf.eu:

Currently `fs.fstatSync` does throw if the file does not exist,
so current code has be be wrapped by a try/catch statement every
time.

This method returns false and does not throw when a given path
does not exist, like `fs.existsSync`.

`fs.fstatSync` was is not changed and a new method is introduced
for backwards-compability.
