### PR TITLE
build: change `graphviz.py` to support "all"

### DIFF
--- a/tools/gyp/tools/graphviz.py
+++ b/tools/gyp/tools/graphviz.py
@@ -27,6 +27,10 @@ def LoadEdges(filename, targets):
   edges = json.load(file)
   file.close()
 
+  if len(targets) == 0:
+    # all edges
+    return edges
+
   # Copy out only the edges we're interested in from the full edge list.
   target_edges = {}
   to_visit = targets[:]
@@ -84,11 +88,6 @@ def WriteGraph(edges):
 
 
 def main():
-  if len(sys.argv) < 2:
-    print >>sys.stderr, __doc__
-    print >>sys.stderr
-    print >>sys.stderr, 'usage: %s target1 target2...' % (sys.argv[0])
-    return 1
 
   edges = LoadEdges('dump.json', sys.argv[1:])
 


### PR DESCRIPTION
With this change, the following:

```
python tools/gyp_node.py -f dump_dependency_json
python tools/gyp/tools/graphviz.py > node_deps.dot
```

.. will produce node_deps.dot with all deps.  Previously, `graphviz.dot` needed exact targets, including pathnames.

I know this is a change to upstream, just putting it here for reference.

Sample output [here](https://drive.google.com/file/d/0B1J55jsbiIIpdE5lUFVzbTdHRXc/view?usp=sharing)
