### PR TITLE
net: remove use of arguments object in Server constructor

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -62,8 +62,8 @@ function isPipeName(s) {
 }
 
 
-exports.createServer = function() {
-  return new Server(arguments[0], arguments[1]);
+exports.createServer = function(options, connectionListener) {
+  return new Server(options, connectionListener);
 };
 
 
@@ -984,22 +984,21 @@ function afterConnect(status, handle, req, readable, writable) {
 }
 
 
-function Server(/* [ options, ] listener */) {
-  if (!(this instanceof Server)) return new Server(arguments[0], arguments[1]);
+function Server(options, connectionListener) {
+  if (!(this instanceof Server)) return new Server(options, connectionListener);
   events.EventEmitter.call(this);
 
   var self = this;
 
-  var options;
-
-  if (util.isFunction(arguments[0])) {
+  if (util.isFunction(options)) {
+    connectionListener = options;
     options = {};
-    self.on('connection', arguments[0]);
+    self.on('connection', connectionListener);
   } else {
-    options = arguments[0] || {};
+    options = options || {};
 
-    if (util.isFunction(arguments[1])) {
-      self.on('connection', arguments[1]);
+    if (util.isFunction(connectionListener)) {
+      self.on('connection', connectionListener);
     }
   }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -985,7 +985,9 @@ function afterConnect(status, handle, req, readable, writable) {
 
 
 function Server(options, connectionListener) {
-  if (!(this instanceof Server)) return new Server(options, connectionListener);
+  if (!(this instanceof Server))
+    return new Server(options, connectionListener);
+
   events.EventEmitter.call(this);
 
   var self = this;
@@ -997,9 +999,8 @@ function Server(options, connectionListener) {
   } else {
     options = options || {};
 
-    if (util.isFunction(connectionListener)) {
+    if (util.isFunction(connectionListener))
       self.on('connection', connectionListener);
-    }
   }
 
   this._connections = 0;


### PR DESCRIPTION
The current implementation uses the `arguments` object in the `Server()` constructor. Since both arguments to `Server()` are optional, there was a high likelihood of accessing a non-existent element in `arguments`, which carries a [performance overhead](http://jsperf.com/arguments-woes). This commit replaces the `arguments` object with named arguments.

In a simple test which calls `Server()` in a loop one million times, invoking with both arguments saw minimal improvements. However, invoking `Server()` with no arguments lead to approximately 12% increase in performance.
