### PR TITLE
tls_wrap: ensure that TLSCallbacks are gc-able

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -79,6 +79,7 @@ TLSCallbacks::TLSCallbacks(Environment* env,
       cycle_depth_(0),
       eof_(false) {
   node::Wrap<TLSCallbacks>(object(), this);
+  MakeWeak(this);
 
   // Initialize queue for clearIn writes
   QUEUE_INIT(&write_item_queue_);

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -46,6 +46,8 @@ class TLSCallbacks : public crypto::SSLWrap<TLSCallbacks>,
                      public StreamWrapCallbacks,
                      public AsyncWrap {
  public:
+  ~TLSCallbacks();
+
   static void Initialize(v8::Handle<v8::Object> target,
                          v8::Handle<v8::Value> unused,
                          v8::Handle<v8::Context> context);
@@ -94,7 +96,6 @@ class TLSCallbacks : public crypto::SSLWrap<TLSCallbacks>,
                Kind kind,
                v8::Handle<v8::Object> sc,
                StreamWrapCallbacks* old);
-  ~TLSCallbacks();
 
   static void SSLInfoCallback(const SSL* ssl_, int where, int ret);
   void InitSSL();


### PR DESCRIPTION
Call `MakeWeak()` to destruct TLSCallbacks when the js-object dies.

fix #8416
