### PR TITLE
src: fix builtin modules failing with --use-strict

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -426,6 +426,24 @@ CryptoStream.prototype.end = function(chunk, encoding) {
   stream.Duplex.prototype.end.call(this, chunk, encoding);
 };
 
+/*
+ * Wait for both `finish` and `end` events to ensure that all data that
+ * was written on this side was read from the other side.
+ */
+function _destroyWhenReadAndWriteEndsDone(cryptoStream) {
+  var waiting = 1;
+
+  function finish() {
+    if (--waiting === 0) cryptoStream.destroy();
+  }
+
+  cryptoStream._opposite.once('end', finish);
+
+  if (!cryptoStream._finished) {
+    cryptoStream.once('finish', finish);
+    ++waiting;
+  }
+}
 
 CryptoStream.prototype.destroySoon = function(err) {
   if (this === this.pair.cleartext) {
@@ -440,18 +458,7 @@ CryptoStream.prototype.destroySoon = function(err) {
   if (this._writableState.finished && this._opposite._ended) {
     this.destroy();
   } else {
-    // Wait for both `finish` and `end` events to ensure that all data that
-    // was written on this side was read from the other side.
-    var self = this;
-    var waiting = 1;
-    function finish() {
-      if (--waiting === 0) self.destroy();
-    }
-    this._opposite.once('end', finish);
-    if (!this._finished) {
-      this.once('finish', finish);
-      ++waiting;
-    }
+    _destroyWhenReadAndWriteEndsDone(this);
   }
 };
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -89,13 +89,13 @@ Console.prototype.timeEnd = function(label) {
 };
 
 
-Console.prototype.trace = function() {
+Console.prototype.trace = function trace() {
   // TODO probably can to do this better with V8's debug object once that is
   // exposed.
   var err = new Error;
   err.name = 'Trace';
   err.message = util.format.apply(this, arguments);
-  Error.captureStackTrace(err, arguments.callee);
+  Error.captureStackTrace(err, trace);
   this.error(err.stack);
 };
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -592,20 +592,22 @@ exports.pbkdf2Sync = function(password, salt, iterations, keylen, digest) {
 
 
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
+  var encoding = exports.DEFAULT_ENCODING;
+
+  function next(er, ret) {
+    if (ret)
+      ret = ret.toString(encoding);
+    callback(er, ret);
+  }
+
   password = toBuf(password);
   salt = toBuf(salt);
 
-  if (exports.DEFAULT_ENCODING === 'buffer')
+  if (encoding === 'buffer')
     return binding.PBKDF2(password, salt, iterations, keylen, digest, callback);
 
   // at this point, we need to handle encodings.
-  var encoding = exports.DEFAULT_ENCODING;
   if (callback) {
-    function next(er, ret) {
-      if (ret)
-        ret = ret.toString(encoding);
-      callback(er, ret);
-    }
     binding.PBKDF2(password, salt, iterations, keylen, digest, next);
   } else {
     var ret = binding.PBKDF2(password, salt, iterations, keylen, digest);

--- a/test/simple/test-use-strict-builtin-modules.js
+++ b/test/simple/test-use-strict-builtin-modules.js
@@ -1,0 +1,34 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * This test makes sure that every builtin module can be loaded
+ * when the V8's --use-strict command line option is passed to node.
+ */
+
+var child_process = require('child_process');
+
+if (process.argv[2] !== 'child') {
+  child_process.fork(__filename, ['child'], { execArgv: ['--use-strict']});
+} else {
+  var natives = process.binding('natives');
+  Object.keys(natives).forEach(require);
+}


### PR DESCRIPTION
Currently, lib/_tls_legacy.js and lib/crypto.js cannot be loaded when
--use-strict is passed to node. This change adds a test that makes sure
every external built-in module can be loaded with require when
--use-strict is enabled, and fixes the built-in modules that are
currently broken.

Fixes #9187.
