### PR TITLE
domains: fix issues with abort on uncaught

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2846,6 +2846,17 @@ class V8EXPORT Isolate {
   static Isolate* GetCurrent();
 
   /**
+   * Custom callback used by embedders to help V8 determine if it should abort
+   * when it throws and no internal handler can catch the exception.
+   * If FLAG_abort_on_uncaught_exception is true, then V8 will abort if either:
+   * - no custom callback is set.
+   * - the custom callback set returns true.
+   * Otherwise it won't abort.
+   */
+  typedef bool (*abort_on_uncaught_exception_t)();
+  void SetAbortOnUncaughtException(abort_on_uncaught_exception_t callback);
+
+  /**
    * Methods below this point require holding a lock (using Locker) in
    * a multi-threaded environment.
    */

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -5565,6 +5565,11 @@ void Isolate::Enter() {
   isolate->Enter();
 }
 
+void Isolate::SetAbortOnUncaughtException(
+      abort_on_uncaught_exception_t callback) {
+  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);
+  isolate->SetAbortOnUncaughtException(callback);
+}
 
 void Isolate::Exit() {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);

--- a/deps/v8/src/isolate.cc
+++ b/deps/v8/src/isolate.cc
@@ -1152,18 +1152,26 @@ void Isolate::DoThrow(Object* exception, MessageLocation* location) {
         thread_local_top()->pending_message_end_pos_ = location->end_pos();
       }
 
-      // If the abort-on-uncaught-exception flag is specified, abort on any
-      // exception not caught by JavaScript, even when an external handler is
-      // present.  This flag is intended for use by JavaScript developers, so
-      // print a user-friendly stack trace (not an internal one).
+      // If the abort-on-uncaught-exception flag is specified, and if the
+      // exception is not caught by JavaScript (even when an external handler is
+      // present).
       if (fatal_exception_depth == 0 &&
           FLAG_abort_on_uncaught_exception &&
           (report_exception || can_be_caught_externally)) {
-        fatal_exception_depth++;
-        fprintf(stderr, "%s\n\nFROM\n",
-          *MessageHandler::GetLocalizedMessage(message_obj));
-        PrintCurrentStackTrace(stderr);
-        OS::Abort();
+        // If the embedder didn't specify a custom uncaught exception callback,
+        // or if the custom callback determined that V8 should abort, then
+        // abort
+        bool should_abort = !abort_on_uncaught_exception_callback_ ||
+                             abort_on_uncaught_exception_callback_();
+        if (should_abort) {
+          fatal_exception_depth++;
+          // This flag is intended for use by JavaScript developers, so
+          // print a user-friendly stack trace (not an internal one).
+          fprintf(stderr, "%s\n\nFROM\n",
+            *MessageHandler::GetLocalizedMessage(message_obj));
+          PrintCurrentStackTrace(stderr);
+          OS::Abort();
+        }
       }
     } else if (location != NULL && !location->script().is_null()) {
       // We are bootstrapping and caught an error where the location is set
@@ -1339,6 +1347,10 @@ void Isolate::SetCaptureStackTraceForUncaughtExceptions(
   stack_trace_for_uncaught_exceptions_options_ = options;
 }
 
+void Isolate::SetAbortOnUncaughtException(
+      v8::Isolate::abort_on_uncaught_exception_t callback) {
+  abort_on_uncaught_exception_callback_ = callback;
+}
 
 bool Isolate::is_out_of_memory() {
   if (has_pending_exception()) {
@@ -1534,7 +1546,8 @@ Isolate::Isolate()
       date_cache_(NULL),
       context_exit_happened_(false),
       deferred_handles_head_(NULL),
-      optimizing_compiler_thread_(this) {
+      optimizing_compiler_thread_(this),
+      abort_on_uncaught_exception_callback_(NULL) {
   TRACE_ISOLATE(constructor);
 
   memset(isolate_addresses_, 0,

--- a/deps/v8/src/isolate.h
+++ b/deps/v8/src/isolate.h
@@ -692,6 +692,9 @@ class Isolate {
       int frame_limit,
       StackTrace::StackTraceOptions options);
 
+  typedef bool (*abort_on_uncaught_exception_t)();
+  void SetAbortOnUncaughtException(abort_on_uncaught_exception_t callback);
+
   // Tells whether the current context has experienced an out of memory
   // exception.
   bool is_out_of_memory();
@@ -1291,6 +1294,8 @@ class Isolate {
 
   DeferredHandles* deferred_handles_head_;
   OptimizingCompilerThread optimizing_compiler_thread_;
+
+  abort_on_uncaught_exception_t abort_on_uncaught_exception_callback_;
 
   friend class ExecutionAccess;
   friend class HandleScopeImplementer;

--- a/src/node.js
+++ b/src/node.js
@@ -236,37 +236,60 @@
 
         er.domain = domain;
         er.domainThrown = true;
-        // wrap this in a try/catch so we don't get infinite throwing
-        try {
-          // One of three things will happen here.
-          //
-          // 1. There is a handler, caught = true
-          // 2. There is no handler, caught = false
-          // 3. It throws, caught = false
-          //
-          // If caught is false after this, then there's no need to exit()
-          // the domain, because we're going to crash the process anyway.
-          caught = domain.emit('error', er);
 
-          // Exit all domains on the stack.  Uncaught exceptions end the
-          // current tick and no domains should be left on the stack
-          // between ticks.
-          var domainModule = NativeModule.require('domain');
-          domainStack.length = 0;
-          domainModule.active = process.domain = null;
-        } catch (er2) {
-          // The domain error handler threw!  oh no!
-          // See if another domain can catch THIS error,
-          // or else crash on the original one.
-          // If the user already exited it, then don't double-exit.
-          if (domain === domainModule.active)
-            domainStack.pop();
-          if (domainStack.length) {
-            var parentDomain = domainStack[domainStack.length - 1];
-            process.domain = domainModule.active = parentDomain;
-            caught = process._fatalException(er2);
-          } else
-            caught = false;
+        // The top-level domain-handler is handled separately.
+        //
+        // The reason is that if V8 was passed a command line option
+        // asking it to abort on an uncaught exception (currently
+        // "--abort-on-uncaught-exception"), we want an uncaught exception
+        // in the top-level domain error handler to make the
+        // process abort. Using try/catch here would always make V8 think
+        // that these exceptions are caught, and thus would prevent it from
+        // aborting in these cases.
+        if (domainStack.length === 1) {
+          try {
+            // Set the _emittingTopLevelDomainError so that we know that, even
+            // if technically the top-level domain is still active, it would
+            // be ok to abort on an uncaught exception at this point
+            process._emittingTopLevelDomainError = true;
+            caught = domain.emit('error', er);
+          } finally {
+            process._emittingTopLevelDomainError = false;
+          }
+        } else {
+          // wrap this in a try/catch so we don't get infinite throwing
+          try {
+            // One of three things will happen here.
+            //
+            // 1. There is a handler, caught = true
+            // 2. There is no handler, caught = false
+            // 3. It throws, caught = false
+            //
+            // If caught is false after this, then there's no need to exit()
+            // the domain, because we're going to crash the process anyway.
+            caught = domain.emit('error', er);
+
+            // Exit all domains on the stack.  Uncaught exceptions end the
+            // current tick and no domains should be left on the stack
+            // between ticks.
+            var domainModule = NativeModule.require('domain');
+            domainStack.length = 0;
+            domainModule.active = process.domain = null;
+          } catch (er2) {
+            // The domain error handler threw!  oh no!
+            // See if another domain can catch THIS error,
+            // or else crash on the original one.
+            // If the user already exited it, then don't double-exit.
+            if (domain === domainModule.active)
+              domainStack.pop();
+            if (domainStack.length) {
+              var parentDomain = domainStack[domainStack.length - 1];
+              process.domain = domainModule.active = parentDomain;
+              caught = process._fatalException(er2);
+            } else {
+              caught = false;
+            }
+          }
         }
       } else {
         caught = process.emit('uncaughtException', er);

--- a/test/simple/test-domain-top-level-error-handler-throw.js
+++ b/test/simple/test-domain-top-level-error-handler-throw.js
@@ -1,0 +1,74 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * The goal of this test is to make sure that when a top-level error
+ * handler throws an error following the handling of a previous error,
+ * the process reports the error message from the error thrown in the
+ * top-level error handler, not the one from the previous error.
+ */
+
+var domainErrHandlerExMessage = 'exception from domain error handler';
+var internalExMessage = 'You should NOT see me';
+
+if (process.argv[2] === 'child') {
+  var domain = require('domain');
+  var d = domain.create();
+
+  d.on('error', function() {
+    throw new Error(domainErrHandlerExMessage);
+  });
+
+  d.run(function doStuff() {
+    process.nextTick(function () {
+      throw new Error(internalExMessage);
+    });
+  });
+} else {
+  var fork = require('child_process').fork;
+  var assert = require('assert');
+
+  function test() {
+    var child = fork(process.argv[1], ['child'], {silent:true});
+    var gotDataFromStderr = false;
+    var stderrOutput = '';
+    if (child) {
+      child.stderr.on('data', function onStderrData(data) {
+        gotDataFromStderr = true;
+        stderrOutput += data.toString();
+      })
+
+      child.on('exit', function onChildExited(exitCode, signal) {
+        assert(gotDataFromStderr);
+        assert(stderrOutput.indexOf(domainErrHandlerExMessage) !== -1);
+        assert(stderrOutput.indexOf(internalExMessage) === -1);
+
+        var expectedExitCode = 7;
+        var expectedSignal = null;
+
+        assert.equal(exitCode, expectedExitCode);
+        assert.equal(signal, expectedSignal);
+      });
+    }
+  }
+
+  test();
+}

--- a/test/simple/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/simple/test-domain-with-abort-on-uncaught-exception.js
@@ -1,0 +1,188 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+
+/*
+ * The goal of this test is to make sure that:
+ *
+ * - Even if --abort-on-uncaught-exception is passed on the command line,
+ * setting up a top-level domain error handler and throwing an error
+ * within this domain does *not* make the process abort. The process exits
+ * gracefully.
+ *
+ * - When passing --abort-on-uncaught-exception on the command line and
+ * setting up a top-level domain error handler, an error thrown
+ * within this domain's error handler *does* make the process abort.
+ *
+ * - When *not* passing --abort-on-uncaught-exception on the command line and
+ * setting up a top-level domain error handler, an error thrown within this
+ * domain's error handler does *not* make the process abort, but makes it exit
+ * with the proper failure exit code.
+ *
+ * - When throwing an error within the top-level domain's error handler
+ * within a try/catch block, the process should exit gracefully, whether or
+ * not --abort-on-uncaught-exception is passed on the command line.
+ */
+
+var domainErrHandlerExMessage = 'exception from domain error handler';
+
+if (process.argv[2] === 'child') {
+  var domain = require('domain');
+  var d = domain.create();
+  var triggeredProcessUncaughtException = false;
+
+  process.on('uncaughtException', function onUncaughtException() {
+    process.send('triggeredProcessUncaughtEx');
+  });
+
+  d.on('error', function() {
+    // Swallowing the error on purpose if 'throwInDomainErrHandler' is not
+    // set
+    if (process.argv.indexOf('throwInDomainErrHandler') !== -1) {
+      if (process.argv.indexOf('useTryCatch') !== -1) {
+        try {
+          throw new Error(domainErrHandlerExMessage);
+        } catch (e) {
+        }
+      } else {
+        throw new Error(domainErrHandlerExMessage);
+      }
+    }
+  });
+
+  d.run(function doStuff() {
+    process.nextTick(function () {
+      throw new Error("You should NOT see me");
+    });
+  });
+} else {
+  var fork = require('child_process').fork;
+
+  function testDomainExceptionHandling(cmdLineOption, options) {
+    if (typeof cmdLineOption === 'object') {
+      options = cmdLineOption;
+      cmdLineOption = undefined;
+    }
+
+    var forkOptions;
+    if (cmdLineOption) {
+      forkOptions = { execArgv: [cmdLineOption] };
+    }
+
+    var throwInDomainErrHandlerOpt;
+    if (options.throwInDomainErrHandler)
+     throwInDomainErrHandlerOpt = 'throwInDomainErrHandler';
+
+    var useTryCatchOpt;
+    if (options.useTryCatch)
+      useTryCatchOpt = 'useTryCatch';
+
+    var child = fork(process.argv[1], [
+                       'child',
+                       throwInDomainErrHandlerOpt,
+                       useTryCatchOpt
+                     ],
+                     forkOptions);
+
+    if (child) {
+      var childTriggeredOnUncaughtExceptionHandler = false;
+      child.on('message', function onChildMsg(msg) {
+        if (msg === 'triggeredProcessUncaughtEx') {
+          childTriggeredOnUncaughtExceptionHandler = true;
+        }
+      });
+
+      child.on('exit', function onChildExited(exitCode, signal) {
+        // The process' uncaughtException event must not be emitted when
+        // an error handler is setup on the top-level domain.
+        assert(childTriggeredOnUncaughtExceptionHandler === false,
+               "Process' uncaughtException should not be emitted when " +
+               "an error handler is set on the top-level domain");
+
+        // If the top-level domain's error handler does not throw,
+        // the process must exit gracefully, whether or not
+        // --abort-on-uncaught-exception was passed on the command line
+        var expectedExitCode = 0;
+        var expectedSignal = null;
+
+        // When not throwing errors from the top-level domain error handler
+        // or if throwing them within a try/catch block, the process
+        // should exit gracefully
+        if (!options.useTryCatch && options.throwInDomainErrHandler) {
+          expectedExitCode = 7;
+          if (cmdLineOption === '--abort-on-uncaught-exception') {
+            // If the top-level domain's error handler throws, and only if
+            // --abort-on-uncaught-exception is passed on the command line,
+            // the process must abort.
+            expectedExitCode = null;
+            expectedSignal = 'SIGABRT';
+
+            // On linux, v8 raises SIGTRAP when aborting because
+            // the "debug break" flag is on by default
+            if (process.platform === 'linux')
+              expectedSignal = 'SIGTRAP';
+
+            // On Windows, v8's OS::Abort also triggers a debug breakpoint
+            // which makes the process exit with code -2147483645
+            if (process.platform === 'win32') {
+              expectedExitCode = -2147483645;
+              expectedSignal = null;
+            }
+          }
+        }
+
+        assert.equal(exitCode, expectedExitCode);
+        assert.equal(signal, expectedSignal);
+      });
+    }
+  }
+
+  testDomainExceptionHandling('--abort-on-uncaught-exception', {
+                              throwInDomainErrHandler: false,
+                              useTryCatch: false
+                            });
+  testDomainExceptionHandling('--abort-on-uncaught-exception', {
+                              throwInDomainErrHandler: false,
+                              useTryCatch: true
+                            });
+
+  testDomainExceptionHandling('--abort-on-uncaught-exception', {
+                              throwInDomainErrHandler: true,
+                              useTryCatch: false
+                            });
+  testDomainExceptionHandling('--abort-on-uncaught-exception', {
+                              throwInDomainErrHandler: true,
+                              useTryCatch: true
+                            });
+
+  testDomainExceptionHandling({
+    throwInDomainErrHandler: false
+  });
+  testDomainExceptionHandling({
+    throwInDomainErrHandler: false,
+    useTryCatch: false
+  });
+  testDomainExceptionHandling({
+    throwInDomainErrHandler: true,
+    useTryCatch: true
+  });
+}


### PR DESCRIPTION
Do not abort the process if an error is thrown from within a domain, an
error handler is setup for the domain and --abort-on-uncaught-exception
was passed on the command line.

However, if an error is thrown from within the top-level domain's error
handler and --abort-on-uncaught-exception was passed on the command
line, make the process abort.

Fixes #8631. Also fixes #8630.
