### PR TITLE
doc: fix brackets for optional parameters

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -9,35 +9,35 @@ access it with `require('assert')`.
 
 Throws an exception that displays the values for `actual` and `expected` separated by the provided operator.
 
-## assert(value, message), assert.ok(value, [message])
+## assert(value, message), assert.ok(value[, message])
 
 Tests if value is truthy, it is equivalent to `assert.equal(true, !!value, message);`
 
-## assert.equal(actual, expected, [message])
+## assert.equal(actual, expected[, message])
 
 Tests shallow, coercive equality with the equal comparison operator ( `==` ).
 
-## assert.notEqual(actual, expected, [message])
+## assert.notEqual(actual, expected[, message])
 
 Tests shallow, coercive non-equality with the not equal comparison operator ( `!=` ).
 
-## assert.deepEqual(actual, expected, [message])
+## assert.deepEqual(actual, expected[, message])
 
 Tests for deep equality.
 
-## assert.notDeepEqual(actual, expected, [message])
+## assert.notDeepEqual(actual, expected[, message])
 
 Tests for any deep inequality.
 
-## assert.strictEqual(actual, expected, [message])
+## assert.strictEqual(actual, expected[, message])
 
 Tests strict equality, as determined by the strict equality operator ( `===` )
 
-## assert.notStrictEqual(actual, expected, [message])
+## assert.notStrictEqual(actual, expected[, message])
 
 Tests strict non-equality, as determined by the strict not equal operator ( `!==` )
 
-## assert.throws(block, [error], [message])
+## assert.throws(block[, error]\[, message])
 
 Expects `block` to throw an error. `error` can be constructor, `RegExp` or
 validation function.
@@ -74,7 +74,7 @@ Custom error validation:
       "unexpected error"
     );
 
-## assert.doesNotThrow(block, [message])
+## assert.doesNotThrow(block[, message])
 
 Expects `block` not to throw an error, see `assert.throws` for details.
 

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -72,7 +72,7 @@ will be thrown here.
 
 Allocates a new buffer using an `array` of octets.
 
-### new Buffer(str, [encoding])
+### new Buffer(str[, encoding])
 
 * `str` String - string to encode.
 * `encoding` String - encoding to use, Optional.
@@ -94,7 +94,7 @@ otherwise.
 
 Tests if `obj` is a `Buffer`.
 
-### Class Method: Buffer.byteLength(string, [encoding])
+### Class Method: Buffer.byteLength(string[, encoding])
 
 * `string` String
 * `encoding` String, Optional, Default: 'utf8'
@@ -113,7 +113,7 @@ Example:
 
     // ½ + ¼ = ¾: 9 characters, 12 bytes
 
-### Class Method: Buffer.concat(list, [totalLength])
+### Class Method: Buffer.concat(list[, totalLength])
 
 * `list` {Array} List of Buffer objects to concat
 * `totalLength` {Number} Total length of the buffers when concatenated
@@ -162,7 +162,7 @@ buffer object.  It does not change when the contents of the buffer are changed.
     // 1234
     // 1234
 
-### buf.write(string, [offset], [length], [encoding])
+### buf.write(string[, offset]\[, length]\[, encoding])
 
 * `string` String - data to be written to buffer
 * `offset` Number, Optional, Default: 0
@@ -181,7 +181,7 @@ The method will not write partial characters.
     console.log(len + " bytes: " + buf.toString('utf8', 0, len));
 
 
-### buf.toString([encoding], [start], [end])
+### buf.toString([encoding]\[, start]\[, end])
 
 * `encoding` String, Optional, Default: 'utf8'
 * `start` Number, Optional, Default: 0
@@ -252,7 +252,7 @@ Returns a number indicating whether `this` comes before or after or is
 the same as the `otherBuffer` in sort order.
 
 
-### buf.copy(targetBuffer, [targetStart], [sourceStart], [sourceEnd])
+### buf.copy(targetBuffer[, targetStart]\[, sourceStart]\[, sourceEnd])
 
 * `targetBuffer` Buffer object - Buffer to copy into
 * `targetStart` Number, Optional, Default: 0
@@ -283,7 +283,7 @@ into `buf2`, starting at the 8th byte in `buf2`.
     // !!!!!!!!qrst!!!!!!!!!!!!!
 
 
-### buf.slice([start], [end])
+### buf.slice([start]\[, end])
 
 * `start` Number, Optional, Default: 0
 * `end` Number, Optional, Default: `buffer.length`
@@ -311,7 +311,7 @@ byte from the original Buffer.
     // abc
     // !bc
 
-### buf.readUInt8(offset, [noAssert])
+### buf.readUInt8(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -340,8 +340,8 @@ Example:
     // 0x23
     // 0x42
 
-### buf.readUInt16LE(offset, [noAssert])
-### buf.readUInt16BE(offset, [noAssert])
+### buf.readUInt16LE(offset[, noAssert])
+### buf.readUInt16BE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -376,8 +376,8 @@ Example:
     // 0x2342
     // 0x4223
 
-### buf.readUInt32LE(offset, [noAssert])
-### buf.readUInt32BE(offset, [noAssert])
+### buf.readUInt32LE(offset[, noAssert])
+### buf.readUInt32BE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -404,7 +404,7 @@ Example:
     // 0x03042342
     // 0x42230403
 
-### buf.readInt8(offset, [noAssert])
+### buf.readInt8(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -418,8 +418,8 @@ may be beyond the end of the buffer. Defaults to `false`.
 Works as `buffer.readUInt8`, except buffer contents are treated as two's
 complement signed values.
 
-### buf.readInt16LE(offset, [noAssert])
-### buf.readInt16BE(offset, [noAssert])
+### buf.readInt16LE(offset[, noAssert])
+### buf.readInt16BE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -434,8 +434,8 @@ may be beyond the end of the buffer. Defaults to `false`.
 Works as `buffer.readUInt16*`, except buffer contents are treated as two's
 complement signed values.
 
-### buf.readInt32LE(offset, [noAssert])
-### buf.readInt32BE(offset, [noAssert])
+### buf.readInt32LE(offset[, noAssert])
+### buf.readInt32BE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -450,8 +450,8 @@ may be beyond the end of the buffer. Defaults to `false`.
 Works as `buffer.readUInt32*`, except buffer contents are treated as two's
 complement signed values.
 
-### buf.readFloatLE(offset, [noAssert])
-### buf.readFloatBE(offset, [noAssert])
+### buf.readFloatLE(offset[, noAssert])
+### buf.readFloatBE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -476,8 +476,8 @@ Example:
 
     // 0x01
 
-### buf.readDoubleLE(offset, [noAssert])
-### buf.readDoubleBE(offset, [noAssert])
+### buf.readDoubleLE(offset[, noAssert])
+### buf.readDoubleBE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -506,7 +506,7 @@ Example:
 
     // 0.3333333333333333
 
-### buf.writeUInt8(value, offset, [noAssert])
+### buf.writeUInt8(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -532,8 +532,8 @@ Example:
 
     // <Buffer 03 04 23 42>
 
-### buf.writeUInt16LE(value, offset, [noAssert])
-### buf.writeUInt16BE(value, offset, [noAssert])
+### buf.writeUInt16LE(value, offset[, noAssert])
+### buf.writeUInt16BE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -563,8 +563,8 @@ Example:
     // <Buffer de ad be ef>
     // <Buffer ad de ef be>
 
-### buf.writeUInt32LE(value, offset, [noAssert])
-### buf.writeUInt32BE(value, offset, [noAssert])
+### buf.writeUInt32LE(value, offset[, noAssert])
+### buf.writeUInt32BE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -592,7 +592,7 @@ Example:
     // <Buffer fe ed fa ce>
     // <Buffer ce fa ed fe>
 
-### buf.writeInt8(value, offset, [noAssert])
+### buf.writeInt8(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -609,8 +609,8 @@ should not be used unless you are certain of correctness. Defaults to `false`.
 Works as `buffer.writeUInt8`, except value is written out as a two's complement
 signed integer into `buffer`.
 
-### buf.writeInt16LE(value, offset, [noAssert])
-### buf.writeInt16BE(value, offset, [noAssert])
+### buf.writeInt16LE(value, offset[, noAssert])
+### buf.writeInt16BE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -627,8 +627,8 @@ should not be used unless you are certain of correctness. Defaults to `false`.
 Works as `buffer.writeUInt16*`, except value is written out as a two's
 complement signed integer into `buffer`.
 
-### buf.writeInt32LE(value, offset, [noAssert])
-### buf.writeInt32BE(value, offset, [noAssert])
+### buf.writeInt32LE(value, offset[, noAssert])
+### buf.writeInt32BE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -645,8 +645,8 @@ should not be used unless you are certain of correctness. Defaults to `false`.
 Works as `buffer.writeUInt32*`, except value is written out as a two's
 complement signed integer into `buffer`.
 
-### buf.writeFloatLE(value, offset, [noAssert])
-### buf.writeFloatBE(value, offset, [noAssert])
+### buf.writeFloatLE(value, offset[, noAssert])
+### buf.writeFloatBE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -674,8 +674,8 @@ Example:
     // <Buffer 4f 4a fe bb>
     // <Buffer bb fe 4a 4f>
 
-### buf.writeDoubleLE(value, offset, [noAssert])
-### buf.writeDoubleBE(value, offset, [noAssert])
+### buf.writeDoubleLE(value, offset[, noAssert])
+### buf.writeDoubleBE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -703,7 +703,7 @@ Example:
     // <Buffer 43 eb d5 b7 dd f9 5f d7>
     // <Buffer d7 5f f9 dd b7 d5 eb 43>
 
-### buf.fill(value, [offset], [end])
+### buf.fill(value[, offset]\[, end])
 
 * `value`
 * `offset` Number, Optional

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -167,7 +167,7 @@ to a process.
 
 See `kill(2)`
 
-### child.send(message, [sendHandle])
+### child.send(message[, sendHandle])
 
 * `message` {Object}
 * `sendHandle` {Handle object}
@@ -303,7 +303,7 @@ child process has any open IPC channels with the parent (i.e `fork()`).
 These methods follow the common async programming patterns (accepting a
 callback or returning an EventEmitter).
 
-### child_process.spawn(command, [args], [options])
+### child_process.spawn(command[, args]\[, options])
 
 * `command` {String} The command to run
 * `args` {Array} List of string arguments
@@ -473,7 +473,7 @@ inherited, the child will remain attached to the controlling terminal.
 
 See also: `child_process.exec()` and `child_process.fork()`
 
-### child_process.exec(command, [options], callback)
+### child_process.exec(command[, options], callback)
 
 * `command` {String} The command to run, with space-separated arguments
 * `options` {Object}
@@ -531,7 +531,7 @@ amount of data allowed on stdout or stderr - if this value is exceeded then
 the child process is killed.
 
 
-### child_process.execFile(file, [args], [options], [callback])
+### child_process.execFile(file[, args]\[, options]\[, callback])
 
 * `file` {String} The filename of the program to run
 * `args` {Array} List of string arguments
@@ -555,7 +555,7 @@ subshell but rather the specified file directly. This makes it slightly
 leaner than `child_process.exec`. It has the same options.
 
 
-### child_process.fork(modulePath, [args], [options])
+### child_process.fork(modulePath[, args]\[, options])
 
 * `modulePath` {String} The module to run in the child
 * `args` {Array} List of string arguments
@@ -598,7 +598,7 @@ Blocking calls like these are mostly useful for simplifying general purpose
 scripting tasks and for simplifying the loading/processing of application
 configuration at startup.
 
-### child_process.spawnSync(command, [args], [options])
+### child_process.spawnSync(command[, args]\[, options])
 
 * `command` {String} The command to run
 * `args` {Array} List of string arguments
@@ -629,7 +629,7 @@ until the process has completely exited. That is to say, if the process handles
 the `SIGTERM` signal and doesn't exit, your process will wait until the child
 process has exited.
 
-### child_process.execFileSync(command, [args], [options])
+### child_process.execFileSync(command[, args]\[, options])
 
 * `command` {String} The command to run
 * `args` {Array} List of string arguments
@@ -660,7 +660,7 @@ throw.  The `Error` object will contain the entire result from
 [`child_process.spawnSync`](#child_process_child_process_spawnsync_command_args_options)
 
 
-### child_process.execSync(command, [options])
+### child_process.execSync(command[, options])
 
 * `command` {String} The command to run
 * `options` {Object}

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -415,7 +415,7 @@ exit, the master may choose not to respawn a worker based on this value.
     // kill worker
     worker.kill();
 
-### worker.send(message, [sendHandle])
+### worker.send(message[, sendHandle])
 
 * `message` {Object}
 * `sendHandle` {Handle object}

--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -22,7 +22,7 @@ In daily use, the blocking/non-blocking dichotomy is not something you
 should worry about unless you log huge amounts of data.
 
 
-## console.log([data], [...])
+## console.log([data]\[, ...])
 
 Prints to stdout with newline. This function can take multiple arguments in a
 `printf()`-like way. Example:
@@ -34,19 +34,19 @@ Prints to stdout with newline. This function can take multiple arguments in a
 If formatting elements are not found in the first string then `util.inspect`
 is used on each argument.  See [util.format()][] for more information.
 
-## console.info([data], [...])
+## console.info([data]\[, ...])
 
 Same as `console.log`.
 
-## console.error([data], [...])
+## console.error([data]\[, ...])
 
 Same as `console.log` but prints to stderr.
 
-## console.warn([data], [...])
+## console.warn([data]\[, ...])
 
 Same as `console.error`.
 
-## console.dir(obj, [options])
+## console.dir(obj[, options])
 
 Uses `util.inspect` on `obj` and prints resulting string to stdout. This function
 bypasses any custom `inspect()` function on `obj`. An optional *options* object
@@ -77,12 +77,12 @@ Finish timer, record output. Example:
     console.timeEnd('100-elements');
     // prints 100-elements: 262ms
 
-## console.trace(message, [...])
+## console.trace(message[, ...])
 
 Print to stderr `'Trace :'`, followed by the formatted message and stack trace
 to the current position.
 
-## console.assert(value, [message], [...])
+## console.assert(value[, message]\[, ...])
 
 Similar to [assert.ok()][], but the error message is formatted as
 `util.format(message...)`.

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -12,7 +12,7 @@ It also offers a set of wrappers for OpenSSL's hash, hmac, cipher,
 decipher, sign and verify methods.
 
 
-## crypto.setEngine(engine, [flags])
+## crypto.setEngine(engine[, flags])
 
 Load and set engine for some/all OpenSSL functions (selected by flags).
 
@@ -122,7 +122,7 @@ digest.  The legacy `update` and `digest` methods are also supported.
 
 Returned by `crypto.createHash`.
 
-### hash.update(data, [input_encoding])
+### hash.update(data[, input_encoding])
 
 Updates the hash content with the given `data`, the encoding of which
 is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
@@ -214,7 +214,7 @@ writable.  The written plain text data is used to produce the
 encrypted data on the readable side.  The legacy `update` and `final`
 methods are also supported.
 
-### cipher.update(data, [input_encoding], [output_encoding])
+### cipher.update(data[, input_encoding]\[, output_encoding])
 
 Updates the cipher with `data`, the encoding of which is given in
 `input_encoding` and can be `'utf8'`, `'ascii'` or `'binary'`.  If no
@@ -280,7 +280,7 @@ writable.  The written enciphered data is used to produce the
 plain-text data on the the readable side.  The legacy `update` and
 `final` methods are also supported.
 
-### decipher.update(data, [input_encoding], [output_encoding])
+### decipher.update(data[, input_encoding]\[, output_encoding])
 
 Updates the decipher with `data`, which is encoded in `'binary'`,
 `'base64'` or `'hex'`.  If no encoding is provided, then a buffer is
@@ -345,7 +345,7 @@ written, the `sign` method will return the signature.  The legacy
 Updates the sign object with data.  This can be called many times
 with new data as it is streamed.
 
-### sign.sign(private_key, [output_format])
+### sign.sign(private_key[, output_format])
 
 Calculates the signature on all the updated data passed through the
 sign.
@@ -387,7 +387,7 @@ supported.
 Updates the verifier object with data.  This can be called many times
 with new data as it is streamed.
 
-### verifier.verify(object, signature, [signature_format])
+### verifier.verify(object, signature[, signature_format])
 
 Verifies the signed data by using the `object` and `signature`.
 `object` is  a string containing a PEM encoded object, which can be
@@ -402,13 +402,13 @@ the data and public key.
 Note: `verifier` object can not be used after `verify()` method has been
 called.
 
-## crypto.createDiffieHellman(prime_length, [generator])
+## crypto.createDiffieHellman(prime_length[, generator])
 
 Creates a Diffie-Hellman key exchange object and generates a prime of
 `prime_length` bits and using an optional specific numeric `generator`.
 If no `generator` is specified, then `2` is used.
 
-## crypto.createDiffieHellman(prime, [prime_encoding], [generator], [generator_encoding])
+## crypto.createDiffieHellman(prime[, prime_encoding]\[, generator]\[, generator_encoding])
 
 Creates a Diffie-Hellman key exchange object using the supplied `prime` and an
 optional specific `generator`.
@@ -442,7 +442,7 @@ the public key in the specified encoding. This key should be
 transferred to the other party. Encoding can be `'binary'`, `'hex'`,
 or `'base64'`.  If no encoding is provided, then a buffer is returned.
 
-### diffieHellman.computeSecret(other_public_key, [input_encoding], [output_encoding])
+### diffieHellman.computeSecret(other_public_key[, input_encoding]\[, output_encoding])
 
 Computes the shared secret using `other_public_key` as the other
 party's public key and returns the computed shared secret. Supplied
@@ -477,13 +477,13 @@ Returns the Diffie-Hellman private key in the specified encoding,
 which can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is
 provided, then a buffer is returned.
 
-### diffieHellman.setPublicKey(public_key, [encoding])
+### diffieHellman.setPublicKey(public_key[, encoding])
 
 Sets the Diffie-Hellman public key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is
 expected.
 
-### diffieHellman.setPrivateKey(private_key, [encoding])
+### diffieHellman.setPrivateKey(private_key[, encoding])
 
 Sets the Diffie-Hellman private key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is
@@ -541,7 +541,7 @@ Format specifies point encoding and can be `'compressed'`, `'uncompressed'`, or
 Encoding can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided,
 then a buffer is returned.
 
-### ECDH.computeSecret(other_public_key, [input_encoding], [output_encoding])
+### ECDH.computeSecret(other_public_key[, input_encoding]\[, output_encoding])
 
 Computes the shared secret using `other_public_key` as the other
 party's public key and returns the computed shared secret. Supplied
@@ -569,13 +569,13 @@ Returns the EC Diffie-Hellman private key in the specified encoding,
 which can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is
 provided, then a buffer is returned.
 
-### ECDH.setPublicKey(public_key, [encoding])
+### ECDH.setPublicKey(public_key[, encoding])
 
 Sets the EC Diffie-Hellman public key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is
 expected.
 
-### ECDH.setPrivateKey(private_key, [encoding])
+### ECDH.setPrivateKey(private_key[, encoding])
 
 Sets the EC Diffie-Hellman private key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is
@@ -596,7 +596,7 @@ Example (obtaining a shared secret):
     /* alice_secret and bob_secret should be the same */
     console.log(alice_secret == bob_secret);
 
-## crypto.pbkdf2(password, salt, iterations, keylen, [digest], callback)
+## crypto.pbkdf2(password, salt, iterations, keylen[, digest], callback)
 
 Asynchronous PBKDF2 function.  Applies the selected HMAC digest function
 (default: SHA1) to derive a key of the requested length from the password,
@@ -614,11 +614,11 @@ Example:
 You can get a list of supported digest functions with
 [crypto.getHashes()](#crypto_crypto_gethashes).
 
-## crypto.pbkdf2Sync(password, salt, iterations, keylen, [digest])
+## crypto.pbkdf2Sync(password, salt, iterations, keylen[, digest])
 
 Synchronous PBKDF2 function.  Returns derivedKey or throws error.
 
-## crypto.randomBytes(size, [callback])
+## crypto.randomBytes(size[, callback])
 
 Generates cryptographically strong pseudo-random data. Usage:
 
@@ -642,7 +642,7 @@ accumulated entropy to generate cryptographically strong data. In other words,
 `crypto.randomBytes` without callback will not block even if all entropy sources
 are drained.
 
-## crypto.pseudoRandomBytes(size, [callback])
+## crypto.pseudoRandomBytes(size[, callback])
 
 Generates *non*-cryptographically strong pseudo-random data. The data
 returned will be unique if it is sufficiently long, but is not

--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -21,8 +21,8 @@ You have to change it to this:
     });
 
 
-## dgram.createSocket(type, [callback])
-## dgram.createSocket(options, [callback])
+## dgram.createSocket(type[, callback])
+## dgram.createSocket(options[, callback])
 
 * `type` String. Either 'udp4' or 'udp6'
 * `options` Object. Should contain a `type` property and could contain
@@ -77,7 +77,7 @@ on this socket.
 
 Emitted when an error occurs.
 
-### socket.send(buf, offset, length, port, address, [callback])
+### socket.send(buf, offset, length, port, address[, callback])
 
 * `buf` Buffer object or string.  Message to be sent
 * `offset` Integer. Offset in the buffer where the message starts.
@@ -142,7 +142,7 @@ a packet might travel, and that generally sending a datagram greater than
 the (receiver) `MTU` won't work (the packet gets silently dropped, without
 informing the source that the data did not reach its intended recipient).
 
-### socket.bind(port, [address], [callback])
+### socket.bind(port[, address]\[, callback])
 
 * `port` Integer
 * `address` String, Optional
@@ -188,7 +188,7 @@ Example of a UDP server listening on port 41234:
     // server listening 0.0.0.0:41234
 
 
-### socket.bind(options, [callback])
+### socket.bind(options[, callback])
 
 * `options` {Object} - Required. Supports the following properties:
   * `port` {Number} - Required.
@@ -262,7 +262,7 @@ systems is 1.
 Sets or clears the `IP_MULTICAST_LOOP` socket option.  When this option is set, multicast
 packets will also be received on the local interface.
 
-### socket.addMembership(multicastAddress, [multicastInterface])
+### socket.addMembership(multicastAddress[, multicastInterface])
 
 * `multicastAddress` String
 * `multicastInterface` String, Optional
@@ -272,7 +272,7 @@ Tells the kernel to join a multicast group with `IP_ADD_MEMBERSHIP` socket optio
 If `multicastInterface` is not specified, the OS will try to add membership to all valid
 interfaces.
 
-### socket.dropMembership(multicastAddress, [multicastInterface])
+### socket.dropMembership(multicastAddress[, multicastInterface])
 
 * `multicastAddress` String
 * `multicastInterface` String, Optional

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -31,7 +31,7 @@ resolves the IP addresses which are returned.
       });
     });
 
-## dns.lookup(hostname, [options], callback)
+## dns.lookup(hostname[, options], callback)
 
 Resolves a hostname (e.g. `'google.com'`) into the first found A (IPv4) or
 AAAA (IPv6) record. `options` can be an object or integer. If `options` is
@@ -79,7 +79,7 @@ The callback has arguments `(err, hostname, service)`. The `hostname` and
 On error, `err` is an `Error` object, where `err.code` is the error code.
 
 
-## dns.resolve(hostname, [rrtype], callback)
+## dns.resolve(hostname[, rrtype], callback)
 
 Resolves a hostname (e.g. `'google.com'`) into an array of the record types
 specified by rrtype.

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -104,7 +104,7 @@ Returns an array of listeners for the specified event.
     console.log(util.inspect(server.listeners('connection'))); // [ [Function] ]
 
 
-### emitter.emit(event, [arg1], [arg2], [...])
+### emitter.emit(event[, arg1]\[, arg2]\[, ...])
 
 Execute each of the listeners in order with the supplied arguments.
 

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -208,7 +208,7 @@ the completion callback.
 
 Synchronous link(2).
 
-## fs.symlink(srcpath, dstpath, [type], callback)
+## fs.symlink(srcpath, dstpath[, type], callback)
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
@@ -217,7 +217,7 @@ is `'file'`) and is only available on Windows (ignored on other platforms).
 Note that Windows junction points require the destination path to be absolute.  When using
 `'junction'`, the `destination` argument will automatically be normalized to absolute path.
 
-## fs.symlinkSync(srcpath, dstpath, [type])
+## fs.symlinkSync(srcpath, dstpath[, type])
 
 Synchronous symlink(2).
 
@@ -230,7 +230,7 @@ linkString)`.
 
 Synchronous readlink(2). Returns the symbolic link's string value.
 
-## fs.realpath(path, [cache], callback)
+## fs.realpath(path[, cache], callback)
 
 Asynchronous realpath(2). The `callback` gets two arguments `(err,
 resolvedPath)`. May use `process.cwd` to resolve relative paths. `cache` is an
@@ -245,7 +245,7 @@ Example:
       console.log(resolvedPath);
     });
 
-## fs.realpathSync(path, [cache])
+## fs.realpathSync(path[, cache])
 
 Synchronous realpath(2). Returns the resolved path.
 
@@ -267,12 +267,12 @@ to the completion callback.
 
 Synchronous rmdir(2).
 
-## fs.mkdir(path, [mode], callback)
+## fs.mkdir(path[, mode], callback)
 
 Asynchronous mkdir(2). No arguments other than a possible exception are given
 to the completion callback. `mode` defaults to `0777`.
 
-## fs.mkdirSync(path, [mode])
+## fs.mkdirSync(path[, mode])
 
 Synchronous mkdir(2).
 
@@ -296,7 +296,7 @@ to the completion callback.
 
 Synchronous close(2).
 
-## fs.open(path, flags, [mode], callback)
+## fs.open(path, flags[, mode], callback)
 
 Asynchronous file open. See open(2). `flags` can be:
 
@@ -353,7 +353,7 @@ On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
-## fs.openSync(path, flags, [mode])
+## fs.openSync(path, flags[, mode])
 
 Synchronous version of `fs.open()`.
 
@@ -451,7 +451,7 @@ The callback is given the three arguments, `(err, bytesRead, buffer)`.
 
 Synchronous version of `fs.read`. Returns the number of `bytesRead`.
 
-## fs.readFile(filename, [options], callback)
+## fs.readFile(filename[, options], callback)
 
 * `filename` {String}
 * `options` {Object}
@@ -472,7 +472,7 @@ contents of the file.
 If no encoding is specified, then the raw buffer is returned.
 
 
-## fs.readFileSync(filename, [options])
+## fs.readFileSync(filename[, options])
 
 Synchronous version of `fs.readFile`. Returns the contents of the `filename`.
 
@@ -480,7 +480,7 @@ If the `encoding` option is specified then this function returns a
 string. Otherwise it returns a buffer.
 
 
-## fs.writeFile(filename, data, [options], callback)
+## fs.writeFile(filename, data[, options], callback)
 
 * `filename` {String}
 * `data` {String | Buffer}
@@ -503,11 +503,11 @@ Example:
       console.log('It\'s saved!');
     });
 
-## fs.writeFileSync(filename, data, [options])
+## fs.writeFileSync(filename, data[, options])
 
 The synchronous version of `fs.writeFile`.
 
-## fs.appendFile(filename, data, [options], callback)
+## fs.appendFile(filename, data[, options], callback)
 
 * `filename` {String}
 * `data` {String | Buffer}
@@ -527,11 +527,11 @@ Example:
       console.log('The "data to append" was appended to file!');
     });
 
-## fs.appendFileSync(filename, data, [options])
+## fs.appendFileSync(filename, data[, options])
 
 The synchronous version of `fs.appendFile`.
 
-## fs.watchFile(filename, [options], listener)
+## fs.watchFile(filename[, options], listener)
 
     Stability: 2 - Unstable.  Use fs.watch instead, if possible.
 
@@ -557,7 +557,7 @@ These stat objects are instances of `fs.Stat`.
 If you want to be notified when the file was modified, not just accessed
 you need to compare `curr.mtime` and `prev.mtime`.
 
-## fs.unwatchFile(filename, [listener])
+## fs.unwatchFile(filename[, listener])
 
     Stability: 2 - Unstable.  Use fs.watch instead, if possible.
 
@@ -568,7 +568,7 @@ have effectively stopped watching `filename`.
 Calling `fs.unwatchFile()` with a filename that is not being watched is a
 no-op, not an error.
 
-## fs.watch(filename, [options], [listener])
+## fs.watch(filename[, options]\[, listener])
 
     Stability: 2 - Unstable.
 
@@ -728,7 +728,7 @@ Prior to Node v0.12, the `ctime` held the `birthtime` on Windows
 systems.  Note that as of v0.12, `ctime` is not "creation time", and
 on Unix systems, it never was.
 
-## fs.createReadStream(path, [options])
+## fs.createReadStream(path[, options])
 
 Returns a new ReadStream object (See `Readable Stream`).
 
@@ -767,7 +767,7 @@ An example to read the last 10 bytes of a file which is 100 bytes long:
 Emitted when the ReadStream's file is opened.
 
 
-## fs.createWriteStream(path, [options])
+## fs.createWriteStream(path[, options])
 
 Returns a new WriteStream object (See `Writable Stream`).
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -64,7 +64,7 @@ Returns a new web server object.
 The `requestListener` is a function which is automatically
 added to the `'request'` event.
 
-## http.createClient([port], [host])
+## http.createClient([port]\[, host])
 
 This function is **deprecated**; please use [http.request()][] instead.
 Constructs a new HTTP client. `port` and `host` refer to the server to be
@@ -160,7 +160,7 @@ If a client connection emits an 'error' event - it will forwarded here.
 `socket` is the `net.Socket` object that the error originated from.
 
 
-### server.listen(port, [hostname], [backlog], [callback])
+### server.listen(port[, hostname]\[, backlog]\[, callback])
 
 Begin accepting connections on the specified port and hostname.  If the
 hostname is omitted, the server will accept connections directed to any
@@ -177,7 +177,7 @@ This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'][] event.  See also [net.Server.listen(port)][].
 
 
-### server.listen(path, [callback])
+### server.listen(path[, callback])
 
 Start a UNIX socket server listening for connections on the given `path`.
 
@@ -185,7 +185,7 @@ This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'][] event.  See also [net.Server.listen(path)][].
 
 
-### server.listen(handle, [callback])
+### server.listen(handle[, callback])
 
 * `handle` {Object}
 * `callback` {Function}
@@ -275,7 +275,7 @@ After this event, no more events will be emitted on the response object.
 Sends a HTTP/1.1 100 Continue message to the client, indicating that
 the request body should be sent. See the ['checkContinue'][] event on `Server`.
 
-### response.writeHead(statusCode, [statusMessage], [headers])
+### response.writeHead(statusCode[, statusMessage]\[, headers])
 
 Sends a response header to the request. The status code is a 3-digit HTTP
 status code, like `404`. The last argument, `headers`, are the response headers.
@@ -389,7 +389,7 @@ Example:
     response.removeHeader("Content-Encoding");
 
 
-### response.write(chunk, [encoding])
+### response.write(chunk[, encoding])
 
 If this method is called and [response.writeHead()][] has not been called,
 it will switch to implicit header mode and flush the implicit headers.
@@ -433,7 +433,7 @@ emit trailers, with a list of the header fields in its value. E.g.,
     response.end();
 
 
-### response.end([data], [encoding])
+### response.end([data]\[, encoding])
 
 This method signals to the server that all of the response headers and body
 have been sent; that server should consider this message complete.
@@ -444,7 +444,7 @@ If `data` is specified, it is equivalent to calling `response.write(data, encodi
 followed by `response.end()`.
 
 
-## http.request(options, [callback])
+## http.request(options[, callback])
 
 Node maintains several connections per server to make HTTP requests.
 This function allows one to transparently issue requests.
@@ -544,7 +544,7 @@ There are a few special headers that should be noted.
 * Sending an Authorization header will override using the `auth` option
   to compute basic authentication.
 
-## http.get(options, [callback])
+## http.get(options[, callback])
 
 Since most requests are GET requests without bodies, Node provides this
 convenience method. The only difference between this method and `http.request()`
@@ -864,7 +864,7 @@ That's usually what you want (it saves a TCP round-trip) but not when the first
 data isn't sent until possibly much later.  `request.flush()` lets you bypass
 the optimization and kickstart the request.
 
-### request.write(chunk, [encoding])
+### request.write(chunk[, encoding])
 
 Sends a chunk of the body.  By calling this method
 many times, the user can stream a request body to a
@@ -878,7 +878,7 @@ The `encoding` argument is optional and only applies when `chunk` is a string.
 Defaults to `'utf8'`.
 
 
-### request.end([data], [encoding])
+### request.end([data]\[, encoding])
 
 Finishes sending the request. If any parts of the body are
 unsent, it will flush them to the stream. If the request is
@@ -891,7 +891,7 @@ If `data` is specified, it is equivalent to calling
 
 Aborts a request.  (New since v0.3.8.)
 
-### request.setTimeout(timeout, [callback])
+### request.setTimeout(timeout[, callback])
 
 Once a socket is assigned to this request and is connected
 [socket.setTimeout()][] will be called.
@@ -901,7 +901,7 @@ Once a socket is assigned to this request and is connected
 Once a socket is assigned to this request and is connected
 [socket.setNoDelay()][] will be called.
 
-### request.setSocketKeepAlive([enable], [initialDelay])
+### request.setSocketKeepAlive([enable]\[, initialDelay])
 
 Once a socket is assigned to this request and is connected
 [socket.setKeepAlive()][] will be called.

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -18,7 +18,7 @@ See [http.Server#setTimeout()][].
 
 See [http.Server#timeout][].
 
-## https.createServer(options, [requestListener])
+## https.createServer(options[, requestListener])
 
 Returns a new HTTPS web server object. The `options` is similar to
 [tls.createServer()][].  The `requestListener` is a function which is
@@ -55,9 +55,9 @@ Or
     }).listen(8000);
 
 
-### server.listen(port, [host], [backlog], [callback])
-### server.listen(path, [callback])
-### server.listen(handle, [callback])
+### server.listen(port[, host]\[, backlog]\[, callback])
+### server.listen(path[, callback])
+### server.listen(handle[, callback])
 
 See [http.listen()][] for details.
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -6,7 +6,7 @@ The `net` module provides you with an asynchronous network wrapper. It contains
 methods for creating both servers and clients (called streams). You can include
 this module with `require('net');`
 
-## net.createServer([options], [connectionListener])
+## net.createServer([options]\[, connectionListener])
 
 Creates a new TCP server. The `connectionListener` argument is
 automatically set as a listener for the ['connection'][] event.
@@ -50,8 +50,8 @@ Use `nc` to connect to a UNIX domain socket server:
 
     nc -U /tmp/echo.sock
 
-## net.connect(options, [connectionListener])
-## net.createConnection(options, [connectionListener])
+## net.connect(options[, connectionListener])
+## net.createConnection(options[, connectionListener])
 
 A factory method, which returns a new ['net.Socket'](#net_class_net_socket)
 and connects to the supplied address and port.
@@ -107,8 +107,8 @@ changed to
 
     var client = net.connect({path: '/tmp/echo.sock'});
 
-## net.connect(port, [host], [connectListener])
-## net.createConnection(port, [host], [connectListener])
+## net.connect(port[, host]\[, connectListener])
+## net.createConnection(port[, host]\[, connectListener])
 
 Creates a TCP connection to `port` on `host`. If `host` is omitted,
 `'localhost'` will be assumed.
@@ -117,8 +117,8 @@ The `connectListener` parameter will be added as an listener for the
 
 Is a factory method which returns a new ['net.Socket'](#net_class_net_socket).
 
-## net.connect(path, [connectListener])
-## net.createConnection(path, [connectListener])
+## net.connect(path[, connectListener])
+## net.createConnection(path[, connectListener])
 
 Creates unix socket connection to `path`.
 The `connectListener` parameter will be added as an listener for the
@@ -130,7 +130,7 @@ A factory method which returns a new ['net.Socket'](#net_class_net_socket).
 
 This class is used to create a TCP or local server.
 
-### server.listen(port, [host], [backlog], [callback])
+### server.listen(port[, host]\[, backlog]\[, callback])
 
 Begin accepting connections on the specified `port` and `host`.  If the
 `host` is omitted, the server will accept connections directed to any
@@ -162,7 +162,7 @@ would be to wait a second and then try again. This can be done with
 (Note: All sockets in Node set `SO_REUSEADDR` already)
 
 
-### server.listen(path, [callback])
+### server.listen(path[, callback])
 
 * `path` {String}
 * `callback` {Function}
@@ -189,7 +189,7 @@ double-backslashes, such as:
     net.createServer().listen(
         path.join('\\\\?\\pipe', process.cwd(), 'myctl'))
 
-### server.listen(handle, [callback])
+### server.listen(handle[, callback])
 
 * `handle` {Object}
 * `callback` {Function}
@@ -208,7 +208,7 @@ This function is asynchronous.  When the server has been bound,
 the last parameter `callback` will be added as an listener for the
 ['listening'][] event.
 
-### server.listen(options, [callback])
+### server.listen(options[, callback])
 
 * `options` {Object} - Required. Supports the following properties:
   * `port` {Number} - Optional.
@@ -352,8 +352,8 @@ Set `readable` and/or `writable` to `true` to allow reads and/or writes on this
 socket (NOTE: Works only when `fd` is passed).
 About `allowHalfOpen`, refer to `createServer()` and `'end'` event.
 
-### socket.connect(port, [host], [connectListener])
-### socket.connect(path, [connectListener])
+### socket.connect(port[, host]\[, connectListener])
+### socket.connect(path[, connectListener])
 
 Opens the connection for a given socket. If `port` and `host` are given,
 then the socket will be opened as a TCP socket, if `host` is omitted,
@@ -395,7 +395,7 @@ Users who experience large or growing `bufferSize` should attempt to
 Set the encoding for the socket as a Readable Stream. See
 [stream.setEncoding()][] for more information.
 
-### socket.write(data, [encoding], [callback])
+### socket.write(data[, encoding]\[, callback])
 
 Sends data on the socket. The second parameter specifies the encoding in the
 case of a string--it defaults to UTF8 encoding.
@@ -407,7 +407,7 @@ buffer. Returns `false` if all or part of the data was queued in user memory.
 The optional `callback` parameter will be executed when the data is finally
 written out - this may not be immediately.
 
-### socket.end([data], [encoding])
+### socket.end([data]\[, encoding])
 
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the
 server will still send some data.
@@ -429,7 +429,7 @@ Useful to throttle back an upload.
 
 Resumes reading after a call to `pause()`.
 
-### socket.setTimeout(timeout, [callback])
+### socket.setTimeout(timeout[, callback])
 
 Sets the socket to timeout after `timeout` milliseconds of inactivity on
 the socket. By default `net.Socket` do not have a timeout.
@@ -450,7 +450,7 @@ algorithm, they buffer data before sending it off. Setting `true` for
 `noDelay` will immediately fire off data each time `socket.write()` is called.
 `noDelay` defaults to `true`.
 
-### socket.setKeepAlive([enable], [initialDelay])
+### socket.setKeepAlive([enable]\[, initialDelay])
 
 Enable/disable keep-alive functionality, and optionally set the initial
 delay before the first keepalive probe is sent on an idle socket.

--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -22,7 +22,7 @@ Example:
     // returns
     '/foo/bar/baz/asdf'
 
-## path.join([path1], [path2], [...])
+## path.join([path1]\[, path2]\[, ...])
 
 Join all arguments together and normalize the resulting path.
 
@@ -127,7 +127,7 @@ Example:
     // returns
     '/foo/bar/baz/asdf'
 
-## path.basename(p, [ext])
+## path.basename(p[, ext])
 
 Return the last portion of a path.  Similar to the Unix `basename` command.
 

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -539,7 +539,7 @@ An example of the possible output looks like:
          target_arch: 'x64',
          v8_use_snapshot: 'true' } }
 
-## process.kill(pid, [signal])
+## process.kill(pid[, signal])
 
 Send a signal to a process. `pid` is the process id and `signal` is the
 string describing the signal to send.  Signal names are strings like

--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -7,7 +7,7 @@
 This module provides utilities for dealing with query strings.
 It provides the following methods:
 
-## querystring.stringify(obj, [sep], [eq], [options])
+## querystring.stringify(obj[, sep]\[, eq]\[, options])
 
 Serialize an object to a query string.
 Optionally override the default separator (`'&'`) and assignment (`'='`)
@@ -33,7 +33,7 @@ Example:
     // returns
     'w=%D6%D0%CE%C4&foo=bar'
 
-## querystring.parse(str, [sep], [eq], [options])
+## querystring.parse(str[, sep]\[, eq]\[, options])
 
 Deserialize a query string to an object.
 Optionally override the default separator (`'&'`) and assignment (`'='`)

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -128,7 +128,7 @@ Resumes the readline `input` stream.
 Closes the `Interface` instance, relinquishing control on the `input` and
 `output` streams. The "close" event will also be emitted.
 
-### rl.write(data, [key])
+### rl.write(data[, key])
 
 Writes `data` to `output` stream. `key` is an object literal to represent a key
 sequence; available if the terminal is a TTY.

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -328,7 +328,7 @@ readable.resume()
 readable.isPaused() // === false
 ```
 
-#### readable.pipe(destination, [options])
+#### readable.pipe(destination[, options])
 
 * `destination` {[Writable][] Stream} The destination for writing data
 * `options` {Object} Pipe options
@@ -501,7 +501,7 @@ Examples of writable streams include:
 * [child process stdin](child_process.html#child_process_child_stdin)
 * [process.stdout][], [process.stderr][]
 
-#### writable.write(chunk, [encoding], [callback])
+#### writable.write(chunk[, encoding]\[, callback])
 
 * `chunk` {String | Buffer} The data to write
 * `encoding` {String} The encoding, if `chunk` is a String
@@ -564,7 +564,7 @@ Buffered data will be flushed either at `.uncork()` or at `.end()` call.
 
 Flush all data, buffered since `.cork()` call.
 
-#### writable.end([chunk], [encoding], [callback])
+#### writable.end([chunk]\[, encoding]\[, callback])
 
 * `chunk` {String | Buffer} Optional data to write
 * `encoding` {String} The encoding, if `chunk` is a String
@@ -943,7 +943,7 @@ TLS, may ignore this argument, and simply provide data whenever it
 becomes available.  There is no need, for example to "wait" until
 `size` bytes are available before calling [`stream.push(chunk)`][].
 
-#### readable.push(chunk, [encoding])
+#### readable.push(chunk[, encoding])
 
 * `chunk` {Buffer | null | String} Chunk of data to push into the read queue
 * `encoding` {String} Encoding of String chunks.  Must be a valid

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -5,7 +5,7 @@
 All of the timer functions are globals.  You do not need to `require()`
 this module in order to use them.
 
-## setTimeout(callback, delay, [arg], [...])
+## setTimeout(callback, delay[, arg]\[, ...])
 
 To schedule execution of a one-time `callback` after `delay` milliseconds. Returns a
 `timeoutObject` for possible use with `clearTimeout()`. Optionally you can
@@ -20,7 +20,7 @@ be called as close as possible to the time specified.
 
 Prevents a timeout from triggering.
 
-## setInterval(callback, delay, [arg], [...])
+## setInterval(callback, delay[, arg]\[, ...])
 
 To schedule the repeated execution of `callback` every `delay` milliseconds.
 Returns a `intervalObject` for possible use with `clearInterval()`. Optionally
@@ -47,7 +47,7 @@ If you had previously `unref()`d a timer you can call `ref()` to explicitly
 request the timer hold the program open. If the timer is already `ref`d calling
 `ref` again will have no effect.
 
-## setImmediate(callback, [arg], [...])
+## setImmediate(callback[, arg]\[, ...])
 
 To schedule the "immediate" execution of `callback` after I/O events
 callbacks and before `setTimeout` and `setInterval` . Returns an

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -111,7 +111,7 @@ Example:
     console.log(ciphers); // ['AES128-SHA', 'AES256-SHA', ...]
 
 
-## tls.createServer(options, [secureConnectionListener])
+## tls.createServer(options[, secureConnectionListener])
 
 Creates a new [tls.Server][].  The `connectionListener` argument is
 automatically set as a listener for the [secureConnection][] event.  The
@@ -285,8 +285,8 @@ You can test this server by connecting to it with `openssl s_client`:
     openssl s_client -connect 127.0.0.1:8000
 
 
-## tls.connect(options, [callback])
-## tls.connect(port, [host], [options], [callback])
+## tls.connect(options[, callback])
+## tls.connect(port[, host]\[, options]\[, callback])
 
 Creates a new client connection to the given `port` and `host` (old API) or
 `options.port` and `options.host`. (If `host` is omitted, it defaults to
@@ -455,7 +455,7 @@ publicly trusted list of CAs as given in
 <http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>.
 
 
-## tls.createSecurePair([context], [isServer], [requestCert], [rejectUnauthorized])
+## tls.createSecurePair([context]\[, isServer]\[, requestCert]\[, rejectUnauthorized])
 
     Stability: 0 - Deprecated. Use tls.TLSSocket instead.
 
@@ -594,7 +594,7 @@ NOTE: you may want to use some npm module like [asn1.js] to parse the
 certificates.
 
 
-### server.listen(port, [host], [callback])
+### server.listen(port[, host]\[, callback])
 
 Begin accepting connections on the specified `port` and `host`.  If the
 `host` is omitted, the server will accept connections directed to any

--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -65,7 +65,7 @@ string will not be in the parsed object. Examples are shown for the URL
 
 The following methods are provided by the URL module:
 
-## url.parse(urlStr, [parseQueryString], [slashesDenoteHost])
+## url.parse(urlStr[, parseQueryString]\[, slashesDenoteHost])
 
 Take a URL string, and return an object.
 

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -43,7 +43,7 @@ environment variable set, then it will not print anything.
 You may separate multiple `NODE_DEBUG` environment variables with a
 comma.  For example, `NODE_DEBUG=fs,net,tls`.
 
-## util.format(format, [...])
+## util.format(format[, ...])
 
 Returns a formatted string using the first argument as a `printf`-like format.
 
@@ -81,7 +81,7 @@ Output with timestamp on `stdout`.
 
     require('util').log('Timestamped message.');
 
-## util.inspect(object, [options])
+## util.inspect(object[, options])
 
 Return a string representation of `object`, which is useful for debugging.
 
@@ -297,7 +297,7 @@ Deprecated predecessor of `console.log`.
 Deprecated predecessor of `console.log`.
 
 
-## util.pump(readableStream, writableStream, [callback])
+## util.pump(readableStream, writableStream[, callback])
 
     Stability: 0 - Deprecated: Use readableStream.pipe(writableStream)
 

--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -11,7 +11,7 @@ You can access this module with:
 JavaScript code can be compiled and run immediately or compiled, saved, and run
 later.
 
-## vm.runInThisContext(code, [options])
+## vm.runInThisContext(code[, options])
 
 `vm.runInThisContext()` compiles `code`, runs it and returns the result. Running
 code does not have access to local scope, but does have access to the current
@@ -76,7 +76,7 @@ Returns whether or not a sandbox object has been contextified by calling
 `vm.createContext` on it.
 
 
-## vm.runInContext(code, contextifiedSandbox, [options])
+## vm.runInContext(code, contextifiedSandbox[, options])
 
 `vm.runInContext` compiles `code`, then runs it in `contextifiedSandbox` and
 returns the result. Running code does not have access to local scope. The
@@ -105,7 +105,7 @@ Note that running untrusted code is a tricky business requiring great care.
 separate process.
 
 
-## vm.runInNewContext(code, [sandbox], [options])
+## vm.runInNewContext(code[, sandbox]\[, options])
 
 `vm.runInNewContext` compiles `code`, contextifies `sandbox` if passed or
 creates a new contextified sandbox if it's omitted, and then runs the code with
@@ -204,7 +204,7 @@ The options for running a script are:
   execution. If execution is terminated, an `Error` will be thrown.
 
 
-### script.runInContext(contextifiedSandbox, [options])
+### script.runInContext(contextifiedSandbox[, options])
 
 Similar to `vm.runInContext` but a method of a precompiled `Script` object.
 `script.runInContext` runs `script`'s compiled code in `contextifiedSandbox`
@@ -238,7 +238,7 @@ Note that running untrusted code is a tricky business requiring great care.
 requires a separate process.
 
 
-### script.runInNewContext([sandbox], [options])
+### script.runInNewContext([sandbox]\[, options])
 
 Similar to `vm.runInNewContext` but a method of a precompiled `Script` object.
 `script.runInNewContext` contextifies `sandbox` if passed or creates a new

--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -201,38 +201,38 @@ callback with `callback(error, result)`.
 Every method has a `*Sync` counterpart, which accept the same arguments, but
 without a callback.
 
-## zlib.deflate(buf, [options], callback)
-## zlib.deflateSync(buf, [options])
+## zlib.deflate(buf[, options], callback)
+## zlib.deflateSync(buf[, options])
 
 Compress a string with Deflate.
 
-## zlib.deflateRaw(buf, [options], callback)
-## zlib.deflateRawSync(buf, [options])
+## zlib.deflateRaw(buf[, options], callback)
+## zlib.deflateRawSync(buf[, options])
 
 Compress a string with DeflateRaw.
 
-## zlib.gzip(buf, [options], callback)
-## zlib.gzipSync(buf, [options])
+## zlib.gzip(buf[, options], callback)
+## zlib.gzipSync(buf[, options])
 
 Compress a string with Gzip.
 
-## zlib.gunzip(buf, [options], callback)
-## zlib.gunzipSync(buf, [options])
+## zlib.gunzip(buf[, options], callback)
+## zlib.gunzipSync(buf[, options])
 
 Decompress a raw Buffer with Gunzip.
 
-## zlib.inflate(buf, [options], callback)
-## zlib.inflateSync(buf, [options])
+## zlib.inflate(buf[, options], callback)
+## zlib.inflateSync(buf[, options])
 
 Decompress a raw Buffer with Inflate.
 
-## zlib.inflateRaw(buf, [options], callback)
-## zlib.inflateRawSync(buf, [options])
+## zlib.inflateRaw(buf[, options], callback)
+## zlib.inflateRawSync(buf[, options])
 
 Decompress a raw Buffer with InflateRaw.
 
-## zlib.unzip(buf, [options], callback)
-## zlib.unzipSync(buf, [options])
+## zlib.unzip(buf[, options], callback)
+## zlib.unzipSync(buf[, options])
 
 Decompress a raw Buffer with Unzip.
 


### PR DESCRIPTION
Documentation incorrectly used bracket notation for optional parameters.
This caused inconsistencies in usage because of examples like the
following:

```
fs.write(fd, data[, position[, encoding]], callback)
```

This simply fixes all uses of bracket notation in documentation.
