### PR TITLE
Relative junction should behave like dangling symlink

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -707,12 +707,14 @@ fs.readlinkSync = function(path) {
   return binding.readlink(pathModule._makeLong(path));
 };
 
-function preprocessSymlinkDestination(path, type) {
+function preprocessSymlinkDestination(path, type, linkPath) {
   if (!isWindows) {
     // No preprocessing is needed on Unix.
     return path;
   } else if (type === 'junction') {
     // Junctions paths need to be absolute and \\?\-prefixed.
+    // A relative target is relative to the link's parent directory.
+    path = pathModule.resolve(linkPath, '..', path);
     return pathModule._makeLong(path);
   } else {
     // Windows symlinks don't tolerate forward slashes.
@@ -727,7 +729,7 @@ fs.symlink = function(destination, path, type_, callback) {
   if (!nullCheck(destination, callback)) return;
   if (!nullCheck(path, callback)) return;
 
-  binding.symlink(preprocessSymlinkDestination(destination, type),
+  binding.symlink(preprocessSymlinkDestination(destination, type, path),
                   pathModule._makeLong(path),
                   type,
                   callback);
@@ -739,7 +741,7 @@ fs.symlinkSync = function(destination, path, type) {
   nullCheck(destination);
   nullCheck(path);
 
-  return binding.symlink(preprocessSymlinkDestination(destination, type),
+  return binding.symlink(preprocessSymlinkDestination(destination, type, path),
                          pathModule._makeLong(path),
                          type);
 };

--- a/test/simple/test-fs-symlink-dir-junction-relative.js
+++ b/test/simple/test-fs-symlink-dir-junction-relative.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var fs = require('fs');
+var completed = 0;
+var expected_tests = 4;
+
+// test creating and reading symbolic link
+var linkData = path.join(common.fixturesDir, 'cycles/');
+var linkPath = path.join(common.tmpDir, 'cycles_link');
+var relative = '../fixtures/cycles'
+
+// Delete previously created link
+try {
+  fs.unlinkSync(linkPath);
+} catch (e) {}
+
+console.log('linkData: ' + linkData);
+console.log('linkPath: ' + linkPath);
+console.log('relative target: ' + relative)
+
+fs.symlink(relative, linkPath, 'junction', function(err) {
+  if (err) throw err;
+  completed++;
+
+  fs.lstat(linkPath, function(err, stats) {
+    if (err) throw err;
+    assert.ok(stats.isSymbolicLink());
+    completed++;
+
+    fs.readlink(linkPath, function(err, destination) {
+      if (err) throw err;
+      assert.equal(destination, linkData);
+      completed++;
+
+      fs.unlink(linkPath, function(err) {
+        if (err) throw err;
+        assert(!fs.existsSync(linkPath));
+        assert(fs.existsSync(linkData));
+        completed++;
+      });
+    });
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(completed, expected_tests);
+});
+


### PR DESCRIPTION
A junction path must be absolute, which is why fs.symlink resolves paths on Windows if the type is `junction`. E.g. `fs.symlink("../foo", "my/link", "junction")`. From the [docs](http://nodejs.org/api/fs.html#fs_fs_symlink_srcpath_dstpath_type_callback):

> `fs.symlink(srcpath, dstpath, [type], callback)`
> 
> Note that Windows junction points require the destination path to be absolute. When using 'junction', the destination argument will automatically be **normalized to absolute path**.

_Sidenote_: Reading that, you'd think the `dstpath` argument is normalized. What the docs mean to say is that the `srcpath` (the _target_) is normalized. The function signature in the source is `fs.symlink(destination, path)`; these inconsistencies are confusing.

However, the target seems to be normalized relative to the working directory - not relative to the link's parent directory like it should:

> `man ln`
> 
> Symbolic links can hold arbitrary text; if later resolved, a relative link is interpreted in relation to its parent directory.

Of course, a junction is not the same as a symlink, but the behavior should be consistent, given that node on unix ignores the `junction` argument and will create a dangling symlink. It should do the same on Windows, or at least simulate it. This PR normalizes the target, relative to the link's parent directory. Meaning:

`fs.symlink("..\foo", "C:\my\link", "junction")`

becomes:

`fs.symlink("C:\foo", "C:\my\link", "junction")`

The included test is copied from `test-fs-symlink-dir-junction.js`. These tests could probably be merged, I didn't (yet) for the sake of clarity - and because the other (regular symlink) tests fail anyway on Windows XP.
