### PR TITLE
WIP: src: make build pass with GCC < 4.5

### DIFF
--- a/deps/debugger-agent/debugger-agent.gyp
+++ b/deps/debugger-agent/debugger-agent.gyp
@@ -17,6 +17,14 @@
         "include",
       ],
     },
+    'conditions': [
+      [ 'gcc_version<=44', {
+        # GCC versions <= 4.4 do not handle the aliasing in the queue
+        # implementation, so disable aliasing on these platforms
+        # to avoid subtle bugs
+        'cflags': [ '-fno-strict-aliasing' ],
+      }],
+    ],
     "sources": [
       "src/agent.cc",
     ],

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -84,6 +84,12 @@
         'src/version.c'
       ],
       'conditions': [
+        [ 'gcc_version<=44', {
+          # GCC versions <= 4.4 do not handle the aliasing in the queue
+          # implementation, so disable aliasing on these platforms
+          # to avoid subtle bugs
+          'cflags': [ '-fno-strict-aliasing' ],
+        }],
         [ 'OS=="win"', {
           'defines': [
             '_WIN32_WINNT=0x0600',

--- a/node.gyp
+++ b/node.gyp
@@ -168,6 +168,12 @@
       ],
 
       'conditions': [
+        [ 'gcc_version<=44', {
+          # GCC versions <= 4.4 do not handle the aliasing in the queue
+          # implementation, so disable aliasing on these platforms
+          # to avoid subtle bugs
+          'cflags': [ '-fno-strict-aliasing' ],
+        }],
         [ 'v8_enable_i18n_support==1', {
           'defines': [ 'NODE_HAVE_I18N_SUPPORT=1' ],
           'dependencies': [

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -73,7 +73,9 @@ class GetAddrInfoReqWrap : public ReqWrap<uv_getaddrinfo_t> {
 
 GetAddrInfoReqWrap::GetAddrInfoReqWrap(Environment* env,
                                        Local<Object> req_wrap_obj)
-    : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_GETADDRINFOREQWRAP) {
+    : ReqWrap<uv_getaddrinfo_t>(env,
+                                req_wrap_obj,
+                                AsyncWrap::PROVIDER_GETADDRINFOREQWRAP) {
   Wrap(req_wrap_obj, this);
 }
 
@@ -90,7 +92,9 @@ class GetNameInfoReqWrap : public ReqWrap<uv_getnameinfo_t> {
 
 GetNameInfoReqWrap::GetNameInfoReqWrap(Environment* env,
                                        Local<Object> req_wrap_obj)
-    : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_GETNAMEINFOREQWRAP) {
+    : ReqWrap<uv_getnameinfo_t>(env,
+                                req_wrap_obj,
+                                AsyncWrap::PROVIDER_GETNAMEINFOREQWRAP) {
   Wrap(req_wrap_obj, this);
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -75,7 +75,7 @@ class FSReqWrap: public ReqWrap<uv_fs_t> {
             Local<Object> req,
             const char* syscall,
             char* data = NULL)
-    : ReqWrap(env, req, AsyncWrap::PROVIDER_FSREQWRAP),
+    : ReqWrap<uv_fs_t>(env, req, AsyncWrap::PROVIDER_FSREQWRAP),
       syscall_(syscall),
       data_(data),
       dest_len_(0) {

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -61,7 +61,7 @@ class PipeConnectWrap : public ReqWrap<uv_connect_t> {
 
 
 PipeConnectWrap::PipeConnectWrap(Environment* env, Local<Object> req_wrap_obj)
-    : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_PIPEWRAP) {
+    : ReqWrap<uv_connect_t>(env, req_wrap_obj, AsyncWrap::PROVIDER_PIPEWRAP) {
   Wrap(req_wrap_obj, this);
 }
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -36,7 +36,9 @@ class StreamWrap;
 class ShutdownWrap : public ReqWrap<uv_shutdown_t> {
  public:
   ShutdownWrap(Environment* env, v8::Local<v8::Object> req_wrap_obj)
-      : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_SHUTDOWNWRAP) {
+      : ReqWrap<uv_shutdown_t>(env,
+                               req_wrap_obj,
+                               AsyncWrap::PROVIDER_SHUTDOWNWRAP) {
     Wrap(req_wrap_obj, this);
   }
 
@@ -50,7 +52,7 @@ class WriteWrap: public ReqWrap<uv_write_t> {
   // TODO(trevnorris): WrapWrap inherits from ReqWrap, which I've globbed
   // into the same provider. How should these be broken apart?
   WriteWrap(Environment* env, v8::Local<v8::Object> obj, StreamWrap* wrap)
-      : ReqWrap(env, obj, AsyncWrap::PROVIDER_WRITEWRAP),
+      : ReqWrap<uv_write_t>(env, obj, AsyncWrap::PROVIDER_WRITEWRAP),
         wrap_(wrap) {
     Wrap(obj, this);
   }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -61,7 +61,7 @@ class TCPConnectWrap : public ReqWrap<uv_connect_t> {
 
 
 TCPConnectWrap::TCPConnectWrap(Environment* env, Local<Object> req_wrap_obj)
-    : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_TCPWRAP) {
+    : ReqWrap<uv_connect_t>(env, req_wrap_obj, AsyncWrap::PROVIDER_TCPWRAP) {
   Wrap(req_wrap_obj, this);
 }
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -64,7 +64,7 @@ class SendWrap : public ReqWrap<uv_udp_send_t> {
 SendWrap::SendWrap(Environment* env,
                    Local<Object> req_wrap_obj,
                    bool have_callback)
-    : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_UDPWRAP),
+    : ReqWrap<uv_udp_send_t>(env, req_wrap_obj, AsyncWrap::PROVIDER_UDPWRAP),
       have_callback_(have_callback) {
   Wrap(req_wrap_obj, this);
 }


### PR DESCRIPTION
Building node with GCC > 4.4 on CentOS makes the node binary depend on a
more recent version of the C/C++ runtime that is not installed by
default on these older CentOS platforms, and probably on other platforms
as well.

Building node with the default gcc and g++ compilers that come with
these older versions of CentOS allows to ship a node binary that runs
out of the box on these setups with older C/C++ runtimes.

This change works around a bug that was fixed in GCC 4.5. Versions of
GCC < 4.5 would not support using the injected-class-name of a
template base class as a type name.

This change also fixes a lot of strict-aliasing warnings due to type
casts in the src/queue.h headers.

Fixes #9079.
