### PR TITLE
src: fix windows build error

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -64,9 +64,9 @@ enum node_zlib_mode {
 };
 
 enum node_zlib_error {
-  NO_ERROR,
-  FAILED,
-  WRITE_PENDING
+  kNoError,
+  kFailed,
+  kWritePending
 };
 
 void InitZlib(v8::Handle<v8::Object> target);
@@ -212,7 +212,7 @@ class ZCtx : public AsyncWrap {
     if (!async) {
       // sync version
       Process(work_req);
-      if (CheckError(ctx) == NO_ERROR)
+      if (CheckError(ctx) == kNoError)
         AfterSync(ctx, args);
       return;
     }
@@ -310,18 +310,18 @@ class ZCtx : public AsyncWrap {
         ZCtx::Error(ctx, "Missing dictionary");
       else
         ZCtx::Error(ctx, "Bad dictionary");
-      return FAILED;
+      return kFailed;
     default:
       // something else.
       if (ctx->strm_.total_out == 0) {
         ZCtx::Error(ctx, "Zlib error");
-        return FAILED;
+        return kFailed;
       } else {
-        return WRITE_PENDING;
+        return kWritePending;
       }
     }
 
-    return NO_ERROR;
+    return kNoError;
   }
 
 
@@ -336,7 +336,7 @@ class ZCtx : public AsyncWrap {
     Context::Scope context_scope(env->context());
 
     node_zlib_error error = CheckError(ctx);
-    if (error == FAILED)
+    if (error == kFailed)
       return;
 
     Local<Integer> avail_out = Integer::New(env->isolate(),
@@ -350,7 +350,7 @@ class ZCtx : public AsyncWrap {
     Local<Value> args[2] = { avail_in, avail_out };
     ctx->MakeCallback(env->callback_string(), ARRAY_SIZE(args), args);
 
-    if (error == WRITE_PENDING) {
+    if (error == kWritePending) {
       ZCtx::Error(ctx, "Zlib error");
       return;
     }


### PR DESCRIPTION
Fix a Windows-only build error that was introduced in
commit 1183ba4 ("zlib: support concatenated gzip files").

Rename the NO_ERROR and FAILED enumerations, they conflict
with macros of the same name in <winerror.h>.

PR-URL: https://github.com/node-forward/node/pull/57
Reviewed-By: Fedor Indutny fedor@indutny.com
Reviewed-By: Rod Vagg rod@vagg.org
