### PR TITLE
doc: add explanations for querystring

### DIFF
--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -42,7 +42,7 @@ characters.
 Options object may contain `maxKeys` property (equal to 1000 by default), it'll
 be used to limit processed keys. Set it to 0 to remove key count limitation.
 
-Options object may contain `decodeURIComponent` property (`decodeURIComponent` by default),
+Options object may contain `decodeURIComponent` property (`querystring.unescape` by default),
 it can be used to decode `non-utf8` encoding string if necessary.
 
 Example:

--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -43,7 +43,7 @@ Options object may contain `maxKeys` property (equal to 1000 by default), it'll
 be used to limit processed keys. Set it to 0 to remove key count limitation.
 
 Options object may contain `decodeURIComponent` property (`querystring.unescape` by default),
-it can be used to decode `non-utf8` encoding string if necessary.
+it can be used to decode a `non-utf8` encoding string if necessary.
 
 Example:
 
@@ -67,3 +67,7 @@ provided so that it could be overridden if necessary.
 
 The unescape function used by `querystring.parse`,
 provided so that it could be overridden if necessary.
+
+It will try to use `decodeURIComponent` in the first place,
+but if that fails it falls back to a safer equivalent that
+doesn't throw on malformed URLs.


### PR DESCRIPTION
- add an article: `decode a non-utf8 string`
- explain default behaviour of `querystring.unescape`
- add a note that the baviour can change if other folks on your
  team have overridden it

related to #9207
