### PR TITLE
smalloc: don't allow to dispose typed arrays

### DIFF
--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -86,6 +86,8 @@ function dispose(obj) {
     throw new TypeError('obj must be an Object');
   if (util.isBuffer(obj))
     throw new TypeError('obj cannot be a Buffer');
+  if (smalloc.isTypedArray(obj))
+    throw new TypeError('obj cannot be a typed array');
   if (!smalloc.hasExternalData(obj))
     throw new Error('obj has no external array data');
 

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -446,6 +446,9 @@ bool HasExternalData(Environment* env, Local<Object> obj) {
   return obj->HasIndexedPropertiesInExternalArrayData();
 }
 
+void IsTypedArray(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(args[0]->IsTypedArray());
+}
 
 void AllocTruncate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
@@ -547,6 +550,7 @@ void Initialize(Handle<Object> exports,
   NODE_SET_METHOD(exports, "truncate", AllocTruncate);
 
   NODE_SET_METHOD(exports, "hasExternalData", HasExternalData);
+  NODE_SET_METHOD(exports, "isTypedArray", IsTypedArray);
 
   exports->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxLength"),
                Uint32::NewFromUnsigned(env->isolate(), kMaxLength));

--- a/test/simple/test-smalloc.js
+++ b/test/simple/test-smalloc.js
@@ -324,5 +324,9 @@ assert.throws(function() {
 });
 
 assert.throws(function() {
+  smalloc.dispose(new Uint8Array(new ArrayBuffer(1)));
+});
+
+assert.throws(function() {
   smalloc.dispose({});
 });


### PR DESCRIPTION
Typed arrays behave as objects with external data in some cases, but disposing them is a bad idea:

``` javascript
var smalloc = require('smalloc');

var ab = new ArrayBuffer(3);
var a1 = new Uint8Array(ab);
var a2 = new Uint8Array(ab);

for (var i = 0; i < a1.length; i++)
  a1[i] = 6;

console.log(a1);
console.log(a2);

smalloc.dispose(a1);

console.log(a1);
console.log(a2);

// node(72543,0x7fff7ada2310) malloc: *** error for object 0x100f0b2f0: pointer being freed was not allocated
// *** set a breakpoint in malloc_error_break to debug
// Abort trap: 6
```

/cc @trevnorris 
