### PR TITLE
windows: Create npm folder in AppData directory

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -70,6 +70,7 @@
       <ComponentRef Id="NpmCmdScript"/>
       <ComponentRef Id="NpmBashScript"/>
       <ComponentRef Id="NpmConfigurationFile"/>
+      <ComponentRef Id="AppData" />
       <ComponentGroupRef Id="NpmSourceFiles"/>
     </Feature>
 
@@ -182,6 +183,16 @@
           <Component Id="NpmConfigurationFile">
             <File Id="npm.rc" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\npm\npmrc"/>
           </Component>
+        </Directory>
+      </Directory>
+
+      <Directory Id="AppDataFolder">
+        <Directory Id="AppDataDir" Name="npm">
+            <Component Id="AppData" Guid="D3B35D0E-D0F9-4D11-A773-D4608E90E1D1">
+                <CreateFolder />
+                <RemoveFolder Id="AppDataDir" On="uninstall" />
+                <RegistryValue Root="HKCU" Key="$(var.RegistryKeyPath)\Components" Type="string" Value="" />
+            </Component>
         </Directory>
       </Directory>
     </DirectoryRef>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -46,6 +46,7 @@
       <ComponentRef Id="NodeExecutable"/>
       <ComponentRef Id="NodeVarsScript"/>
       <ComponentRef Id="NodeStartMenuAndRegistryEntries"/>
+      <ComponentRef Id="AppData" />
       <ComponentGroupRef Id="Product.Generated"/>
 
       <Feature Id="NodePerfCtrSupport"
@@ -182,6 +183,16 @@
           <Component Id="NpmConfigurationFile">
             <File Id="npm.rc" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\npm\npmrc"/>
           </Component>
+        </Directory>
+      </Directory>
+
+      <Directory Id="AppDataFolder">
+        <Directory Id="AppDataDir" Name="npm">
+            <Component Id="AppData" Guid="D3B35D0E-D0F9-4D11-A773-D4608E90E1D1">
+                <CreateFolder />
+                <RemoveFolder Id="AppDataDir" On="uninstall" />
+                <RegistryValue Root="HKCU" Key="$(var.RegistryKeyPath)\Components" Type="string" Value="" />
+            </Component>
         </Directory>
       </Directory>
     </DirectoryRef>


### PR DESCRIPTION
Create the empty npm folder in Roaming\Appdata so that
non-Administrator users have a place to store global packages.
This fixes the error Error: ENOENT, stat error that occurs
when a user tries to run the npm install <package> command.

Fixes #8141
