### PR TITLE
dns: propagate domain for c-ares methods

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -230,6 +230,8 @@ class QueryWrap : public AsyncWrap {
  public:
   QueryWrap(Environment* env, Local<Object> req_wrap_obj)
       : AsyncWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_CARES) {
+    if (env->in_domain())
+      req_wrap_obj->Set(env->domain_string(), env->domain_array()->Get(0));
   }
 
   virtual ~QueryWrap() {

--- a/test/simple/test-dns-cares-domains.js
+++ b/test/simple/test-dns-cares-domains.js
@@ -1,0 +1,46 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var dns = require('dns');
+var domain = require('domain');
+
+var methods = [
+  'resolve4',
+  'resolve6',
+  'resolveCname',
+  'resolveMx',
+  'resolveNs',
+  'resolveTxt',
+  'resolveSrv',
+  'resolveNaptr',
+  'resolveSoa'
+]
+
+methods.forEach(function(method) {
+  var d = domain.create();
+  d.run(function() {
+    dns[method]('google.com', function() {
+      assert.strictEqual(process.domain, d, method + ' retains domain')
+    });
+  });
+});


### PR DESCRIPTION
Per https://github.com/joyent/node/issues/5471, domains were not being propagated for certain dns methods (those using `class Query` in `cares_wrap.cc`). This rectifies the situation.

/cc @trevnorris
