### PR TITLE
build: add win32 convenience build rule

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -62,6 +62,7 @@ if /i "%1"=="test"          set test=test&goto arg-ok
 if /i "%1"=="msi"           set msi=1&set licensertf=1&goto arg-ok
 if /i "%1"=="upload"        set upload=1&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
+if /i "%1"=="build-release" set nosnapshot=1&set config=Release&set msi=1&set licensertf=1&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -223,6 +224,7 @@ echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build
 echo   vcbuild.bat release msi    : builds release build and MSI installer package
 echo   vcbuild.bat test           : builds debug build and runs tests
+echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
 goto exit
 
 :exit


### PR DESCRIPTION
Make sure the windows release builds are built with the same options as the unix builds.
