### PR TITLE
src/node.cc: fix OpenSSL build error

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -82,7 +82,6 @@ typedef int mode_t;
 #include "node_script.h"
 #include "v8_typed_array.h"
 
-#include "node_crypto.h"
 #include "util.h"
 
 using namespace v8;
@@ -2544,8 +2543,10 @@ static void PrintHelp() {
          "  --trace-deprecation  show stack traces on deprecations\n"
          "  --v8-options         print v8 command line options\n"
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
+#if HAVE_OPENSSL
          "  --enable-ssl2        enable ssl2\n"
          "  --enable-ssl3        enable ssl3\n"
+#endif
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2579,12 +2580,14 @@ static void ParseArgs(int argc, char **argv) {
       p = 1 + strchr(arg, '=');
       max_stack_size = atoi(p);
       argv[i] = const_cast<char*>("");
+#if HAVE_OPENSSL
     } else if (strcmp(arg, "--enable-ssl2") == 0) {
       SSL2_ENABLE = true;
       argv[i] = const_cast<char*>("");
     } else if (strcmp(arg, "--enable-ssl3") == 0) {
       SSL3_ENABLE = true;
       argv[i] = const_cast<char*>("");
+#endif
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);


### PR DESCRIPTION
Since version 0.10.33 (commit d601c76f4d728dd7adfa2fbbed2fe86de2e6b479) building nodejs without OpenSSL is broken. This issue is already reported upstream: https://github.com/joyent/node/issues/8676.

This issue is fixed by this patch.

Signed-off-by: Jörg Krause jkrause@posteo.de
