### PR TITLE
src: don't handle UTF16 external string

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -277,13 +277,6 @@ bool StringBytes::GetExternalParts(Isolate* isolate,
     *data = ext->data();
     *len = ext->length();
     return true;
-
-  } else if (str->IsExternal()) {
-    const String::ExternalStringResource* ext;
-    ext = str->GetExternalStringResource();
-    *data = reinterpret_cast<const char*>(ext->data());
-    *len = ext->length();
-    return true;
   }
 
   return false;


### PR DESCRIPTION
The external string of V8 is in UTF16 encoding, force converting it to `char*` would always get wrong results.
