### PR TITLE
url: do not stringify query if this.search exist

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -392,7 +392,8 @@ Url.prototype.format = function() {
     }
   }
 
-  if (this.query &&
+  if (!this.search &&
+      this.query &&
       util.isObject(this.query) &&
       Object.keys(this.query).length) {
     query = querystring.stringify(this.query);


### PR DESCRIPTION
it is unnecessary to stringify `this.query` when `this.search` exist.

what's worse, `querystring.stringify` will throw when:

```
var query = 'q=%CE%ED%BB%AF%C6%F7';
var parsed = qs.parse(query);
qs.stringify(parsed); // URIError: URI malformed throwed
```

so `url.parse` will throw when `url.parse('/index?q=%CE%ED%BB%AF%C6%F7', true)`.

BTW, can we fix `querystring.stringify` ?
