### PR TITLE
timers: don't close interval timers when unrefd

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -293,7 +293,7 @@ var Timeout = function(after) {
 
 function unrefdHandle() {
   this.owner._onTimeout();
-  if (!this.owner.repeat)
+  if (!this.owner._repeat)
     this.owner.close();
 }
 

--- a/test/simple/test-timers-unrefd-interval-still-fires.js
+++ b/test/simple/test-timers-unrefd-interval-still-fires.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * This test is a regression test for joyent/node#8900.
+ */
+var assert = require('assert');
+
+var N = 5;
+var nbIntervalFired = 0;
+var timer = setInterval(function() {
+  ++nbIntervalFired;
+  if (nbIntervalFired === N)
+    clearInterval(timer);
+}, 1);
+
+timer.unref();
+
+setTimeout(function onTimeout() {
+  assert.strictEqual(nbIntervalFired, N);
+}, 100);


### PR DESCRIPTION
This change fixes a regression introduced by commit
0d051238be2e07e671d7d9f4f444e0cc1efadf1b, which contained a typo that
would cause every unrefd interval to fire only once.

Fixes #8900.
