### PR TITLE
dns: allow v8 to optimize lookup()

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -21,7 +21,7 @@
 
 var cares = process.binding('cares_wrap'),
     net = require('net'),
-    isIp = net.isIP;
+    isIP = net.isIP;
 
 
 function errnoException(errorno, syscall) {
@@ -78,7 +78,9 @@ function makeAsync(callback) {
 
 // Easy DNS A/AAAA look up
 // lookup(domain, [family,] callback)
-exports.lookup = function(domain, family, callback) {
+exports.lookup = function(domain, family_, callback_) {
+  var family = family_,
+      callback = callback_;
   // parse arguments
   if (arguments.length === 2) {
     callback = family;
@@ -102,12 +104,12 @@ exports.lookup = function(domain, family, callback) {
   // localhost entry from c:\WINDOWS\system32\drivers\etc\hosts
   // See http://daniel.haxx.se/blog/2011/02/21/localhost-hack-on-windows/
   // TODO Remove this once c-ares handles this problem.
-  if (process.platform == 'win32' && domain == 'localhost') {
+  if (process.platform === 'win32' && domain === 'localhost') {
     callback(null, '127.0.0.1', 4);
     return {};
   }
 
-  var matchedFamily = net.isIP(domain);
+  var matchedFamily = isIP(domain);
   if (matchedFamily) {
     callback(null, domain, matchedFamily);
     return {};


### PR DESCRIPTION
Reassigning the values of parameter variables causes
v8 to disable function optimization.
