### PR TITLE
test: add test for spawnSync() env option

### DIFF
--- a/test/simple/test-child-process-spawnsync-env.js
+++ b/test/simple/test-child-process-spawnsync-env.js
@@ -1,0 +1,35 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  console.log(process.env.foo);
+} else {
+  var expected = 'bar';
+  var child = cp.spawnSync(process.execPath, [__filename, 'child'], {
+    env: {foo: expected}
+  });
+
+  assert.equal(child.stdout.toString().trim(), expected);
+}


### PR DESCRIPTION
The `env` option to `spawnSync()` is currently broken. A fix is available in #8546, but no test is provided. This PR adds a test, which will fail until #8546 is merged.
