### PR TITLE
Corrected a grammar mistake in Stream documentation

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1175,7 +1175,7 @@ as a result of this chunk.
 
 Call the callback function only when the current chunk is completely
 consumed.  Note that there may or may not be output as a result of any
-particular input chunk. If you supply output as the second argument to the 
+particular input chunk. If you supply output as the second argument to the
 callback, it will be passed to push method, in other words the following are
 equivalent:
 

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1175,8 +1175,8 @@ as a result of this chunk.
 
 Call the callback function only when the current chunk is completely
 consumed.  Note that there may or may not be output as a result of any
-particular input chunk. If you supply as the second argument to the
-it will be passed to push method, in other words the following are
+particular input chunk. If you supply output as the second argument to the 
+callback, it will be passed to push method, in other words the following are
 equivalent:
 
 ```javascript


### PR DESCRIPTION
This morning I was reading through the documentation on Streams and came across this sentence, which seemed not valid:

"If you supply as the second argument to the it will be passed to push method,.."

So I corrected it to:

"If you supply output as the second argument to the callback, it will be passed to push method,.."

That is the only change in this pull request.
