### PR TITLE
Handle trailing bytes for chunked encoding more gracefully

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -246,6 +246,30 @@ does not imply that the client has received anything yet.
 
 After this event, no more events will be emitted on the response object.
 
+### Event: 'chunkedRemainingBytes'
+
+`function (buff) { }`
+
+Fired when the incoming stream is `Transfer-Encoding: chunked` and the stream
+has been parsed successfully but there are trailing bytes at the end of the
+response. The callback is passed the bytes that were not successfully parsed.
+
+For backwards compatibility, if there is no listener attached to this event,
+an [Error][] will be emitted on the `request` side of this request/response
+pair. To detect this scenario has happened you can use the following code:
+
+    if (res.headers['transfer-encoding'] === 'chunked' &&
+        res.complete === true &&
+        err.code === 'HPE_INVALID_CONSTANT') {
+      console.error('we have trailing bytes', err.bytesParsed);
+    } else {
+      console.error('request error', err);
+    }
+
+In either scenario all of the data has been successfully delivered through to
+the EOF for the stream, but without the listener the request object will have
+an error and the socket will be destroyed.
+
 ### response.writeContinue()
 
 Sends a HTTP/1.1 100 Continue message to the client, indicating that

--- a/lib/http.js
+++ b/lib/http.js
@@ -945,10 +945,6 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   if (encoding === 'hex' || encoding === 'base64')
     hot = false;
 
-  // Transfer-encoding: chunked responses to HEAD requests
-  if (this._hasBody && this.chunkedEncoding)
-    hot = false;
-
   if (hot) {
     // Hot path. They're doing
     //   res.writeHead();

--- a/lib/http.js
+++ b/lib/http.js
@@ -950,6 +950,7 @@ OutgoingMessage.prototype.end = function(data, encoding) {
     //   res.writeHead();
     //   res.end(blah);
     // HACKY.
+    debug('we have hot path');
 
     if (typeof data === 'string') {
       if (this.chunkedEncoding) {
@@ -1582,11 +1583,21 @@ function socketOnData(d, start, end) {
 
   var ret = parser.execute(d, start, end - start);
   if (ret instanceof Error) {
-    debug('parse error');
-    freeParser(parser, req);
-    socket.destroy();
-    req.emit('error', ret);
-    req._hadError = true;
+    var response = parser.incoming;
+    if (response &&
+        response.headers['transfer-encoding'] === 'chunked' &&
+        response.complete &&
+        EventEmitter.listenerCount(response, 'chunkedRemainingBytes') > 0) {
+      var buff = d.slice(start + ret.bytesParsed, end);
+      debug('chunked encoding stream had extra bytes ' + ret.bytesParsed + ' ' + buff.length);
+      response.emit('chunkedRemainingBytes', buff);
+    } else {
+      debug('parse error');
+      freeParser(parser, req);
+      socket.destroy();
+      req.emit('error', ret);
+      req._hadError = true;
+    }
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade or CONNECT
     var bytesParsed = ret;

--- a/test/simple/test-http-head-request.js
+++ b/test/simple/test-http-head-request.js
@@ -52,8 +52,16 @@ function test(headers) {
         gotEnd = true;
       });
       response.resume();
+      response.on('chunkedRemainingBytes', function(bytes) {
+        console.error('we had extra bytes', bytes);
+        assert(false);
+      });
     });
     request.end();
+    request.on('error', function() {
+      console.error('we should not be getting a client error');
+      assert(false);
+    });
   });
 
   process.on('exit', function() {

--- a/test/simple/test-http-response-trailing-bytes.js
+++ b/test/simple/test-http-response-trailing-bytes.js
@@ -1,0 +1,92 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var http = require('http');
+
+var responseMessage = [
+  'HTTP/1.1 200 OK',
+  'Transfer-Encoding: chunked',
+  '',
+  '5',
+  'hello',
+  '0',
+  '',
+  '0',
+  '',
+  '',
+].join('\r\n');
+
+var expectedResult = 'hello';
+var expectedBuff = new Buffer(responseMessage.slice(responseMessage.length - 5));
+var responseError = false;
+var requestError = false;
+var leftOver = false;
+var result = '';
+
+var server = net.createServer(function(conn) {
+  conn.end(responseMessage);
+  server.close();
+}).listen().on('listening', function() {
+  var request = http.get({
+    path: '/',
+    port: server.address().port,
+    method: 'GET',
+  }, function(response) {
+    response.setEncoding('utf8');
+    response.on('data', function(d) {
+      result += d;
+    });
+    response.on('error', function(err) {
+      responseError = err;
+      console.error('response error', err);
+      console.error(response);
+    });
+    // hypothetical interface for 0.12 (maybe 0.10?)
+    response.on('chunkedRemainingBytes', function(buff) {
+      leftOver = buff;
+      console.error('chunkedRemainingBytes', buff);
+    });
+  }).on('error', function(err) {
+    /* This should never run, it's an example how to do this on older 0.10 and before */
+    console.error(err);
+    leftOver = err;
+    requestError = err;
+    var res = this.res;
+    // backwards compatible way to detect if this is the case
+    if (res.headers['transfer-encoding'] === 'chunked' &&
+        res.complete === true &&
+        err.code === 'HPE_INVALID_CONSTANT') {
+      console.error('we have trailing bytes', err.bytesParsed);
+    } else {
+      console.error('request error', err);
+    }
+  });
+});
+
+process.on('exit', function() {
+  assert.strictEqual(result, expectedResult);
+  assert.strictEqual(responseError, false);
+  assert.strictEqual(requestError, false);
+  assert.deepEqual(leftOver, expectedBuff);
+});


### PR DESCRIPTION
http requests may encounter a response stream that outputs extra bytes -- for instance see 1fddc1fee84785d296e37337dcb0dc12c13a049f where Node.js itself was sending too much. In that case our parser will currently give a parse error, which results in us unilaterally destroying the socket and raising an error on the `request` (not the `response`).

This change adds an event `chunkedRemainingBytes` which will be emitted on the `response` object, that callback will be passed the bytes that we were unable to parse. If there is no listener for this event we will fall back to the previous behavior. The documentation includes some mediation for detecting this case, but it cannot interrupt the socket from being destroyed.

As part of this PR, I also have a commit that partially reverts 1fddc1fee84785d296e37337dcb0dc12c13a049f, it was opting out of the hot path detection code for responses that have a body, resulting in the many pipeline test taking too long and timing out particularly on linux.

/cc @indutny @trevnorris 
