### PR TITLE
doc: fix wording and punctuation in modules

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -61,8 +61,7 @@ The module system is implemented in the `require("module")` module.
 
 <!--type=misc-->
 
-When there are circular `require()` calls, a module might not be
-done being executed when it is returned.
+When there are circular `require()` calls, a module might not have finished executing when it is returned.
 
 Consider this situation:
 
@@ -93,7 +92,7 @@ Consider this situation:
 
 When `main.js` loads `a.js`, then `a.js` in turn loads `b.js`.  At that
 point, `b.js` tries to load `a.js`.  In order to prevent an infinite
-loop an **unfinished copy** of the `a.js` exports object is returned to the
+loop, an **unfinished copy** of the `a.js` exports object is returned to the
 `b.js` module.  `b.js` then finishes loading, and its `exports` object is
 provided to the `a.js` module.
 
@@ -248,7 +247,7 @@ a global but rather local to each module.
 * {Object}
 
 The `module.exports` object is created by the Module system. Sometimes this is not
-acceptable; many want their module to be an instance of some class. To do this
+acceptable; many want their module to be an instance of some class. To do this,
 assign the desired export object to `module.exports`. Note that assigning the
 desired object to `exports` will simply rebind the local `exports` variable,
 which is probably not what you want to do.


### PR DESCRIPTION
Fixed some of the wording and punctuation in Modules section of the docs.
