### PR TITLE
crypto: allow creation of GCM ciphers with createCipher

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -214,7 +214,18 @@ Cipher.prototype.setAutoPadding = function(ap) {
   return this;
 };
 
+Cipher.prototype.getAuthTag = function() {
+  return this._handle.getAuthTag();
+};
 
+
+Cipher.prototype.setAuthTag = function(tagbuf) {
+  this._handle.setAuthTag(tagbuf);
+};
+
+Cipher.prototype.setAAD = function(aadbuf) {
+  this._handle.setAAD(aadbuf);
+};
 
 exports.createCipheriv = exports.Cipheriv = Cipheriv;
 function Cipheriv(cipher, key, iv, options) {
@@ -234,20 +245,9 @@ Cipheriv.prototype._flush = Cipher.prototype._flush;
 Cipheriv.prototype.update = Cipher.prototype.update;
 Cipheriv.prototype.final = Cipher.prototype.final;
 Cipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
-
-Cipheriv.prototype.getAuthTag = function() {
-  return this._handle.getAuthTag();
-};
-
-
-Cipheriv.prototype.setAuthTag = function(tagbuf) {
-  this._handle.setAuthTag(tagbuf);
-};
-
-Cipheriv.prototype.setAAD = function(aadbuf) {
-  this._handle.setAAD(aadbuf);
-};
-
+Cipheriv.prototype.getAuthTag = Cipher.prototype.getAuthTag;
+Cipheriv.prototype.setAuthTag = Cipher.prototype.setAuthTag;
+Cipheriv.prototype.setAAD = Cipher.prototype.setAAD;
 
 exports.createDecipher = exports.Decipher = Decipher;
 function Decipher(cipher, password, options) {
@@ -269,7 +269,9 @@ Decipher.prototype.update = Cipher.prototype.update;
 Decipher.prototype.final = Cipher.prototype.final;
 Decipher.prototype.finaltol = Cipher.prototype.final;
 Decipher.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
-
+Decipher.prototype.getAuthTag = Cipher.prototype.getAuthTag;
+Decipher.prototype.setAuthTag = Cipher.prototype.setAuthTag;
+Decipher.prototype.setAAD = Cipher.prototype.setAAD;
 
 
 exports.createDecipheriv = exports.Decipheriv = Decipheriv;
@@ -292,9 +294,9 @@ Decipheriv.prototype.update = Cipher.prototype.update;
 Decipheriv.prototype.final = Cipher.prototype.final;
 Decipheriv.prototype.finaltol = Cipher.prototype.final;
 Decipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
-Decipheriv.prototype.getAuthTag = Cipheriv.prototype.getAuthTag;
-Decipheriv.prototype.setAuthTag = Cipheriv.prototype.setAuthTag;
-Decipheriv.prototype.setAAD = Cipheriv.prototype.setAAD;
+Decipheriv.prototype.getAuthTag = Cipher.prototype.getAuthTag;
+Decipheriv.prototype.setAuthTag = Cipher.prototype.setAuthTag;
+Decipheriv.prototype.setAAD = Cipher.prototype.setAAD;
 
 
 

--- a/test/simple/test-crypto-authenticated.js
+++ b/test/simple/test-crypto-authenticated.js
@@ -41,26 +41,31 @@ crypto.DEFAULT_ENCODING = 'buffer';
 //
 
 var TEST_CASES = [
-  { algo: 'aes-128-gcm', key: 'ipxp9a6i1Mb4USb4',
-    iv: 'X6sIq117H0vR', plain: 'Hello World!',
+  { algo: 'aes-128-gcm', key: '6970787039613669314d623455536234',
+    iv: '583673497131313748307652', plain: 'Hello World!',
     ct: '4BE13896F64DFA2C2D0F2C76',
     tag: '272B422F62EB545EAA15B5FF84092447', tampered: false },
-  { algo: 'aes-128-gcm', key: 'ipxp9a6i1Mb4USb4',
-    iv: 'X6sIq117H0vR', plain: 'Hello World!',
+  { algo: 'aes-128-gcm', key: '6970787039613669314d623455536234',
+    iv: '583673497131313748307652', plain: 'Hello World!',
     ct: '4BE13896F64DFA2C2D0F2C76', aad: '000000FF',
     tag: 'BA2479F66275665A88CB7B15F43EB005', tampered: false },
-  { algo: 'aes-128-gcm', key: 'ipxp9a6i1Mb4USb4',
-    iv: 'X6sIq117H0vR', plain: 'Hello World!',
+  { algo: 'aes-128-gcm', key: '6970787039613669314d623455536234',
+    iv: '583673497131313748307652', plain: 'Hello World!',
     ct: '4BE13596F64DFA2C2D0FAC76',
     tag: '272B422F62EB545EAA15B5FF84092447', tampered: true },
-  { algo: 'aes-256-gcm', key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY',
-    iv: '60iP0h6vJoEa', plain: 'Hello node.js world!',
+  { algo: 'aes-256-gcm', key: '337a54767a7233703637564336316a6d56353472495975313534357834546c59',
+    iv: '36306950306836764a6f4561', plain: 'Hello node.js world!',
     ct: '58E62CFE7B1D274111A82267EBB93866E72B6C2A',
     tag: '9BB44F663BADABACAE9720881FB1EC7A', tampered: false },
-  { algo: 'aes-256-gcm', key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY',
-    iv: '60iP0h6vJoEa', plain: 'Hello node.js world!',
+  { algo: 'aes-256-gcm', key: '337a54767a7233703637564336316a6d56353472495975313534357834546c59',
+    iv: '36306950306836764a6f4561', plain: 'Hello node.js world!',
     ct: '58E62CFF7B1D274011A82267EBB93866E72B6C2B',
     tag: '9BB44F663BADABACAE9720881FB1EC7A', tampered: true },
+  { algo: 'aes-192-gcm', key: '1ed2233fa2223ef5d7df08546049406c7305220bca40d4c9',
+    iv: '0e1791e9db3bd21a9122c416', plain: 'Hello node.js world!',
+    password: 'very bad password', aad: '63616c76696e',
+    ct: 'DDA53A4059AA17B88756984995F7BBA3C636CC44',
+    tag: 'D2A35E5C611E5E3D2258360241C5B045', tampered: false }
 ];
 
 var ciphers = crypto.getCiphers();
@@ -74,7 +79,8 @@ for (var i in TEST_CASES) {
   }
 
   (function() {
-    var encrypt = crypto.createCipheriv(test.algo, test.key, test.iv);
+    var encrypt = crypto.createCipheriv(test.algo,
+      new Buffer(test.key, 'hex'), new Buffer(test.iv, 'hex'));
     if (test.aad)
       encrypt.setAAD(new Buffer(test.aad, 'hex'));
     var hex = encrypt.update(test.plain, 'ascii', 'hex');
@@ -88,7 +94,39 @@ for (var i in TEST_CASES) {
   })();
 
   (function() {
-    var decrypt = crypto.createDecipheriv(test.algo, test.key, test.iv);
+    var decrypt = crypto.createDecipheriv(test.algo,
+      new Buffer(test.key, 'hex'), new Buffer(test.iv, 'hex'));
+    decrypt.setAuthTag(new Buffer(test.tag, 'hex'));
+    if (test.aad)
+      decrypt.setAAD(new Buffer(test.aad, 'hex'));
+    var msg = decrypt.update(test.ct, 'hex', 'ascii');
+    if (!test.tampered) {
+      msg += decrypt.final('ascii');
+      assert.equal(msg, test.plain);
+    } else {
+      // assert that final throws if input data could not be verified!
+      assert.throws(function() { decrypt.final('ascii'); }, / auth/);
+    }
+  })();
+
+  (function() {
+    if (!test.password) return;
+    var encrypt = crypto.createCipher(test.algo, test.password);
+    if (test.aad)
+      encrypt.setAAD(new Buffer(test.aad, 'hex'));
+    var hex = encrypt.update(test.plain, 'ascii', 'hex');
+    hex += encrypt.final('hex');
+    var auth_tag = encrypt.getAuthTag();
+    // only test basic encryption run if output is marked as tampered.
+    if (!test.tampered) {
+      assert.equal(hex.toUpperCase(), test.ct);
+      assert.equal(auth_tag.toString('hex').toUpperCase(), test.tag);
+    }
+  })();
+
+  (function() {
+    if (!test.password) return;
+    var decrypt = crypto.createDecipher(test.algo, test.password);
     decrypt.setAuthTag(new Buffer(test.tag, 'hex'));
     if (test.aad)
       decrypt.setAAD(new Buffer(test.aad, 'hex'));
@@ -122,21 +160,24 @@ for (var i in TEST_CASES) {
 
   (function() {
     // trying to get tag before inputting all data:
-    var encrypt = crypto.createCipheriv(test.algo, test.key, test.iv);
+    var encrypt = crypto.createCipheriv(test.algo, 
+      new Buffer(test.key, 'hex'), new Buffer(test.iv, 'hex'));
     encrypt.update('blah', 'ascii');
     assert.throws(function() { encrypt.getAuthTag(); }, / state/);
   })();
 
   (function() {
     // trying to set tag on encryption object:
-    var encrypt = crypto.createCipheriv(test.algo, test.key, test.iv);
+    var encrypt = crypto.createCipheriv(test.algo, 
+      new Buffer(test.key, 'hex'), new Buffer(test.iv, 'hex'));
     assert.throws(function() {
       encrypt.setAuthTag(new Buffer(test.tag, 'hex')); }, / state/);
   })();
 
   (function() {
     // trying to read tag from decryption object:
-    var decrypt = crypto.createDecipheriv(test.algo, test.key, test.iv);
+    var decrypt = crypto.createDecipheriv(test.algo,
+      new Buffer(test.key, 'hex'), new Buffer(test.iv, 'hex'));
     assert.throws(function() { decrypt.getAuthTag(); }, / state/);
   })();
 }


### PR DESCRIPTION
Sets the authenticated encryption specific methods ([set|get]AuthTag and setAAD)
on the Cipher prototype not just the Cipheriv prototype.
