### PR TITLE
doc: fix Folders as Modules omission of index.json

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -197,12 +197,13 @@ If this was in a folder at `./some-library`, then
 
 This is the extent of Node's awareness of package.json files.
 
-If there is no package.json file present in the directory, then node
-will attempt to load an `index.js` or `index.node` file out of that
+If there is no package.json file present in the directory, then node will
+attempt to load an `index.js`, `index.json`, or `index.node` file out of that
 directory.  For example, if there was no package.json file in the above
 example, then `require('./some-library')` would attempt to load:
 
 * `./some-library/index.js`
+* `./some-library/index.json`
 * `./some-library/index.node`
 
 ## Caching


### PR DESCRIPTION
This section was inconsistent with the actual behavior of `require` and
with other parts of this same document, which do describe the ability
to treat index.json as a module’s default file.

PR inspired by the discussion at https://github.com/michaelficarra/us-states/pull/3
