### PR TITLE
streams: make setDefaultEncoding() throw

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -222,14 +222,12 @@ Writable.prototype.uncork = function() {
 };
 
 Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
-  if (typeof encoding !== 'string')
-    return false;
   // node::ParseEncoding() requires lower case.
-  encoding = encoding.toLowerCase();
+  if (typeof encoding === 'string')
+    encoding = encoding.toLowerCase();
   if (!Buffer.isEncoding(encoding))
-    return false;
+    throw new TypeError('Unknown encoding: ' + encoding);
   this._writableState.defaultEncoding = encoding;
-  return true;
 };
 
 function decodeChunk(state, chunk, encoding) {


### PR DESCRIPTION
This makes behavior consistent with `readable.setEncoding()`.
