### PR TITLE
src: reduce cpu profiler overhead

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2962,6 +2962,7 @@ char** Init(int argc, char *argv[]) {
   V8::SetFlagsFromCommandLine(&v8argc, v8argv, false);
 
 #ifdef __POSIX__
+  uv_loop_configure(uv_default_loop(), UV_LOOP_BLOCK_SIGNAL, SIGPROF);
   // Ignore SIGPIPE
   RegisterSignalHandler(SIGPIPE, SIG_IGN);
   RegisterSignalHandler(SIGINT, SignalExit);


### PR DESCRIPTION
Reduce the overhead of the CPU profiler by suppressing SIGPROF signals
when sleeping / polling for events.  Avoids unnecessary wakeups when
the CPU profiler is active.  Depends on libuv/libuv#15.

Refs strongloop/strong-agent#3 and strongloop-internal/scrum-cs#37.

See also #8789.

R=@trevnorris?
