### PR TITLE
util: Proposed fix for #8696, replacing circular references with "[Circular]"

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -56,17 +56,26 @@ assert.AssertionError = function AssertionError(options) {
 // assert.AssertionError instanceof Error
 util.inherits(assert.AssertionError, Error);
 
-function replacer(key, value) {
-  if (util.isUndefined(value)) {
-    return '' + value;
+function replacer() {
+  var previousValues = [];
+
+  return function (key, value) {
+    if (util.isUndefined(value)) {
+      return '' + value;
+    }
+    if (util.isNumber(value) && !isFinite(value)) {
+      return value.toString();
+    }
+    if (util.isFunction(value) || util.isRegExp(value)) {
+      return value.toString();
+    }
+    var index = previousValues.indexOf(value);
+    if (index !== -1) {
+      return "[Circular]";
+    }
+    previousValues.push(value);
+    return value;
   }
-  if (util.isNumber(value) && !isFinite(value)) {
-    return value.toString();
-  }
-  if (util.isFunction(value) || util.isRegExp(value)) {
-    return value.toString();
-  }
-  return value;
 }
 
 function truncate(s, n) {
@@ -78,9 +87,9 @@ function truncate(s, n) {
 }
 
 function getMessage(self) {
-  return truncate(JSON.stringify(self.actual, replacer), 128) + ' ' +
+  return truncate(JSON.stringify(self.actual, replacer()), 128) + ' ' +
          self.operator + ' ' +
-         truncate(JSON.stringify(self.expected, replacer), 128);
+         truncate(JSON.stringify(self.expected, replacer()), 128);
 }
 
 // At present only the three keys mentioned above are used and

--- a/test/simple/test-assert.js
+++ b/test/simple/test-assert.js
@@ -289,6 +289,11 @@ testAssertionMessage({a: undefined, b: null}, '{"a":"undefined","b":null}');
 testAssertionMessage({a: NaN, b: Infinity, c: -Infinity},
     '{"a":"NaN","b":"Infinity","c":"-Infinity"}');
 
+// # 8696
+var a = {};
+a.b = a;
+testAssertionMessage(a, '{"b":"[Circular]"}');
+
 // #2893
 try {
   assert.throws(function () {


### PR DESCRIPTION
JSON is used to create error messages when assertions fail. This causes a TypeError when there are circular references. This commit replaces circular references with the string "[Circular]"
