### PR TITLE
v8: workaround to arm v6l detection in newer kernel versions as described in Issue 8589

### DIFF
--- a/configure
+++ b/configure
@@ -490,20 +490,19 @@ def configure_arm(o):
   else:
     arm_float_abi = 'default'
 
-  if is_arch_armv7():
-    o['variables']['arm_version'] = '7'
-    o['variables']['arm_fpu'] = 'vfpv3'
-    o['variables']['arm_version'] = '7'  
-  elif is_arch_armv6():
-    o['variables']['arm_version'] = '6'
-    o['variables']['arm_fpu'] = 'vfpv2'
-  else:
-    o['variables']['arm_version'] = 'default'
-    o['variables']['arm_fpu'] = 'vfp'
-    
+  # configure arm defaults which would be most widely supported
   o['variables']['arm_neon'] = int(is_arm_neon())
   o['variables']['arm_thumb'] = 0      # -marm
   o['variables']['arm_float_abi'] = arm_float_abi
+  o['variables']['arm_version'] = 'default'
+  o['variables']['arm_fpu'] = 'vfpv2' # according to 'armcc', ARMv1 is syn. with ARMv2
+
+  # implement arch-specific overrides
+  if is_arch_armv7():
+    o['variables']['arm_version'] = '7'
+    o['variables']['arm_fpu'] = 'vfpv3'
+  elif is_arch_armv6():
+    o['variables']['arm_version'] = '6'
 
 
 def configure_node(o):

--- a/configure
+++ b/configure
@@ -492,12 +492,15 @@ def configure_arm(o):
 
   if is_arch_armv7():
     o['variables']['arm_version'] = '7'
+    o['variables']['arm_fpu'] = 'vfpv3'
+    o['variables']['arm_version'] = '7'  
   elif is_arch_armv6():
     o['variables']['arm_version'] = '6'
+    o['variables']['arm_fpu'] = 'vfpv2'
   else:
     o['variables']['arm_version'] = 'default'
-
-  o['variables']['arm_fpu'] = 'vfpv3'  # V8 3.18 no longer supports VFP2.
+    o['variables']['arm_fpu'] = 'vfp'
+    
   o['variables']['arm_neon'] = int(is_arm_neon())
   o['variables']['arm_thumb'] = 0      # -marm
   o['variables']['arm_float_abi'] = arm_float_abi

--- a/deps/v8/src/base/cpu.cc
+++ b/deps/v8/src/base/cpu.cc
@@ -374,7 +374,20 @@ CPU::CPU() : stepping_(0),
       char* processor = cpu_info.ExtractField("Processor");
       if (HasListItem(processor, "(v6l)")) {
         architecture_ = 6;
-      }
+      } else {
+        // Due to changes in Linux kernel, there is a scenario
+        // where the "Processor" field no longer contains the
+        // processor architecture. The workaround for this issue
+        // is to inspect the "model name" field.
+        //
+        // See: https://github.com/joyent/node/issues/8589
+        // See: https://code.google.com/p/v8/issues/detail?id=3112
+        delete[] processor;
+        processor = cpu_info.ExtractField("model name");
+        if (HasListItem(processor, "(v6l)")) {
+          architecture_ = 6;
+        }
+      }  
       delete[] processor;
     }
   }

--- a/deps/v8/src/base/cpu.cc
+++ b/deps/v8/src/base/cpu.cc
@@ -365,25 +365,23 @@ CPU::CPU() : stepping_(0),
     //
     // See http://code.google.com/p/android/issues/detail?id=10812
     //
-    // We try to correct this by looking at the 'elf_format'
+    // We try to correct this by looking at the 'elf_platform'
     // field reported by the 'Processor' field, which is of the
     // form of "(v7l)" for an ARMv7-based CPU, and "(v6l)" for
     // an ARMv6-one. For example, the Raspberry Pi is one popular
     // ARMv6 device that reports architecture 7.
+	// NOTE: the 'elf_platform' moved to the model name field in 
+	// Linux v3.8, so we check that first
     if (architecture_ == 7) {
-      char* processor = cpu_info.ExtractField("Processor");
+      char* processor = cpu_info.ExtractField("model name");
       if (HasListItem(processor, "(v6l)")) {
         architecture_ = 6;
       } else {
-        // Due to changes in Linux kernel, there is a scenario
-        // where the "Processor" field no longer contains the
-        // processor architecture. The workaround for this issue
-        // is to inspect the "model name" field.
-        //
-        // See: https://github.com/joyent/node/issues/8589
-        // See: https://code.google.com/p/v8/issues/detail?id=3112
+        // prior to Linux v3.8 'elf_platform' was found in the
+        // "Processor" field, we check this second for backward 
+        //compatibility
         delete[] processor;
-        processor = cpu_info.ExtractField("model name");
+        processor = cpu_info.ExtractField("Processor");
         if (HasListItem(processor, "(v6l)")) {
           architecture_ = 6;
         }


### PR DESCRIPTION
v8: workaround to arm v6l detection in newer kernel versions as described in Issue 8589

See: https://github.com/iojs/io.js/issues/283
See: https://github.com/joyent/node/issues/7222
See: https://github.com/joyent/node/issues/8589
See: https://code.google.com/p/v8/issues/detail?id=3112

Also reflected in v8 pull: https://github.com/v8/v8/pull/18
