### PR TITLE
doc: document the tracing api

### DIFF
--- a/doc/api/_toc.markdown
+++ b/doc/api/_toc.markdown
@@ -29,7 +29,6 @@
 * [String Decoder](string_decoder.html)
 * [Timers](timers.html)
 * [TLS/SSL](tls.html)
-* [Tracing](tracing.html)
 * [TTY](tty.html)
 * [UDP/Datagram](dgram.html)
 * [URL](url.html)


### PR DESCRIPTION
readd the missing tracing api

closes joyent/node-website#77
