### PR TITLE
buffer: reword Buffer.concat error message

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -181,7 +181,7 @@ Buffer.isEncoding = function(encoding) {
 
 Buffer.concat = function(list, length) {
   if (!util.isArray(list))
-    throw new TypeError('Usage: Buffer.concat(list[, length])');
+    throw new TypeError('list argument must be an Array of Buffers.');
 
   if (util.isUndefined(length)) {
     length = 0;


### PR DESCRIPTION
this brings the error messaging in line with other node TypeError messages.

fixes joyent/node#7766.
