### PR TITLE
Update path.extname documentation

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -163,6 +163,10 @@ an empty string.  Examples:
     path.extname('index')
     // returns
     ''
+    
+    path.extname('.index')
+    // returns
+    ''
 
 ## path.sep
 


### PR DESCRIPTION
Adding an additional example to `path.extname` documentation to demonstrate the case where the first character of the last path component is `'.'`. This case is  interesting, as something like `path.extname('.txt')` returns an empty string. In this case, `.txt` can be used as a valid file name (while arguably maintaining an extension). I agree with Node's behavior in this case, but  I think the added example provides additional clarity for the developer.
