### PR TITLE
documentation: add server.listen docs for random port assignment

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -203,6 +203,16 @@ This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'](net.html#event_listening_) event.
 See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
 
+### server.listen([callback])
+
+* `callback` {Function}
+
+Begin accepting connections on a random port. In order to get the assigned port number you must use `server.address().port`. The port is only available when the ['listening'](net.html#event_listening_) event is triggered.
+
+This function is asynchronous. The last parameter `callback` will be added as
+a listener for the ['listening'](net.html#event_listening_) event.
+See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
+
 ### server.close([callback])
 
 Stops the server from accepting new connections.  See [net.Server.close()][].

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -164,7 +164,8 @@ If a client connection emits an 'error' event - it will forwarded here.
 
 Begin accepting connections on the specified port and hostname.  If the
 hostname is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`).
+IPv4 address (`INADDR_ANY`). If port is an empty value (0, '0', null or
+undefined), an ephemeral (random) port will be used.
 
 To listen to a unix socket, supply a filename instead of port and hostname.
 
@@ -207,9 +208,10 @@ See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
 
 * `callback` {Function}
 
-Begin accepting connections on a random port. In order to get the assigned port
-number you must use `server.address().port`, which is not available until the
-['listening'](net.html#event_listening_) event has been emitted.
+Begin accepting connections on an ephemeral port, randomly selected. In order
+to get the assigned port number you must use `server.address().port`, which is
+not available until the ['listening'](net.html#event_listening_) event has been
+emitted.
 
 This function is asynchronous. `callback` will be added as a listener for the
 ['listening'](net.html#event_listening_) event. See also

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -160,12 +160,16 @@ If a client connection emits an 'error' event - it will forwarded here.
 `socket` is the `net.Socket` object that the error originated from.
 
 
-### server.listen(port, [hostname], [backlog], [callback])
+### server.listen([port], [hostname], [backlog], [callback])
 
-Begin accepting connections on the specified port and hostname.  If the
-hostname is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`). If port is an empty value (0, '0', null or
-undefined), an ephemeral (random) port will be used.
+Begin accepting connections on the specified port and hostname.
+
+If the port is omitted, an ephemeral port will be used. In order to get the
+assigned port number you must use `server.address().port`, which is not
+available until the ['listening'][] event has been emitted.
+
+If the hostname is omitted, the server will accept connections directed to
+any IPv4 address (`INADDR_ANY`).
 
 To listen to a unix socket, supply a filename instead of port and hostname.
 
@@ -204,18 +208,6 @@ This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'](net.html#event_listening_) event.
 See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
 
-### server.listen([callback])
-
-* `callback` {Function}
-
-Begin accepting connections on an ephemeral port, randomly selected. In order
-to get the assigned port number you must use `server.address().port`, which is
-not available until the ['listening'](net.html#event_listening_) event has been
-emitted.
-
-This function is asynchronous. `callback` will be added as a listener for the
-['listening'](net.html#event_listening_) event. See also
-[net.Server.listen()](net.html#net_server_listen_handle_callback).
 
 ### server.close([callback])
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -207,11 +207,13 @@ See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
 
 * `callback` {Function}
 
-Begin accepting connections on a random port. In order to get the assigned port number you must use `server.address().port`. The port is only available when the ['listening'](net.html#event_listening_) event is triggered.
+Begin accepting connections on a random port. In order to get the assigned port
+number you must use `server.address().port`, which is not available until the
+['listening'](net.html#event_listening_) event has been emitted.
 
-This function is asynchronous. The last parameter `callback` will be added as
-a listener for the ['listening'](net.html#event_listening_) event.
-See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
+This function is asynchronous. `callback` will be added as a listener for the
+['listening'](net.html#event_listening_) event. See also
+[net.Server.listen()](net.html#net_server_listen_handle_callback).
 
 ### server.close([callback])
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -168,8 +168,8 @@ If the port is omitted, an ephemeral port will be used. In order to get the
 assigned port number you must use `server.address().port`, which is not
 available until the ['listening'][] event has been emitted.
 
-If the hostname is omitted, the server will accept connections directed to
-any IPv4 address (`INADDR_ANY`).
+If the hostname is omitted or `0.0.0.0`, the server will accept connections
+directed to any host IP address.
 
 To listen to a unix socket, supply a filename instead of port and hostname.
 
@@ -207,7 +207,6 @@ Listening on a file descriptor is not supported on Windows.
 This function is asynchronous. The last parameter `callback` will be added as
 a listener for the ['listening'](net.html#event_listening_) event.
 See also [net.Server.listen()](net.html#net_server_listen_handle_callback).
-
 
 ### server.close([callback])
 


### PR DESCRIPTION
Documentation was missing the possibility of having server port randomly assigned.
