### PR TITLE
Fix incorrect protocol parsing

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -48,7 +48,7 @@ function Url() {
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-var protocolPattern = /^([a-z0-9.+-]+:)/i,
+var protocolPattern = /^[a-z0-9.+-]+:(?=\/\/)/i,
     portPattern = /:[0-9]*$/,
 
     // Special case for a simple path URL


### PR DESCRIPTION
Hi,
the parse method fails when the parsed url does not contains a valid protocol:

``` js
url.parse('www.google.com:80');  // return www.google.com as protocol
```

Adding a lookahead condition to fix this, maintaing the actual format (char ":" included in the protocol result).

Best regards.
Marcello
