### PR TITLE
Improve querystring parse and stringify

### DIFF
--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -7,11 +7,11 @@
 This module provides utilities for dealing with query strings.
 It provides the following methods:
 
-## querystring.stringify(obj, [sep], [eq])
+## querystring.stringify(obj, [sep], [eq], [name])
 
 Serialize an object to a query string.
 Optionally override the default separator (`'&'`) and assignment (`'='`)
-characters.
+characters and optionally specify a name when obj is primitive.
 
 Example:
 
@@ -22,6 +22,39 @@ Example:
     querystring.stringify({foo: 'bar', baz: 'qux'}, ';', ':')
     // returns
     'foo:bar;baz:qux'
+
+    querystring.stringify('bar', undefined, undefined, 'foo')
+    // returns
+    'foo=bar'
+
+    querystring.stringify(['bar','baz'], undefined, undefined, 'foo')
+    // returns
+    'foo=bar&foo=baz'
+
+## querystring.stringify(obj, [options])
+
+Serialize an object to a query string.
+Optionally override the default separator (`'&'`) and assignment (`'='`)
+characters.
+
+1. `options.sep` - override the separator character
+1. `options.eq` - override the assignment character
+1. `options.name` - set the optional name
+1. `options.omitnull` - true if null/undefined values should be omitted.
+
+Example:
+
+    querystring.stringify({ foo: 'bar', baz: null}, {omitnull:false})
+    // returns
+    'foo=bar&baz='
+
+    querystring.stringify({ foo: 'bar', baz: null}, {omitnull:true})
+    // returns
+    'foo=bar&baz'
+
+    querystring.stringify({ foo: 'bar', baz: null}, {sep:'.'})
+    // returns
+    'foo=bar.baz='
 
 ## querystring.parse(str, [sep], [eq], [options])
 
@@ -37,6 +70,27 @@ Example:
     querystring.parse('foo=bar&baz=qux&baz=quux&corge')
     // returns
     { foo: 'bar', baz: ['qux', 'quux'], corge: '' }
+
+## querystring.parse(str, [options])
+
+Deserialize a query string to an object.
+Optionally override the default separator (`'&'`) and assignment (`'='`)
+characters.
+
+1. `options.sep` = override the separator character
+1. `options.eq` = override the assignment character
+1. `options.omitnull` = true to treat missing assignments as undefined.
+1. `options.maxKeys` = used to limit processed keys. Defaults to 1000. Set to 0 to remove key count limitation.
+
+Example:
+
+    querystring.parse('foo=bar&baz=qux&baz=quux&corge')
+    // returns
+    { foo: 'bar', baz: ['qux', 'quux'], corge: '' }
+
+    querystring.parse('foo=bar&baz=qux&baz=quux&corge', {omitnull:true})
+    // returns
+    { foo: 'bar', baz: ['qux', 'quux'], corge: undefined }
 
 ## querystring.escape
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -134,36 +134,70 @@ var stringifyPrimitive = function(v) {
 };
 
 
+//QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
 QueryString.stringify = QueryString.encode = function(obj, sep, eq, name) {
-  sep = sep || '&';
-  eq = eq || '=';
+  // if using options object instead of separate params
+  var omitnull;
+  if (sep && typeof sep === 'object') {
+    name = sep.name;
+    eq = sep.eq || '=';
+    omitnull = sep.omitnull;
+    sep = sep.sep || '&';
+  } else {
+    sep = sep || '&';
+    eq = eq || '=';
+  }
+
   if (obj === null) {
     obj = undefined;
   }
 
   if (typeof obj === 'object') {
-    return Object.keys(obj).map(function(k) {
-      var ks = QueryString.escape(stringifyPrimitive(k)) + eq;
-      if (Array.isArray(obj[k])) {
-        return obj[k].map(function(v) {
-          return ks + QueryString.escape(stringifyPrimitive(v));
-        }).join(sep);
-      } else {
-        return ks + QueryString.escape(stringifyPrimitive(obj[k]));
-      }
-    }).join(sep);
-
+    if (Array.isArray(obj)) {
+      var idx = 0;
+      return obj.map(function(item) {
+        var ks = name || idx++;
+        var ret = QueryString.escape(stringifyPrimitive(ks));
+        if ((item !== undefined && item !== null) || !omitnull)
+          ret += eq + QueryString.escape(stringifyPrimitive(item));
+        return ret;
+      }).join(sep);
+    } else {
+      return Object.keys(obj).map(function(k) {
+        var ks = QueryString.escape(stringifyPrimitive(k));
+        if ((obj[k] !== undefined && obj[k] !== null) || !omitnull) {
+          ks += eq;
+          if (Array.isArray(obj[k])) {
+            return obj[k].map(function(v) {
+              return ks + QueryString.escape(stringifyPrimitive(v));
+            }).join(sep);
+          } else {
+            return ks + QueryString.escape(stringifyPrimitive(obj[k]));
+          }
+        } else return ks;
+      }).join(sep);
+    }
   }
 
   if (!name) return '';
-  return QueryString.escape(stringifyPrimitive(name)) + eq +
-         QueryString.escape(stringifyPrimitive(obj));
+  var ret = QueryString.escape(stringifyPrimitive(name));
+  if ((obj !== undefined && obj !== null) || !omitnull)
+    ret += eq + QueryString.escape(stringifyPrimitive(obj));
+  return ret;
 };
 
 // Parse a key=val string.
 QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
-  sep = sep || '&';
-  eq = eq || '=';
+  var omitnull;
+  if (sep && typeof sep === 'object') {
+    options = sep;
+    eq = options.eq || '=';
+    sep = options.sep || '&';
+    omitnull = options.omitnull;
+  } else {
+    sep = sep || '&';
+    eq = eq || '=';
+  }
   var obj = {};
 
   if (typeof qs !== 'string' || qs.length === 0) {
@@ -194,11 +228,13 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
       vstr = x.substr(idx + 1);
     } else {
       kstr = x;
-      vstr = '';
+      vstr = !omitnull ? '' : null;
     }
 
     k = QueryString.unescape(kstr, true);
-    v = QueryString.unescape(vstr, true);
+    if ((vstr !== undefined && vstr !== null) || !omitnull) {
+      v = QueryString.unescape(vstr, true);
+    }
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;

--- a/test/simple/test-querystring.js
+++ b/test/simple/test-querystring.js
@@ -237,3 +237,19 @@ qs.unescape = function (str) {
 };
 assert.deepEqual(qs.parse('foo=bor'), {f__: 'b_r'});
 qs.unescape = prevUnescape;
+
+// test using options object and omitnull
+function testOptionsObjectAndOmitNull() {
+  var a = qs.parse('a&b=',{omitnull:true});
+  assert.equal(a.a, undefined);
+  assert.equal(a.b, '');
+  assert.equal('a&b=',qs.stringify(a, {omitnull:true}));
+ }
+ testOptionsObjectAndOmitNull();
+
+ function testArrayInput() {
+  assert.equal('0=1&1=2', qs.stringify([1,2]) );
+  assert.equal('z=1&z=2', qs.stringify([1,2], {name:'z'}) );
+  assert.equal('z=1&z', qs.stringify([1,null], {name:'z',omitnull:true}) );
+ }
+ testArrayInput();


### PR DESCRIPTION
Per https://github.com/joyent/node/issues/8829

Improve querystring.stringify and querystring.parse so that
undefined and null are optionally omitted. Allow sep, eq,
and name to be passed in options instead of as separate
parameters. Add new omitnull option. See documentation
changes for example.
