### PR TITLE
streams: set default encoding for writable streams

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -180,6 +180,48 @@ The method will not write partial characters.
     len = buf.write('\u00bd + \u00bc = \u00be', 0);
     console.log(len + " bytes: " + buf.toString('utf8', 0, len));
 
+### buf.writeUIntLE(value, offset, byteLength[, noAssert])
+### buf.writeUIntBE(value, offset, byteLength[, noAssert])
+### buf.writeIntLE(value, offset, byteLength[, noAssert])
+### buf.writeIntBE(value, offset, byteLength[, noAssert])
+
+* `value` {Number} Bytes to be written to buffer
+* `offset` {Number} `0 <= offset <= buf.length`
+* `byteLength` {Number} `0 < byteLength <= 6`
+* `noAssert` {Boolean} Default: false
+* Return: {Number}
+
+Writes `value` to the buffer at the specified `offset` and `byteLength`.
+Supports up to 48 bits of accuracy. For example:
+
+    var b = new Buffer(6);
+    b.writeUIntBE(0x1234567890ab, 0, 6);
+    // <Buffer 12 34 56 78 90 ab>
+
+Set `noAssert` to `true` to skip validation of `value` and `offset`. Defaults
+to `false`.
+
+### buf.readUIntLE(offset, byteLength[, noAssert])
+### buf.readUIntBE(offset, byteLength[, noAssert])
+### buf.readIntLE(offset, byteLength[, noAssert])
+### buf.readIntBE(offset, byteLength[, noAssert])
+
+* `offset` {Number} `0 <= offset <= buf.length`
+* `byteLength` {Number} `0 < byteLength <= 6`
+* `noAssert` {Boolean} Default: false
+* Return: {Number}
+
+A generalized version of all numeric read methods. Supports up to 48 bits of
+accuracy. For example:
+
+    var b = new Buffer(6);
+    b.writeUint16LE(0x90ab, 0);
+    b.writeUInt32LE(0x12345678, 2);
+    b.readUIntLE(0, 6).toString(16);  // Specify 6 bytes (48 bits)
+    // output: '1234567890ab'
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
 
 ### buf.toString([encoding][, start][, end])
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -603,3 +603,4 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [server.getConnections()]: #net_server_getconnections_callback
 [Readable Stream]: stream.html#stream_readable_stream
 [stream.setEncoding()]: stream.html#stream_stream_setencoding_encoding
+[dns.lookup()]: dns.html#dns_dns_lookup_domain_family_callback

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -125,6 +125,8 @@ Example usage:
 
 Pauses the readline `input` stream, allowing it to be resumed later if needed.
 
+Note that this doesn't immediately pause the stream of events. Several events may be emitted after calling `pause`, including `line`.
+
 ### rl.resume()
 
 Resumes the readline `input` stream.

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -568,7 +568,8 @@ Flush all data, buffered since `.cork()` call.
 
 `encoding` {String} The new default encoding
 
-Sets the default encoding for a writable stream
+Sets the default encoding for a writable stream. Returns true if the encoding
+is valid and is set otherwise, it returns false.
 
 #### writable.end([chunk][, encoding][, callback])
 

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -564,6 +564,12 @@ Buffered data will be flushed either at `.uncork()` or at `.end()` call.
 
 Flush all data, buffered since `.cork()` call.
 
+#### writable.setDefaultEncoding(encoding)
+
+`encoding` {String} The new default encoding
+
+Sets the default encoding for a writable stream
+
 #### writable.end([chunk][, encoding][, callback])
 
 * `chunk` {String | Buffer} Optional data to write

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -221,6 +221,12 @@ Writable.prototype.uncork = function() {
   }
 };
 
+Writable.prototype.setDefaultEncoding = function(encoding) {
+  if (encoding) {
+    this._writableState.defaultEncoding = encoding;
+  }
+};
+
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -222,9 +222,11 @@ Writable.prototype.uncork = function() {
 };
 
 Writable.prototype.setDefaultEncoding = function(encoding) {
-  if (encoding) {
+  if (encoding && typeof encoding === 'string') {
     this._writableState.defaultEncoding = encoding;
+    return true;
   }
+  return false;
 };
 
 function decodeChunk(state, chunk, encoding) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -482,6 +482,37 @@ function checkOffset(offset, ext, length) {
 }
 
 
+Buffer.prototype.readUIntLE = function(offset, byteLength, noAssert) {
+  offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
+  if (!noAssert)
+    checkOffset(offset, byteLength, this.length);
+
+  var val = this[offset];
+  var mul = 1;
+  var i = 0;
+  while (++i < byteLength && (mul *= 0x100))
+    val += this[offset + i] * mul;
+
+  return val;
+};
+
+
+Buffer.prototype.readUIntBE = function(offset, byteLength, noAssert) {
+  offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
+  if (!noAssert)
+    checkOffset(offset, byteLength, this.length);
+
+  var val = this[offset + --byteLength];
+  var mul = 1;
+  while (byteLength > 0 && (mul *= 0x100))
+    val += this[offset + --byteLength] * mul;
+
+  return val;
+};
+
+
 Buffer.prototype.readUInt8 = function(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
@@ -527,6 +558,46 @@ Buffer.prototype.readUInt32BE = function(offset, noAssert) {
       ((this[offset + 1] << 16) |
       (this[offset + 2] << 8) |
       this[offset + 3]);
+};
+
+
+Buffer.prototype.readIntLE = function(offset, byteLength, noAssert) {
+  offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
+  if (!noAssert)
+    checkOffset(offset, byteLength, this.length);
+
+  var val = this[offset];
+  var mul = 1;
+  var i = 0;
+  while (++i < byteLength && (mul *= 0x100))
+    val += this[offset + i] * mul;
+  mul *= 0x80;
+
+  if (val >= mul)
+    val -= Math.pow(2, 8 * byteLength);
+
+  return val;
+};
+
+
+Buffer.prototype.readIntBE = function(offset, byteLength, noAssert) {
+  offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
+  if (!noAssert)
+    checkOffset(offset, byteLength, this.length);
+
+  var i = byteLength;
+  var mul = 1;
+  var val = this[offset + --i];
+  while (i > 0 && (mul *= 0x100))
+    val += this[offset + --i] * mul;
+  mul *= 0x80;
+
+  if (val >= mul)
+    val -= Math.pow(2, 8 * byteLength);
+
+  return val;
 };
 
 
@@ -623,6 +694,40 @@ function checkInt(buffer, value, offset, ext, max, min) {
 }
 
 
+Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, Math.pow(2, 8 * byteLength), 0);
+
+  var mul = 1;
+  var i = 0;
+  this[offset] = value;
+  while (++i < byteLength && (mul *= 0x100))
+    this[offset + i] = (value / mul) >>> 0;
+
+  return offset + byteLength;
+};
+
+
+Buffer.prototype.writeUIntBE = function(value, offset, byteLength, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  byteLength = byteLength >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, byteLength, Math.pow(2, 8 * byteLength), 0);
+
+  var i = byteLength - 1;
+  var mul = 1;
+  this[offset + i] = value;
+  while (--i >= 0 && (mul *= 0x100))
+    this[offset + i] = (value / mul) >>> 0;
+
+  return offset + byteLength;
+};
+
+
 Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
@@ -678,6 +783,52 @@ Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
   this[offset + 2] = (value >>> 8);
   this[offset + 3] = value;
   return offset + 4;
+};
+
+
+Buffer.prototype.writeIntLE = function(value, offset, byteLength, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert) {
+    checkInt(this,
+             value,
+             offset,
+             byteLength,
+             Math.pow(2, 8 * byteLength - 1) - 1,
+             -Math.pow(2, 8 * byteLength - 1));
+  }
+
+  var i = 0;
+  var mul = 1;
+  var sub = value < 0 ? 1 : 0;
+  this[offset] = value;
+  while (++i < byteLength && (mul *= 0x100))
+    this[offset + i] = ((value / mul) >> 0) - sub;
+
+  return offset + byteLength;
+};
+
+
+Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert) {
+    checkInt(this,
+             value,
+             offset,
+             byteLength,
+             Math.pow(2, 8 * byteLength - 1) - 1,
+             -Math.pow(2, 8 * byteLength - 1));
+  }
+
+  var i = byteLength - 1;
+  var mul = 1;
+  var sub = value < 0 ? 1 : 0;
+  this[offset + i] = value;
+  while (--i >= 0 && (mul *= 0x100))
+    this[offset + i] = ((value / mul) >> 0) - sub;
+
+  return offset + byteLength;
 };
 
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -111,10 +111,14 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   }
 
   // Copy chrome, IE, opera backslash-handling behavior.
+  // Back slashes before the query string get converted to forward slashes
   // See: https://code.google.com/p/chromium/issues/detail?id=25916
-  var hashSplit = url.split('#');
-  hashSplit[0] = hashSplit[0].replace(/\\/g, '/');
-  url = hashSplit.join('#');
+  var queryIndex = url.indexOf('?'),
+      splitter = (queryIndex !== -1 && queryIndex < url.indexOf('#')) ? '?' : '#',
+      uSplit = url.split(splitter),
+      slashRegex = /\\/g;
+  uSplit[0] = uSplit[0].replace(slashRegex, '/');
+  url = uSplit.join(splitter);
 
   var rest = url;
 
@@ -122,7 +126,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // This is to support parse stuff like "  http://foo.com  \n"
   rest = rest.trim();
 
-  if (!slashesDenoteHost && hashSplit.length === 1) {
+  if (!slashesDenoteHost && url.split('#').length === 1) {
     // Try fast path regexp
     var simplePath = simplePathPattern.exec(rest);
     if (simplePath) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -174,6 +174,7 @@ inspect.styles = {
   'undefined': 'grey',
   'null': 'bold',
   'string': 'green',
+  'symbol': 'green',
   'date': 'magenta',
   // "name": intentionally not styling
   'regexp': 'red'
@@ -388,6 +389,9 @@ function formatPrimitive(ctx, value) {
   // For some reason typeof null is "object", so special case here.
   if (isNull(value))
     return ctx.stylize('null', 'null');
+  // es6 symbol primitive
+  if (isSymbol(value))
+    return ctx.stylize(value.toString(), 'symbol');
 }
 
 

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -950,8 +950,6 @@ var buf = new Buffer([0xFF]);
 assert.equal(buf.readUInt8(0), 255);
 assert.equal(buf.readInt8(0), -1);
 
-
-
 [16, 32].forEach(function(bits) {
   var buf = new Buffer(bits / 8 - 1);
 
@@ -987,6 +985,91 @@ assert.equal(buf.readInt8(0), -1);
   assert.equal(buf['readInt' + bits + 'LE'](0),
                 (0xFFFFFFFF >> (32 - bits)));
 });
+
+// test for common read(U)IntLE/BE
+(function() {
+  var buf = new Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+
+  assert.equal(buf.readUIntLE(0, 1), 0x01);
+  assert.equal(buf.readUIntBE(0, 1), 0x01);
+  assert.equal(buf.readUIntLE(0, 3), 0x030201);
+  assert.equal(buf.readUIntBE(0, 3), 0x010203);
+  assert.equal(buf.readUIntLE(0, 5), 0x0504030201);
+  assert.equal(buf.readUIntBE(0, 5), 0x0102030405);
+  assert.equal(buf.readUIntLE(0, 6), 0x060504030201);
+  assert.equal(buf.readUIntBE(0, 6), 0x010203040506);
+  assert.equal(buf.readIntLE(0, 1), 0x01);
+  assert.equal(buf.readIntBE(0, 1), 0x01);
+  assert.equal(buf.readIntLE(0, 3), 0x030201);
+  assert.equal(buf.readIntBE(0, 3), 0x010203);
+  assert.equal(buf.readIntLE(0, 5), 0x0504030201);
+  assert.equal(buf.readIntBE(0, 5), 0x0102030405);
+  assert.equal(buf.readIntLE(0, 6), 0x060504030201);
+  assert.equal(buf.readIntBE(0, 6), 0x010203040506);
+})();
+
+// test for common write(U)IntLE/BE
+(function() {
+  var buf = new Buffer(3);
+  buf.writeUIntLE(0x123456, 0, 3);
+  assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
+  assert.equal(buf.readUIntLE(0, 3), 0x123456);
+
+  buf = new Buffer(3);
+  buf.writeUIntBE(0x123456, 0, 3);
+  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
+  assert.equal(buf.readUIntBE(0, 3), 0x123456);
+
+  buf = new Buffer(3);
+  buf.writeIntLE(0x123456, 0, 3);
+  assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
+  assert.equal(buf.readIntLE(0, 3), 0x123456);
+
+  buf = new Buffer(3);
+  buf.writeIntBE(0x123456, 0, 3);
+  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
+  assert.equal(buf.readIntBE(0, 3), 0x123456);
+
+  buf = new Buffer(3);
+  buf.writeIntLE(-0x123456, 0, 3);
+  assert.deepEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
+  assert.equal(buf.readIntLE(0, 3), -0x123456);
+
+  buf = new Buffer(3);
+  buf.writeIntBE(-0x123456, 0, 3);
+  assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
+  assert.equal(buf.readIntBE(0, 3), -0x123456);
+
+  buf = new Buffer(5);
+  buf.writeUIntLE(0x1234567890, 0, 5);
+  assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
+  assert.equal(buf.readUIntLE(0, 5), 0x1234567890);
+
+  buf = new Buffer(5);
+  buf.writeUIntBE(0x1234567890, 0, 5);
+  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
+  assert.equal(buf.readUIntBE(0, 5), 0x1234567890);
+
+  buf = new Buffer(5);
+  buf.writeIntLE(0x1234567890, 0, 5);
+  assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
+  assert.equal(buf.readIntLE(0, 5), 0x1234567890);
+
+  buf = new Buffer(5);
+  buf.writeIntBE(0x1234567890, 0, 5);
+  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
+  assert.equal(buf.readIntBE(0, 5), 0x1234567890);
+
+  buf = new Buffer(5);
+  buf.writeIntLE(-0x1234567890, 0, 5);
+  assert.deepEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
+  assert.equal(buf.readIntLE(0, 5), -0x1234567890);
+
+  buf = new Buffer(5);
+  buf.writeIntBE(-0x1234567890, 0, 5);
+  assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
+  assert.equal(buf.readIntBE(0, 5), -0x1234567890);
+})();
 
 // test Buffer slice
 (function() {

--- a/test/simple/test-stream-writable-change-default-encoding.js
+++ b/test/simple/test-stream-writable-change-default-encoding.js
@@ -49,7 +49,18 @@ MyWritable.prototype._write = function (chunk, encoding, callback) {
   var m = new MyWritable(function(isBuffer, type, enc) {
     assert.equal(enc, 'ascii');
   }, { decodeStrings: false });
-  m.setDefaultEncoding('ascii');
+  var status = m.setDefaultEncoding('ascii');
+  assert.equal(status, true);
+  m.write('bar');
+  m.end();
+}());
+
+;(function changeDefaultEncodingToInvalidValue(){
+  var m = new MyWritable(function(isBuffer, type, enc) {
+    assert.equal(enc, 'utf8');
+  }, { decodeStrings: false });
+  var status = m.setDefaultEncoding({});
+  assert.equal(status, false);
   m.write('bar');
   m.end();
 }());

--- a/test/simple/test-stream-writable-change-default-encoding.js
+++ b/test/simple/test-stream-writable-change-default-encoding.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var stream = require('stream');
+var util = require('util');
+
+function MyWritable(fn, options) {
+  stream.Writable.call(this, options);
+  this.fn = fn;
+};
+
+util.inherits(MyWritable, stream.Writable);
+
+MyWritable.prototype._write = function (chunk, encoding, callback) {
+  this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+  callback();
+};
+
+;(function defaultCondingIsUtf8(){
+  var m = new MyWritable(function(isBuffer, type, enc) {
+    assert.equal(enc, 'utf8');
+  }, { decodeStrings: false });
+  m.write('foo');
+  m.end();
+}());
+
+;(function changeDefaultEncodingToAscii(){
+  var m = new MyWritable(function(isBuffer, type, enc) {
+    assert.equal(enc, 'ascii');
+  }, { decodeStrings: false });
+  m.setDefaultEncoding('ascii');
+  m.write('bar');
+  m.end();
+}());

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -45,6 +45,30 @@ var parseTests = {
     href: 'http://evil-phisher/foo.html#h%5Ca%5Cs%5Ch'
   },
 
+  'http:\\\\evil-phisher\\foo.html?json="\\"foo\\""#h\\a\\s\\h': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'evil-phisher',
+    hostname: 'evil-phisher',
+    pathname: '/foo.html',
+    search: '?json=%22%5C%22foo%5C%22%22',
+    query: 'json=%22%5C%22foo%5C%22%22',
+    path: '/foo.html?json=%22%5C%22foo%5C%22%22',
+    hash: '#h%5Ca%5Cs%5Ch',
+    href: 'http://evil-phisher/foo.html?json=%22%5C%22foo%5C%22%22#h%5Ca%5Cs%5Ch'
+  },
+
+  'http:\\\\evil-phisher\\foo.html#h\\a\\s\\h?blarg': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'evil-phisher',
+    hostname: 'evil-phisher',
+    pathname: '/foo.html',
+    path: '/foo.html',
+    hash: '#h%5Ca%5Cs%5Ch?blarg',
+    href: 'http://evil-phisher/foo.html#h%5Ca%5Cs%5Ch?blarg'
+  },
+
 
   'http:\\\\evil-phisher\\foo.html': {
     protocol: 'http:',

--- a/test/simple/test-util-inspect.js
+++ b/test/simple/test-util-inspect.js
@@ -235,3 +235,12 @@ assert.equal(util.inspect(bool), '{ [Boolean: true] foo: \'bar\' }');
 var num = new Number(13.37);
 num.foo = 'bar';
 assert.equal(util.inspect(num), '{ [Number: 13.37] foo: \'bar\' }');
+
+// test es6 Symbol
+if (typeof Symbol !== 'undefined') {
+  assert.equal(util.inspect(Symbol()), 'Symbol()');
+  assert.equal(util.inspect(Symbol(123)), 'Symbol(123)');
+  assert.equal(util.inspect(Symbol('hi')), 'Symbol(hi)');
+  assert.equal(util.inspect([Symbol()]), '[ Symbol() ]');
+  assert.equal(util.inspect({ foo: Symbol() }), '{ foo: Symbol() }');
+}


### PR DESCRIPTION
This commit adds the ability to set the default encoding for writable streams.

Fixes #7159
