### PR TITLE
net: Make server.connections un-enumerable

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -942,7 +942,7 @@ function Server(/* [ options, ] listener */) {
     set: util.deprecate(function(val) {
       return (self._connections = val);
     }, 'connections property is deprecated. Use getConnections() method'),
-    configurable: true, enumerable: true
+    configurable: true, enumerable: false
   });
 
   this._handle = null;

--- a/test/simple/test-net-server-connections.js
+++ b/test/simple/test-net-server-connections.js
@@ -1,0 +1,32 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var net = require('net');
+
+// test that server.connections property is no longer enumerable now that it
+// has been marked as deprecated
+
+var server = new net.Server();
+
+assert.equal(Object.keys(server).indexOf('connections'), -1);


### PR DESCRIPTION
Since use of server.connnections is deprecated, that property should not
longer be enumerable.  This will prevent deprecation warnings when
server objects are accessed by functions such as JSON.stringify.

Fix #8373
