### PR TITLE
http: fix >90% performance regression for GET requests using response.end

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -946,10 +946,6 @@ OutgoingMessage.prototype.end = function(data, encoding) {
   if (encoding === 'hex' || encoding === 'base64')
     hot = false;
 
-  // Transfer-encoding: chunked responses to HEAD requests
-  if (this._hasBody && this.chunkedEncoding)
-    hot = false;
-
   if (hot) {
     // Hot path. They're doing
     //   res.writeHead();


### PR DESCRIPTION
## Problem

This is an attempt to fix issue #8940, which describes a performance regression which started with commit 1fddc1f; more specifically, the number of requests per second dropped from ~18k to ~1.1k (on my machine) in between v0.10.31 and v0.10.32. This can be tested easily as described in issue #8940:

```
var http = require('http');
var body = new Buffer('Hello World');
http.createServer(function(req, res) {
  res.writeHead(200); // or: `res.statusCode = 200;`
  res.end(body); // change this to `res.end();` to see the expected speed post-1fddc1f
}).listen(3333);
```

```
wrk 'http://localhost:3333/' -d 3 -c 50 -t 4 | grep 'Requests/sec'
```

The problem comes from commit 1fddc1f, in particular from the following lines, which are aimed at HEAD requests:

```
// Transfer-encoding: chunked responses to HEAD requests
if (this._hasBody && this.chunkedEncoding)
   hot = false; // This will never execute for HEAD requests, only GET
```

However, the `hot = false;` instruction will never execute for HEAD requests, since `this._hasBody` is always `false` because of line [lib/http.js:1073](https://github.com/joyent/node/blob/1fddc1fee84785d296e37337dcb0dc12c13a049f/lib/http.js#L1073), but it will execute for all GET requests since the conditions will match. Therefore, hot-path optimization will never be done for GET requests when sending data via `response.end()`.
## Fix

The fix is simply to remove the lines mentioned above:

```
- // Transfer-encoding: chunked responses to HEAD requests
- if (this._hasBody && this.chunkedEncoding)
-   hot = false;
```

As previously explained, this executes only for GET requests, not for HEAD requests, as it was intended. Simply removing them will allow GET requests to have the hot-path optimization when `response.end(...);` is not empty, while HEAD requests will be non-optimized since there is no need (i.e no body).
## Testing

As far as I can tell, there are three conditions which need to be met in order for the fix to be considered safe:
1. Performance should be at pre-1fddc1f levels for the script in #8940.
2. Pass all of the node tests, which also includes the one which came packaged with 1fddc1f.
3. As a bonus, make sure that #8361 is still fixed.

For no. 1, I have tested that the performance is at pre-1fddc1 levels after deleting those three lines.

```
Original
wrk 'http://localhost:3333/' -d 3 -c 50 -t 4 | grep 'Requests/sec' | awk '{ print "  " $2 }'
1184.48 

With fix 
wrk 'http://localhost:3333/' -d 3 -c 50 -t 4 | grep 'Requests/sec' | awk '{ print "  " $2 }'
18378.13
```

For no. 2, I have made sure that the Node tests run/pass in the same way with/without the fix. 

For no. 3, I have tried those scripts, everything is fine.

```
status: 404
{ 'transfer-encoding': 'chunked',
  date: 'Tue, 13 Jan 2015 17:10:21 GMT',
  connection: 'close' }
end
```
