### PR TITLE
cluster: avoid race enabling debugger in worker

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -285,7 +285,7 @@ function masterInit() {
       var key;
       for (key in cluster.workers) {
         var worker = cluster.workers[key];
-        if (worker.state === 'online') {
+        if (worker.state === 'online' || worker.state === 'listening') {
           process._debugProcess(worker.process.pid);
         } else {
           worker.once('online', function() {

--- a/test/simple/test-debug-signal-cluster.js
+++ b/test/simple/test-debug-signal-cluster.js
@@ -35,32 +35,32 @@ var pids = null;
 
 child.stderr.on('data', function(data) {
   var lines = data.toString().replace(/\r/g, '').trim().split('\n');
-  var line = lines[0];
 
-  lines.forEach(function(ln) { console.log('> ' + ln) } );
+  lines.forEach(function(line) {
+    console.log('> ' + line);
 
-  if (outputTimerId !== undefined)
-    clearTimeout(outputTimerId);
+    if (line === 'all workers are running') {
+      child.on('message', function(msg) {
+        if (msg.type !== 'pids')
+          return;
 
-  if (waitingForDebuggers) {
-    outputLines = outputLines.concat(lines);
-    outputTimerId = setTimeout(onNoMoreLines, 800);
-  } else if (line === 'all workers are running') {
-    child.on('message', function(msg) {
-      if (msg.type !== 'pids')
-        return;
+        pids = msg.pids;
+        console.error('got pids %j', pids);
 
-      pids = msg.pids;
-      console.error('got pids %j', pids);
+        waitingForDebuggers = true;
+        process._debugProcess(child.pid);
+      });
 
-      waitingForDebuggers = true;
-      process._debugProcess(child.pid);
-    });
+      child.send({
+        type: 'getpids'
+      });
+    } else if (waitingForDebuggers) {
+      outputLines.push(line);
+    }
 
-    child.send({
-      type: 'getpids'
-    });
-  }
+  });
+  if (outputLines.length >= expectedLines.length)
+    onNoMoreLines();
 });
 
 function onNoMoreLines() {
@@ -70,7 +70,7 @@ function onNoMoreLines() {
 
 setTimeout(function testTimedOut() {
   assert(false, 'test timed out.');
-}, 6000);
+}, 6000).unref();
 
 process.on('exit', function onExit() {
   pids.forEach(function(pid) {
@@ -78,16 +78,16 @@ process.on('exit', function onExit() {
   });
 });
 
-function assertOutputLines() {
-  var expectedLines = [
-    'Starting debugger agent.',
-    'Debugger listening on port ' + 5858,
-    'Starting debugger agent.',
-    'Debugger listening on port ' + 5859,
-    'Starting debugger agent.',
-    'Debugger listening on port ' + 5860,
-  ];
+var expectedLines = [
+  'Starting debugger agent.',
+  'Debugger listening on port ' + 5858,
+  'Starting debugger agent.',
+  'Debugger listening on port ' + 5859,
+  'Starting debugger agent.',
+  'Debugger listening on port ' + 5860,
+];
 
+function assertOutputLines() {
   // Do not assume any particular order of output messages,
   // since workers can take different amout of time to
   // start up


### PR DESCRIPTION
Previously if a worker's state machine had already transitioned into the
'listening' state when it received the message enabling the debugger,
the worker would never enable its debugger.

Change the logic to allow the 'listening' as a valid state for enabling
the debugger.

Fixes #6440

Also improve the test that covers this mechanism.
