### PR TITLE
child_process: populate all error fields in execFile() callback

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -717,9 +717,7 @@ exports.execFile = function(file /* args, options, callback */) {
       stderr = _stderr;
     }
 
-    if (ex) {
-      // Will be handled later
-    } else if (code === 0 && signal === null) {
+    if (!ex && code === 0 && signal === null) {
       callback(null, stdout, stderr);
       return;
     }
@@ -728,14 +726,14 @@ exports.execFile = function(file /* args, options, callback */) {
     if (args.length !== 0)
       cmd += ' ' + args.join(' ');
 
-    if (!ex) {
+    if (!ex)
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
-      ex.killed = child.killed || killed;
-      ex.code = code < 0 ? uv.errname(code) : code;
-      ex.signal = signal;
-    }
 
     ex.cmd = cmd;
+    ex.killed = child.killed || killed;
+    ex.code = ex.code || (code < 0 ? uv.errname(code) : code);
+    ex.signal = signal;
+
     callback(ex, stdout, stderr);
   }
 

--- a/test/simple/test-exec-max-buffer.js
+++ b/test/simple/test-exec-max-buffer.js
@@ -31,4 +31,7 @@ var cmd = 'echo "hello world"';
 exec(cmd, { maxBuffer: 5 }, function(err, stdout, stderr) {
   assert.ok(err);
   assert.ok(/maxBuffer/.test(err.message));
+  assert.equal(err.killed, true);
+  assert.notStrictEqual(err.code, undefined);
+  assert.notStrictEqual(err.signal, undefined);
 });


### PR DESCRIPTION
Currently, most `execFile()` errors do not set the `killed`, `code`, and `signal` fields. This commit ensures that they are set before calling back.

Fixes #6189
