### PR TITLE
util: add es6 Symbol support for `util.inspect`

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -174,6 +174,7 @@ inspect.styles = {
   'undefined': 'grey',
   'null': 'bold',
   'string': 'green',
+  'symbol': 'green',
   'date': 'magenta',
   // "name": intentionally not styling
   'regexp': 'red'
@@ -388,6 +389,9 @@ function formatPrimitive(ctx, value) {
   // For some reason typeof null is "object", so special case here.
   if (isNull(value))
     return ctx.stylize('null', 'null');
+  // es6 symbol primitive
+  if (isSymbol(value))
+    return ctx.stylize(value.toString(), 'symbol');
 }
 
 

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -235,3 +235,12 @@ assert.equal(util.inspect(bool), '{ [Boolean: true] foo: \'bar\' }');
 var num = new Number(13.37);
 num.foo = 'bar';
 assert.equal(util.inspect(num), '{ [Number: 13.37] foo: \'bar\' }');
+
+// test es6 Symbol
+if (typeof Symbol !== 'undefined') {
+  assert.equal(util.inspect(Symbol()), 'Symbol()');
+  assert.equal(util.inspect(Symbol(123)), 'Symbol(123)');
+  assert.equal(util.inspect(Symbol('hi')), 'Symbol(hi)');
+  assert.equal(util.inspect([Symbol()]), '[ Symbol() ]');
+  assert.equal(util.inspect({ foo: Symbol() }), '{ foo: Symbol() }');
+}


### PR DESCRIPTION
- `util.inspect` cannot accept es6 symbol primitive
- it will throw exception if do `util.inspect(Symbol())`
- this also affects repl, console.log, etc.

```
$ node --harmony
> Symbol()
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at formatValue (util.js:235:21)
    at Object.inspect (util.js:147:10)
    at REPLServer.self.writer (repl.js:209:19)
    at finish (repl.js:316:38)
    at REPLServer.defaultEval (repl.js:145:5)
    at bound (domain.js:257:14)
    at REPLServer.runBound [as eval] (domain.js:270:12)
    at REPLServer.<anonymous> (repl.js:277:12)
    at REPLServer.EventEmitter.emit (events.js:107:17)
```

This pull request adds a symbol check in `formatPrimitive`

Note, we don't need concern about boxed symbol primitive because
`new Symbol()` will throw a `TypeError`
