### PR TITLE
test: make test-npm uses custom node, not global

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,12 +154,12 @@ test-npm: node
 	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
 	     npm_config_prefix="$(shell pwd)/npm-prefix" \
 	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     ../../node cli.js install
+	     PATH="../../:${PATH}" node cli.js install
 	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
 	     npm_config_prefix="$(shell pwd)/npm-prefix" \
 	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     ../../node cli.js run-script test-all && \
-	     ../../node cli.js prune --prod && \
+	     PATH="../../:${PATH}" node cli.js run-script test-all && \
+	     PATH="../../:${PATH}" node cli.js prune --prod && \
 	     cd ../.. && \
 	     rm -rf npm-cache npm-tmp npm-prefix
 


### PR DESCRIPTION
When running make test-npm, make would use the node binary available in
the PATH, which would most of the time not be the same binary as the one
built from the source tree from where the make test-npm command in run.

This can be confusing, as it can lead users to think that they tested
npm with the version of node that was built from the current checkout of
the source tree when it would actually run the tests with a completely
different version.

This change modifies the PATH environment variable for all commands that
need to run the node binary to run npm's tests by adding the root of the
local checkout as the first entry, so that the custom built node is
always used.
