### PR TITLE
Don't share dgram sockets that are implicitly bound

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -101,7 +101,7 @@ SharedHandle.prototype.add = function(worker, send) {
 
 SharedHandle.prototype.remove = function(worker) {
   var index = this.workers.indexOf(worker);
-  assert(index !== -1);
+  if (index === -1) return false; // The worker wasn't sharing this handle.
   this.workers.splice(index, 1);
   if (this.workers.length !== 0) return false;
   this.handle.close();

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -407,7 +407,8 @@ function masterInit() {
     } else {
       for (var key in workers) {
         key = workers[key];
-        cluster.workers[key].disconnect();
+        if (cluster.workers[key].isConnected())
+          cluster.workers[key].disconnect();
       }
     }
     if (cb) intercom.once('disconnect', cb);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -292,7 +292,7 @@ Socket.prototype.send = function(buffer,
   self._healthCheck();
 
   if (self._bindState == BIND_STATE_UNBOUND)
-    self.bind(0, null);
+    self.bind({port: 0, exclusive: true}, null);
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.

--- a/test/simple/test-cluster-dgram-2.js
+++ b/test/simple/test-cluster-dgram-2.js
@@ -74,6 +74,11 @@ function worker() {
   var socket = dgram.createSocket('udp4');
   var buf = new Buffer('hello world');
 
+  // This test is intended to exercise the cluster binding of udp sockets, but
+  // since sockets aren't clustered when implicitly bound by at first call of
+  // send(), explicitly bind them to an ephemeral port.
+  socket.bind(0);
+
   for (var i = 0; i < PACKETS_PER_WORKER; i++)
     socket.send(buf, 0, buf.length, common.PORT, '127.0.0.1');
 

--- a/test/simple/test-cluster-disconnect-before-exit.js
+++ b/test/simple/test-cluster-disconnect-before-exit.js
@@ -1,0 +1,36 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var cluster = require('cluster');
+
+if (cluster.isMaster) {
+  var worker = cluster.fork().on('online', disconnect);
+
+  function disconnect() {
+    worker.disconnect();
+    // The worker remains in cluster.workers until both disconnect AND exit.
+    // Disconnect is supposed to disconnect all workers, but not workers that
+    // are already disconnected, since calling disconnect() on an already
+    // disconnected worker would error.
+    worker.on('disconnect', cluster.disconnect);
+  }
+} else {
+}

--- a/test/simple/test-cluster-disconnect-unshared-tcp.js
+++ b/test/simple/test-cluster-disconnect-unshared-tcp.js
@@ -1,0 +1,44 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+process.env.NODE_CLUSTER_SCHED_POLICY = 'none';
+
+var cluster = require('cluster');
+var net = require('net');
+
+if (cluster.isMaster) {
+  var unbound = cluster.fork().on('online', bind);
+
+  function bind() {
+    cluster.fork({BOUND: 'y'}).on('listening', disconnect);
+  }
+
+  function disconnect() {
+    unbound.disconnect();
+    unbound.on('disconnect', cluster.disconnect);
+  }
+} else {
+  if (process.env.BOUND === 'y') {
+    var source = net.createServer()
+
+    source.listen(0);
+  }
+}

--- a/test/simple/test-cluster-disconnect-unshared-udp.js
+++ b/test/simple/test-cluster-disconnect-unshared-udp.js
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if (process.platform === 'win32') {
+  console.log('skipping test on windows, where clustered dgram is ENOTSUP');
+  process.exit(0);
+}
+
+var cluster = require('cluster');
+var dgram = require('dgram');
+
+if (cluster.isMaster) {
+  var unbound = cluster.fork().on('online', bind);
+
+  function bind() {
+    cluster.fork({BOUND: 'y'}).on('listening', disconnect);
+  }
+
+  function disconnect() {
+    unbound.disconnect();
+    unbound.on('disconnect', cluster.disconnect);
+  }
+} else {
+  if (process.env.BOUND === 'y') {
+    var source = dgram.createSocket('udp4');
+
+    source.bind(0);
+  }
+}

--- a/test/simple/test-dgram-exclusive-implicit-bind.js
+++ b/test/simple/test-dgram-exclusive-implicit-bind.js
@@ -1,0 +1,100 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cluster = require('cluster');
+var dgram = require('dgram');
+
+// Without an explicit bind, send() causes an implicit bind, which always
+// generate a unique per-socket ephemeral port. An explicit bind to a port
+// number causes all sockets bound to that number to share a port.
+//
+// The 2 workers that call bind() will share a port, the two workers that do
+// not will not share a port, so master will see 3 unique source ports.
+
+// Note that on Windows, clustered dgram is not supported. Since explicit
+// binding causes the dgram to be clustered, don't fork the workers that bind.
+// This is a useful test, still, because it demonstrates that by avoiding
+// clustering, client (ephemeral, implicitly bound) dgram sockets become
+// supported while using cluster, though servers still cause the master to error
+// with ENOTSUP.
+
+var windows = process.platform === 'win32';
+
+if (cluster.isMaster) {
+  var pass;
+  var messages = 0;
+  var ports = {};
+
+  process.on('exit', function() {
+    assert.equal(pass, true);
+  });
+
+  var target = dgram.createSocket('udp4');
+
+  target.on('message', function(buf, rinfo) {
+    messages++;
+    ports[rinfo.port] = true;
+
+    if (windows && messages === 2) {
+      assert.equal(Object.keys(ports).length, 2);
+      done();
+    }
+
+    if (!windows && messages === 4) {
+      assert.equal(Object.keys(ports).length, 3);
+      done();
+    }
+
+    function done() {
+      pass = true;
+      cluster.disconnect();
+      target.close();
+    }
+  });
+
+  target.on('listening', function() {
+    cluster.fork();
+    cluster.fork();
+    if (!windows) {
+      cluster.fork({BOUND: 'y'});
+      cluster.fork({BOUND: 'y'});
+    }
+  });
+
+  target.bind({port: common.PORT, exclusive: true});
+
+  return;
+}
+
+var source = dgram.createSocket('udp4');
+
+if (process.env.BOUND === 'y') {
+  source.bind(0);
+} else {
+  // cluster doesn't know about exclusive sockets, so it won't close them. This
+  // is expected, its the same situation for timers, outgoing tcp connections,
+  // etc, which also keep workers alive after disconnect was requested.
+  source.unref();
+}
+
+source.send(Buffer('abc'), 0, 3, common.PORT, '127.0.0.1');


### PR DESCRIPTION
Server sockets should be shared by default, and client sockets should be
exclusive by default. For net/TCP, this is how it is, for dgram/UDP, its
a little less clear what a client socket is, but a socket that is
auto-bound during a dgram.send() is not usefully shared among cluster
workers, any more than an outgoing TCP connection would be usefully
shared.

See https://github.com/joyent/node/pull/8027#issuecomment-60817257

/to @asilvas @bnoordhuis  @rmg

Test triggers a pre-existing bug, so is based on https://github.com/joyent/node/pull/8642.
