### PR TITLE
http:make test destroyed-socket-write2.js robust

### DIFF
--- a/test/simple/test-http-destroyed-socket-write2.js
+++ b/test/simple/test-http-destroyed-socket-write2.js
@@ -49,8 +49,9 @@ server.listen(common.PORT, function() {
       req.end();
       test();
     } else {
-      timer = setImmediate(write);
-      req.write('hello');
+      req.write('hello', function() {
+        timer = setImmediate(write);
+      });
     }
   }
 


### PR DESCRIPTION
test/simple/test-http-destroyed-socket-write2.js validates
that you get an appropriate error when trying to write to
a request when the response on the other side has been destroyed.

The test uses http.request to get a request and then keeps writing
to it until either it hits 128 writes or gets the expected error.
Since the writes are asynchronous we see that the writes just end
up adding events to the event loop, which then later get processed
once the connection supporting the request is fully ready.

The test is timing dependent and if takes too long for the connection
to be made the limit of 128 writes is exceeded and the test fails.
The fact that the test allows a number of writes is probably to allow
some delay for the connection to be ready for writing.

On AIX, in the default configuration using the loopback interface
is slower and the test fails because the delay is such that many
more writes can be queued up before the connection takes place.
If we use the host ip instead of defaulting to the loopback then
the test passes.

The test needs to be made more robust to delays. Since each write
simply enqueues an additional write to the event queue there is
probably no point in doing the second write until the first has
completed. This patch schedules the next write when the first one
completes and allows the test to pass even if it takes longer for
the connection to be ready for writing

```
modified:   test/simple/test-http-destroyed-socket-write2.js
```
