### PR TITLE
tests: add test for buffer.slice.

### DIFF
--- a/test/simple/test-buffer-slice.js
+++ b/test/simple/test-buffer-slice.js
@@ -1,0 +1,32 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var Buffer = require('buffer').Buffer;
+
+var buff = new Buffer(Buffer.poolSize + 1);
+var slicedBuffer = buff.slice();
+assert.equal(slicedBuffer.parent,
+             buff,
+             "slicedBufffer should have its parent set to the original " +
+             " buffer");


### PR DESCRIPTION
4c9b30d introduced a regression in buffer.slice that 7c3c51b fixed, but
no test had been added to make sure that a similar regression is caught
by the tests suite in the future.
