### PR TITLE
Fix issue 8390

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4334,7 +4334,7 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   // maybe allow a buffer to write to? cuts down on object creation
   // when generating random data in a loop
   if (!args[0]->IsUint32()) {
-    return env->ThrowTypeError("Argument #1 must be number > 0");
+    return env->ThrowTypeError("size must be a number >= 0");
   }
 
   const uint32_t size = args[0]->Uint32Value();


### PR DESCRIPTION
crypto: Fixes joyent/node#8390 by making the error message more verbose and consistent with the behaviour of RandomBytes() when the size argument is equal to 0.
