### PR TITLE
build: fix build for SmartOS

### DIFF
--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -321,11 +321,15 @@ int OS::GetCurrentProcessId() {
 
 
 int OS::GetCurrentThreadId() {
-#if defined(ANDROID)
+#if V8_OS_MACOSX
+  return static_cast<int>(pthread_mach_thread_np(pthread_self()));
+#elif V8_OS_LINUX
   return static_cast<int>(syscall(__NR_gettid));
+#elif V8_OS_ANDROID
+  return static_cast<int>(gettid());
 #else
-  return static_cast<int>(syscall(SYS_gettid));
-#endif  // defined(ANDROID)
+  return static_cast<int>(pthread_self());
+#endif
 }
 
 

--- a/deps/v8/src/base/platform/platform.h
+++ b/deps/v8/src/base/platform/platform.h
@@ -35,6 +35,7 @@ namespace std {
 int signbit(double x);
 }
 # endif
+#include <alloca.h>
 #endif
 
 #if V8_OS_QNX


### PR DESCRIPTION
This change in V8: https://code.google.com/p/v8/source/detail?r=22210
has introduced a method named OS::GetCurrentThreadId which fails to
compile on OSes where a "gettid" syscall does not exist.
This build issue has been fixed upstream by another change:
https://code.google.com/p/v8/source/detail?r=23459. This commit
integrates this fix. It's still not clear if this is good enough for the
long term, see https://code.google.com/p/v8/issues/detail?id=3620 for
more information.

The other build issue was due to the fact that alloca.h is not included
by other system includes on SmartOS, which is assumed by V8.
