### PR TITLE
http: verify http method is a valid http token

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1344,6 +1344,39 @@ Agent.prototype.removeSocket = function(s, name, host, port, localAddress) {
 var globalAgent = new Agent();
 exports.globalAgent = globalAgent;
 
+// http token is defined in RFC2616 as...
+//   token          = 1*<any CHAR except CTLs or separators>
+//   separators     = "(" | ")" | "<" | ">" | "@"
+//                  | "," | ";" | ":" | "\" | <">
+//                  | "/" | "[" | "]" | "?" | "="
+//                  | "{" | "}" | SP | HT
+// and redefined in RFC7230 as ...
+//   tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+//     "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+//   token = 1*tchar
+//
+// This checks the input to make sure it's valid according to the
+// http token rule. If the input doesn't match, it throws, if it
+// does match, val is returned.
+function checkIsHttpToken(val, label) {
+  if (!val || typeof val !== 'string')
+    return false;
+  for (var n = 0, l = val.length; n < l; n++) {
+    var c = val.charCodeAt(n);
+    if (c <= 32 || c == 34 ||
+        c == 44 || c == 47 ||
+        c == 123 || c == 125 ||
+        c == 40 || c == 41 ||
+        (c >= 58 && c <= 64) ||
+        (c >= 91 && c <= 93) ||
+        c >= 128)
+      throw new Error(
+          'Invalid character (' +
+          String.fromCharCode(c) +
+          ') in HTTP ' + label + ' at position ' + (n + 1));
+  }
+  return val;
+}
 
 function ClientRequest(options, cb) {
   var self = this;
@@ -1365,6 +1398,7 @@ function ClientRequest(options, cb) {
   self.socketPath = options.socketPath;
 
   var method = self.method = (options.method || 'GET').toUpperCase();
+  checkIsHttpToken(method, 'method');
   self.path = options.path || '/';
   if (cb) {
     self.once('response', cb);
@@ -2140,7 +2174,7 @@ Client.prototype.request = function(method, path, headers) {
     path = method;
     method = 'GET';
   }
-  options.method = method;
+  options.method = checkIsHttpToken(method, 'method');
   options.path = path;
   options.headers = headers;
   options.agent = self.agent;

--- a/test/simple/test-http-malformed-method.js
+++ b/test/simple/test-http-malformed-method.js
@@ -1,0 +1,76 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+// http token is defined in RFC2616 as...
+//   token          = 1*<any CHAR except CTLs or separators>
+//   separators     = "(" | ")" | "<" | ">" | "@"
+//                  | "," | ";" | ":" | "\" | <">
+//                  | "/" | "[" | "]" | "?" | "="
+//                  | "{" | "}" | SP | HT
+// and redefined in RFC7230 as ...
+//   tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+//     "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+//   token = 1*tchar
+// 
+// the rfc2616 version tells us what characters are not allowed,
+// the rfc7230 version tells us what characters are allowed.
+
+var fail = ['GET\n', 'POST(', 'PUT)', 'GET<', 'DELETE>',
+ 'MET@HOD', 'GET,', 'GET;', 'POST:', 'METHOD\\',
+ 'GET"', 'GET/', 'ABC[', 'XYZ]', 'XYZ?', 'XYZ=',
+ 'ABC{', 'ABC}', '123 ', '123\t'];
+
+var ok = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH',
+ 'GET!', 'POST#', 'PUT$', 'DELETE%', 'OPTIONS&',
+ "GET'", 'POST*', 'PUT+', 'DELETE-', 'OPTIONS.',
+ 'GET^', 'POST_', 'PUT`', 'DELETE|', 'OPTIONS~',
+ 'GET~', '1234567890', 'ABCDEFGHHIJKLMNOPQRSTUV',
+ 'get', 'post', 'put', 'delete', 'options', 'patch',
+ 'get!', 'post#', 'put$', 'delete%', 'options&',
+ "get'", 'post*', 'put+', 'delete-', 'options.',
+ 'get^', 'post', 'put`', 'delete|', 'options~',
+ 'get~'
+ ];
+
+// These should throw... they include invalid characters
+fail.forEach(function(test) {
+  assert.throws(
+    function() { http.request({method:test}); },
+    Error);
+});
+
+//These shouldn't throw because the characters are permitted,
+//even if the values are not actually good http methods.
+ok.forEach(function(test) {
+  assert.doesNotThrow(
+    function() { 
+      http.request({method:test}).on('error', function() {
+        // an invalid method won't trigger this.
+      }).abort() }
+  );
+});
+
+
+


### PR DESCRIPTION
RFC 2616/7230 requires that http method conform to
the token rule. This adds a check to verify that there are
no invalid characters in the method. If there are, then
we throw, otherwise fall through and continue.

Replacement for https://github.com/joyent/node/pull/9017 based on
feedback.
Targeted at v0.10

(I have a version targeted at v0.12 just in case).
