### PR TITLE
build: configure return exit status from gyp

### DIFF
--- a/configure
+++ b/configure
@@ -912,4 +912,4 @@ else:
 
 gyp_args += args
 
-subprocess.call(gyp_args)
+sys.exit(subprocess.call(gyp_args))


### PR DESCRIPTION
Previously, 'configure' would not return an exit status
if gyp blows up. This can be tested by adding some garbage to `node.gyp` (I have skills!)

```
date >> node.gyp ; ./configure && echo A-OK
```

You will get "A-OK" even though gyp had failed.

( Found this while working on srl295/node#12 )
