### PR TITLE
http: do not send `0\r\n\r\n` in TE HEAD responses

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -945,6 +945,10 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   if (encoding === 'hex' || encoding === 'base64')
     hot = false;
 
+  // Transfer-encoding: chunked responses to HEAD requests
+  if (this._hasBody && this.chunkedEncoding)
+    hot = false;
+
   if (hot) {
     // Hot path. They're doing
     //   res.writeHead();
@@ -982,7 +986,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   }
 
   if (!hot) {
-    if (this.chunkedEncoding) {
+    if (this._hasBody && this.chunkedEncoding) {
       ret = this._send('0\r\n' + this._trailer + '\r\n', 'ascii');
     } else {
       // Force a flush, HACK.


### PR DESCRIPTION
When replying to a HEAD request, do not attempt to send the trailers and
EOF sequence (`0\r\n\r\n`). The HEAD request MUST not have body.

Quote from RFC:

The presence of a message body in a response depends on both the
request method to which it is responding and the response status code
(Section 3.1.2).  Responses to the HEAD request method (Section 4.3.2
of [RFC7231]) never include a message body because the associated
response header fields (e.g., Transfer-Encoding, Content-Length,
etc.), if present, indicate only what their values would have been if
the request method had been GET (Section 4.3.1 of [RFC7231]).

fix #8361
