### PR TITLE
doc: remove tls.createSecurePair deprecation

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -455,8 +455,6 @@ publicly trusted list of CAs as given in
 
 ## tls.createSecurePair([context][, isServer][, requestCert][, rejectUnauthorized])
 
-    Stability: 0 - Deprecated. Use tls.TLSSocket instead.
-
 Creates a new secure pair object with two streams, one of which reads/writes
 encrypted data, and one reads/writes cleartext data.
 Generally the encrypted one is piped to/from an incoming encrypted data stream,


### PR DESCRIPTION
Pending `tls.TLSSocket` growing the ability to work with non-`net.Socket` streams, createSecurePair will remain in.
