### PR TITLE
Ensuring private Buffer require in lib/* files

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -24,6 +24,7 @@ Readable.ReadableState = ReadableState;
 
 var EE = require('events').EventEmitter;
 var Stream = require('stream');
+var Buffer = require('buffer').Buffer;
 var util = require('util');
 var StringDecoder;
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -28,6 +28,7 @@ Writable.WritableState = WritableState;
 
 var util = require('util');
 var Stream = require('stream');
+var Buffer = require('buffer').Buffer;
 
 util.inherits(Writable, Stream);
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -24,6 +24,7 @@
 
 // UTILITY
 var util = require('util');
+var b = require('buffer');
 var pSlice = Array.prototype.slice;
 
 // 1. The assert module provides functions that throw
@@ -144,7 +145,7 @@ function _deepEqual(actual, expected) {
   if (actual === expected) {
     return true;
 
-  } else if (Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
+  } else if (b.Buffer.isBuffer(actual) && b.Buffer.isBuffer(expected)) {
     if (actual.length != expected.length) return false;
 
     for (var i = 0; i < actual.length; i++) {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -22,6 +22,7 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
+var Buffer = require('buffer').Buffer;
 
 var UDP = process.binding('udp_wrap').UDP;
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -31,6 +31,7 @@ var pathModule = require('path');
 var binding = process.binding('fs');
 var constants = process.binding('constants');
 var fs = exports;
+var Buffer = require('buffer').Buffer;
 var Stream = require('stream').Stream;
 var EventEmitter = require('events').EventEmitter;
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -24,6 +24,7 @@ var net = require('net');
 var Stream = require('stream');
 var timers = require('timers');
 var url = require('url');
+var Buffer = require('buffer').Buffer;
 var EventEmitter = require('events').EventEmitter;
 var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;

--- a/lib/net.js
+++ b/lib/net.js
@@ -25,6 +25,7 @@ var timers = require('timers');
 var util = require('util');
 var assert = require('assert');
 var cares = process.binding('cares_wrap');
+var Buffer = require('buffer').Buffer;
 var cluster;
 
 function noop() {}

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -29,6 +29,7 @@ var kHistorySize = 30;
 var kBufSize = 10 * 1024;
 
 var util = require('util');
+var Buffer = require('buffer').Buffer;
 var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -26,6 +26,7 @@ var url = require('url');
 var events = require('events');
 var stream = require('stream');
 var assert = require('assert').ok;
+var Buffer = require('buffer').Buffer;
 var constants = require('constants');
 
 var Timer = process.binding('timer_wrap').Timer;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -23,6 +23,7 @@ var Transform = require('_stream_transform');
 
 var binding = process.binding('zlib');
 var util = require('util');
+var Buffer = require('buffer').Buffer;
 var assert = require('assert').ok;
 
 // zlib doesn't provide these, so kludge them in following the same


### PR DESCRIPTION
This addresses issue #8588 in which Buffer was being used globally in lib/\* files. Any redefinition of Buffer when using a repl would crash. Credits to @indutny and @vkurchatkin for providing the remedy.
