### PR TITLE
Improve performance of event and timer interfaces

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -117,15 +117,30 @@ EventEmitter.prototype.emit = function emit(type, arg1, arg2) {
           args[i - 1] = arguments[i];
         handler.apply(this, args);
     }
-  } else if (util.isObject(handler)) {
-    args = new Array(len - 1);
-    for (i = 1; i < len; i++)
-      args[i - 1] = arguments[i];
-
+  } else if (util.isArray(handler)) {
     listeners = handler.slice();
-    len = listeners.length;
-    for (i = 0; i < len; i++)
-      listeners[i].apply(this, args);
+    switch (len) {
+      // fast cases
+      case 1:
+        for (i = 0, len = listeners.length; i < len; i++)
+          listeners[i].call(this);
+        break;
+      case 2:
+        for (i = 0, len = listeners.length; i < len; i++)
+          listeners[i].call(this, arg1);
+        break;
+      case 3:
+        for (i = 0, len = listeners.length; i < len; i++)
+          listeners[i].call(this, arg1, arg2);
+        break;
+      // slower
+      default:
+        args = new Array(len - 1);
+        for (i = 1; i < len; i++)
+          args[i - 1] = arguments[i];
+        for (i = 0, len = listeners.length; i < len; i++)
+          listeners[i].apply(this, args);
+    }
   }
 
   if (this.domain && this !== process)

--- a/lib/events.js
+++ b/lib/events.js
@@ -65,7 +65,7 @@ EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   return this;
 };
 
-EventEmitter.prototype.emit = function emit(type) {
+EventEmitter.prototype.emit = function emit(type, arg1, arg2) {
   var er, handler, len, args, i, listeners;
 
   if (!this._events)
@@ -97,28 +97,27 @@ EventEmitter.prototype.emit = function emit(type) {
   if (this.domain && this !== process)
     this.domain.enter();
 
+  len = arguments.length;
   if (util.isFunction(handler)) {
-    switch (arguments.length) {
+    switch (len) {
       // fast cases
       case 1:
         handler.call(this);
         break;
       case 2:
-        handler.call(this, arguments[1]);
+        handler.call(this, arg1);
         break;
       case 3:
-        handler.call(this, arguments[1], arguments[2]);
+        handler.call(this, arg1, arg2);
         break;
       // slower
       default:
-        len = arguments.length;
         args = new Array(len - 1);
         for (i = 1; i < len; i++)
           args[i - 1] = arguments[i];
         handler.apply(this, args);
     }
   } else if (util.isObject(handler)) {
-    len = arguments.length;
     args = new Array(len - 1);
     for (i = 1; i < len; i++)
       args[i - 1] = arguments[i];

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -413,22 +413,37 @@ Immediate.prototype._idlePrev = undefined;
 Immediate.prototype._asyncFlags = 0;
 
 
-exports.setImmediate = function(callback) {
+exports.setImmediate = function(callback, arg1, arg2) {
   var immediate = new Immediate();
-  var args, index;
+  var i, args, len = arguments.length;
 
   L.init(immediate);
 
-  immediate._onImmediate = callback;
+  switch (len) {
+    // fast cases
+    case 0:
+    case 1:
+      immediate._onImmediate = callback;
+      break;
+    case 2:
+      immediate._onImmediate = function() {
+        callback.call(immediate, arg1);
+      };
+      break;
+    case 3:
+      immediate._onImmediate = function() {
+        callback.call(immediate, arg1, arg2);
+      };
+      break;
+    // slow case
+    default:
+      args = new Array(len - 1);
+      for (i = 1; i < len; i++)
+        args[i - 1] = arguments[i];
 
-  if (arguments.length > 1) {
-    args = [];
-    for (index = 1; index < arguments.length; index++)
-      args.push(arguments[index]);
-
-    immediate._onImmediate = function() {
-      callback.apply(immediate, args);
-    };
+      immediate._onImmediate = function() {
+        callback.apply(immediate, args);
+      };
   }
 
   if (!process._needImmediateCallback) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -217,8 +217,8 @@ exports.active = function(item) {
  */
 
 
-exports.setTimeout = function(callback, after) {
-  var timer;
+exports.setTimeout = function(callback, after, arg1, arg2) {
+  var timer, i, args, len = arguments.length;
 
   after *= 1; // coalesce to number or NaN
 
@@ -228,22 +228,41 @@ exports.setTimeout = function(callback, after) {
 
   timer = new Timeout(after);
 
-  if (arguments.length <= 2) {
-    timer._onTimeout = callback;
-  } else {
-    /*
-     * Sometimes setTimeout is called with arguments, EG
-     *
-     *   setTimeout(callback, 2000, "hello", "world")
-     *
-     * If that's the case we need to call the callback with
-     * those args. The overhead of an extra closure is not
-     * desired in the normal case.
-     */
-    var args = Array.prototype.slice.call(arguments, 2);
-    timer._onTimeout = function() {
-      callback.apply(timer, args);
-    }
+  /*
+   * Sometimes setTimeout is called with arguments, EG
+   *
+   *   setTimeout(callback, 2000, "hello", "world")
+   *
+   * If that's the case we need to call the callback with
+   * those args. The overhead of an extra closure is not
+   * desired in the normal case.
+   */
+  switch (len) {
+    // fast cases
+    case 0:
+    case 1:
+    case 2:
+      timer._onTimeout = callback;
+      break;
+    case 3:
+      timer._onTimeout = function() {
+        callback.call(timer, arg1);
+      };
+      break;
+    case 4:
+      timer._onTimeout = function() {
+        callback.call(timer, arg1, arg2);
+      };
+      break;
+    // slow case
+    default:
+      args = new Array(len - 2);
+      for (i = 2; i < len; i++)
+        args[i - 2] = arguments[i];
+
+      timer._onTimeout = function() {
+        callback.apply(timer, args);
+      }
   }
 
   if (process.domain) timer.domain = process.domain;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -285,17 +285,21 @@ exports.clearTimeout = function(timer) {
 };
 
 
-exports.setInterval = function(callback, repeat) {
+exports.setInterval = function(callback, repeat, arg1, arg2) {
   repeat *= 1; // coalesce to number or NaN
 
   if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour
   }
 
-  var timer = new Timeout(repeat);
-  var args = Array.prototype.slice.call(arguments, 2);
+  var timer = new Timeout(repeat), len = arguments.length - 2, args, i;
   timer._onTimeout = wrapper;
   timer._repeat = true;
+  if (len > 2) {
+    args = new Array(len);
+    for (i = 0; i < len; i++)
+      args[i] = arguments[i + 2];
+  }
 
   if (process.domain) timer.domain = process.domain;
   exports.active(timer);
@@ -303,7 +307,21 @@ exports.setInterval = function(callback, repeat) {
   return timer;
 
   function wrapper() {
-    callback.apply(this, args);
+    switch (len) {
+      // fast cases
+      case 0:
+        callback.call(this);
+        break;
+      case 1:
+        callback.call(this, arg1);
+        break;
+      case 2:
+        callback.call(this, arg1, arg2);
+        break;
+      // slow case
+      default:
+        callback.apply(this, args);
+    }
     // If callback called clearInterval().
     if (timer._repeat === false) return;
     // If timer is unref'd (or was - it's permanently removed from the list.)


### PR DESCRIPTION
**This pull request speeds up multi-listener event callbacks, `setImmediate`, `setTimeout`, and `setInterval` by differentiating between zero-, one-, and two-argument callbacks. This technique was previously only applied to single-listener event callbacks—and even they have been sped up.**
### Current situation

The `EventEmitter#emit` code has special cases for zero-, one-, and two-argument callbacks as follows:

``` JavaScript
len = arguments.length;
switch (len) {
  // fast cases
  case 1: handler.call(this); break;
  case 2: handler.call(this, arguments[1]); break;
  case 3: handler.call(this, arguments[1], arguments[2]); break;
  // slower
  default:
    args = new Array(len - 1);
    for (i = 1; i < len; i++)
      args[i - 1] = arguments[i];
    handler.apply(this, args);
}
```
### Improvements in this pull request

On the one hand, this pull request speeds up this technique by avoiding the use of `arguments` indexing, instead adding actual function arguments `arg1` and `arg2`.

On the other hand, this pull request also applies the same technique to listeners with multiple callbacks, as well as the timer functions `setImmediate`, `setTimeout`, and `setInterval`.

Below are my results of [performance tests](https://github.com/RubenVerborgh/Node-Events-Timers-Performance) that examine these cases (ran on a 2010 MacBook Pro).

|  | v0.10.29 | ← diff → | @master | ← diff → | #9007 |
| --- | --: | --: | --: | --: | --: |
| **event with one listener** | 1.341 ms | +298% | 5.337 ms | **-54,11%** | **2.449 ms** |
| **event with two listeners** | 2.868 ms | +70% | 4.872 ms | **-44,33%** | **2.712 ms** |
| **setImmediate** | 21.079 ms | -73% | 5.786 ms | **-37,28%** | **3.629 ms** |
| **setTimeout** | 7.377 ms | -2% | 7.229 ms | **-50,84%** | **3.554 ms** |
| **setInterval** | 11.706 ms | -44% | 6.518 ms | **-50,43%** | **3.231 ms** |

Note how the current _master_ branch has worsened the performance of event listeners in comparison to v0.10, and this pull request compensates for that difference. In cases where the _master_ branch improved performance, this pull request improves it even more.
### Considerations

Given the importance of callbacks in Node, delivering maximum performance for common cases is crucial. The only drawback of this pull request seems to be the increased code length; but it brings consistency since the optimization technique was previously only applied to one particular case (and slightly suboptimally).

I added each change in a different commit, so you can decide which ones to merge. All commits are independent of each other, except for the second (ca3a08d242c4bb25ad93062a05a049e368912a9e), which depends on the first (e4d4c9809a67fa65ade03449ff3303ff434f6953).

If you want these commits squashed, or applied to a different branch, please let me know and I'll do so.
