### PR TITLE
net: forward Socket#end cb argument to Duplex#end

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -354,13 +354,16 @@ buffer. Returns `false` if all or part of the data was queued in user memory.
 The optional `callback` parameter will be executed when the data is finally
 written out - this may not be immediately.
 
-### socket.end([data], [encoding])
+### socket.end([data], [encoding], [callback])
 
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the
 server will still send some data.
 
 If `data` is specified, it is equivalent to calling
 `socket.write(data, encoding)` followed by `socket.end()`.
+
+If supplied, the `callback` parameter will be attached as a listener for
+the `finish` event of the stream.
 
 ### socket.destroy()
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -393,8 +393,8 @@ Socket.prototype._read = function(n) {
 };
 
 
-Socket.prototype.end = function(data, encoding) {
-  stream.Duplex.prototype.end.call(this, data, encoding);
+Socket.prototype.end = function(data, encoding, cb) {
+  stream.Duplex.prototype.end.call(this, data, encoding, cb);
   this.writable = false;
   DTRACE_NET_STREAM_END(this);
 

--- a/test/simple/test-net-socket-end.js
+++ b/test/simple/test-net-socket-end.js
@@ -1,0 +1,38 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var server = net.createServer(function(conn) {
+  conn.resume();
+}).listen(common.PORT, function() {
+  var conn = net.createConnection(common.PORT);
+
+  conn.end('hello', 'utf8', function() {
+    server.close();
+  });
+
+  setTimeout(function() {
+    assert.ok(false, 'should have exited!');
+  }, 1000).unref();
+});


### PR DESCRIPTION
The callback parameter was being dropped when Socket.prototype.end
called Duplex.prototype.end. This remedies that situation.

This problem exists in both the v0.10 and v0.12 branches.

Fixes: https://github.com/joyent/node/issues/8759

R=@indutny 
