### PR TITLE
Feature/fix child process type checking

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -116,7 +116,7 @@ emulation with `process.kill()`, and `child_process.kill()`:
 
 ## process.stdout
 
-A `Writable Stream` to `stdout`.
+A `Writable Stream` to `stdout` (on fd `1`).
 
 Example: the definition of `console.log`
 
@@ -150,7 +150,7 @@ See [the tty docs](tty.html#tty_tty) for more information.
 
 ## process.stderr
 
-A writable stream to stderr.
+A writable stream to stderr (on fd `2`).
 
 `process.stderr` and `process.stdout` are unlike other streams in Node in
 that writes to them are usually blocking.
@@ -164,7 +164,7 @@ that writes to them are usually blocking.
 
 ## process.stdin
 
-A `Readable Stream` for stdin. 
+A `Readable Stream` for stdin (on fd `0`).
 
 Example of opening standard input and listening for both events:
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -591,7 +591,7 @@ exports.exec = function(command /*, options, callback */) {
 
 
 exports.execFile = function(file /* args, options, callback */) {
-  var args, optionArg, callback;
+  var args = [], optionArg, callback;
   var options = {
     encoding: 'utf8',
     timeout: 0,
@@ -601,18 +601,28 @@ exports.execFile = function(file /* args, options, callback */) {
     env: null
   };
 
-  // Parse the parameters.
-
-  if (typeof arguments[arguments.length - 1] === 'function') {
-    callback = arguments[arguments.length - 1];
+  // Parse the optional positional parameters.
+  var pos = 1;
+  if (pos < arguments.length && Array.isArray(arguments[pos])) {
+    args = arguments[pos++];
+  }
+  else if(pos < arguments.length && arguments[pos] == null) {
+    pos++;
   }
 
-  if (Array.isArray(arguments[1])) {
-    args = arguments[1];
-    options = util._extend(options, arguments[2]);
-  } else {
-    args = [];
-    options = util._extend(options, arguments[1]);
+  if (pos < arguments.length && typeof arguments[pos] === 'object') {
+    options = util._extend(options, arguments[pos++]);
+  }
+  else if(pos < arguments.length && arguments[pos] == null) {
+    pos++;
+  }
+
+  if (pos < arguments.length && typeof arguments[pos] === 'function') {
+    callback = arguments[pos++];
+  }
+
+  if (pos === 1 && arguments.length > 1) {
+    throw new TypeError('Incorrect value of args option');
   }
 
   var child = spawn(file, args, {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -525,6 +525,8 @@ exports.fork = function(modulePath /*, args, options*/) {
   if (Array.isArray(arguments[1])) {
     args = arguments[1];
     options = util._extend({}, arguments[2]);
+  } else if (arguments[1] && typeof arguments[1] !== 'object') {
+    throw new TypeError('Incorrect value of args option');
   } else {
     args = [];
     options = util._extend({}, arguments[1]);

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -22,6 +22,7 @@
 var assert = require('assert');
 var child_process = require('child_process');
 var spawn = child_process.spawn;
+var execFile = child_process.execFile;
 var cmd = (process.platform === 'win32') ? 'dir' : 'ls';
 
 
@@ -33,4 +34,14 @@ assert.throws(function() {
 // verify that args argument is optional
 assert.doesNotThrow(function() {
   spawn(cmd, {});
+});
+
+
+// verify that execFile has same argument parsing behaviour as spawn
+assert.throws(function() {
+  execFile(cmd, 'this is not an array');
+}, TypeError);
+
+assert.doesNotThrow(function() {
+  execFile(cmd, {});
 });

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -24,35 +24,86 @@ var child_process = require('child_process');
 var spawn = child_process.spawn;
 var fork = child_process.fork;
 var execFile = child_process.execFile;
-var cmd = (process.platform === 'win32') ? 'dir' : 'ls';
+var cmd = (process.platform === 'win32') ? 'rundll32' : 'ls';
 var empty = require('../common').fixturesDir + '/empty.js';
 
+// Argument types for combinatorics
+var a=[], o={}, c=(function callback(){}), s='string', u=undefined, n=null;
 
-// verify that args argument must be an array
-assert.throws(function() {
-  spawn(cmd, 'this is not an array');
-}, TypeError);
+// function spawn(file=f [,args=a] [, options=o]) has valid combinations:
+//   (f)
+//   (f, a)
+//   (f, a, o)
+//   (f, o)
+assert.doesNotThrow(function() { spawn(cmd); });
+assert.doesNotThrow(function() { spawn(cmd, a); });
+assert.doesNotThrow(function() { spawn(cmd, a, o); });
+assert.doesNotThrow(function() { spawn(cmd, o); });
 
-// verify that args argument is optional
-assert.doesNotThrow(function() {
-  spawn(cmd, {});
-});
+// Variants of undefined as explicit 'no argument' at a position
+assert.doesNotThrow(function() { execFile(empty, u, o); });
+assert.doesNotThrow(function() { execFile(empty, a, u); });
+assert.doesNotThrow(function() { execFile(empty, n, o); });
+assert.doesNotThrow(function() { execFile(empty, a, n); });
+
+assert.throws(function() { spawn(cmd, s); }, TypeError);
+assert.doesNotThrow(function() { spawn(cmd, a, s); }, TypeError);
 
 
 // verify that execFile has same argument parsing behaviour as spawn
-assert.throws(function() {
-  execFile(cmd, 'this is not an array');
-}, TypeError);
+//
+// function execFile(file=f [,args=a] [, options=o] [, callback=c]) has valid
+// combinations:
+//   (f)
+//   (f, a)
+//   (f, a, o)
+//   (f, a, o, c)
+//   (f, a, c)
+//   (f, o)
+//   (f, o, c)
+//   (f, c)
+assert.doesNotThrow(function() { execFile(cmd); });
+assert.doesNotThrow(function() { execFile(cmd, a); });
+assert.doesNotThrow(function() { execFile(cmd, a, o); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, c); });
+assert.doesNotThrow(function() { execFile(cmd, o); });
+assert.doesNotThrow(function() { execFile(cmd, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, c); });
 
-assert.doesNotThrow(function() {
-  execFile(cmd, {});
-});
+// Variants of undefined as explicit 'no argument' at a position
+assert.doesNotThrow(function() { execFile(cmd, u, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, u, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, u); });
+assert.doesNotThrow(function() { execFile(cmd, n, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, n, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, n); });
+
+// string is invalid in arg position (this may seem strange, but is
+// consistent across node API, cf. `net.createServer('not options', 'not
+// callback')`
+assert.throws(function() { execFile(cmd, s, o, c); }, TypeError);
+assert.doesNotThrow(function() { execFile(cmd, a, s, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, s); });
+
 
 // verify that fork has same argument parsing behaviour as spawn
-assert.throws(function() {
-  fork(empty, 'this is not an array');
-}, TypeError);
+//
+// function fork(file=f [,args=a] [, options=o]) has valid combinations:
+//   (f)
+//   (f, a)
+//   (f, a, o)
+//   (f, o)
+assert.doesNotThrow(function() { fork(empty); });
+assert.doesNotThrow(function() { fork(empty, a); });
+assert.doesNotThrow(function() { fork(empty, a, o); });
+assert.doesNotThrow(function() { fork(empty, o); });
 
-assert.doesNotThrow(function() {
-  execFile(empty, {});
-});
+// Variants of undefined as explicit 'no argument' at a position
+assert.doesNotThrow(function() { execFile(empty, u, o); });
+assert.doesNotThrow(function() { execFile(empty, a, u); });
+assert.doesNotThrow(function() { execFile(empty, n, o); });
+assert.doesNotThrow(function() { execFile(empty, a, n); });
+
+assert.throws(function() { fork(empty, s); }, TypeError);
+assert.doesNotThrow(function() { fork(empty, a, s); }, TypeError);

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -22,8 +22,10 @@
 var assert = require('assert');
 var child_process = require('child_process');
 var spawn = child_process.spawn;
+var fork = child_process.fork;
 var execFile = child_process.execFile;
 var cmd = (process.platform === 'win32') ? 'dir' : 'ls';
+var empty = require('../common').fixturesDir + '/empty.js';
 
 
 // verify that args argument must be an array
@@ -44,4 +46,13 @@ assert.throws(function() {
 
 assert.doesNotThrow(function() {
   execFile(cmd, {});
+});
+
+// verify that fork has same argument parsing behaviour as spawn
+assert.throws(function() {
+  fork(empty, 'this is not an array');
+}, TypeError);
+
+assert.doesNotThrow(function() {
+  execFile(empty, {});
 });

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -19,30 +19,18 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var spawn = require('child_process').spawn,
-  assert = require('assert'),
-  windows = (process.platform === 'win32'),
-  cmd = (windows) ? 'dir' : 'ls',
-  invalidcmd = (windows) ? 'ls' : 'dir',
-  errors = 0;
+var assert = require('assert');
+var child_process = require('child_process');
+var spawn = child_process.spawn;
+var cmd = (process.platform === 'win32') ? 'dir' : 'ls';
 
-try {
-  // Ensure this throws a TypeError
-  var child = spawn(invalidcmd, 'this is not an array');
 
-  child.on('error', function (err) {
-    errors++;
-  });
-
-} catch (e) {
-  assert.equal(e instanceof TypeError, true);
-}
+// verify that args argument must be an array
+assert.throws(function() {
+  spawn(cmd, 'this is not an array');
+}, TypeError);
 
 // verify that args argument is optional
 assert.doesNotThrow(function() {
   spawn(cmd, {});
-});
-
-process.on('exit', function() {
-  assert.equal(errors, 0);
 });


### PR DESCRIPTION
https://github.com/joyent/node/pull/8392 introduced a test that doesn't fail when the code it is testing is deleted.

Also, behaviour of execFile and spawn have drifted apart again, unnecessarily, I think. This brings them into line again.

/to @cjihrig  
