### PR TITLE
path: refactor normalizeArray() - improve performance

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -25,33 +25,30 @@ var util = require('util');
 
 
 // resolves . and .. elements in a path array with directory names there
-// must be no slashes, empty elements, or device names (c:\) in the array
+// must be no slashes or device names (c:\) in the array
 // (so also no leading and trailing slashes - it does not distinguish
 // relative and absolute paths)
 function normalizeArray(parts, allowAboveRoot) {
-  // if the path tries to go above the root, `up` ends up > 0
-  var up = 0;
-  for (var i = parts.length - 1; i >= 0; i--) {
-    var last = parts[i];
-    if (last === '.') {
-      parts.splice(i, 1);
-    } else if (last === '..') {
-      parts.splice(i, 1);
-      up++;
-    } else if (up) {
-      parts.splice(i, 1);
-      up--;
+  var res = [];
+  for (var i = 0; i < parts.length; i++) {
+    var p = parts[i];
+
+    // ignore empty parts
+    if (!p || p === '.')
+      continue;
+
+    if (p === '..') {
+      if (res.length && res[res.length - 1] !== '..') {
+        res.pop();
+      } else if (allowAboveRoot) {
+        res.push('..');
+      }
+    } else {
+      res.push(p);
     }
   }
 
-  // if the path is allowed to go above the root, restore leading ..s
-  if (allowAboveRoot) {
-    for (; up--; up) {
-      parts.unshift('..');
-    }
-  }
-
-  return parts;
+  return res;
 }
 
 // Regex to split a windows path into three parts: [*, device, slash,
@@ -153,12 +150,7 @@ win32.resolve = function() {
   // fails)
 
   // Normalize the tail path
-
-  function f(p) {
-    return !!p;
-  }
-
-  resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/).filter(f),
+  resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/),
                                 !resolvedAbsolute).join('\\');
 
   // If device is a drive letter, we'll normalize to lower case.
@@ -186,9 +178,7 @@ win32.normalize = function(path) {
   }
 
   // Normalize the tail path
-  tail = normalizeArray(tail.split(/[\\\/]+/).filter(function(p) {
-    return !!p;
-  }), !isAbsolute).join('\\');
+  tail = normalizeArray(tail.split(/[\\\/]+/), !isAbsolute).join('\\');
 
   if (!tail && !isAbsolute) {
     tail = '.';
@@ -453,9 +443,8 @@ posix.resolve = function() {
   // handle relative paths to be safe (might happen when process.cwd() fails)
 
   // Normalize the path
-  resolvedPath = normalizeArray(resolvedPath.split('/').filter(function(p) {
-    return !!p;
-  }), !resolvedAbsolute).join('/');
+  resolvedPath = normalizeArray(resolvedPath.split('/'),
+                                !resolvedAbsolute).join('/');
 
   return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
 };
@@ -464,17 +453,10 @@ posix.resolve = function() {
 // posix version
 posix.normalize = function(path) {
   var isAbsolute = posix.isAbsolute(path),
-      trailingSlash = path.substr(-1) === '/',
-      segments = path.split('/'),
-      nonEmptySegments = [];
+      trailingSlash = path.substr(-1) === '/';
 
   // Normalize the path
-  for (var i = 0; i < segments.length; i++) {
-    if (segments[i]) {
-      nonEmptySegments.push(segments[i]);
-    }
-  }
-  path = normalizeArray(nonEmptySegments, !isAbsolute).join('/');
+  path = normalizeArray(path.split('/'), !isAbsolute).join('/');
 
   if (!path && !isAbsolute) {
     path = '.';


### PR DESCRIPTION
Improves performance of `path.normalize()` and `path.resolve()` (up to 3x faster in some cases).
#8342 didn't look like anyone was paying attention to it anymore so I came up with a solution that addresses @trevnorris's issue with it.

I used @dead-horse's same [test code](https://gist.github.com/dead-horse/ae3d6d34b6ec44d8d6ed) to obtain the following benchmarks:

| Test | Original | dead-horse | This PR |
| --- | --- | --- | --- |
| normalize simple path | 353 ms | 351 ms | 335 ms |
| resolve simple path | 1709 ms | 920 ms | 910 ms |
| normalize path contains **.** | 885 ms | 388 ms | 357 ms |
| resolve path contains **.** | 2653 ms | 1000 ms | 975 ms |
| normalize path contains **..** | 1186 ms | 553 ms | 370 ms |
| resolve path contains **..** | 2973 ms | 1223 ms | 1017 ms |

Addressing @trevnorris's issue with using `Array#reverse()` didn't affect the first 4 tests much but removing it seems to have improved performance on the last 2 tests.
