### PR TITLE
Make url.query consistent between slow & fast path

### DIFF
--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -69,9 +69,10 @@ The following methods are provided by the URL module:
 
 Take a URL string, and return an object.
 
-Pass `true` as the second argument to also parse
-the query string using the `querystring` module.
-Defaults to `false`.
+Pass `true` as the second argument to also parse the query string using the
+`querystring` module. If `true` then the `query` property will always be
+assigned an object, and the `search` property will always be a (possibly
+empty) string.  Defaults to `false`.
 
 Pass `true` as the third argument to treat `//foo/bar` as
 `{ host: 'foo', pathname: '/bar' }` rather than

--- a/lib/url.js
+++ b/lib/url.js
@@ -136,6 +136,9 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
         } else {
           this.query = this.search.substr(1);
         }
+      } else if (parseQueryString) {
+        this.search = '';
+        this.query = {};
       }
       return this;
     }

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -868,6 +868,20 @@ var parseTestsWithQueryString = {
     'pathname': '/',
     'path': '/'
   },
+  '/example':{
+    protocol: null,
+    slashes: null,
+    auth: null,
+    host: null,
+    port: null,
+    hostname: null,
+    hash: null,
+    search: '',
+    query: {},
+    pathname: '/example',
+    path: '/example',
+    href: '/example'
+  },
   '/example?query=value':{
     protocol: null,
     slashes: null,


### PR DESCRIPTION
Match the behavior of the slow path by setting url.query to an empty object
when the url contains no query, but query parsing is requested.

Also add a test for this case.

issue: #8332
