### PR TITLE
tls: remove the deprecation for tls.createSecurePair

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -246,8 +246,4 @@ exports.TLSSocket = require('_tls_wrap').TLSSocket;
 exports.Server = require('_tls_wrap').Server;
 exports.createServer = require('_tls_wrap').createServer;
 exports.connect = require('_tls_wrap').connect;
-
-// Legacy API
-exports.__defineGetter__('createSecurePair', util.deprecate(function() {
-  return require('_tls_legacy').createSecurePair;
-}, 'createSecurePair() is deprecated, use TLSSocket instead'));
+exports.createSecurePair = require('_tls_legacy').createSecurePair;


### PR DESCRIPTION
In #8695, the deprecation was removed from doc.
Remove the deprecation from code now.
