### PR TITLE
build: i18n: `icutrim.py` needs to support BIG-endian machines.

### DIFF
--- a/tools/icu/icutrim.py
+++ b/tools/icu/icutrim.py
@@ -154,8 +154,8 @@ if(config.has_key("comment")):
     print "%s: %s" % (options.filterfile, config["comment"])
 
 ## STEP 1 - copy the data file, swapping endianness
-endian_letter = "l"
-
+## The first letter of endian_letter will be 'b' or 'l' for big or little
+endian_letter = options.endian[0]
 
 runcmd("icupkg", "-t%s %s %s""" % (endian_letter, options.datfile, outfile))
 


### PR DESCRIPTION
I am tracking some other related ppc/aix issues in https://github.com/srl295/node/issues/7
and this commit is itself a port of https://github.com/srl295/node/commit/ba8ab91bc4762ade646474276c4a4b8cdaf83115

This is itself to support joyent/node/#7676
Update: this is about _big_ endian support, of course.
