### PR TITLE
process: execute nextTick callback after microtask

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -499,8 +499,6 @@ Module._extensions['.node'] = process.dlopen;
 Module.runMain = function() {
   // Load the main module--the command line argument.
   Module._load(process.argv[1], null, true);
-  // Handle any nextTicks added in the first tick of the program
-  process._tickCallback();
 };
 
 Module._initPaths = function() {

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -5,6 +5,3 @@
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
     at process._tickCallback (node.js:*:*)
-    at Function.Module.runMain (module.js:*:*)
-    at startup (node.js:*:*)
-    at node.js:*:*

--- a/test/simple/test-next-tick-ordering3.js
+++ b/test/simple/test-next-tick-ordering3.js
@@ -1,0 +1,109 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var util = require('util');
+
+if (!util.isFunction(Object.observe) && !util.isFunction(Promise)) {
+  console.error('Skipping because node does not support Object.observe and Promise');
+  process.exit(0);
+}
+
+var results = {};
+
+
+function Test1() {
+  var order = results['Test1'] = [];
+  var obj = {};
+  Object.observe(obj, function(changeRecord) {
+    order.push('Object.observe');
+  });
+  process.nextTick(function() {
+    order.push('nextTick');
+  });
+  obj.a = 1;
+}
+
+
+function Test2() {
+  var order = results['Test2'] = [];
+  var obj = {};
+  Object.observe(obj, function(changeRecord) {
+    order.push('Object.observe');
+  });
+  setTimeout(function() {
+    process.nextTick(function() {
+      order.push('nextTick');
+    });
+    obj.a = 1;
+  }, 0);
+}
+
+
+function Test3() {
+  var order = results['Test3'] = [];
+  var obj = {};
+
+  var promise = new Promise(function(onFulfilled, onRejected) {
+    onFulfilled();
+  });
+
+  process.nextTick(function() {
+    order.push('nextTick');
+  });
+
+  promise.then(function() {
+    order.push('Promise.onFullfilled');
+  }, null);
+}
+
+
+function Test4() {
+  var order = results['Test4'] = [];
+  var obj = {};
+
+  setTimeout(function() {
+    var promise = new Promise(function(onFulfilled, onRejected) {
+      onFulfilled();
+    });
+
+    process.nextTick(function() {
+      order.push('nextTick');
+    });
+
+    promise.then(function() {
+      order.push('Promise.onFullfilled');
+    }, null);
+  }, 0);
+}
+
+Test1();
+Test2();
+Test3();
+Test4();
+
+process.on('exit', function() {
+  assert.deepEqual(results.Test1, ['Object.observe', 'nextTick']);
+  assert.deepEqual(results.Test2, ['Object.observe', 'nextTick']);
+  assert.deepEqual(results.Test3, ['Promise.onFullfilled', 'nextTick']);
+  assert.deepEqual(results.Test4, ['Promise.onFullfilled', 'nextTick']);
+});


### PR DESCRIPTION
The current process.nextTick callback in a main module is executed before microtasks such as callbacks of Object.observe and Promise while not in the other I/O or timer callbacks as below.

``` JS
// test1.js 
// check the callback order of process.nextTick and Object.observe in a main module.
var obj = {};

Object.observe(obj, function(changeRecord) {
  console.log('Object.observe callback:', changeRecord);
});

process.nextTick(function() {
  console.log('process.nextTick');
});
obj.a = 1;
```

``` sh
$ ~/tmp/oldnode/node-v0.11.13/node test1.js
nextTick
Object.observe
```

``` JS
// test2.js
// check the callback order of process.nextTick and Object.observe in a setTimeout callback
var obj = {};

setTimeout(function() {
  Object.observe(obj, function(changeRecord) {
    console.log('Object.observe');
  });

  process.nextTick(function() {
    console.log('nextTick');
  });
  obj.a = 1;
}, 0);
```

``` sh
$ ~/tmp/oldnode/node-v0.11.13/node test2.js
Object.observe
nextTick
```

These inconsistent behaviors would cause issues in the future use of Object.observe and Promise so this fix makes process.nextTick callback always execute after microtasks.
