### PR TITLE
test: use executable in spawn() test

### DIFF
--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -62,10 +62,11 @@ assert.doesNotThrow(function() { spawn(cmd, a, o); });
 assert.doesNotThrow(function() { spawn(cmd, o); });
 
 // Variants of undefined as explicit 'no argument' at a position
-assert.doesNotThrow(function() { execFile(empty, u, o); });
-assert.doesNotThrow(function() { execFile(empty, a, u); });
-assert.doesNotThrow(function() { execFile(empty, n, o); });
-assert.doesNotThrow(function() { execFile(empty, a, n); });
+assert.doesNotThrow(function() { spawn(cmd, u, o); });
+assert.doesNotThrow(function() { spawn(cmd, a, u); });
+
+assert.throws(function() { spawn(cmd, n, o); }, TypeError);
+assert.throws(function() { spawn(cmd, a, n); }, TypeError);
 
 assert.throws(function() { spawn(cmd, s); }, TypeError);
 assert.throws(function() { spawn(cmd, a, s); }, TypeError);


### PR DESCRIPTION
Currently, the `test-child-process-spawn-typeerror.js` is calling `execFile()` on a JavaScript source file, which is causing failures on Windows. This commit switches the source file to an actual executable.
