### PR TITLE
fs: deprecate exists() and existsSync()

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -641,6 +641,8 @@ callback, and have some fallback logic if it is null.
 
 ## fs.exists(path, callback)
 
+This function is **deprecated**.
+
 Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
 
@@ -657,6 +659,8 @@ file between the calls to `fs.exists()` and `fs.open()`.  Just open the file
 and handle the error when it's not there.
 
 ## fs.existsSync(path)
+
+This function is **deprecated**.
 
 Synchronous version of `fs.exists`.
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -180,15 +180,15 @@ fs.Stats.prototype.isSocket = function() {
   return this._checkModeProperty(constants.S_IFSOCK);
 };
 
-fs.exists = function(path, callback) {
+fs.exists = util.deprecate(function(path, callback) {
   if (!nullCheck(path, cb)) return;
   binding.stat(pathModule._makeLong(path), cb);
   function cb(err, stats) {
     if (callback) callback(err ? false : true);
   }
-};
+}, 'fs: exists() is deprecated.');
 
-fs.existsSync = function(path) {
+fs.existsSync = util.deprecate(function(path) {
   try {
     nullCheck(path);
     binding.stat(pathModule._makeLong(path));
@@ -196,7 +196,7 @@ fs.existsSync = function(path) {
   } catch (e) {
     return false;
   }
-};
+}, 'fs: existsSync() is deprecated.');
 
 fs.readFile = function(path, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);

--- a/test/common.js
+++ b/test/common.js
@@ -37,8 +37,12 @@ if (process.platform === 'win32') {
   exports.PIPE = exports.tmpDir + '/test.sock';
   exports.opensslCli = path.join(process.execPath, '..', 'openssl-cli');
 }
-if (!fs.existsSync(exports.opensslCli))
+
+try {
+  fs.statSync(exports.opensslCli);
+} catch (err) {
   exports.opensslCli = false;
+}
 
 if (process.platform === 'win32') {
   exports.faketimeCli = false;


### PR DESCRIPTION
`fs.exists()` does not currently support Node's standard callback signature. This commit adds errback support while maintaining backwards compatibility. Closes #8369.
