### PR TITLE
Add option to systematically activate HTTP 1.1 requests

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -128,7 +128,7 @@ function ClientRequest(options, cb) {
   if (util.isArray(options.headers)) {
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
                       options.headers);
-  } else if (self.getHeader('expect') || options.useHTTP11) {
+  } else if (self.getHeader('expect') || options.forceHTTP11) {
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
                       self._renderHeaders());
   }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -128,7 +128,7 @@ function ClientRequest(options, cb) {
   if (util.isArray(options.headers)) {
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
                       options.headers);
-  } else if (self.getHeader('expect')) {
+  } else if (self.getHeader('expect') || options.useHTTP11) {
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
                       self._renderHeaders());
   }


### PR DESCRIPTION
When trying to get documents from an Alfresco server, I got 505
errors. I investigated this only to discover that node only emit
HTTP 1.1 requests under some particular conditions.

This commit add support for a new option named useHTTP11.
When this option is found, the HTTP client will specify HTTP 1.1
protocol version. This has fixed my alfresco connectivity problem.

Example:

var opts = {
    useHTTP11: true
};

httpClient.get("http://server/url", opts);
