### PR TITLE
src: cast uv_thread_self() to unsigned long

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -151,7 +151,7 @@ template int SSLWrap<TLSCallbacks>::TLSExtStatusCallback(SSL* s, void* arg);
 
 
 static void crypto_threadid_cb(CRYPTO_THREADID* tid) {
-  CRYPTO_THREADID_set_numeric(tid, uv_thread_self());
+  CRYPTO_THREADID_set_numeric(tid, (unsigned long) uv_thread_self());
 }
 
 


### PR DESCRIPTION
The update to libuv 1.0.0rc-2 in #8566 introduced a compiler error, as the return type of `uv_thread_self()` changed in https://github.com/joyent/libuv/pull/1516. This commit restores the old behavior by casting the return type.
