### PR TITLE
Clear domain stack after uncaught exception

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -253,6 +253,13 @@
             // be ok to abort on an uncaught exception at this point
             process._emittingTopLevelDomainError = true;
             caught = domain.emit('error', er);
+
+            // Exit all domains on the stack.  Uncaught exceptions end the
+            // current tick and no domains should be left on the stack
+            // between ticks.
+            var domainModule = NativeModule.require('domain');
+            domainStack.length = 0;
+            domainModule.active = process.domain = null;
           } finally {
             process._emittingTopLevelDomainError = false;
           }


### PR DESCRIPTION
After the patch caeb677 the uncaught exception handler does not clear
the domain stack after an exception in the top level domain has been
handled. This leaves unexpected domains on the domain stack. Fix this by
clearing the domain stack also in this case.

The affects node version starting with v0.10.34, but not v0.11.

This script demonstrates the problem:

``` js
var domain = require('domain');

var d = domain.create();

d.on('error', function() {
    process.nextTick(function() {
      console.log('domain._stack.length = %d', domain._stack.length);
    }, 100);
});

d.run(function() {
  throw new Error('Inside');
});
```

It yields these results:

```
> nvm use 0.10.33
Now using node v0.10.33
> node domain-stack-length
domain._stack.length = 1
> nvm use 0.10.34
Now using node v0.10.34
> node domain-stack-length
domain._stack.length = 2
> nvm use 0.10.35
Now using node v0.10.35
> node domain-stack-length
domain._stack.length = 2
> node-with-this-fix domain-stack-length
domain._stack.length = 1
> nvm use 0.11.15
Now using node v0.11.15
> node domain-stack-length
domain._stack.length = 1
```
