### PR TITLE
QueryString optimization: moved try-catch UNTESTED

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -187,6 +187,18 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   if (options && typeof options.decodeURIComponent === 'function') {
     decode = options.decodeURIComponent;
   }
+  var preventDeopt = function (kstr, vstr) {
+    var pDout = {};
+    try {
+      pDout.k = decode(kstr);
+      pDout.v = decode(vstr);
+    } catch (e) {
+      pDout.k = QueryString.unescape(kstr, true);
+      pDout.v = QueryString.unescape(vstr, true);
+    }
+    return pDout;
+  };
+  var out = {};
 
   for (var i = 0; i < len; ++i) {
     var x = qs[i].replace(regexp, '%20'),
@@ -201,13 +213,9 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
       vstr = '';
     }
 
-    try {
-      k = decode(kstr);
-      v = decode(vstr);
-    } catch (e) {
-      k = QueryString.unescape(kstr, true);
-      v = QueryString.unescape(vstr, true);
-    }
+    out = preventDeopt(kstr, vstr);
+    k = out.k;
+    v = out.v;
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;


### PR DESCRIPTION
After reading and becoming aware of V8 Optimization Killers I was
reviewing the code to extract the URL module for my own uses when
I saw this performance killer - the try-catch in a loop.  The
statement seemed simple enough to move to its own function, so
I did just that and declared it outside of the loop.

Also, at worst case scenario, this module can be **two** try-catches
deep. This may be another area of performance improvement.

I have not tested this code. If someone more fluent in using node
could do a benchmark and verify my tweak, that would be great.
