### PR TITLE
test: fix test-child-process-spawn-typeerror

### DIFF
--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -22,8 +22,8 @@
 var spawn = require('child_process').spawn,
   assert = require('assert'),
   windows = (process.platform === 'win32'),
-  cmd = (windows) ? 'dir' : 'ls',
-  invalidcmd = (windows) ? 'ls' : 'dir',
+  cmd = (windows) ? 'rundll32' : 'ls',
+  invalidcmd = 'hopefully_you_dont_have_this_on_your_machine',
   invalidArgsMsg = /Incorrect value of args option/,
   invalidOptionsMsg = /options argument must be an object/,
   errors = 0;


### PR DESCRIPTION
You cannot spawn 'dir' on Windows because it's not an executable.
Also, some people might have 'ls' on their path on Windows, so
I changed invalidCmd to something that's highly unlikely to exist.
