### PR TITLE
Added check for already defined macro NOMINMAX

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -46,7 +46,9 @@
 # define _WIN32_WINNT   0x0501
 #endif
 
-#define NOMINMAX
+#ifndef NOMINMAX
+# define NOMINMAX
+#endif
 
 #endif
 


### PR DESCRIPTION
In order to avoid Visual C++ warning C4005 about macro redefinition
