### PR TITLE
crypto: allow runtime opt in using SSLv2/SSLv3

### DIFF
--- a/configure
+++ b/configure
@@ -112,15 +112,15 @@ parser.add_option("--systemtap-includes",
     dest="systemtap_includes",
     help=optparse.SUPPRESS_HELP)
 
-parser.add_option("--ssl2",
+parser.add_option("--without-ssl2",
     action="store_true",
     dest="ssl2",
-    help="Enable SSL v2")
+    help="Disable SSL v2")
 
-parser.add_option("--ssl3",
+parser.add_option("--without-ssl3",
     action="store_true",
     dest="ssl3",
-    help="Enable SSL v3")
+    help="Disable SSL v3")
 
 parser.add_option("--shared-zlib",
     action="store_true",
@@ -625,10 +625,10 @@ def configure_openssl(o):
   if options.without_ssl:
     return
 
-  if not options.ssl2:
+  if options.ssl2:
     o['defines'] += ['OPENSSL_NO_SSL2=1']
 
-  if not options.ssl3:
+  if options.ssl3:
     o['defines'] += ['OPENSSL_NO_SSL3=1']
 
   if options.shared_openssl:

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -126,8 +126,8 @@ The following options from [tls.connect()][] can also be specified. However, a
   the list of supplied CAs. An `'error'` event is emitted if verification
   fails. Verification happens at the connection level, *before* the HTTP
   request is sent. Default `true`.
-- `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
-  SSL version 3. The possible values depend on your installation of
+- `secureProtocol`: The SSL method to use, e.g. `TLSv1_method` to force
+  TLS version 1. The possible values depend on your installation of
   OpenSSL and are defined in the constant [SSL_METHODS][].
 
 In order to specify these options, use a custom `Agent`.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -40,11 +40,13 @@ To create .pfx or .p12, do this:
 
 ## Protocol support
 
-Node.js is compiled without SSL2/SSL3 protocol support by default. These
-protocols are insecure and could be easily compromised as was shown by
-[CVE-2014-3566][]. However, in some situations, it may cause
-problems with legacy clients/servers (such as Internet Explorer 6). If you do
-really wish to use them, please rebuild node.js with `./configure --with-ssl3`.
+Node.js is compiled with SSLv2 and SSLv3 protocol support by default, but these
+protocols are **disabled**. They are considered insecure and could be easily
+compromised as was shown by [CVE-2014-3566][]. However, in some situations, it
+may cause problems with legacy clients/servers (such as Internet Explorer 6).
+If you wish to enable SSLv2 or SSLv3, run node with the `--enable-ssl2` or
+`--enable-ssl3` flag respectively.  In future versions of Node.js SSLv2 and
+SSLv3 will not be compiled in by default.
 
 
 ## Client-initiated renegotiation attack mitigation

--- a/doc/node.1
+++ b/doc/node.1
@@ -62,6 +62,12 @@ and servers.
 
   --max-stack-size=val   set max v8 stack size (bytes)
 
+  --enable-ssl2          enable ssl2 in crypto, tls, and https
+                         modules
+
+  --enable-ssl3          enable ssl3 in crypto, tls, and https
+                         modules
+
 
 .SH ENVIRONMENT VARIABLES
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -82,6 +82,7 @@ typedef int mode_t;
 #include "node_script.h"
 #include "v8_typed_array.h"
 
+#include "node_crypto.h"
 #include "util.h"
 
 using namespace v8;
@@ -124,7 +125,6 @@ static Persistent<String> fatal_exception_symbol;
 static Persistent<String> enter_symbol;
 static Persistent<String> exit_symbol;
 static Persistent<String> disposed_symbol;
-
 
 static bool print_eval = false;
 static bool force_repl = false;
@@ -2543,6 +2543,8 @@ static void PrintHelp() {
          "  --trace-deprecation  show stack traces on deprecations\n"
          "  --v8-options         print v8 command line options\n"
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
+         "  --enable-ssl2        enable ssl2\n"
+         "  --enable-ssl3        enable ssl3\n"
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2575,6 +2577,12 @@ static void ParseArgs(int argc, char **argv) {
       const char *p = 0;
       p = 1 + strchr(arg, '=');
       max_stack_size = atoi(p);
+      argv[i] = const_cast<char*>("");
+    } else if (strcmp(arg, "--enable-ssl2") == 0) {
+      SSL2_ENABLE = true;
+      argv[i] = const_cast<char*>("");
+    } else if (strcmp(arg, "--enable-ssl3") == 0) {
+      SSL3_ENABLE = true;
       argv[i] = const_cast<char*>("");
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
@@ -3044,6 +3052,7 @@ static char **copy_argv(int argc, char **argv) {
 
   return argv_copy;
 }
+
 
 int Start(int argc, char *argv[]) {
   const char* replaceInvalid = getenv("NODE_INVALID_UTF8");

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -44,6 +44,10 @@
 #define EVP_F_EVP_DECRYPTFINAL 101
 
 namespace node {
+
+extern bool SSL2_ENABLE;
+extern bool SSL3_ENABLE;
+
 namespace crypto {
 
 static X509_STORE* root_cert_store;

--- a/test/simple/test-tls-disable-ssl2.js
+++ b/test/simple/test-tls-disable-ssl2.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var SSL_Method = 'SSLv2_method';
+var localhost = '127.0.0.1';
+
+function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
+  var soptions = {
+    secureProtocol: SSL_Method,
+    key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+    cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+    ciphers: 'AES256-SHA:RC4-SHA:DES-CBC-SHA',
+    honorCipherOrder: !!honorCipherOrder
+  };
+
+  var server;
+
+  assert.throws(function() {
+    server = tls.createServer(soptions, function(cleartextStream) {
+      nconns++;
+    });
+  }, /SSLv2 is considered unsafe/);
+}
+
+test1();
+
+function test1() {
+  // Client has the preference of cipher suites by default
+  test(false, 'DES-CBC-SHA:RC4-SHA:AES256-SHA','DES-CBC-SHA');
+}

--- a/test/simple/test-tls-disable-ssl3.js
+++ b/test/simple/test-tls-disable-ssl3.js
@@ -1,0 +1,53 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var SSL_Method = 'SSLv3_method';
+var localhost = '127.0.0.1';
+
+function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
+  var soptions = {
+    secureProtocol: SSL_Method,
+    key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+    cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+    ciphers: 'AES256-SHA:RC4-SHA:DES-CBC-SHA',
+    honorCipherOrder: !!honorCipherOrder
+  };
+
+  var server;
+
+  assert.throws(function() {
+    server = tls.createServer(soptions, function(cleartextStream) {
+      nconns++;
+    });
+  }, /SSLv3 is considered unsafe/);
+}
+
+test1();
+
+function test1() {
+  // Client has the preference of cipher suites by default
+  test(false, 'DES-CBC-SHA:RC4-SHA:AES256-SHA','DES-CBC-SHA');
+}

--- a/test/simple/test-tls-enable-ssl2.js
+++ b/test/simple/test-tls-enable-ssl2.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Flags: --enable-ssl2
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var SSL_Method = 'SSLv2_method';
+var localhost = '127.0.0.1';
+
+function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
+  var soptions = {
+    secureProtocol: SSL_Method,
+    key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+    cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+    ciphers: 'AES256-SHA:RC4-SHA:DES-CBC-SHA',
+    honorCipherOrder: !!honorCipherOrder
+  };
+
+  var server;
+
+  assert.doesNotThrow(function() {
+    server = tls.createServer(soptions, function(cleartextStream) {
+      nconns++;
+    });
+  }, /SSLv2 Disabled/);
+}
+
+test1();
+
+function test1() {
+  // Client has the preference of cipher suites by default
+  test(false, 'DES-CBC-SHA:RC4-SHA:AES256-SHA','DES-CBC-SHA');
+}

--- a/test/simple/test-tls-enable-ssl3.js
+++ b/test/simple/test-tls-enable-ssl3.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Flags: --enable-ssl3
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var SSL_Method = 'SSLv3_method';
+var localhost = '127.0.0.1';
+
+function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
+  var soptions = {
+    secureProtocol: SSL_Method,
+    key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+    cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+    ciphers: 'AES256-SHA:RC4-SHA:DES-CBC-SHA',
+    honorCipherOrder: !!honorCipherOrder
+  };
+
+  var server;
+
+  assert.doesNotThrow(function() {
+    server = tls.createServer(soptions, function(cleartextStream) {
+      nconns++;
+    });
+  }, /SSLv3 Disabled/);
+}
+
+test1();
+
+function test1() {
+  // Client has the preference of cipher suites by default
+  test(false, 'DES-CBC-SHA:RC4-SHA:AES256-SHA','DES-CBC-SHA');
+}


### PR DESCRIPTION
This change disables SSLv2/SSLv3 use by default, and introduces a command line flag to opt into using SSLv2/SSLv3.

SSLv2 and SSLv3 are considered unsafe, and should only be used in situations where compatibility with other components is required and they cannot be upgrade to support newer forms of TLS.
