### PR TITLE
include error argument in thrown Error msg

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -84,7 +84,7 @@ EventEmitter.prototype.emit = function emit(type) {
     } else if (er instanceof Error) {
       throw er; // Unhandled 'error' event
     } else {
-      throw Error('Uncaught, unspecified "error" event.');
+      throw Error('Uncaught, unspecified "error" event: ' + er);
     }
     return false;
   }

--- a/test/simple/test-event-emitter-non-error-emitted.js
+++ b/test/simple/test-event-emitter-non-error-emitted.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var events = require('events');
+
+var errorCaught = false;
+
+process.on('uncaughtException', function (er) {
+  assert(er instanceof Error, 'error created');
+  assert.equal('Uncaught, unspecified "error" event: a string', er.message );
+  errorCaught = true;
+})
+
+process.on('exit', function () {
+  assert(errorCaught, 'error got caught');
+});
+
+var e = new events.EventEmitter();
+e.emit('error', 'a string');


### PR DESCRIPTION
when a non-Error is emitted, include it in the constructed Error message.
