### PR TITLE
zlib: do not Unref() if wasn't Ref()ed

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -307,8 +307,9 @@ class ZCtx : public ObjectWrap {
     MakeCallback(ctx->handle_, onerror_sym, ARRAY_SIZE(args), args);
 
     // no hope of rescue.
+    if (ctx->write_in_progress_)
+      ctx->Unref();
     ctx->write_in_progress_ = false;
-    ctx->Unref();
     if (ctx->pending_close_)
       ctx->Close();
   }


### PR DESCRIPTION
In very unlikely case, where `deflateInit2()` may return error (right
now happening only on exhausting all memory), the `ZCtx::Error()` will
be called and will try to `Unref()` the handle. But the problem is that
this handle was never `Ref()`ed, so it will trigger an assertion error
and crash the program.

(Discovered at Voxer).

cc @tjfontaine @bnoordhuis 
