### PR TITLE
Gaurd against infinite memory leak in dgram

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -311,7 +311,9 @@ Socket.prototype.send = function(buffer,
     return;
   }
 
-  self._handle.lookup(address, function(ex, ip) {
+  self._handle.lookup(address, dgramSocketSendLookupCallback);
+
+  function dgramSocketSendLookupCallback(ex, ip) {
     if (ex) {
       if (callback) callback(ex);
       self.emit('error', ex);
@@ -336,7 +338,7 @@ Socket.prototype.send = function(buffer,
         });
       }
     }
-  });
+  }
 };
 
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -110,6 +110,7 @@ function Socket(type, listener) {
   this._bindState = BIND_STATE_UNBOUND;
   this.type = type;
   this.fd = null; // compatibility hack
+  this.highWaterMark = 100;
 
   // If true - UV_UDP_REUSEADDR flag will be set
   this._reuseAddr = options && options.reuseAddr;
@@ -330,8 +331,11 @@ Socket.prototype.send = function(buffer,
       self.on('listening', onListening);
       self.on('error', onError);
     }
-    self._sendQueue.push(new SocketSendQueueItem(
+
+    if (self._sendQueue.length <= self.highWaterMark) {
+      self._sendQueue.push(new SocketSendQueueItem(
         buffer, offset, length, port, address, callback));
+    }
     return;
   }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -151,6 +151,11 @@ function replaceHandle(self, newHandle) {
   self._handle = newHandle;
 }
 
+function cleanupAndError(self, err) {
+  self._sendQueue = undefined;
+  self.emit('error', err);
+}
+
 Socket.prototype.bind = function(port /*, address, callback*/) {
   var self = this;
 
@@ -187,7 +192,7 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
   self._handle.lookup(address, function(err, ip) {
     if (err) {
       self._bindState = BIND_STATE_UNBOUND;
-      self.emit('error', err);
+      cleanupAndError(self, err);
       return;
     }
 
@@ -197,7 +202,7 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
     if (cluster.isWorker && !exclusive) {
       cluster._getServer(self, ip, port, self.type, -1, function(err, handle) {
         if (err) {
-          self.emit('error', errnoException(err, 'bind'));
+          cleanupAndError(self, errnoException(err, 'bind'));
           self._bindState = BIND_STATE_UNBOUND;
           return;
         }
@@ -220,7 +225,7 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
 
       var err = self._handle.bind(ip, port || 0, flags);
       if (err) {
-        self.emit('error', errnoException(err, 'bind'));
+        cleanupAndError(self, errnoException(err, 'bind'));
         self._bindState = BIND_STATE_UNBOUND;
         // Todo: close?
         return;
@@ -311,14 +316,6 @@ Socket.prototype.send = function(buffer,
           item.port, item.address, item.callback);
     }
     self._sendQueue = undefined;
-    self.removeListener('listening', onListening);
-    self.removeListener('error', onError);
-  }
-
-  function onError() {
-    self._sendQueue = undefined;
-    self.removeListener('listening', onListening);
-    self.removeListener('error', onError);
   }
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
@@ -328,8 +325,7 @@ Socket.prototype.send = function(buffer,
     // event handler that flushes the send queue after binding is done.
     if (!self._sendQueue) {
       self._sendQueue = [];
-      self.on('listening', onListening);
-      self.on('error', onError);
+      self.once('listening', onListening);
     }
 
     if (self._sendQueue.length <= self.highWaterMark) {
@@ -344,7 +340,7 @@ Socket.prototype.send = function(buffer,
   function dgramSocketSendLookupCallback(ex, ip) {
     if (ex) {
       if (callback) callback(ex);
-      self.emit('error', ex);
+      cleanupAndError(self, ex);
     }
     else if (self._handle) {
       var req = { buffer: buffer, length: length };  // Keep reference alive.
@@ -492,7 +488,7 @@ Socket.prototype._stopReceiving = function() {
 function onMessage(nread, handle, buf, rinfo) {
   var self = handle.owner;
   if (nread < 0) {
-    return self.emit('error', errnoException(nread, 'recvmsg'));
+    return cleanupAndError(self, errnoException(nread, 'recvmsg'));
   }
   rinfo.size = buf.length; // compatibility
   self.emit('message', buf, rinfo);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -306,13 +306,8 @@ Socket.prototype.send = function(buffer,
     // Flush the send queue.
     for (var i = 0; i < self._sendQueue.length; i++) {
       var item = self._sendQueue[i];
-      self.send.call(self,
-        item.buffer,
-        item.offset,
-        item.length,
-        item.port,
-        item.address,
-        item.callback);
+      self.send.call(self, item.buffer, item.offset, item.length,
+          item.port, item.address, item.callback);
     }
     self._sendQueue = undefined;
     self.removeListener('listening', onListening);
@@ -336,7 +331,7 @@ Socket.prototype.send = function(buffer,
       self.on('error', onError);
     }
     self._sendQueue.push(new SocketSendQueueItem(
-      buffer, offset, length, port, address, callback));
+        buffer, offset, length, port, address, callback));
     return;
   }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -247,6 +247,15 @@ Socket.prototype.sendto = function(buffer,
   this.send(buffer, offset, length, port, address, callback);
 };
 
+function SocketSendQueueItem(buffer, offset, length, port, address, callback) {
+  this.buffer = buffer;
+  this.offset = offset;
+  this.length = length;
+  this.port = port;
+  this.address = address;
+  this.callback = callback;
+}
+
 
 Socket.prototype.send = function(buffer,
                                  offset,
@@ -295,8 +304,16 @@ Socket.prototype.send = function(buffer,
 
   function onListening() {
     // Flush the send queue.
-    for (var i = 0; i < self._sendQueue.length; i++)
-      self.send.apply(self, self._sendQueue[i]);
+    for (var i = 0; i < self._sendQueue.length; i++) {
+      var item = self._sendQueue[i];
+      self.send.call(self,
+        item.buffer,
+        item.offset,
+        item.length,
+        item.port,
+        item.address,
+        item.callback);
+    }
     self._sendQueue = undefined;
     self.removeListener('listening', onListening);
     self.removeListener('error', onError);
@@ -318,7 +335,8 @@ Socket.prototype.send = function(buffer,
       self.on('listening', onListening);
       self.on('error', onError);
     }
-    self._sendQueue.push([buffer, offset, length, port, address, callback]);
+    self._sendQueue.push(new SocketSendQueueItem(
+      buffer, offset, length, port, address, callback));
     return;
   }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -293,6 +293,21 @@ Socket.prototype.send = function(buffer,
   if (self._bindState == BIND_STATE_UNBOUND)
     self.bind(0, null);
 
+  function onListening() {
+    // Flush the send queue.
+    for (var i = 0; i < self._sendQueue.length; i++)
+      self.send.apply(self, self._sendQueue[i]);
+    self._sendQueue = undefined;
+    self.removeListener('listening', onListening);
+    self.removeListener('error', onError);
+  }
+
+  function onError() {
+    self._sendQueue = undefined;
+    self.removeListener('listening', onListening);
+    self.removeListener('error', onError);
+  }
+
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.
   if (self._bindState != BIND_STATE_BOUND) {
@@ -300,12 +315,8 @@ Socket.prototype.send = function(buffer,
     // event handler that flushes the send queue after binding is done.
     if (!self._sendQueue) {
       self._sendQueue = [];
-      self.once('listening', function() {
-        // Flush the send queue.
-        for (var i = 0; i < self._sendQueue.length; i++)
-          self.send.apply(self, self._sendQueue[i]);
-        self._sendQueue = undefined;
-      });
+      self.on('listening', onListening);
+      self.on('error', onError);
     }
     self._sendQueue.push([buffer, offset, length, port, address, callback]);
     return;


### PR DESCRIPTION
There is a unbounded array in the dgram library. We've seen this array have over 250 thousands items in production heap dumps.

We put about a huge amount of traffic through our statsd UDP socket. When we get DNS failures this unbounded queue buffers
all statsd data which causes a huge memory leak.

cc @tjfontaine @indutny 
