### PR TITLE
doc: supplement docs for Writable and Transform streams

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -975,12 +975,11 @@ initialized.
 
 #### writable.\_write(chunk, encoding, callback)
 
-* `chunk` {Buffer | String} The chunk to be written.  Will always
+* `chunk` {Buffer | String} The chunk to be written. Will **always**
   be a buffer unless the `decodeStrings` option was set to `false`.
 * `encoding` {String} If the chunk is a string, then this is the
-  encoding type.  Ignore chunk is a buffer.  Note that chunk will
-  **always** be a buffer unless the `decodeStrings` option is
-  explicitly set to `false`.
+  encoding type. If chunk is a buffer, then this is the special
+  value - 'buffer', ignore it in this case.
 * `callback` {Function} Call this function (optionally with an error
   argument) when you are done processing the supplied chunk.
 
@@ -1066,10 +1065,11 @@ initialized.
 
 #### transform.\_transform(chunk, encoding, callback)
 
-* `chunk` {Buffer | String} The chunk to be transformed.  Will always
+* `chunk` {Buffer | String} The chunk to be transformed. Will **always**
   be a buffer unless the `decodeStrings` option was set to `false`.
 * `encoding` {String} If the chunk is a string, then this is the
-  encoding type.  (Ignore if `decodeStrings` chunk is a buffer.)
+  encoding type. If chunk is a buffer, then this is the special
+  value - 'buffer', ignore it in this case.
 * `callback` {Function} Call this function (optionally with an error
   argument and data) when you are done processing the supplied chunk.
 


### PR DESCRIPTION
Slightly fix and supplement the documentation for Writable#_write and
Transform#_transform methods. Make it more consistent. Mention
passing 'buffer' as a encoding param in case chunk is a Buffer.
