### PR TITLE
process: throw on read of stdout or stderr

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -468,7 +468,6 @@
         // we'll just add this hack and set the `readable` member to false.
         // Test: ./node test/fixtures/echo.js < /etc/passwd
         stream.readable = false;
-        stream.read = null;
         stream._type = 'pipe';
 
         // FIXME Hack to have stream not keep the event loop alive.
@@ -501,6 +500,11 @@
         er = er || new Error('process.stdout cannot be closed.');
         stdout.emit('error', er);
       };
+      stdout.read = function() {
+        var er = new Error('process.stdout cannot be read.');
+        stdout.emit('error', er);
+      };
+
       if (stdout.isTTY) {
         process.on('SIGWINCH', function() {
           stdout._refreshSize();
@@ -516,6 +520,11 @@
         er = er || new Error('process.stderr cannot be closed.');
         stderr.emit('error', er);
       };
+      stderr.read = function() {
+        var er = new Error('process.stderr cannot be read.');
+        stderr.emit('error', er);
+      };
+
       return stderr;
     });
 

--- a/test/simple/test-stdio-readable-writable.js
+++ b/test/simple/test-stdio-readable-writable.js
@@ -24,9 +24,11 @@ var assert = require('assert');
 
 assert(process.stdout.writable);
 assert(!process.stdout.readable);
+assert.throws(process.stdout.read, /process\.stdout cannot be read\./);
 
 assert(process.stderr.writable);
 assert(!process.stderr.readable);
+assert.throws(process.stderr.read, /process\.stderr cannot be read\./);
 
 assert(!process.stdin.writable);
 assert(process.stdin.readable);


### PR DESCRIPTION
Currently, attempting to read `stdout` or `stderr` leads to somewhat ambiguous errors. This commit makes an attempted read fail in a more obvious fashion, similar to what is currently done with `destroy()`. Closes #8349.
