### PR TITLE
V0.10.35 http method check

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -30,7 +30,7 @@ var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;
 var assert = require('assert').ok;
 
-var token = /^[^\x00-\x31\x127\(\)<>@,;:\\"/\[\]\?=\{}]+$/
+var token = /^[^\x00-\x31\x127\(\)<>@,;:\\"/\[\]\?=\{}]+$/;
 
 var debug;
 if (process.env.NODE_DEBUG && /http/.test(process.env.NODE_DEBUG)) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -30,6 +30,8 @@ var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;
 var assert = require('assert').ok;
 
+var token = /^[^\x00-\x31\x127\(\)<>@,;:\\"/\[\]\?=\{}]+$/
+
 var debug;
 if (process.env.NODE_DEBUG && /http/.test(process.env.NODE_DEBUG)) {
   debug = function(x) { console.error('HTTP: %s', x); };
@@ -1365,6 +1367,10 @@ function ClientRequest(options, cb) {
   self.socketPath = options.socketPath;
 
   var method = self.method = (options.method || 'GET').toUpperCase();
+  if (!method.match(token)) {
+    throw new Error('Invalid HTTP method');
+  }
+
   self.path = options.path || '/';
   if (cb) {
     self.once('response', cb);


### PR DESCRIPTION
Per #8947, the http.request constructor is not properly checking the validity
of the HTTP method input by the user. The problem allowed HTTP request
headers to be injected via the method option as reported in #8947. This fixes
the problem by introducing a quick check against a the HTTP token rule to 
ensure that the method is valid.
