### PR TITLE
Remove the option of building against a shared cares

### DIFF
--- a/configure
+++ b/configure
@@ -83,26 +83,6 @@ parser.add_option('--openssl-use-sys',
     dest='shared_openssl',
     help=optparse.SUPPRESS_HELP)
 
-parser.add_option('--shared-cares',
-    action='store_true',
-    dest='shared_cares',
-    help='link to a shared cares DLL instead of static linking')
-
-parser.add_option('--shared-cares-includes',
-    action='store',
-    dest='shared_cares_includes',
-    help='directory containing cares header files')
-
-parser.add_option('--shared-cares-libname',
-    action='store',
-    dest='shared_cares_libname',
-    help='alternative lib name to link to (default: \'cares\')')
-
-parser.add_option('--shared-cares-libpath',
-    action='store',
-    dest='shared_cares_libpath',
-    help='a directory to search for the shared cares DLL')
-
 parser.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -586,20 +566,6 @@ def configure_http_parser(o):
         o['include_dirs'] += [options.shared_http_parser_includes]
 
 
-def configure_cares(o):
-    o['variables']['node_shared_cares'] = b(options.shared_cares)
-
-    # assume shared cares if one of these is set?
-    if options.shared_cares_libpath:
-        o['libraries'] += ['-L%s' % options.shared_cares_libpath]
-    if options.shared_cares_libname:
-        o['libraries'] += ['-l%s' % options.shared_cares_libname]
-    elif options.shared_cares:
-        o['libraries'] += ['-lcares']
-    if options.shared_cares_includes:
-        o['include_dirs'] += [options.shared_cares_includes]
-
-
 def configure_libuv(o):
   o['variables']['node_shared_libuv'] = b(options.shared_libuv)
 
@@ -863,7 +829,6 @@ output = {
 configure_node(output)
 configure_libz(output)
 configure_http_parser(output)
-configure_cares(output)
 configure_libuv(output)
 configure_v8(output)
 configure_openssl(output)

--- a/node.gyp
+++ b/node.gyp
@@ -8,7 +8,6 @@
     'node_shared_v8%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
-    'node_shared_cares%': 'false',
     'node_shared_libuv%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
@@ -79,6 +78,7 @@
       'dependencies': [
         'node_js2c#host',
         'deps/debugger-agent/debugger-agent.gyp:debugger-agent',
+        'deps/cares/cares.gyp:cares'
       ],
 
       'include_dirs': [
@@ -309,10 +309,6 @@
 
         [ 'node_shared_http_parser=="false"', {
           'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
-        }],
-
-        [ 'node_shared_cares=="false"', {
-          'dependencies': [ 'deps/cares/cares.gyp:cares' ],
         }],
 
         [ 'node_shared_libuv=="false"', {

--- a/tools/install.py
+++ b/tools/install.py
@@ -153,8 +153,7 @@ def files(action):
     'src/smalloc.h',
   ], 'include/node/')
 
-  if 'false' == variables.get('node_shared_cares'):
-    subdir_files('deps/cares/include', 'include/node/', action)
+  subdir_files('deps/cares/include', 'include/node/', action)
 
   if 'false' == variables.get('node_shared_libuv'):
     subdir_files('deps/uv/include', 'include/node/', action)


### PR DESCRIPTION
..since it won't build anyway. Should be reverted if/when upstream adapts a similar featureset.

Ping @indutny 
