### PR TITLE
http: rename flush to flushHeaders

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -855,7 +855,7 @@ Emitted when the server sends a '100 Continue' HTTP response, usually because
 the request contained 'Expect: 100-continue'. This is an instruction that
 the client should send the request body.
 
-### request.flush()
+### request.flushHeaders()
 
 Flush the request headers.
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -613,7 +613,7 @@ OutgoingMessage.prototype._flush = function() {
 };
 
 
-OutgoingMessage.prototype.flush = function() {
+OutgoingMessage.prototype.flushHeaders = function outgoingFlushHeaders() {
   if (!this._header) {
     // Force-flush the headers.
     this._implicitHeader();

--- a/test/simple/test-http-flush.js
+++ b/test/simple/test-http-flush.js
@@ -32,6 +32,6 @@ http.createServer(function(req, res) {
     host: '127.0.0.1',
     port: common.PORT,
   });
-  req.flush();  // Flush the request headers.
-  req.flush();  // Should be idempotent.
+  req.flushHeaders();  // Flush the request headers.
+  req.flushHeaders();  // Should be idempotent.
 });


### PR DESCRIPTION
In order to preserve the potential for a flush method being added to the
streams API, rename flush to flushHeaders which is much more clear about
the behavior of this method.
