### PR TITLE
Fix a bug in module loading when package.json's main does not resolve.

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -91,13 +91,17 @@ function statPath(path) {
 // check if the directory is a package.json dir
 var packageMainCache = {};
 
+function getPackageJsonPath(requestPath) {
+  return path.resolve(requestPath, 'package.json');
+}
+
 function readPackage(requestPath) {
   if (hasOwnProperty(packageMainCache, requestPath)) {
     return packageMainCache[requestPath];
   }
 
   try {
-    var jsonPath = path.resolve(requestPath, 'package.json');
+    var jsonPath = getPackageJsonPath(requestPath);
     var json = fs.readFileSync(jsonPath, 'utf8');
   } catch (e) {
     return false;
@@ -119,8 +123,13 @@ function tryPackage(requestPath, exts) {
   if (!pkg) return false;
 
   var filename = path.resolve(requestPath, pkg);
-  return tryFile(filename) || tryExtensions(filename, exts) ||
-         tryExtensions(path.resolve(filename, 'index'), exts);
+  var result = tryFile(filename) || tryExtensions(filename, exts) ||
+      tryExtensions(path.resolve(filename, 'index'), exts);
+  if (!result) {
+    throw new Error(
+        'Could not resolve "main" in ' + getPackageJsonPath(requestPath));
+  }
+  return result;
 }
 
 // In order to minimize unnecessary lstat() calls,

--- a/test/fixtures/module-require-package/index.js
+++ b/test/fixtures/module-require-package/index.js
@@ -1,0 +1,1 @@
+exports.a = require('a')

--- a/test/fixtures/module-require-package/node_modules/a/index.js
+++ b/test/fixtures/module-require-package/node_modules/a/index.js
@@ -1,0 +1,5 @@
+try {
+  exports.b = require('b')
+} catch (e) {
+  exports.b = e.message
+}

--- a/test/fixtures/module-require-package/node_modules/a/node_modules/b/package.json
+++ b/test/fixtures/module-require-package/node_modules/a/node_modules/b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "packagejson-with-typo",
+  "main": "typo.js"
+}
+

--- a/test/fixtures/module-require-package/node_modules/b/index.js
+++ b/test/fixtures/module-require-package/node_modules/b/index.js
@@ -1,0 +1,1 @@
+module.exports = 'You got the wrong module B!'

--- a/test/simple/test-module-loading.js
+++ b/test/simple/test-module-loading.js
@@ -306,3 +306,13 @@ process.on('exit', function() {
 // #1440 Loading files with a byte order marker.
 assert.equal(42, require('../fixtures/utf8-bom.js'));
 assert.equal(42, require('../fixtures/utf8-bom.json'));
+
+// #9118 resolution to the wrong module when package.json fails.
+assert.deepEqual({
+  a: {
+    b: 'Could not resolve "main" in ' +
+        path.resolve(__dirname,
+                     '../fixtures/module-require-package/' +
+                     'node_modules/a/node_modules/b/package.json')
+  }
+}, require('../fixtures/module-require-package'));


### PR DESCRIPTION
Fixes https://github.com/joyent/node/issues/9118.

Before this change, the test would load the wrong module 'b'.
