### PR TITLE
crypto: use domains for any callback-taking method

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3986,18 +3986,9 @@ Handle<Value> PBKDF2(const Arguments& args) {
   req->keylen = keylen;
 
   if (args[4]->IsFunction()) {
-    Local<Value> domain = Context::GetCurrent()
-                                  ->Global()
-                                  ->Get(process_symbol)
-                                  ->ToObject()
-                                  ->Get(domain_symbol);
-
     req->obj = Persistent<Object>::New(Object::New());
     req->obj->Set(String::New("ondone"), args[4]);
-
-    if (!domain->IsUndefined()) {
-      req->obj->Set(domain_symbol, domain);
-    }
+    SetActiveDomain(req->obj);
 
     uv_queue_work(uv_default_loop(),
                   &req->work_req,
@@ -4126,16 +4117,7 @@ Handle<Value> RandomBytes(const Arguments& args) {
   if (args[1]->IsFunction()) {
     req->obj_ = Persistent<Object>::New(Object::New());
     req->obj_->Set(String::New("ondone"), args[1]);
-    Local<Value> domain = Context::GetCurrent()
-                                  ->Global()
-                                  ->Get(process_symbol)
-                                  ->ToObject()
-                                  ->Get(domain_symbol);
-
-
-    if (!domain->IsUndefined()) {
-      req->obj_->Set(domain_symbol, domain);
-    }
+    SetActiveDomain(req->obj_);
 
     uv_queue_work(uv_default_loop(),
                   &req->work_req_,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -64,10 +64,6 @@ static const int X509_NAME_FLAGS = ASN1_STRFLGS_ESC_CTRL
 
 namespace node {
 
-// defined in node.cc
-extern v8::Persistent<v8::String> process_symbol;
-extern v8::Persistent<v8::String> domain_symbol;
-
 const char* root_certs[] = {
 #include "node_root_certs.h"  // NOLINT(build/include_order)
   NULL

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,8 @@ extern v8::Persistent<v8::String> process_symbol;
 extern v8::Persistent<v8::String> domain_symbol;
 
 inline void SetActiveDomain(v8::Persistent<v8::Object> obj) {
+  assert(!process_symbol.IsEmpty());
+  assert(!domain_symbol.IsEmpty());
   v8::Local<v8::Value> domain = v8::Context::GetCurrent()
          ->Global()
          ->Get(process_symbol)

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,18 @@
 #include "string_bytes.h"
 
 namespace node {
+// defined in node.cc
+extern v8::Persistent<v8::String> process_symbol;
+extern v8::Persistent<v8::String> domain_symbol;
+
+inline void SetActiveDomain(v8::Persistent<v8::Object> obj) {
+  v8::Local<v8::Value> domain = v8::Context::GetCurrent()
+         ->Global()
+         ->Get(process_symbol)
+         ->ToObject()
+         ->Get(domain_symbol);
+  obj->Set(domain_symbol, domain);
+}
 
 class Utf8Value {
   public:

--- a/test/simple/test-crypto-domains.js
+++ b/test/simple/test-crypto-domains.js
@@ -1,0 +1,38 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var crypto = require('crypto');
+var domain = require('domain');
+var d = domain.create();
+d.on('error', function (e) { console.log('got', e.message); });
+d.run(function () {
+  crypto.pbkdf2('a', 'b', 1, 8, function () {
+    throw new Error('pdbkdf2');
+  });
+
+  crypto.randomBytes(4, function () {
+    throw new Error('randomBytes');
+  });
+
+  crypto.pseudoRandomBytes(4, function () {
+    throw new Error('pseudoRandomBytes');
+  });
+});

--- a/test/simple/test-crypto-domains.js
+++ b/test/simple/test-crypto-domains.js
@@ -21,11 +21,17 @@
 
 var crypto = require('crypto');
 var domain = require('domain');
+var assert = require('assert');
 var d = domain.create();
-d.on('error', function (e) { console.log('got', e.message); });
+var expect = ['pbkdf2', 'randomBytes', 'pseudoRandomBytes']
+
+d.on('error', function (e) {
+  assert.equal(e.message, expect.shift());
+});
+
 d.run(function () {
   crypto.pbkdf2('a', 'b', 1, 8, function () {
-    throw new Error('pdbkdf2');
+    throw new Error('pbkdf2');
   });
 
   crypto.randomBytes(4, function () {


### PR DESCRIPTION
This adds domains coverage for pdbkdf2, pseudoRandomBytes, and randomBytes.
All others should be covered by event emitters.

Fixes #5801.
