### PR TITLE
Documentation improvement on buffer.copy

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -187,12 +187,19 @@ The method will not write partial characters.
 * `start` Number, Optional, Default: 0
 * `end` Number, Optional, Default: `buffer.length`
 
-Decodes and returns a string from buffer data encoded with `encoding`
-(defaults to `'utf8'`) beginning at `start` (defaults to `0`) and ending at
-`end` (defaults to `buffer.length`).
+Decodes and returns a string from buffer data encoded using the specified
+character set encoding. If `encoding` is not specified or is `undefined` or
+`null`, `encoding` defaults to `'utf8'. The `start` and `end` parameters 
+default to `0` and `buffer.length` when not specified or passed as `undefined`/`NaN`.
 
-See `buffer.write()` example, above.
-
+    buf = new Buffer(26);
+    for (var i = 0 ; i < 26 ; i++) {
+      buf[i] = i + 97; // 97 is ASCII a
+    }
+    buf.toString('ascii'); // outputs: abcdefghijklmnopqrstuvwxyz
+    buf.toString('ascii',0,5); // outputs: abcde
+    buf.toString('utf8',0,5); // outputs: abcde
+    buf.toString(undefined,0,5); // encoding defaults to 'utf8', outputs abcde
 
 ### buf.toJSON()
 

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -259,12 +259,10 @@ the same as the `otherBuffer` in sort order.
 * `sourceStart` Number, Optional, Default: 0
 * `sourceEnd` Number, Optional, Default: `buffer.length`
 
-Does copy between buffers. The source and target regions can be overlapped.
-`targetStart` and `sourceStart` default to `0`.
-`sourceEnd` defaults to `buffer.length`.
-
-All values passed that are `undefined`/`NaN` or are out of bounds are set equal
-to their respective defaults.
+Copies data from a region of this buffer to a region in the target buffer even 
+if the target memory region overlaps with the source. If not specified or passed 
+as `undefined`/`NaN`, the `targetStart` and `sourceStart` parameters default 
+to `0` and `sourceEnd` defaults to `buffer.length`.
 
 Example: build two Buffers, then copy `buf1` from byte 16 through byte 19
 into `buf2`, starting at the 8th byte in `buf2`.
@@ -282,6 +280,19 @@ into `buf2`, starting at the 8th byte in `buf2`.
 
     // !!!!!!!!qrst!!!!!!!!!!!!!
 
+Example: Build a single buffer, then copy data from one region to an overlapping
+region in the same buffer
+
+    buf = new Buffer(26);
+
+    for (var i = 0 ; i < 26 ; i++) {
+      buf[i] = i + 97; // 97 is ASCII a
+    }
+
+    buf.copy(buf, 0, 4, 10);
+    console.log(buf.toString('ascii'));
+
+    // efghijghijklmnopqrstuvwxyz
 
 ### buf.slice([start], [end])
 


### PR DESCRIPTION
Per https://github.com/joyent/node/issues/8857.. a slight documentation improvement discussing overlapping buffers...

Per https://github.com/joyent/node/issues/8859 .. slight documentation improvement discussing buffer.toString
