### PR TITLE
Adding wrappers for missing OpenSSL SSL methods.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -296,6 +296,24 @@ Handle<Value> SecureContext::Init(const Arguments& args) {
       method = TLSv1_server_method();
     } else if (strcmp(*sslmethod, "TLSv1_client_method") == 0) {
       method = TLSv1_client_method();
+    } else if (strcmp(*sslmethod, "TLSv1_1_method") == 0) {
+      method = TLSv1_1_method();
+    } else if (strcmp(*sslmethod, "TLSv1_1_server_method") == 0) {
+      method = TLSv1_1_server_method();
+    } else if (strcmp(*sslmethod, "TLSv1_1_client_method") == 0) {
+      method = TLSv1_1_client_method();
+    } else if (strcmp(*sslmethod, "TLSv1_2_method") == 0) {
+      method = TLSv1_2_method();
+    } else if (strcmp(*sslmethod, "TLSv1_2_server_method") == 0) {
+      method = TLSv1_2_server_method();
+    } else if (strcmp(*sslmethod, "TLSv1_2_client_method") == 0) {
+      method = TLSv1_2_client_method();
+    } else if (strcmp(*sslmethod, "DTLSv1_method") == 0) {
+      method = DTLSv1_method();
+    } else if (strcmp(*sslmethod, "DTLSv1_server_method") == 0) {
+      method = DTLSv1_server_method();
+    } else if (strcmp(*sslmethod, "DTLSv1_client_method") == 0) {
+      method = DTLSv1_client_method();
     } else {
       return ThrowException(Exception::Error(String::New("Unknown method")));
     }


### PR DESCRIPTION
This patch adds support for the following selectable SSL/TLS
methods, which are provided by OpenSSL:
- TLSv1.1
- TLSv1.2
- DTLSv1.0
