### PR TITLE
src: fix intermittent SIGSEGV in resolveTxt

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -633,8 +633,9 @@ class QueryTxtWrap: public QueryWrap {
       }
       txt_chunk->Set(j++, txt);
     }
-    // Push last chunk
-    txt_records->Set(i, txt_chunk);
+    // Push last chunk if it isn't empty
+    if (!txt_chunk.IsEmpty())
+      txt_records->Set(i, txt_chunk);
 
     ares_free_data(txt_out);
 

--- a/test/internet/test-dns-txt-sigsegv.js
+++ b/test/internet/test-dns-txt-sigsegv.js
@@ -1,0 +1,8 @@
+var common = require('../common');
+var assert = require('assert');
+var dns = require('dns');
+
+dns.resolveTxt('www.microsoft.com', function(err, records) {
+  assert.equal(err, null);
+  assert.equal(records.length, 0);
+});


### PR DESCRIPTION
Fixes a SIGSEGV by making sure `txt_chunk` is not empty before setting
it on `txt_records`

Ref: https://github.com/joyent/node/issues/9285

This is the same fix applied in https://github.com/iojs/io.js/pull/960
