### PR TITLE
Revert "doc: clarify fs.symlink and fs.symlinkSync parameters"

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -208,7 +208,7 @@ the completion callback.
 
 Synchronous link(2).
 
-## fs.symlink(srcpath, dstpath[, type], callback)
+## fs.symlink(destination, path[, type], callback)
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
@@ -217,7 +217,7 @@ is `'file'`) and is only available on Windows (ignored on other platforms).
 Note that Windows junction points require the destination path to be absolute.  When using
 `'junction'`, the `destination` argument will automatically be normalized to absolute path.
 
-## fs.symlinkSync(srcpath, dstpath[, type])
+## fs.symlinkSync(destination, path[, type])
 
 Synchronous symlink(2).
 


### PR DESCRIPTION
The offending doc change clarified nothing, but put the arguments to
fs.symlink() and fs.symlinkSync() in the wrong order.

This patch should be applied to v0.10 too.

See also #8920
