### PR TITLE
net: partial revert of 8180

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -878,10 +878,18 @@ Socket.prototype.connect = function(options, cb) {
 
   if (pipe) {
     connect(self, options.path);
+  } else if (!options.host) {
+    var port = options.port | 0;
 
+    if (port <= 0 || port > 65535)
+      throw new RangeError('port should be > 0 and < 65536: ' + port);
+
+    debug('connect: missing host');
+    self._host = '127.0.0.1';
+    connect(self, self._host, port, 4);
   } else {
     var dns = require('dns');
-    var host = options.host || 'localhost';
+    var host = options.host;
     var port = options.port | 0;
     var localAddress = options.localAddress;
     var localPort = options.localPort;


### PR DESCRIPTION
Commit b636ba8186d191c52ee36f2f2b1aebbbb4d95575 removed a code path, causing a test failure on Windows. This commit reverts the relevant changes. Closes #8986.

cc: @misterdjules 
