### PR TITLE
child_process: properly support optional args argument

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -711,7 +711,7 @@ var spawn = exports.spawn = function(file /*, args, options*/) {
   if (Array.isArray(arguments[1])) {
     args = arguments[1].slice(0);
     options = arguments[2];
-  } else if (arguments[1] && !Array.isArray(arguments[1])) {
+  } else if (arguments[1] && typeof arguments[1] !== 'object') {
     throw new TypeError('Incorrect value of args option');
   } else {
     args = [];

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -22,12 +22,13 @@
 var spawn = require('child_process').spawn,
   assert = require('assert'),
   windows = (process.platform === 'win32'),
-  cmd = (windows) ? 'ls' : 'dir',
+  cmd = (windows) ? 'dir' : 'ls',
+  invalidcmd = (windows) ? 'ls' : 'dir',
   errors = 0;
 
 try {
   // Ensure this throws a TypeError
-  var child = spawn(cmd, 'this is not an array');
+  var child = spawn(invalidcmd, 'this is not an array');
 
   child.on('error', function (err) {
     errors++;
@@ -36,6 +37,11 @@ try {
 } catch (e) {
   assert.equal(e instanceof TypeError, true);
 }
+
+// verify that args argument is optional
+assert.doesNotThrow(function() {
+  spawn(cmd, {});
+});
 
 process.on('exit', function() {
   assert.equal(errors, 0);


### PR DESCRIPTION
Currently, a `TypeError` is incorrectly thrown if the second argument is an object. This commit allows the `args` argument to be properly omitted. Closes #6068
