### PR TITLE
Update OpenSSL commands on TLS API docs to use best practices

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -10,14 +10,14 @@ Secure Socket Layer: encrypted stream communication.
 TLS/SSL is a public/private key infrastructure. Each client and each
 server must have a private key. A private key is created like this:
 
-    openssl genrsa -out ryans-key.pem 1024
+    openssl genrsa -out ryans-key.pem 2048
 
 All servers and some clients need to have a certificate. Certificates are public
 keys signed by a Certificate Authority or self-signed. The first step to
 getting a certificate is to create a "Certificate Signing Request" (CSR)
 file. This is done with:
 
-    openssl req -new -key ryans-key.pem -out ryans-csr.pem
+    openssl req -new -sha256 -key ryans-key.pem -out ryans-csr.pem
 
 To create a self-signed certificate with the CSR, do this:
 


### PR DESCRIPTION
This updates the suggested keysize to provide `openssl` from 1024 to 2048, the current minimum acceptable keysize.

It also adds the `-sha256` flag to the CSR creation command, which will sign the CSR itself with SHA-256 instead of SHA-1. For at least a couple of CAs, this sends a signal to sign the resulting certificate with SHA-256 instead of SHA-1 ([which is now heavily deprecated](https://shaaaaaaaaaaaaa.com)).
