### PR TITLE
node: avoid automatic microtask runs

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -138,6 +138,8 @@ inline v8::Handle<v8::Value> AsyncWrap::MakeDomainCallback(
     return ret;
   }
 
+  env()->isolate()->RunMicrotasks();
+
   if (tick_info->length() == 0) {
     tick_info->set_index(0);
     return ret;
@@ -200,6 +202,8 @@ inline v8::Handle<v8::Value> AsyncWrap::MakeCallback(
   if (tick_info->in_tick()) {
     return ret;
   }
+
+  env()->isolate()->RunMicrotasks();
 
   if (tick_info->length() == 0) {
     tick_info->set_index(0);

--- a/src/node.cc
+++ b/src/node.cc
@@ -1081,6 +1081,8 @@ Handle<Value> MakeDomainCallback(Environment* env,
     return ret;
   }
 
+  env->isolate()->RunMicrotasks();
+
   if (tick_info->length() == 0) {
     tick_info->set_index(0);
     return ret;
@@ -1144,6 +1146,8 @@ Handle<Value> MakeCallback(Environment* env,
   if (tick_info->in_tick()) {
     return ret;
   }
+
+  env->isolate()->RunMicrotasks();
 
   if (tick_info->length() == 0) {
     tick_info->set_index(0);
@@ -3554,6 +3558,8 @@ Environment* CreateEnvironment(Isolate* isolate,
 
   Context::Scope context_scope(context);
   Environment* env = Environment::New(context);
+
+  isolate->SetAutorunMicrotasks(false);
 
   uv_check_init(env->event_loop(), env->immediate_check_handle());
   uv_unref(

--- a/test/simple/test-microtask-queue-run-domain.js
+++ b/test/simple/test-microtask-queue-run-domain.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+
+function enqueueMicrotask(fn) {
+  Promise.resolve().then(fn);
+}
+
+var done = 0;
+
+process.on('exit', function() {
+  assert.equal(done, 2);
+});
+
+// no nextTick, microtask
+setTimeout(function() {
+  enqueueMicrotask(function() {
+    done++;
+  });
+}, 0);
+
+
+// no nextTick, microtask with nextTick
+setTimeout(function() {
+  var called = false;
+
+  enqueueMicrotask(function() {
+    process.nextTick(function() {
+      called = true;
+    });
+  });
+
+  setTimeout(function() {
+    if (called)
+      done++;
+  }, 0);
+
+}, 0);

--- a/test/simple/test-microtask-queue-run-immediate-domain.js
+++ b/test/simple/test-microtask-queue-run-immediate-domain.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+
+function enqueueMicrotask(fn) {
+  Promise.resolve().then(fn);
+}
+
+var done = 0;
+
+process.on('exit', function() {
+  assert.equal(done, 2);
+});
+
+// no nextTick, microtask
+setImmediate(function() {
+  enqueueMicrotask(function() {
+    done++;
+  });
+});
+
+
+// no nextTick, microtask with nextTick
+setImmediate(function() {
+  var called = false;
+
+  enqueueMicrotask(function() {
+    process.nextTick(function() {
+      called = true;
+    });
+  });
+
+  setImmediate(function() {
+    if (called)
+      done++;
+  });
+
+});

--- a/test/simple/test-microtask-queue-run-immediate.js
+++ b/test/simple/test-microtask-queue-run-immediate.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+function enqueueMicrotask(fn) {
+  Promise.resolve().then(fn);
+}
+
+var done = 0;
+
+process.on('exit', function() {
+  assert.equal(done, 2);
+});
+
+// no nextTick, microtask
+setImmediate(function() {
+  enqueueMicrotask(function() {
+    done++;
+  });
+});
+
+
+// no nextTick, microtask with nextTick
+setImmediate(function() {
+  var called = false;
+
+  enqueueMicrotask(function() {
+    process.nextTick(function() {
+      called = true;
+    });
+  });
+
+  setImmediate(function() {
+    if (called)
+      done++;
+  });
+
+});

--- a/test/simple/test-microtask-queue-run.js
+++ b/test/simple/test-microtask-queue-run.js
@@ -1,0 +1,58 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+function enqueueMicrotask(fn) {
+  Promise.resolve().then(fn);
+}
+
+var done = 0;
+
+process.on('exit', function() {
+  assert.equal(done, 2);
+});
+
+// no nextTick, microtask
+setTimeout(function() {
+  enqueueMicrotask(function() {
+    done++;
+  });
+}, 0);
+
+
+// no nextTick, microtask with nextTick
+setTimeout(function() {
+  var called = false;
+
+  enqueueMicrotask(function() {
+    process.nextTick(function() {
+      called = true;
+    });
+  });
+
+  setTimeout(function() {
+    if (called)
+      done++;
+  }, 0);
+
+}, 0);


### PR DESCRIPTION
As discussed in #8325 we should take advantage of `Isolate::SetAutorunMicrotasks`. This requires running microtasks manually prior to checking `tick_info->length()` as `process.nextTick` can be called inside of a microtask.

This change helps to avoid unnecessary automatic microtask runs and should positively affect performance.
/cc @trevnorris 
