### PR TITLE
test: fix test-crypto-stream.js

### DIFF
--- a/test/simple/test-crypto-stream.js
+++ b/test/simple/test-crypto-stream.js
@@ -70,7 +70,7 @@ var key = new Buffer('48fb56eb10ffeb13fc0ef551bbca3b1b', 'hex'),
 
 cipher.pipe(decipher)
   .on('error', common.mustCall(function end(err) {
-    assert(/:00000000:/.test(err));
+    assert(/Unsupported/.test(err));
   }));
 
 cipher.end('Papaya!');  // Should not cause an unhandled exception.


### PR DESCRIPTION
A recent merge of v0.10 to v0.12
(0c7f6ca83091eb5516d07153f35f851e47f753ee) upgraded OpenSSL to version
1.0.1j. In v0.10, this required test-crypto-stream.js to be fixed with
commit 707cc25011d142fe4ade14ce2aa083a96ef15bcb. Basically, instead of
returning the proper error, Err_get_error() would return 0 and the test
for the error message needed to be updated in test-crypto-stream.js.

However, in the v0.12 branch, crypto error messages are handled a bit
differently since commit 26a1b712ec4e39cedc0b305165ce4660f47ba4d5
landed. Instead of returning the default OpenSSL error message, it makes
the decipher stream return a default message specific to Node.js.

This commit updates test-crypto-stream.js to test the error object
against the proper default error message.

Fixes #9019.
