### PR TITLE
fs: properly handle fd passed to truncate()

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -106,7 +106,8 @@ Synchronous ftruncate(2).
 ## fs.truncate(path, len, callback)
 
 Asynchronous truncate(2). No arguments other than a possible exception are
-given to the completion callback.
+given to the completion callback. A file descriptor can also be passed as the
+first argument. In this case, `fs.ftruncate()` is called.
 
 ## fs.truncateSync(path, len)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -639,9 +639,7 @@ fs.renameSync = function(oldPath, newPath) {
 
 fs.truncate = function(path, len, callback) {
   if (util.isNumber(path)) {
-    var req = new FSReqWrap();
-    req.oncomplete = callback;
-    return fs.ftruncate(path, len, req);
+    return fs.ftruncate(path, len, callback);
   }
   if (util.isFunction(len)) {
     callback = len;

--- a/test/simple/test-regress-GH-9161.js
+++ b/test/simple/test-regress-GH-9161.js
@@ -1,0 +1,45 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var fs = require('fs');
+var tmp = common.tmpDir;
+if (!fs.existsSync(tmp)) 
+  fs.mkdirSync(tmp);
+var filename = path.resolve(tmp, 'truncate-file.txt');
+
+var success = 0;
+
+fs.writeFileSync(filename, 'hello world', 'utf8');
+var fd = fs.openSync(filename, 'r+');
+fs.truncate(fd, 5, function(err) {
+  assert.ok(!err);
+  success++;
+});
+
+process.on('exit', function() {
+  fs.closeSync(fd);
+  fs.unlinkSync(filename);
+  assert.equal(success, 1);
+  console.log('ok');
+});


### PR DESCRIPTION
Currently, fs.truncate() silently fails when a file descriptor
is passed as the first argument. This commit changes this
behavior to properly call fs.ftruncate().

PR-URL: https://github.com/joyent/node/pull/9161
Reviewed-By: Colin Ihrig cjihrig@gmail.com
Reviewed-By: Timothy J Fontaine tjfontaine@gmail.com
