### PR TITLE
http: use strict mode for setHeader

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -323,6 +323,8 @@ function storeHeader(self, state, field, value) {
 
 
 OutgoingMessage.prototype.setHeader = function(name, value) {
+  'use strict';
+
   if (arguments.length < 2) {
     throw new Error('`name` and `value` are required for setHeader().');
   }


### PR DESCRIPTION
When I profile http server module, I find `setHeader()` use 3% self time in benchmark test. Although V8 will optimize it, but it take too many time. This patch speed up the function ~10%.

This change effect http benchmark very little. So I use this benchmark to present result: https://gist.github.com/JacksonTian/4849b7c3845eec56bc9e .

Anyway, the strict mode is amazing.
