### PR TITLE
Windows: manifest node.exe for Windows 8.1

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -361,6 +361,10 @@
         'VCLinkerTool': {
           'SubSystem': 1, # /subsystem:console
         },
+        'VCManifestTool': {
+          'EmbedManifest': 'true',
+          'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'
+        }
       },
     },
     # generate ETW header and resource files

--- a/src/res/node.exe.extra.manifest
+++ b/src/res/node.exe.extra.manifest
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+    <application> 
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+  </application> 
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Adding a compatibility section to node.exe embedded manifest
so that node is declared expliticly compatible with Windows 8.1.
This is required so that os.release() canreturn the correct version
on Windows 8.1.

See http://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx

This fixes https://github.com/joyent/node/issues/7534
