### PR TITLE
net: make Server.prototype.unref() persistent

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1041,6 +1041,7 @@ function Server(/* [ options, ] listener */) {
   this._handle = null;
   this._usingSlaves = false;
   this._slaves = [];
+  this._unref = false;
 
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
@@ -1155,6 +1156,10 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
   // generate connection key, this should be unique to the connection
   this._connectionKey = addressType + ':' + address + ':' + port;
+
+  // unref the handle if the server was unref'ed prior to listening
+  if (this._unref)
+    this.unref();
 
   process.nextTick(function() {
     // ensure handle hasn't closed
@@ -1422,11 +1427,15 @@ Server.prototype._setupSlave = function(socketList) {
 };
 
 Server.prototype.ref = function() {
+  this._unref = false;
+
   if (this._handle)
     this._handle.ref();
 };
 
 Server.prototype.unref = function() {
+  this._unref = true;
+
   if (this._handle)
     this._handle.unref();
 };

--- a/test/simple/test-net-server-unref-persistent.js
+++ b/test/simple/test-net-server-unref-persistent.js
@@ -1,0 +1,39 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var closed = false;
+var server = net.createServer();
+
+// unref before listening
+server.unref();
+server.listen();
+
+setTimeout(function() {
+  closed = true;
+  server.close();
+}, 1000).unref();
+
+process.on('exit', function() {
+  assert.strictEqual(closed, false, 'server should not hold loop open');
+});


### PR DESCRIPTION
Currently, the `unref()` method does not remember any state if called before the server's handle has been created. This commit adds state to track calls to `ref()` and `unref()`.

Related to #7077. Note - a similar fix is possible for `Socket.prototype.unref()` (which I have code for). However, `Socket` appears to have additional `unref()` issues other than persistence.
