### PR TITLE
http.OutgoingMessage.prototype.setHeaders

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -324,6 +324,28 @@ or
 
 Boolean (read-only). True if headers were sent, false otherwise.
 
+### response.setHeaders(headers) 
+
+Sets multiple header values for implicit headers. When multiple headers are 
+to be set, rather than calling `response.setHeader` for each, an object or
+an array containing each of the headers to be set can be passed to 
+`response.setHeaders`. If a header already exists in the to-be-sent headers,
+its value will be replaced. Use an array of strings as the value to send 
+multiple headers with the same name.
+
+    response.setHeaders({
+      "Content-Type": "text/html",
+      "Set-Cookie": ["type=ninja", "language=javascript"]
+    });
+
+The `headers` parameter can be passed either as an object (as illustrated above)
+or an array whose members are arrays (as illustrated below)
+
+    response.setHeaders([
+      ['Content-Type', 'text/html'],
+      ['Set-Cookie', ["type=ninja", "language=javascript"]]
+    ]);
+
 ### response.sendDate
 
 When true, the Date header will be automatically generated and sent in
@@ -394,6 +416,10 @@ emit trailers, with a list of the header fields in its value. E.g.,
     response.addTrailers({'Content-MD5': "7895bf4b8828b55ceaf47747b4bca667"});
     response.end();
 
+The `headers` parameter can be passed either as an object (as illustrated above)
+or an array whose members are arrays (as illustrated below)
+
+    response.addTrailers([['Content-MD5', '7895bf4b8828b55ceaf47747b4bca667']]);
 
 ### response.end([data], [encoding])
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -698,6 +698,44 @@ OutgoingMessage.prototype.setHeader = function(name, value) {
 };
 
 
+/**
+ * Convenience shortcut. Rather than calling setHeader once
+ * for every header to be set, call setHeaders, passing in
+ * a dictionary of headers to set. e.g.
+ *  res.setHeaders({
+ *    a:'b',
+ *    c:'d'}
+ *  );
+ * is equivalent to:
+ *  res.setHeader('a','b');
+ *  res.setHeader('c','d');
+ **/
+OutgoingMessage.prototype.setHeaders = function(headers) {
+  if (arguments.length < 1) {
+    // ignore, there's nothing to do
+    return;
+  }
+  if (typeof headers !== 'object' ||
+      (headers.valueOf && headers.valueOf() !== headers)) {
+    throw new Error('Headers must be an object or an array');
+  }
+  var keys = Object.keys(headers);
+  var isArray = (Array.isArray(headers));
+  for (var n = 0, l = keys.length; n < l; n++) {
+    var key = keys[n];
+    var name, value;
+    if (isArray) {
+      name = headers[key][0];
+      value = headers[key][1];
+    } else {
+      name = key;
+      value = headers[key];
+    }
+    this.setHeader(name, value);
+  }
+};
+
+
 OutgoingMessage.prototype.getHeader = function(name) {
   if (arguments.length < 1) {
     throw new Error('`name` is required for getHeader().');

--- a/test/simple/test-http-mutable-headers.js
+++ b/test/simple/test-http-mutable-headers.js
@@ -46,18 +46,32 @@ var s = http.createServer(function(req, res) {
       assert.throws(function() { res.setHeader('someHeader') });
       assert.throws(function() { res.getHeader() });
       assert.throws(function() { res.removeHeader() });
+      assert.throws(function() { res.setHeaders(1) });
+      assert.throws(function() { res.setHeaders([1]) });
 
       res.setHeader('x-test-header', 'testing');
       res.setHeader('X-TEST-HEADER2', 'testing');
       res.setHeader('set-cookie', cookies);
       res.setHeader('x-test-array-header', [1, 2, 3]);
+      res.setHeaders({
+        'x-test-setheaders': 'abc', 
+        'x-test-setheaders2': 'xyz'
+      });
 
       var val1 = res.getHeader('x-test-header');
       var val2 = res.getHeader('x-test-header2');
+
+      var val3 = res.getHeader('x-test-setheaders');
+      var val4 = res.getHeader('x-test-setheaders2');
+
       assert.equal(val1, 'testing');
       assert.equal(val2, 'testing');
+      assert.equal(val3, 'abc');
+      assert.equal(val4, 'xyz');
 
       res.removeHeader('x-test-header2');
+      res.removeHeader('x-test-setheaders');
+      res.removeHeader('x-test-setheaders2');
       break;
 
     case 'contentLength':


### PR DESCRIPTION
Small suggested api addition to http.OutgoingMessage ... add a
setHeaders to OutgoingMessage that allows multiple headers to be set at
once, similar to addTrailers.

Example:

``` javascript
response.setHeaders({a:'b', c:'c'});
```

Also, add documentation to addTrailers that illustrates how setting
headers using an array is supposed to work.
