### PR TITLE
tls: catch race condition to prevent memory leak

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -321,6 +321,14 @@ function onCryptoStreamEnd() {
   }
 
   if (this.onend) this.onend();
+
+  if (this._opposite._finished &&
+      !this._opposite._ended &&
+      !this._opposite._doneFlag) {
+    this._opposite.once('end', function(xs) {
+      this._done();
+    });
+  }
 }
 
 

--- a/test/internet/test-tls-ensure-ssl-free.js
+++ b/test/internet/test-tls-ensure-ssl-free.js
@@ -1,0 +1,45 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+var assert = require('assert');
+var https = require('https');
+
+var wasClosed = 0;
+var options = {
+  host: 'google.com',
+  rejectUnauthorized: false,
+  agent: false
+};
+
+https.get(options, function(res) {
+  var originalClose = res.socket.pair.ssl.close;
+
+  res.socket.pair.ssl.close = function() {
+    wasClosed++;
+    return originalClose.apply(this, arguments);
+  };
+
+  res.resume();
+});
+
+process.on('exit', function() {
+  assert.equal(wasClosed, 1);
+});
+


### PR DESCRIPTION
My co-worker @hayes and I spent the better part of last week hunting this bug. Today we presented it to @chrisdickinson and he helped us further debug the issue and assisted in writing the patch/test.

Digging into the issue. The [node-newrelic](https://github.com/newrelic/node-newrelic) module has had a very small leak for a long time. In the core dumps we'd find many copies of our custom certs that we use for outbound connections to new relic servers. A bug was fixed in [yakaa](https://github.com/newrelic/yakaa) one of our dependencies which should have removed the ability for it to hold onto dead sockets, and I confirmed that it was indeed not keeping any references to those sockets.

Further digging revealed that `CryptoStream` pair that is returned from `tls.connect()` was never being garbage collected, and the `Connection` (from src/node_crypto) was never freeing its `ssl_` property nor was its destructor ever called. After spending many hours tracing all the states that the duplex stream pair could be in and how this could happen, we found that the writable side of the `ClearTextStream` was emitting `'finish'` before either of the streams emitted `'end'`. This lead to `_done` not being called on `EncryptedStream` which means that the pair would be leaked and the underlying SSL object would never be freed.

We tried to create a "simple" test but could not reproduce against the node tls server nor the node https server. We could, however, reliably reproduce the issue hitting https://google.com/ so we put the test in "internet" but hope that someone else can make a "simple" regression test.

r=@indutny 
