### PR TITLE
build: remove the duplicate expression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,6 @@ jslint:
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_dtrace.cc
-CPPLINT_EXCLUDE += src/node_dtrace.cc
 CPPLINT_EXCLUDE += src/node_root_certs.h
 CPPLINT_EXCLUDE += src/node_win32_perfctr_provider.cc
 CPPLINT_EXCLUDE += src/queue.h


### PR DESCRIPTION
remove the duplicate `CPPLINT_EXCLUDE += src/node_dtrace.cc`
