### PR TITLE
readline: fix performance issue when large line in

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -310,11 +310,14 @@ Interface.prototype._normalWrite = function(b) {
     this._sawReturn = false;
   }
 
+  //do test() only on the new part, avoid needless computing
+  var new_part_contains_ending = lineEnding.test(string);
+
   if (this._line_buffer) {
     string = this._line_buffer + string;
     this._line_buffer = null;
   }
-  if (lineEnding.test(string)) {
+  if (new_part_contains_ending) {
     this._sawReturn = /\r$/.test(string);
 
     // got one or more newlines; process into "line" events

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -311,13 +311,13 @@ Interface.prototype._normalWrite = function(b) {
   }
 
   //do test() only on the new part, avoid needless computing
-  var new_part_contains_ending = lineEnding.test(string);
+  var newPartContainsEnding = lineEnding.test(string);
 
   if (this._line_buffer) {
     string = this._line_buffer + string;
     this._line_buffer = null;
   }
-  if (new_part_contains_ending) {
+  if (newPartContainsEnding) {
     this._sawReturn = /\r$/.test(string);
 
     // got one or more newlines; process into "line" events


### PR DESCRIPTION
In general situation, it works well. But when large line arrived ,
(>2M will be obviously). Because the "lineEnding.test" would run again
and again on the growing _line_buffer, time ticks and CPU run out.

Do the "lineEnding.test" only on the new arrived part, this shoud be
economical practice. When I process 10M Bytes a line, this saved me at
least 5s time.(recive a Base64 string of an Image from child process)
