### PR TITLE
repl: added support for custom completions

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -33,7 +33,7 @@ For example, you could add this to your bashrc file:
 ## repl.start(options)
 
 Returns and starts a `REPLServer` instance, that inherits from 
-[Readline Interface][]. Accepts an "options" Object that takes 
+[Readline Interface](readline.html#readline_readline). Accepts an "options" Object that takes 
 the following values:
 
  - `prompt` - the prompt and `stream` for all I/O. Defaults to `> `.
@@ -63,6 +63,9 @@ the following values:
  - `writer` - the function to invoke for each command that gets evaluated which
    returns the formatting (including coloring) to display. Defaults to
    `util.inspect`.
+
+ - `completer` - an optional function that is used for Tab autocompletion.
+   See [Readline Interface](readline.html#readline_readline) for an example of using this.
 
 You can use your own `eval` function if it has following signature:
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -182,14 +182,15 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.bufferedCommand = '';
   self.lines.level = [];
 
-  function complete(text, callback) {
-    self.complete(text, callback);
-  }
+  // Figure out which "complete" function to use.
+  self.completer = (typeof options.completer === 'function')
+    ? options.completer
+    : complete;
 
   rl.Interface.apply(this, [
     self.inputStream,
     self.outputStream,
-    complete,
+    self.completer,
     options.terminal
   ]);
 
@@ -429,6 +430,9 @@ var requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
 var simpleExpressionRE =
     /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
 
+REPLServer.prototype.complete = function() {
+  this.completer.apply(this, arguments);
+};
 
 // Provide a list of completions for the given leading text. This is
 // given to the readline interface for handling tab completion.
@@ -440,7 +444,7 @@ var simpleExpressionRE =
 //
 // Warning: This eval's code like "foo.bar.baz", so it will run property
 // getter code.
-REPLServer.prototype.complete = function(line, callback) {
+function complete(line, callback) {
   // There may be local variables to evaluate, try a nested REPL
   if (!util.isUndefined(this.bufferedCommand) && this.bufferedCommand.length) {
     // Get a new array of inputed lines
@@ -692,7 +696,7 @@ REPLServer.prototype.complete = function(line, callback) {
 
     callback(null, [completions || [], completeOn]);
   }
-};
+}
 
 
 /**

--- a/test/simple/test-repl-tab-complete.js
+++ b/test/simple/test-repl-tab-complete.js
@@ -211,3 +211,36 @@ testMe.complete(' ', function(error, data) {
 testMe.complete('toSt', function(error, data) {
   assert.deepEqual(data, [['toString'], 'toSt']);
 });
+
+// To test custom completer function.
+var putIn2 = new ArrayStream();
+var testMe2 = repl.start({
+  prompt: '',
+  input : putIn2,
+  output: putIn2,
+  completer: function customCompleter(line, cb) {
+    var completions = 'aaa aa1 aa2 bbb bb1 bb2 bb3 ccc ddd eee'.split(' ');
+    var hits = completions.filter(function (item) {
+      return item.indexOf(line) === 0;
+    });
+    // Show all completions if none was found.
+    cb([hits.length ? hits : completions, line]);
+  }
+});
+
+putIn2.run(['.clear']);
+
+// On empty line should output all the custom completions
+// without complete anything.
+putIn2.run(['']);
+testMe2.complete('', function(error, data) {
+  assert.deepEqual(data, [
+    'aaa aa1 aa2 bbb bb1 bb2 bb3 ccc ddd eee'.split(' '), ''
+  ]);
+});
+
+// On `a` should output `aaa aa1 aa2` and complete until `aa`.
+putIn2.run(['a']);
+testMe2.complete('a', function(error, data) {
+  assert.deepEqual(data, ['aaa aa1 aa2'.split(' '), 'a']);
+});


### PR DESCRIPTION
Currently I'm working on a project that uses the REPL to implement a mid complex CLI app found out that the REPL module doesn't have a way to override the default `complete()` function, which is used for TAB completions of commands.

I think that the REPL module can benefit from this addition, and specifically the repl applications that may wants to use this functionality.

I added the docs & tests, and the tests passed fine in my environment, this is just a little change, after all.
