### PR TITLE
url: Urls containing invalid hostname return blank

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -216,7 +216,6 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       var hostparts = this.hostname.split(/\./);
       for (var i = 0, l = hostparts.length; i < l; i++) {
         var part = hostparts[i];
-        if (!part) continue;
         if (!part.match(hostnamePartPattern)) {
           var newpart = '';
           for (var j = 0, k = part.length; j < k; j++) {
@@ -231,17 +230,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
           }
           // we test again with ASCII char only
           if (!newpart.match(hostnamePartPattern)) {
-            var validParts = hostparts.slice(0, i);
-            var notHost = hostparts.slice(i + 1);
-            var bit = part.match(hostnamePartStart);
-            if (bit) {
-              validParts.push(bit[1]);
-              notHost.unshift(bit[2]);
-            }
-            if (notHost.length) {
-              rest = '/' + notHost.join('.') + rest;
-            }
-            this.hostname = validParts.join('.');
+            this.hostname = '';
             break;
           }
         }

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -155,30 +155,30 @@ var parseTests = {
 
   // an unexpected invalid char in the hostname.
   'HtTp://x.y.cOm*a/b/c?d=e#f g<h>i' : {
-    'href': 'http://x.y.com/*a/b/c?d=e#f%20g%3Ch%3Ei',
+    'href': 'http:///b/c?d=e#f%20g%3Ch%3Ei',
     'protocol': 'http:',
     'slashes': true,
-    'host': 'x.y.com',
-    'hostname': 'x.y.com',
-    'pathname': '/*a/b/c',
+    'host': '',
+    'hostname': '',
+    'pathname': '/b/c',
     'search': '?d=e',
     'query': 'd=e',
     'hash': '#f%20g%3Ch%3Ei',
-    'path': '/*a/b/c?d=e'
+    'path': '/b/c?d=e'
   },
 
   // make sure that we don't accidentally lcast the path parts.
-  'HtTp://x.y.cOm*A/b/c?d=e#f g<h>i' : {
-    'href': 'http://x.y.com/*A/b/c?d=e#f%20g%3Ch%3Ei',
+  'HtTp://x.y.cOm*A/B/c?d=e#f g<h>i' : {
+    'href': 'http:///B/c?d=e#f%20g%3Ch%3Ei',
     'protocol': 'http:',
     'slashes': true,
-    'host': 'x.y.com',
-    'hostname': 'x.y.com',
-    'pathname': '/*A/b/c',
+    'host': '',
+    'hostname': '',
+    'pathname': '/B/c',
     'search': '?d=e',
     'query': 'd=e',
     'hash': '#f%20g%3Ch%3Ei',
-    'path': '/*A/b/c?d=e'
+    'path': '/B/c?d=e'
   },
 
   'http://x...y...#p': {
@@ -494,16 +494,16 @@ var parseTests = {
   },
 
   'http://www.Äffchen.cOm*A/b/c?d=e#f g<h>i' : {
-    'href': 'http://www.xn--ffchen-9ta.com/*A/b/c?d=e#f%20g%3Ch%3Ei',
+    'href': 'http:///b/c?d=e#f%20g%3Ch%3Ei',
     'protocol': 'http:',
     'slashes': true,
-    'host': 'www.xn--ffchen-9ta.com',
-    'hostname': 'www.xn--ffchen-9ta.com',
-    'pathname': '/*A/b/c',
+    'host': '',
+    'hostname': '',
+    'pathname': '/b/c',
     'search': '?d=e',
     'query': 'd=e',
     'hash': '#f%20g%3Ch%3Ei',
-    'path': '/*A/b/c?d=e'
+    'path': '/b/c?d=e'
   },
 
   'http://SÉLIER.COM/' : {


### PR DESCRIPTION
Fixes #8520 in v0.10

From the issue:

> url.parse misinterpreted `https://good.com+.evil.org/` as `https://good.com/+.evil.org/`
> If we use url.parse to check the validity of the hostname, the test passes, but in the browser the user is redirected to the evil.org website.

This pull takes the approach of returning an empty host(name) field when a hostname part is deemed to contain invalid characters, similar to the way a hostname that is too long is handled currently.
