### PR TITLE
remove double declaration of `var i`

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -23,8 +23,8 @@ var formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (!isString(f)) {
     var objects = [];
-    for (var i = 0; i < arguments.length; i++) {
-      objects.push(inspect(arguments[i]));
+    for (var idx = 0; idx < arguments.length; idx++) {
+      objects.push(inspect(arguments[idx]));
     }
     return objects.join(' ');
   }


### PR DESCRIPTION
The `ì` variable is defined again in line 32.
This trips up code linters.
