### PR TITLE
crypto: never store pointer to conn in SSL_CTX

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -188,7 +188,7 @@ class SSLWrap {
   inline bool is_waiting_new_session() const { return new_session_wait_; }
 
  protected:
-  static void InitNPN(SecureContext* sc, Base* base);
+  static void InitNPN(SecureContext* sc);
   static void AddMethods(Environment* env, v8::Handle<v8::FunctionTemplate> t);
 
   static SSL_SESSION* GetSessionCallback(SSL* s,

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -186,7 +186,7 @@ void TLSCallbacks::InitSSL() {
   }
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
-  InitNPN(sc_, this);
+  InitNPN(sc_);
 
   if (is_server()) {
     SSL_set_accept_state(ssl_);
@@ -800,7 +800,7 @@ int TLSCallbacks::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   p->sni_context_.Reset(env->isolate(), ctx);
 
   SecureContext* sc = Unwrap<SecureContext>(ctx.As<Object>());
-  InitNPN(sc, p);
+  InitNPN(sc);
   SSL_set_SSL_CTX(s, sc->ctx_);
   return SSL_TLSEXT_ERR_OK;
 }


### PR DESCRIPTION
SSL_CTX is shared between multiple connections and is not a right place
to store per-connection data.

fix #8348
