### PR TITLE
Fix build with systemtap/DTRACE providers on Fedora 21

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -462,7 +462,7 @@
       'target_name': 'node_dtrace_header',
       'type': 'none',
       'conditions': [
-        [ 'node_use_dtrace=="true"', {
+        [ 'node_use_dtrace=="true" and OS!="mac" and OS!="linux"', {
           'actions': [
             {
               'action_name': 'node_dtrace_header',
@@ -472,7 +472,18 @@
                 '-o', '<@(_outputs)' ]
             }
           ]
-        } ]
+        } ],
+        [ 'node_use_dtrace=="true" and OS=="linux"', {
+          'actions': [
+            {
+              'action_name': 'node_dtrace_header',
+              'inputs': [ 'src/node_provider.d' ],
+              'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/node_provider.h' ],
+              'action': [ 'dtrace', '-h', '-s', '<@(_inputs)',
+                '-o', '<@(_outputs)' ]
+            }
+          ]
+        } ],
       ]
     },
     {


### PR DESCRIPTION
The "dtrace" script version include in systemtap-sdt-devel-2.6-3
(part of Fedora 21) no longer ignores unknown command line
arguments, but will instead error out and refuse to run.
This patch adds a separate condition to node's gyp input so
that on Linux it will run dtrace without the -xnolibs
argument that trips it up on systemtap-std-devel-2.6-3.
