### PR TITLE
docs: clarify url.format documentation

### DIFF
--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -81,6 +81,8 @@ Pass `true` as the third argument to treat `//foo/bar` as
 
 Take a parsed URL object, and return a formatted URL string.
 
+Here's how the formatting process works:
+
 * `href` will be ignored.
 * `protocol` is treated the same with or without the trailing `:` (colon).
   * The protocols `http`, `https`, `ftp`, `gopher`, `file` will be
@@ -95,9 +97,9 @@ Take a parsed URL object, and return a formatted URL string.
 * `port` will only be used if `host` is absent.
 * `host` will be used in place of `hostname` and `port`
 * `pathname` is treated the same with or without the leading `/` (slash)
-* `search` will be used in place of `query`
 * `query` (object; see `querystring`) will only be used if `search` is absent.
-* `search` is treated the same with or without the leading `?` (question mark)
+* `search` will be used in place of `query`.
+  * It is treated the same with or without the leading `?` (question mark)
 * `hash` is treated the same with or without the leading `#` (pound sign, anchor)
 
 ## url.resolve(from, to)


### PR DESCRIPTION
The original documentation was slightly confusing. It seemed that the
list of items described the properties of the urlObj object, while it
was actually describing the formatting process. This change makes this
clearer.

Fixes #8796.
