### PR TITLE
crypto: store thread id as pointer-sized

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -151,7 +151,8 @@ template int SSLWrap<TLSCallbacks>::TLSExtStatusCallback(SSL* s, void* arg);
 
 
 static void crypto_threadid_cb(CRYPTO_THREADID* tid) {
-  CRYPTO_THREADID_set_numeric(tid, uv_thread_self());
+  assert(sizeof(uv_thread_t) <= sizeof(void*));
+  CRYPTO_THREADID_set_pointer(tid, (void*) uv_thread_self());
 }
 
 


### PR DESCRIPTION
In https://github.com/MSOpenTech/libuv/commit/59658a8de7cc05a58327a164fd2ed4b050f8b4f4
the return of uv_thread_self() was changed from unsigned long to
uv_thread_t.

uv_thread_t is a HANDLE (pointer-sized) on Windows, which means that
on Win64 it cannot be stored with CRYPTO_THREADID_set_numeric without
data loss.

Furthermore, without this change there will be a build break on Windows
when the libuv change is integrated into Node, because of the
conversion from HANDLE to unsigned long.

Other related commits:
https://github.com/joyent/node/commit/5845a6bcd5b36168bdddeb85da8d8d9d36de7642
https://github.com/MSOpenTech/libuv/commit/919d8ec63ac53566ad1f090058ec15966bd0e960
