### PR TITLE
Allow url.format to take the 'path' parameter

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -420,7 +420,9 @@ Url.prototype.format = function() {
   });
   search = search.replace('#', '%23');
 
-  return protocol + host + pathname + search + hash;
+  var path = this.path || pathname + search;
+
+  return protocol + host + path + hash;
 };
 
 function urlResolve(source, relative) {


### PR DESCRIPTION
I know there are already a few tickets relating to the url parse/format inconsistency (https://github.com/joyent/node/issues/3770), but I'm wondering if adding support for 'path', (pathname + search) makes sense. I don't believe this will create any stability issues, as 'path' is not a part of currently allowed url.fromat parameters. What do you think?
