### PR TITLE
add cache for module with same version

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -25,7 +25,7 @@ var runInThisContext = require('vm').runInThisContext;
 var runInNewContext = require('vm').runInNewContext;
 var assert = require('assert').ok;
 var fs = NativeModule.require('fs');
-var moduleVersionCache = {},
+var moduleVersionCache = {};
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.

--- a/lib/module.js
+++ b/lib/module.js
@@ -25,7 +25,7 @@ var runInThisContext = require('vm').runInThisContext;
 var runInNewContext = require('vm').runInNewContext;
 var assert = require('assert').ok;
 var fs = NativeModule.require('fs');
-
+var moduleVersionCache = {},
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -104,7 +104,7 @@ function readPackage(requestPath) {
   }
 
   try {
-    var pkg = packageMainCache[requestPath] = JSON.parse(json).main;
+    var pkg = packageMainCache[requestPath] = JSON.parse(json);
   } catch (e) {
     e.path = jsonPath;
     e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
@@ -116,9 +116,24 @@ function readPackage(requestPath) {
 function tryPackage(requestPath, exts) {
   var pkg = readPackage(requestPath);
 
-  if (!pkg) return false;
+  if (!(pkg && pkg.main)) return false;
 
-  var filename = path.resolve(requestPath, pkg);
+  var name = pkg.name,
+      version = pkg.version,
+      main = pkg.main;
+
+  var cache = moduleVersionCache[name];
+  if(!cache){
+    cache = moduleVersionCache[name] = {};
+  }
+
+  var filename =  cache[version];
+
+  if(!filename) {
+     filename = path.resolve(requestPath, main);
+     cache[version] = filename;
+  }
+
   return tryFile(filename) || tryExtensions(filename, exts) ||
          tryExtensions(path.resolve(filename, 'index'), exts);
 }


### PR DESCRIPTION
In a large project  developed with node.Js, some modules are used frequently, let's say `underscore` or `lodash`,  module A depends on it,and module B  depends on it too,  they are depended on the same version. So module `underscore` is loaded twice , right?  and that may cost more memory, so why don't we set the cache for the same module with the same version. Thanks!
