### PR TITLE
hdr: always define NODE_WANT_INTERNALS

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -66,6 +66,10 @@
 
 #include "node_object_wrap.h"
 
+#ifndef NODE_WANT_INTERNALS
+# define NODE_WANT_INTERNALS 0
+#endif
+
 #if NODE_WANT_INTERNALS
 # include "node_internals.h"
 #endif


### PR DESCRIPTION
Otherwise the warning could be printed on some systems.

fix #8419
