### PR TITLE
build: i18n: fix issue with icu toolset dependencies

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -90,7 +90,7 @@
     {
       'target_name': 'icui18n',
       'type': '<(library)',
-      'toolsets': [ 'host', 'target' ],
+      'toolsets': [ 'target' ],
       'sources': [
         '<@(icu_src_i18n)'
       ],
@@ -107,28 +107,6 @@
         ],
       },
       'export_dependent_settings': [ 'icuucx' ],
-    },
-    # this library is only built for derb..
-    {
-      'target_name': 'icuio',
-      'type': '<(library)',
-      'toolsets': [ 'host' ],
-      'sources': [
-        '<@(icu_src_io)'
-      ],
-      'include_dirs': [
-        '../../deps/icu/source/io',
-      ],
-      'defines': [
-        'U_IO_IMPLEMENTATION=1',
-      ],
-      'dependencies': [ 'icuucx', 'icui18n', 'icu_implementation', 'icu_uconfig' ],
-      'direct_dependent_settings': {
-        'include_dirs': [
-          '../../deps/icu/source/io',
-        ],
-      },
-      'export_dependent_settings': [ 'icuucx', 'icui18n' ],
     },
     # This exports actual ICU data
     {
@@ -288,7 +266,7 @@
     {
       'target_name': 'icustubdata',
       'type': '<(library)',
-      'toolsets': [ 'host', 'target' ],
+      'toolsets': [ 'target' ],
       'dependencies': [ 'icu_implementation' ],
       'sources': [
         '<@(icu_src_stubdata)'
@@ -313,7 +291,7 @@
       'target_name': 'icuucx',
       'type': '<(library)',
       'dependencies': [ 'icu_implementation', 'icu_uconfig' ],
-      'toolsets': [ 'host', 'target' ],
+      'toolsets': [ 'target' ],
       'sources': [
         '<@(icu_src_common)'
       ],
@@ -342,23 +320,43 @@
       'target_name': 'icutools',
       'type': '<(library)',
       'toolsets': [ 'host' ],
-      'dependencies': [ 'icuucx', 'icui18n', 'icustubdata' ],
+      'dependencies': [ 'icu_implementation', 'icu_uconfig' ],
       'sources': [
-        '<@(icu_src_tools)'
+        '<@(icu_src_tools)',
+        '<@(icu_src_common)',
+        '<@(icu_src_i18n)',
+        '<@(icu_src_io)',
+        '<@(icu_src_stubdata)',
       ],
       'include_dirs': [
+        '../../deps/icu/source/common',
+        '../../deps/icu/source/i18n',
+        '../../deps/icu/source/io',
         '../../deps/icu/source/tools/toolutil',
       ],
       'defines': [
+        'U_COMMON_IMPLEMENTATION=1',
+        'U_I18N_IMPLEMENTATION=1',
+        'U_IO_IMPLEMENTATION=1',
         'U_TOOLUTIL_IMPLEMENTATION=1',
         #'DEBUG=0', # http://bugs.icu-project.org/trac/ticket/10977
       ],
       'direct_dependent_settings': {
         'include_dirs': [
+          '../../deps/icu/source/common',
+          '../../deps/icu/source/i18n',
+          '../../deps/icu/source/io',
           '../../deps/icu/source/tools/toolutil',
         ],
+        'conditions': [
+          [ 'OS=="win"', {
+            'link_settings': {
+              'libraries': [ '-lAdvAPI32.Lib', '-lUser32.lib' ],
+            },
+          }],
+        ],
       },
-      'export_dependent_settings': [ 'icuucx', 'icui18n', 'icustubdata' ],
+      'export_dependent_settings': [ 'icu_implementation', 'icu_uconfig' ],
     },
     # This tool is needed to rebuild .res files from .txt,
     # or to build index (res_index.txt) files for small-icu
@@ -366,7 +364,7 @@
       'target_name': 'genrb',
       'type': 'executable',
       'toolsets': [ 'host' ],
-      'dependencies': [ 'icutools', 'icuucx', 'icui18n' ],
+      'dependencies': [ 'icutools' ],
       'sources': [
         '<@(icu_src_genrb)'
       ],
@@ -382,7 +380,7 @@
       'target_name': 'iculslocs',
       'toolsets': [ 'host' ],
       'type': 'executable',
-      'dependencies': [ 'icutools', 'icuucx', 'icui18n', 'icuio' ],
+      'dependencies': [ 'icutools' ],
       'sources': [
         'iculslocs.cc',
         'no-op.cc',
@@ -394,7 +392,7 @@
       'target_name': 'icupkg',
       'toolsets': [ 'host' ],
       'type': 'executable',
-      'dependencies': [ 'icutools', 'icuucx', 'icui18n' ],
+      'dependencies': [ 'icutools' ],
       'sources': [
         '<@(icu_src_icupkg)',
         'no-op.cc',
@@ -405,7 +403,7 @@
       'target_name': 'genccode',
       'toolsets': [ 'host' ],
       'type': 'executable',
-      'dependencies': [ 'icutools', 'icuucx', 'icui18n' ],
+      'dependencies': [ 'icutools' ],
       'sources': [
         '<@(icu_src_genccode)',
         'no-op.cc',


### PR DESCRIPTION
So what I did here is to make the `icutools` library
actually contain the entire ICU dependencies needed
for host-side tools. Sadly, this will build ICU twice,
but avoids conflicts between host and target side.
This all seems like a gyp bug of some sort, but without
docs for `toolsets`, who’s to say?

I removed the `icuio` library, because it was only
used by the host-side tools.

ref: https://github.com/joyent/node/issues/7676
