### PR TITLE
doc: document the fds behind stdin/out/err

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -116,7 +116,7 @@ emulation with `process.kill()`, and `child_process.kill()`:
 
 ## process.stdout
 
-A `Writable Stream` to `stdout`.
+A `Writable Stream` to `stdout` (uses fd `1`).
 
 Example: the definition of `console.log`
 
@@ -150,7 +150,7 @@ See [the tty docs](tty.html#tty_tty) for more information.
 
 ## process.stderr
 
-A writable stream to stderr.
+A writable stream to stderr (uses fd `2`).
 
 `process.stderr` and `process.stdout` are unlike other streams in Node in
 that writes to them are usually blocking.
@@ -164,7 +164,7 @@ that writes to them are usually blocking.
 
 ## process.stdin
 
-A `Readable Stream` for stdin. 
+A `Readable Stream` for stdin (uses fd `0`).
 
 Example of opening standard input and listening for both events:
 


### PR DESCRIPTION
Its common knowledge on unix, but node documentation depends on knowing
this, as it exposes both streams named after stdio, and the fd numbers,
so make this explicit.

Closes #8624
