### PR TITLE
Change an ungraceful repetition of 'that'

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -189,8 +189,8 @@ function done(stream, er) {
   if (er)
     return stream.emit('error', er);
 
-  // if there's nothing in the write buffer, then that means
-  // that nothing more will ever be provided
+  // if there's nothing in the write buffer, then
+  // this means nothing more will ever be provided
   var ws = stream._writableState;
   var ts = stream._transformState;
 


### PR DESCRIPTION
The sentence felt clunky so rephrased the second part of the sentence to:
- "if there's nothing in the write buffer, then this means nothing more will ever be provided".
  Instead of:
- "if there's nothing in the write buffer, then that means that nothing more will ever be provided".
