### PR TITLE
test: more thorough tests for npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,19 @@ test-debugger: all
 	$(PYTHON) tools/test.py debugger
 
 test-npm: node
-	./node deps/npm/test/run.js
+	rm -rf npm-cache npm-tmp npm-prefix
+	mkdir npm-cache npm-tmp npm-prefix
+	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
+	     npm_config_prefix="$(shell pwd)/npm-prefix" \
+	     npm_config_tmp="$(shell pwd)/npm-tmp" \
+	     ../../node cli.js install
+	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
+	     npm_config_prefix="$(shell pwd)/npm-prefix" \
+	     npm_config_tmp="$(shell pwd)/npm-tmp" \
+	     ../../node cli.js run-script test-all && \
+	     ../../node cli.js prune --prod && \
+	     cd ../.. && \
+	     rm -rf npm-cache npm-tmp npm-prefix
 
 test-npm-publish: node
 	npm_package_config_publishtest=true ./node deps/npm/test/run.js


### PR DESCRIPTION
I'm open to cleaning this up, but the basic idea is that the deps/npm installs its own `devDependencies`, runs both the legacy and tap tests against them, and cleans up after itself. It creates temporary directories to use as the cache and tmp directories (to avoid leaving detritus behind in any system / vm-wide caches), and removes them after a successful test run.

Right now, all the tests except the tests that spin up their own CouchDB instance are passing on my own machine. On a machine without Couch installed, these tests won't even be run, which means that they might just work out of the box.

Let me know if I need to rebase this change against a different branch.
