### PR TITLE
tests: fix race in test-http-curl-chunk-problem

### DIFF
--- a/test/simple/test-http-curl-chunk-problem.js
+++ b/test/simple/test-http-curl-chunk-problem.js
@@ -69,13 +69,16 @@ var server = http.createServer(function(req, res) {
     res.write(data);
   });
 
+  cat.stdout.on('end', function onStdoutEnd() {
+    res.end();
+  });
+
   // End the response on exit (and log errors)
   cat.on('exit', function(code) {
     if (code !== 0) {
       console.error('subprocess exited with code ' + code);
       process.exit(1);
     }
-    res.end();
   });
 
 });


### PR DESCRIPTION
This test setups two event listeners: one on a child process' exit event
, another for the same child process' stdandard output's 'data' event.
The data even listener writes to a stream, and the exit event listener
ends it.

Because the exit event can be emitted before the data event, there is a
chance that something will be written to the stream after it's ended,
and that an error is thrown.

This change makes the test end the stream in the listener for the child
process' standard output's end event, which is guaranteed to be emitted
after the last data event, thus avoiding the race.
