### PR TITLE
timers test: unref does not return this

### DIFF
--- a/test/simple/test-timers-unref.js
+++ b/test/simple/test-timers-unref.js
@@ -42,7 +42,8 @@ setTimeout(function() {
 interval = setInterval(function() {
   unref_interval = true;
   clearInterval(interval);
-}, SHORT_TIME).unref();
+}, SHORT_TIME);
+interval.unref();
 
 setTimeout(function() {
   unref_timer = true;


### PR DESCRIPTION
The unref() call returns undefined, not this.
The test already worked before, because the interval was still unref'd,
and the test also succeeds without clearing the interval.
