### PR TITLE
Fixing typo imparative -> imperative

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2091,7 +2091,7 @@ int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx) {
   //
   // Since we cannot perform I/O quickly enough in this callback, we ignore
   // all preverify_ok errors and let the handshake continue. It is
-  // imparative that the user use Connection::VerifyError after the
+  // imperative that the user use Connection::VerifyError after the
   // 'secure' callback has been made.
   return 1;
 }


### PR DESCRIPTION
Fixing a small typo imparative -> imperative.
