### PR TITLE
build: vcbuild fix "The input line is too long."

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -108,7 +108,10 @@ if defined nobuild goto sign
 @rem Look for Visual Studio 2013
 if not defined VS120COMNTOOLS goto vc-set-2012
 if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2012
-call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if "%VCVARS_VER%" NEQ "120" (
+  call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
+  SET VCVARS_VER=120
+)
 if not defined VCINSTALLDIR goto msbuild-not-found
 set GYP_MSVS_VERSION=2013
 goto msbuild-found
@@ -117,7 +120,10 @@ goto msbuild-found
 @rem Look for Visual Studio 2012
 if not defined VS110COMNTOOLS goto vc-set-2010
 if not exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2010
-call "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if "%VCVARS_VER%" NEQ "110" (
+  call "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat"
+  SET VCVARS_VER=110
+)
 if not defined VCINSTALLDIR goto msbuild-not-found
 set GYP_MSVS_VERSION=2012
 goto msbuild-found
@@ -125,7 +131,10 @@ goto msbuild-found
 :vc-set-2010
 if not defined VS100COMNTOOLS goto msbuild-not-found
 if not exist "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat" goto msbuild-not-found
-call "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if "%VCVARS_VER%" NEQ "100" (
+  call "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat"
+  SET VCVARS_VER=100
+)
 if not defined VCINSTALLDIR goto msbuild-not-found
 goto msbuild-found
 


### PR DESCRIPTION
vcbuild.bat is calling vcvars.bat, which doesn't detect if the environment
has already been set. This causes repeated entries to be added to the PATH,
which after a few invocations will lead to an error:
The input line is too long.
