### PR TITLE
Fixes compile error if configured without ssl

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2927,8 +2927,10 @@ static void PrintHelp() {
          "                       present.\n"
 #endif
 #endif
+#if HAVE_OPENSSL
          "  --enable-ssl2        enable ssl2\n"
          "  --enable-ssl3        enable ssl3\n"
+#endif
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2996,10 +2998,12 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--version") == 0 || strcmp(arg, "-v") == 0) {
       printf("%s\n", NODE_VERSION);
       exit(0);
+#if HAVE_OPENSSL
     } else if (strcmp(arg, "--enable-ssl2") == 0) {
       SSL2_ENABLE = true;
     } else if (strcmp(arg, "--enable-ssl3") == 0) {
       SSL3_ENABLE = true;
+#endif
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);


### PR DESCRIPTION
If node is configured with **--without-ssl** _node_crypto.h_ is not included in _node.cc_, 
but variables declared in it are still used - it leads to compile error.

This change disables **--enable-ssl2** and **--enable-ssl3** options for given configuration.
