### PR TITLE
Improvement to events docs per #8853

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -33,7 +33,10 @@ added and `'removeListener'` when a listener is removed.
 ### emitter.addListener(event, listener)
 ### emitter.on(event, listener)
 
-Adds a listener to the end of the listeners array for the specified event.
+Adds a listener to the end of the listeners array for the specified `event`. 
+No checks are made to see if the `listener` has already been added. Multiple
+calls passing the same combination of `event` and `listener` will result 
+in the `listener` being added multiple times.
 
     server.on('connection', function (stream) {
       console.log('someone connected!');
@@ -64,6 +67,11 @@ Remove a listener from the listener array for the specified event.
     server.on('connection', callback);
     // ...
     server.removeListener('connection', callback);
+
+`removeListener` will remove, at most, one instance of a listener from the 
+listener array. If any single listener has been added multiple times to the 
+listener array for the specified `event`, then `removeListener` must be called 
+multiple times to remove each instance.
 
 Returns emitter, so calls can be chained.
 
@@ -121,8 +129,8 @@ Return the number of listeners for a given event.
 * `event` {String} The event name
 * `listener` {Function} The event handler function
 
-This event is emitted any time someone adds a new listener.  It is unspecified
-if `listener` is in the list returned by `emitter.listeners(event)`.
+This event is emitted any time a listener is added. When this event is triggered,
+the listener may not yet have been added to the array of listeners for the `event`.
 
 
 ### Event: 'removeListener'


### PR DESCRIPTION
Per #8853, improvements to documentation for addListener, removeListener and newListener to reflect the fact that addListener allows any single listener to be added multiple times (which is silly, but needs to documented)
