### PR TITLE
http: Check for malformed HTTP method for request

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1344,6 +1344,22 @@ Agent.prototype.removeSocket = function(s, name, host, port, localAddress) {
 var globalAgent = new Agent();
 exports.globalAgent = globalAgent;
 
+function check_is_token(val) {
+  if (!val || typeof val !== 'string')
+    return false;
+  for (var n = 0, l = val.length; n < l; n++) {
+    var c = val.charCodeAt(n);
+    if (c <= 32 || c == 34 ||
+        c == 44 || c == 47 ||
+        c == 123 || c == 125 ||
+        c == 40 || c == 41 ||
+        (c >= 58 && c <= 64) ||
+        (c >= 91 && c <= 93) || 
+        c >= 128)
+      return false;
+  }
+  return true;
+}
 
 function ClientRequest(options, cb) {
   var self = this;
@@ -1365,6 +1381,9 @@ function ClientRequest(options, cb) {
   self.socketPath = options.socketPath;
 
   var method = self.method = (options.method || 'GET').toUpperCase();
+  if (!check_is_token(method)) {
+    throw new Error('Malformed HTTP request method');
+  }
   self.path = options.path || '/';
   if (cb) {
     self.once('response', cb);
@@ -2139,6 +2158,9 @@ Client.prototype.request = function(method, path, headers) {
     headers = path;
     path = method;
     method = 'GET';
+  }
+  if (!check_is_token(method)) {
+    throw new Error('Malformed HTTP request method');
   }
   options.method = method;
   options.path = path;

--- a/test/simple/test-http-malformed-method.js
+++ b/test/simple/test-http-malformed-method.js
@@ -1,0 +1,34 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+// this should throw
+var c = 0;
+try {
+  var req = http.request({method:'GET\n'});
+} catch (err) {
+  console.log(err);
+  c++;
+}
+assert.equal(c,1);


### PR DESCRIPTION
Add a check to make sure that the specified HTTP method is a valid
token per the spec. To do so, we look at the method string and check
that each character is valid per the token rule. The first violation
aborts the check and throws.

This check is necessary to avoid malicious http request header
injection. per https://github.com/joyent/node/issues/8947
