### PR TITLE
http: write() after end() emits an error.

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -403,6 +403,18 @@ Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
 
 
 OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
+  var self = this;
+
+  if (this.finished) {
+    var err = new Error('write after end');
+    process.nextTick(function() {
+      self.emit('error', err);
+      if (callback) callback(err);
+    });
+
+    return true;
+  }
+
   if (!this._header) {
     this._implicitHeader();
   }

--- a/test/simple/test-http-res-write-after-end.js
+++ b/test/simple/test-http-res-write-after-end.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var responseError;
+
+var server = http.Server(function(req, res) {
+  res.on('error', function onResError(err) {
+    responseError = err;
+  });
+
+  res.write('This should write.');
+  res.end();
+
+  var r = res.write('This should raise an error.');
+  assert.equal(r, true, 'write after end should return true');
+});
+
+server.listen(common.PORT, function() {
+  var req = http.get({port: common.PORT}, function(res) {
+    server.close();
+  });
+});
+
+process.on('exit', function onProcessExit(code) {
+  assert(responseError, 'response should have emitted error');
+  assert.equal(responseError.message, 'write after end');
+});


### PR DESCRIPTION
When calling write() after end() has been called on an OutgoingMessage,
an error is emitted and the write's callback is called with an instance
of Error.

Fix #7477.
