### PR TITLE
contextify: share security token with debug ctx

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -257,7 +257,13 @@ class ContextifyContext {
     Local<String> script_source(args[0]->ToString());
     if (script_source.IsEmpty())
       return;  // Exception pending.
-    Context::Scope context_scope(Debug::GetDebugContext());
+
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    Local<Context> ctx = Debug::GetDebugContext();
+    if (!ctx.IsEmpty())
+      ctx->SetSecurityToken(env->context()->GetSecurityToken());
+
+    Context::Scope context_scope(ctx);
     Local<Script> script = Script::Compile(script_source);
     if (script.IsEmpty())
       return;  // Exception pending.

--- a/test/simple/test-vm-debug-context-token.js
+++ b/test/simple/test-vm-debug-context-token.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var vm = require('vm');
+var assert = require('assert');
+
+var proto = vm.runInDebugContext('DebugCommandProcessor.prototype');
+proto.prop = true;
+assert.equal(proto.prop, true);
+proto = vm.runInDebugContext('DebugCommandProcessor.prototype');
+assert.equal(proto.prop, true);
+proto = vm.runInDebugContext('DebugCommandProcessor.prototype.prop = true;' +
+                             'DebugCommandProcessor.prototype');
+assert.equal(proto.prop, true);


### PR DESCRIPTION
If security token does not match - no changes are allowed to the objects
from different context. We already copy the security token to the newly
created contexts in contextify.cc . Copy the security token to the debug
context too.

Fix: https://github.com/joyent/node/issues/9156
