### PR TITLE
timers: Avoid linear scan in _unrefActive.

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -401,11 +401,10 @@ function unrefTimeout() {
 
   debug('unrefTimer fired');
 
-  var timeSinceLastActive,
-      nextTimeoutTime,
-      nextTimeoutDuration,
-      minNextTimeoutTime;
-
+  var timeSinceLastActive;
+  var nextTimeoutTime;
+  var nextTimeoutDuration;
+  var minNextTimeoutTime;
   var itemToDelete;
 
   // The actual timer fired and has not yet been rearmed,
@@ -424,6 +423,9 @@ function unrefTimeout() {
     timeSinceLastActive = now - cur._monotonicStartTime;
 
     if (timeSinceLastActive < cur._idleTimeout) {
+      // This timer hasn't expired yet, but check if its expiring time is
+      // earlier than the actual timer's expiring time
+
       nextTimeoutDuration = cur._idleTimeout - timeSinceLastActive;
       nextTimeoutTime = now + nextTimeoutDuration;
       if (minNextTimeoutTime == null ||
@@ -435,36 +437,41 @@ function unrefTimeout() {
         minNextTimeoutTime = nextTimeoutTime;
       }
 
+      // This timer hasn't expired yet, skipping
       cur = cur._idlePrev;
-    } else {
-      var domain = cur.domain;
+      continue;
+    }
 
-      if (!cur._onTimeout) continue;
-      if (domain && domain._disposed) continue;
+    // We found a timer that expired
+    var domain = cur.domain;
 
-      try {
-        if (domain) domain.enter();
+    if (!cur._onTimeout) continue;
 
-        var threw = true;
+    if (domain && domain._disposed)
+      continue;
 
-        itemToDelete = cur;
-        // Move to the previous item before calling the _onTimeout callback,
-        // as it can mutate the list.
-        cur = cur._idlePrev;
+    try {
+      var threw = true;
 
-        // Remove the timeout from the list because it expired.
-        L.remove(itemToDelete);
+      if (domain) domain.enter();
 
-        debug('unreftimer firing timeout');
-        itemToDelete._onTimeout();
+      itemToDelete = cur;
+      // Move to the previous item before calling the _onTimeout callback,
+      // as it can mutate the list.
+      cur = cur._idlePrev;
 
-        threw = false;
+      // Remove the timeout from the list because it expired.
+      L.remove(itemToDelete);
 
-        if (domain)
-          domain.exit();
-      } finally {
-        if (threw) process.nextTick(unrefTimeout);
-      }
+      debug('unreftimer firing timeout');
+      itemToDelete._onTimeout();
+
+      threw = false;
+
+      if (domain)
+        domain.exit();
+    } finally {
+      if (threw) process.nextTick(unrefTimeout);
     }
   }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -401,39 +401,82 @@ function unrefTimeout() {
 
   debug('unrefTimer fired');
 
-  var first;
-  while (first = L.peek(unrefList)) {
-    var diff = now - first._monotonicStartTime;
+  var timeSinceLastActive,
+      nextTimeoutTime,
+      nextTimeoutDuration,
+      minNextTimeoutTime;
 
-    if (diff < first._idleTimeout) {
-      diff = first._idleTimeout - diff;
-      unrefTimer.start(diff, 0);
-      unrefTimer.when = now + diff;
-      debug('unrefTimer rescheudling for later');
-      return;
-    }
+  var itemToDelete;
 
-    L.remove(first);
+  // The actual timer fired and has not yet been rearmed,
+  // let's consider its next firing time is invalid for now.
+  // It may be set to a relevant time in the future once
+  // we scanned through the whole list of timeouts and if
+  // we find a timeout that needs to expire.
+  unrefTimer.when = -1;
 
-    var domain = first.domain;
+  // Iterate over the list of timeouts,
+  // call the onTimeout callback for those expired,
+  // and rearm the actual timer if the next timeout to expire
+  // will expire before the current actual timer.
+  var cur = unrefList._idlePrev;
+  while (cur != unrefList) {
+    timeSinceLastActive = now - cur._monotonicStartTime;
 
-    if (!first._onTimeout) continue;
-    if (domain && domain._disposed) continue;
+    if (timeSinceLastActive < cur._idleTimeout) {
+      nextTimeoutDuration = cur._idleTimeout - timeSinceLastActive;
+      nextTimeoutTime = now + nextTimeoutDuration;
+      if (minNextTimeoutTime == null ||
+          (nextTimeoutTime < minNextTimeoutTime)) {
+        // We found a timeout that will expire earlier,
+        // store its next timeout time now so that we
+        // can rearm the actual timer accordingly when
+        // we scanned through the whole list.
+        minNextTimeoutTime = nextTimeoutTime;
+      }
 
-    try {
-      if (domain) domain.enter();
-      var threw = true;
-      debug('unreftimer firing timeout');
-      first._onTimeout();
-      threw = false;
-      if (domain) domain.exit();
-    } finally {
-      if (threw) process.nextTick(unrefTimeout);
+      cur = cur._idlePrev;
+    } else {
+      var domain = cur.domain;
+
+      if (!cur._onTimeout) continue;
+      if (domain && domain._disposed) continue;
+
+      try {
+        if (domain) domain.enter();
+
+        var threw = true;
+
+        itemToDelete = cur;
+        // Move to the previous item before calling the _onTimeout callback,
+        // as it can mutate the list.
+        cur = cur._idlePrev;
+
+        // Remove the timeout from the list because it expired.
+        L.remove(itemToDelete);
+
+        debug('unreftimer firing timeout');
+        itemToDelete._onTimeout();
+
+        threw = false;
+
+        if (domain)
+          domain.exit();
+      } finally {
+        if (threw) process.nextTick(unrefTimeout);
+      }
     }
   }
 
-  debug('unrefList is empty');
-  unrefTimer.when = -1;
+  // Rearm the actual timer with the timeout delay
+  // of the earliest timeout found.
+  if (minNextTimeoutTime != null) {
+    unrefTimer.start(minNextTimeoutTime - now, 0);
+    unrefTimer.when = minNextTimeoutTime;
+    debug('unrefTimer rescheduled');
+  } else if (L.isEmpty(unrefList)) {
+    debug('unrefList is empty');
+  }
 }
 
 
@@ -462,38 +505,14 @@ exports._unrefActive = function(item) {
   item._idleStart = nowDate;
   item._monotonicStartTime = nowMonotonicTimestamp;
 
-  if (L.isEmpty(unrefList)) {
-    debug('unrefList empty');
-    L.append(unrefList, item);
-
-    unrefTimer.start(msecs, 0);
-    unrefTimer.when = nowMonotonicTimestamp + msecs;
-    debug('unrefTimer scheduled');
-    return;
-  }
-
   var when = nowMonotonicTimestamp + msecs;
 
-  debug('unrefList find where we can insert');
-
-  var cur, them;
-
-  for (cur = unrefList._idlePrev; cur != unrefList; cur = cur._idlePrev) {
-    them = cur._monotonicStartTime + cur._idleTimeout;
-
-    if (when < them) {
-      debug('unrefList inserting into middle of list');
-
-      L.append(cur, item);
-
-      if (unrefTimer.when > when) {
-        debug('unrefTimer is scheduled to fire too late, reschedule');
-        unrefTimer.start(msecs, 0);
-        unrefTimer.when = when;
-      }
-
-      return;
-    }
+  // If the actual timer is set to fire too late, or not set to fire at all,
+  // we need to make it fire earlier
+  if (unrefTimer.when === -1 || unrefTimer.when > when) {
+    unrefTimer.start(msecs, 0);
+    unrefTimer.when = when;
+    debug('unrefTimer scheduled');
   }
 
   debug('unrefList append to end');

--- a/test/simple/test-timers-unref-active.js
+++ b/test/simple/test-timers-unref-active.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * This test is aimed at making sure that unref timers queued with
+ * timers._unrefActive work correctly.
+ *
+ * Basically, it queues one timer in the unref queue, and then queues
+ * it again each time its timeout callback is fired until the callback
+ * has been called ten times.
+ *
+ * At that point, it unenrolls the unref timer so that its timeout callback
+ * is not fired ever again.
+ *
+ * Finally, a ref timeout is used with a delay large enough to make sure that
+ * all 10 timeouts had the time to expire.
+ */
+
+var timers = require('timers');
+var assert = require('assert');
+
+var someObject = {};
+var nbTimeouts = 0;
+
+var N = 10;
+
+timers.unenroll(someObject);
+timers.enroll(someObject, 1);
+
+someObject._onTimeout = function _onTimeout() {
+  ++nbTimeouts;
+
+  if (nbTimeouts === N) timers.unenroll(someObject);
+
+  timers._unrefActive(someObject);
+}
+
+function startTimer() { timers._unrefActive(someObject); }
+
+startTimer();
+
+setTimeout(function() {
+  assert.equal(nbTimeouts, N);
+}, 100);


### PR DESCRIPTION
Before this change, _unrefActive would keep the unrefList sorted when
adding a new timer.

Because _unrefActive is called extremely frequently, this linear scan
(O(n) at worse) would make _unrefActive show high in the list of
contributors when profiling CPU usage.

This commit changes _unrefActive so that it doesn't try to keep the
unrefList sorted. The insertion thus happens in constant time.

However, when a timer expires, unrefTimeout has to go through the whole
unrefList because it's not ordered anymore.

It is usually not large enough to have a significant impact on
performance because:
- Most of the time, the timers will be removed before unrefTimeout is
  called because their users (sockets mainly) cancel them when an I/O
  operation takes place.
- If they're not, it means that some I/O took a long time to happen, and
  the initiator of subsequents I/O operations that would add more timers
  has to wait for them to complete.

With this change, _unrefActive does not show as a significant
contributor in CPU profiling reports anymore.

Fixes #8160.
