### PR TITLE
test: fix ssl/tls options matrix test

### DIFF
--- a/test/external/ssl-options/test.js
+++ b/test/external/ssl-options/test.js
@@ -169,26 +169,17 @@ function testSetupsCompatible(serverSetup, clientSetup) {
     return false;
   }
 
-  if (isSsl2Protocol(serverSetup.secureProtocol) ||
-      isSsl2Protocol(clientSetup.secureProtocol)) {
-
-      /*
-       * It seems that in order to be able to use SSLv2, at least the server
-       * *needs* to advertise at least one cipher compatible with it.
-       */
-      if (serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS) {
-        return false;
-      }
-
-      /*
-       * If only either one of the client or server specify SSLv2 as their
-       * protocol, then *both* of them *need* to advertise at least one cipher
-       * that is compatible with SSLv2.
-       */
-      if ((!isSsl2Protocol(serverSetup.secureProtocol) || !isSsl2Protocol(clientSetup.secureProtocol)) &&
-        (clientSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS || serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS)) {
-        return false;
-      }
+  var ssl2Used = isSsl2Protocol(serverSetup.secureProtocol) ||
+                 isSsl2Protocol(clientSetup.secureProtocol);
+  if (ssl2Used &&
+      ((serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS) ||
+      (clientSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS))) {
+    /*
+     * Default ciphers are not compatible with SSLv2. Both client *and*
+     * server need to specify a SSLv2 compatible cipher to be able to use
+     * SSLv2.
+     */
+    return false;
   }
 
   return true;
@@ -340,7 +331,8 @@ function runClient(port, secureProtocol, secureOptions, ciphers) {
                         {
                           rejectUnauthorized: false,
                           secureProtocol: secureProtocol,
-                          secureOptions: secureOptions
+                          secureOptions: secureOptions,
+                          ciphers: ciphers
                         },
                         function() {
 


### PR DESCRIPTION
The tests suite available in test/external/ssl-options was originally
written for security fixes made in the v0.10 branch. In this branch, the
client's default ciphers list is compatible with SSLv2.

After merging this change from v0.10 to v0.12, this tests suite was
broken because commits 5d2aef17ee56fbbf415ca1e3034cdb02cd97117c and
f4c8020d1068ffba57458b327c62b61b1f29ec63 make SSL/TLS clients use a
default ciphers list that is not compatible with the SSLv2 protocol.

This change fixes two issues:
1) The cipher list that was setup for a given test was not passed
properly to the client.
2) When either or both of clients/servers were using SSLv2, tests were
expected to succeed when at least the server end was using SSLv2
compatible ciphers. Now, tests are expected to succeed only if
SSLv2 compatible ciphers are used on both ends.

Fixes #9020.
