### PR TITLE
v8: don't busy loop in cpu profiler thread

### DIFF
--- a/deps/v8/src/platform-freebsd.cc
+++ b/deps/v8/src/platform-freebsd.cc
@@ -539,11 +539,6 @@ void Thread::SetThreadLocal(LocalStorageKey key, void* value) {
 }
 
 
-void Thread::YieldCPU() {
-  sched_yield();
-}
-
-
 class FreeBSDMutex : public Mutex {
  public:
   FreeBSDMutex() {

--- a/deps/v8/src/platform-linux.cc
+++ b/deps/v8/src/platform-linux.cc
@@ -812,11 +812,6 @@ void Thread::SetThreadLocal(LocalStorageKey key, void* value) {
 }
 
 
-void Thread::YieldCPU() {
-  sched_yield();
-}
-
-
 class LinuxMutex : public Mutex {
  public:
   LinuxMutex() {

--- a/deps/v8/src/platform-macos.cc
+++ b/deps/v8/src/platform-macos.cc
@@ -640,11 +640,6 @@ void Thread::SetThreadLocal(LocalStorageKey key, void* value) {
 }
 
 
-void Thread::YieldCPU() {
-  sched_yield();
-}
-
-
 class MacOSMutex : public Mutex {
  public:
   MacOSMutex() {

--- a/deps/v8/src/platform-openbsd.cc
+++ b/deps/v8/src/platform-openbsd.cc
@@ -593,11 +593,6 @@ void Thread::SetThreadLocal(LocalStorageKey key, void* value) {
 }
 
 
-void Thread::YieldCPU() {
-  sched_yield();
-}
-
-
 class OpenBSDMutex : public Mutex {
  public:
   OpenBSDMutex() {

--- a/deps/v8/src/platform-posix.cc
+++ b/deps/v8/src/platform-posix.cc
@@ -392,6 +392,12 @@ void OS::StrNCpy(Vector<char> dest, const char* src, size_t n) {
 }
 
 
+void Thread::YieldCPU() {
+  const timespec delay = { 0, 1 };
+  nanosleep(&delay, NULL);
+}
+
+
 // ----------------------------------------------------------------------------
 // POSIX socket support.
 //

--- a/deps/v8/src/platform-solaris.cc
+++ b/deps/v8/src/platform-solaris.cc
@@ -527,11 +527,6 @@ void Thread::SetThreadLocal(LocalStorageKey key, void* value) {
 }
 
 
-void Thread::YieldCPU() {
-  sched_yield();
-}
-
-
 class SolarisMutex : public Mutex {
  public:
   SolarisMutex() {

--- a/deps/v8/tools/gyp/v8.gyp
+++ b/deps/v8/tools/gyp/v8.gyp
@@ -715,7 +715,7 @@
             ['OS=="solaris"', {
                 'link_settings': {
                   'libraries': [
-                    '-lsocket -lnsl',
+                    '-lsocket -lnsl -lrt',
                 ]},
                 'sources': [
                   '../../src/platform-solaris.cc',


### PR DESCRIPTION
Reduce the overhead of the CPU profiler by replacing sched_yield() with
nanosleep() in V8's tick event processor thread.  The former only yields
the CPU when there is another process scheduled on the same CPU.

Before this commit, the thread would effectively busy loop and consume
100% CPU time.  By forcing a one nanosecond sleep period rounded up to
the task scheduler's granularity (about 50 us on Linux), CPU usage for
the processor thread now hovers around 10-20% for a busy application.

Refs strongloop/strong-agent#3 and strongloop-internal/scrum-cs#37.

R=@trevnorris?
