### PR TITLE
crypto: extra caution in setting ssl options

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -337,15 +337,11 @@ Handle<Value> SecureContext::Init(const Arguments& args) {
 
   int options = 0;
 
-#ifndef OPENSSL_NO_SSL2
   if (!SSL2_ENABLE)
     options |= SSL_OP_NO_SSLv2;
-#endif
 
-#ifndef OPENSSL_NO_SSL3 
   if (!SSL3_ENABLE)
     options |= SSL_OP_NO_SSLv3;
-#endif
 
   SSL_CTX_set_options(sc->ctx_, options);
 


### PR DESCRIPTION
Always set ssl2/ssl3 disabled based on whether they are enabled in Node.
In some corner-case scenario, node with OPENSSL_NO_SSL3 defined could
be linked to openssl that has SSL3 enabled.
