### PR TITLE
smalloc: fix `copyOnto` optimization

### DIFF
--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -207,7 +207,7 @@ void CopyOnto(const FunctionCallbackInfo<Value>& args) {
   size_t dest_size = ExternalArraySize(dest_type);
 
   // optimization for Uint8 arrays (i.e. Buffers)
-  if (source_size != 1 && dest_size != 1) {
+  if (source_size != 1 || dest_size != 1) {
     if (source_size == 0)
       return env->ThrowTypeError("unknown source external array type");
     if (dest_size == 0)

--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -161,6 +161,20 @@ if (os.endianness() === 'LE') {
 copyOnto(c, 0, b, 0, 2);
 assert.equal(b[0], 0.1);
 
+var b = alloc(1, Types.Uint16);
+var c = alloc(2, Types.Uint8);
+c[0] = c[1] = 0xff;
+copyOnto(c, 0, b, 0, 2);
+assert.equal(b[0], 0xffff);
+
+var b = alloc(2, Types.Uint8);
+var c = alloc(1, Types.Uint16);
+c[0] = 0xffff;
+copyOnto(c, 0, b, 0, 1);
+assert.equal(b[0], 0xff);
+assert.equal(b[1], 0xff);
+
+
 
 // verify checking external if has external memory
 


### PR DESCRIPTION
`copyOnto` is broken when one argument has 1 byte size and the other >1 byte. Probably just a typo.

/cc @trevnorris 
