### PR TITLE
Improve URL parsing speed by 300%

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -309,11 +309,13 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // need to be.
     for (var i = 0, l = autoEscape.length; i < l; i++) {
       var ae = autoEscape[i];
-      var esc = encodeURIComponent(ae);
-      if (esc === ae) {
-        esc = escape(ae);
+      if (rest.indexOf(ae) !== -1) {
+        var esc = encodeURIComponent(ae);
+        if (esc === ae) {
+          esc = escape(ae);
+        }
+        rest = rest.split(ae).join(esc);
       }
-      rest = rest.split(ae).join(esc);
     }
   }
 


### PR DESCRIPTION
At the moment, the `url.parse()` function escapes every character in the list of escapable characters without checking whether it is necessary or not - i.e. it does a lot of work without any reason, leading to performance degradation.

The reason I started looking into this was [commit 17a379](https://github.com/joyent/node/commit/17a379ec39a34408477ac6a43751c1b9b2e952a4), which lead to a slight performance drop due to the fact that it doubled the list of escapable characters, which is actually a legitimate security fix. However, after digging into it a bit, it became clear that the could actually be improved without affecting security.

My patch simply checks whether the character that needs escaping is in the URL before encoding and replacing it with the safe option. Basically, the only change is represented by this if-statement: `if (rest.indexOf(ae) !== -1)`.

On average, this should amount to a ~3x performance increase.
## Results

```
var ITERATIONS = 100000;

var url = require('url');

var urls = [
  'http://nodejs.org/docs/latest/api/url.html#url_url_format_urlobj',
  'http://blog.nodejs.org/',
  'https://encrypted.google.com/search?q=url&q=site:npmjs.org&hl=en',
  'javascript:alert("node is awesome");',
  'some.ran/dom/url.thing?oh=yes#whoo'
];

var parsedLink;

for(var i=0; i<ITERATIONS; i++)
    for(var j=0;j<urls.length; j++)
        parsedLink = url.parse(urls[j]);
```

Running the code (inspired by the node [benchmarks](https://github.com/joyent/node/blob/master/benchmark/misc/url.js)) above on the current v0.12 HEAD (or any version since approx. v0.4.x) with and without the one-line fix:
##### Without fix

```
cristian@fatcat:~/work/node$ time ./node test.js 

real    0m10.552s
user    0m10.525s
sys 0m0.020s
```
##### With fix

```
cristian@fatcat:~/work/node$ time ./node test.js 

real    0m3.124s
user    0m3.124s
sys 0m0.008s
```
## Testing

All the unit tests that ship with Node and pass without the fix, pass with the fix as well. Also, by placing a `console.log(parsedLink);` at the end of the microbenchmark above, the output is identical for both versions.
