### PR TITLE
Fixed spawnSync ignoring its 'env' option

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1264,6 +1264,7 @@ function spawnSync(/*file, args, options*/) {
 
   options.file = opts.file;
   options.args = opts.args;
+  options.envPairs = opts.envPairs;
 
   if (options.killSignal)
     options.killSignal = lookupSignal(options.killSignal);

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -737,9 +737,9 @@ int SyncProcessRunner::ParseOptions(Local<Value> js_value) {
     r = CopyJsStringArray(js_env_pairs, &env_buffer_);
     if (r < 0)
       return r;
-    uv_process_options_.args = reinterpret_cast<char**>(env_buffer_);
-  }
 
+    uv_process_options_.env = reinterpret_cast<char**>(env_buffer_);
+  }
   Local<Value> js_uid = js_options->Get(env()->uid_string());
   if (IsSet(js_uid)) {
     if (!CheckRange<uv_uid_t>(js_uid))


### PR DESCRIPTION
spawnSync ignores its env option. It can be reproduced using the below snippet:

```
var child_process = require('child_process');
var r = child_process.spawnSync("bash", ['-c', 'echo FOO=$FOO'], { env: { FOO: 'BAR' }});
console.log(r.stdout.toString());
```

The expected output should be: 

```
FOO=BAR
```

But as the 'env' option is ignored, it simply prints:

```
FOO=
```
