### PR TITLE
deps: revert backport b593aa8 from v8 upstream

### DIFF
--- a/deps/v8/src/debug-debugger.js
+++ b/deps/v8/src/debug-debugger.js
@@ -24,7 +24,6 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-"use strict";
 
 // Default number of frames to include in the response to backtrace request.
 var kDefaultBacktraceLength = 10;
@@ -678,7 +677,7 @@ Debug.setBreakPoint = function(func, opt_line, opt_column, opt_condition) {
 Debug.setBreakPointByScriptIdAndPosition = function(script_id, position,
                                                     condition, enabled)
 {
-  var break_point = MakeBreakPoint(position);
+  break_point = MakeBreakPoint(position);
   break_point.setCondition(condition);
   if (!enabled) {
     break_point.disable();
@@ -743,7 +742,7 @@ Debug.clearBreakPoint = function(break_point_number) {
 
 Debug.clearAllBreakPoints = function() {
   for (var i = 0; i < break_points.length; i++) {
-    var break_point = break_points[i];
+    break_point = break_points[i];
     %ClearBreakPoint(break_point);
   }
   break_points = [];

--- a/deps/v8/src/mirror-debugger.js
+++ b/deps/v8/src/mirror-debugger.js
@@ -24,7 +24,6 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-"use strict";
 
 // Handle id counters.
 var next_handle_ = 0;
@@ -56,7 +55,7 @@ function MakeMirror(value, opt_transient) {
 
   // Look for non transient mirrors in the mirror cache.
   if (!opt_transient) {
-    for (var id in mirror_cache_) {
+    for (id in mirror_cache_) {
       mirror = mirror_cache_[id];
       if (mirror.value() === value) {
         return mirror;
@@ -1155,11 +1154,11 @@ ErrorMirror.prototype.toText = function() {
   // Use the same text representation as in messages.js.
   var text;
   try {
-    text = %_CallFunction(this.value_, builtins.ErrorToString);
+    str = %_CallFunction(this.value_, builtins.ErrorToString);
   } catch (e) {
-    text = '#<Error>';
+    str = '#<Error>';
   }
-  return text;
+  return str;
 };
 
 


### PR DESCRIPTION
This reverts commit 45f1330425b671905a02fe30ee7a1dd9544c2709.

45f1330425b671905a02fe30ee7a1dd9544c2709 was basically breaking
node-inspector. V8 landed a patch upstream that would probably fix these
issues (see https://codereview.chromium.org/813873007), but without the
ability to properly test it in the wild, it's safer to just revert the
breaking change.

Fixes #8948.
