### PR TITLE
net: Allow custom DNS resolvers

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -70,7 +70,9 @@ For TCP sockets, `options` argument should be an object which specifies:
 
   - `localPort`: Local port to bind to for network connections.
 
-  - `family` : Version of IP stack. Defaults to `4`.
+  - `family`: Version of IP stack. Defaults to `4`.
+
+  - `resolver`: Function to resolve domain names. Defaults to `dns.lookup`.
 
 For local domain sockets, `options` argument should be an object which
 specifies:

--- a/lib/net.js
+++ b/lib/net.js
@@ -887,6 +887,7 @@ Socket.prototype.connect = function(options, cb) {
   } else {
     var dns = require('dns');
     var host = options.host;
+    var resolver = options.resolver;
     var dnsopts = {
       family: options.family,
       hints: 0
@@ -898,7 +899,13 @@ Socket.prototype.connect = function(options, cb) {
     debug('connect: find host ' + host);
     debug('connect: dns options ' + dnsopts);
     self._host = host;
-    dns.lookup(host, dnsopts, function(err, ip, addressType) {
+
+    if (!util.isFunction(resolver)) {
+      debug('connect: using default resolver (dns.lookup)');
+      resolver = dns.lookup;
+    }
+
+    resolver(host, dnsopts, function(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType);
 
       // It's possible we were destroyed while looking this up.

--- a/test/simple/test-net-resolver.js
+++ b/test/simple/test-net-resolver.js
@@ -1,0 +1,48 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var resolver_called = false;
+var connection_ok = false;
+
+var server = net.createServer(function(client) {
+  client.end();
+  server.close();
+});
+
+function simple_resolver(host, options, callback) { // world's worst dns resolver
+  resolver_called = true;
+  callback(false, '127.0.0.1', 4);
+}
+
+server.listen(common.PORT, 'localhost', function() {
+  net.connect({port: common.PORT, host: 'localhost', resolver: simple_resolver}).on('connect', function() {
+  	connection_ok = true;
+  });
+});
+
+process.on('exit', function() {
+  assert(resolver_called);
+  assert(connection_ok);
+});

--- a/test/simple/test-net-resolver.js
+++ b/test/simple/test-net-resolver.js
@@ -21,28 +21,34 @@
 
 var common = require('../common');
 var assert = require('assert');
+var dns = require('dns');
 var net = require('net');
 
-var resolver_called = false;
-var connection_ok = false;
+var resolverCalled = false;
+var connectionOK = false;
 
 var server = net.createServer(function(client) {
   client.end();
   server.close();
 });
 
-function simple_resolver(host, options, callback) { // world's worst dns resolver
-  resolver_called = true;
-  callback(false, '127.0.0.1', 4);
+function simpleResolver(host, options, callback) {
+  resolverCalled = true;
+  dns.lookup(host, options, callback);
 }
 
 server.listen(common.PORT, 'localhost', function() {
-  net.connect({port: common.PORT, host: 'localhost', resolver: simple_resolver}).on('connect', function() {
-  	connection_ok = true;
+  var options = {
+    port: common.PORT,
+    host: 'localhost',
+    resolver: simpleResolver
+  };
+  net.connect(options).on('connect', function() {
+    connectionOK = true;
   });
 });
 
 process.on('exit', function() {
-  assert(resolver_called);
-  assert(connection_ok);
+  assert(resolverCalled);
+  assert(connectionOK);
 });


### PR DESCRIPTION
net.connect now checks whether the user has provided a dns
resolution function, this arguments and expected output
for which mirror the existing dns.lookup implementation.

Fixes #8475
