### PR TITLE
docs: document input encoding in hmac

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -161,9 +161,13 @@ Class for creating cryptographic hmac content.
 
 Returned by `crypto.createHmac`.
 
-### hmac.update(data)
+### hmac.update(data, [input_encoding])
 
-Update the hmac content with the given `data`.  This can be called
+Update the hmac content with the given `data`, the encoding of which
+is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
+`'binary'`.  If no encoding is provided and the input is a string an
+encoding of `'binary'` is enforced. If `data` is a `Buffer` then
+`input_encoding` is ignored.  This can be called
 many times with new data as it is streamed.
 
 ### hmac.digest([encoding])


### PR DESCRIPTION
Document the input_encoding parameter in the update function of the
Hmac class. This parameter is similar to the update function of the
Hash class, so I simply replicated the explanation.
