### PR TITLE
deps: fix v8 after 45f1330

### DIFF
--- a/deps/v8/src/debug-debugger.js
+++ b/deps/v8/src/debug-debugger.js
@@ -1961,7 +1961,7 @@ DebugCommandProcessor.prototype.resolveFrameFromScopeDescription_ =
   // Get the frame for which the scope or scopes are requested.
   // With no frameNumber argument use the currently selected frame.
   if (scope_description && !IS_UNDEFINED(scope_description.frameNumber)) {
-    frame_index = scope_description.frameNumber;
+    var frame_index = scope_description.frameNumber;
     if (frame_index < 0 || this.exec_state_.frameCount() <= frame_index) {
       throw new Error('Invalid frame number');
     }
@@ -2221,7 +2221,7 @@ DebugCommandProcessor.prototype.lookupRequest_ = function(request, response) {
 
   // Set 'includeSource' option for script lookup.
   if (!IS_UNDEFINED(request.arguments.includeSource)) {
-    includeSource = %ToBoolean(request.arguments.includeSource);
+    var includeSource = %ToBoolean(request.arguments.includeSource);
     response.setOption('includeSource', includeSource);
   }
 


### PR DESCRIPTION
45f1330 enabled "use strict" in "deps/v8/src/debug-debugger.js", which surfaced usage of undefined variables in this file.

```
ReferenceError: frame_index is not defined
ReferenceError: includeSource is not defined
```

This patch fixes the problem in Node until it is fixed upstream.

Node issue: #8948
V8 issue: https://code.google.com/p/v8/issues/detail?id=3790

@misterdjules @tjfontaine 
