### PR TITLE
buffer: improve Buffer constructor

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -66,6 +66,7 @@ function Buffer(subject, encoding) {
                          'size: 0x' + kMaxLength.toString(16) + ' bytes');
   }
 
+  this.parent = null;
   if (this.length <= (Buffer.poolSize >>> 1) && this.length > 0) {
     if (this.length > poolSize - poolOffset)
       createPool();
@@ -215,11 +216,6 @@ Buffer.byteLength = function(str, enc) {
   }
   return ret;
 };
-
-
-// pre-set for values that may exist in the future
-Buffer.prototype.length = undefined;
-Buffer.prototype.parent = undefined;
 
 
 // toString(encoding, start=0, end=buffer.length)


### PR DESCRIPTION
Increase the performance of new Buffer construction by initializing all properties before SetIndexedPropertiesToExternalArrayData call.

The following measurement is by @JacksonTian. Test case:

```
$ cat new_buffer.js
var runBenchmark = function (byteLength) {
  console.time('byte length: ' + byteLength);
  for (var i = 0; i < 1000000; i++) {
    new Buffer(byteLength);
  }
  console.timeEnd('byte length: ' + byteLength);
};

runBenchmark(1);
runBenchmark(8);
runBenchmark(64);
runBenchmark(512);
runBenchmark(4096);
```

before this patch:

```
byte length: 1: 8333ms
byte length: 8: 7790ms
byte length: 64: 7502ms
byte length: 512: 7774ms
byte length: 4096: 9763ms
```

after this patch:

```
byte length: 1: 411ms
byte length: 8: 376ms
byte length: 64: 347ms
byte length: 512: 832ms
byte length: 4096: 2631ms
```

(I am sending this patch on behalf of Alibaba's JavaScript engine team. Happy BABA IPO :)
