### PR TITLE
which.js: root is allowed to execute files owned by anyone

### DIFF
--- a/deps/npm/node_modules/which/which.js
+++ b/deps/npm/node_modules/which/which.js
@@ -21,7 +21,9 @@ if (process.platform == "win32") {
     //console.error("isExe?", (mod & 0111).toString(8))
     var ret = (mod & 0001)
         || (mod & 0010) && process.getgid && gid === process.getgid()
+        || (mod & 0010) && process.getuid && 0   === process.getuid()
         || (mod & 0100) && process.getuid && uid === process.getuid()
+        || (mod & 0100) && process.getuid && 0   === process.getuid()
     //console.error("isExe?", ret)
     return ret
   }


### PR DESCRIPTION
When running in say, a chroot enviornment, the process UID and GID will be 0,
but the files in the system (like /usr/bin/git) may not be owned by root itself.

This patch modifies the isExe function that tries to determine if a process is
executable and allows root to execute any file that has any executable bit set,
instead of just allowing it if the other executable bit is set.
