### PR TITLE
make: remove node_dtrace from cpplint excludes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,8 +410,6 @@ jslint:
 	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
 
 CPPLINT_EXCLUDE ?=
-CPPLINT_EXCLUDE += src/node_dtrace.cc
-CPPLINT_EXCLUDE += src/node_dtrace.cc
 CPPLINT_EXCLUDE += src/node_root_certs.h
 CPPLINT_EXCLUDE += src/node_win32_perfctr_provider.cc
 CPPLINT_EXCLUDE += src/queue.h

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -19,16 +19,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-#include "util.h"
+#include "node_dtrace.h"
 
 #ifdef HAVE_DTRACE
-#include "node_dtrace.h"
 #include "node_provider.h"
-#include <string.h>
 #elif HAVE_ETW
-#include "node_dtrace.h"
-#include <string.h>
 #include "node_win32_etw_provider.h"
 #include "node_win32_etw_provider-inl.h"
 #else
@@ -54,6 +49,10 @@
 
 #include "env.h"
 #include "env-inl.h"
+
+#include "util.h"
+
+#include <string.h>
 
 namespace node {
 


### PR DESCRIPTION
Builds successfully on OS X, SmartOS, Windows and Linux. Tested that dtrace and ETW probes still work on SmartOS and Windows 7 respectively.
