### PR TITLE
src: enable strict mode in all builtin modules

### DIFF
--- a/deps/debugger-agent/lib/_debugger_agent.js
+++ b/deps/debugger-agent/lib/_debugger_agent.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var assert = require('assert');
 var net = require('net');
 var util = require('util');

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util'),
     path = require('path'),
     net = require('net'),

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var net = require('net');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 var net = require('net');
 var url = require('url');

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var FreeList = require('freelist').FreeList;
 var HTTPParser = process.binding('http_parser').HTTPParser;
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 var Stream = require('stream');
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var assert = require('assert').ok;
 var Stream = require('stream');
 var timers = require('timers');

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 var net = require('net');
 var EventEmitter = require('events').EventEmitter;

--- a/lib/_linklist.js
+++ b/lib/_linklist.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 function init(list) {
   list._idleNext = list;
   list._idlePrev = list;

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // a duplex stream is just a stream that is both readable and writable.
 // Since JS doesn't have multiple prototypal inheritance, this class
 // prototypally inherits from Readable, and then parasitically from

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // a passthrough stream.
 // basically just the most minimal sort of Transform stream.
 // Every written chunk gets output as-is.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 module.exports = Readable;
 Readable.ReadableState = ReadableState;
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 
 // a transform stream is a readable/writable stream where you do
 // something with the data.  Sometimes it's called a "filter",

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // A bit simpler than readable streams.
 // Implement an async ._write(chunk, cb), and it'll handle all
 // the drain event emission and buffering.

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 var constants = require('constants');
 var tls = require('tls');

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var assert = require('assert');
 var events = require('events');
 var stream = require('stream');

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -22,6 +22,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var assert = require('assert');
 var crypto = require('crypto');
 var net = require('net');

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -22,6 +22,8 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // UTILITY
 var util = require('util');
 var b = require('buffer');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var buffer = process.binding('buffer');
 var smalloc = process.binding('smalloc');
 var util = require('util');

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var StringDecoder = require('string_decoder').StringDecoder;
 var EventEmitter = require('events').EventEmitter;
 var net = require('net');

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var EventEmitter = require('events').EventEmitter;
 var assert = require('assert');
 var dgram = require('dgram');

--- a/lib/console.js
+++ b/lib/console.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 
 function Console(stdout, stderr) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,4 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 module.exports = process.binding('constants');

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // Note: In 0.8 and before, crypto functions all defaulted to using
 // binary-encoded strings rather than buffers.
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var assert = require('assert');
 var util = require('util');
 var events = require('events');

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var net = require('net');
 var util = require('util');
 

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 var EventEmitter = require('events');
 var inherits = util.inherits;

--- a/lib/events.js
+++ b/lib/events.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var domain;
 var util = require('util');
 

--- a/lib/freelist.js
+++ b/lib/freelist.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // This is a free list to avoid creating so many of the same object.
 exports.FreeList = function(name, max, constructor) {
   this.name = name;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // Maintainers, keep in mind that octal literals are not allowed
 // in strict mode. Use the decimal value and add a comment with
 // the octal value. Example:

--- a/lib/http.js
+++ b/lib/http.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var tls = require('tls');
 var url = require('url');
 var http = require('http');

--- a/lib/module.js
+++ b/lib/module.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var NativeModule = require('native_module');
 var util = require('util');
 var runInThisContext = require('vm').runInThisContext;

--- a/lib/net.js
+++ b/lib/net.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var events = require('events');
 var stream = require('stream');
 var timers = require('timers');

--- a/lib/os.js
+++ b/lib/os.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var binding = process.binding('os');
 var util = require('util');
 var isWindows = process.platform === 'win32';

--- a/lib/path.js
+++ b/lib/path.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 
 var isWindows = process.platform === 'win32';
 var util = require('util');

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // Query String Utilities
 
 var QueryString = exports;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // Inspiration for this code comes from Salvatore Sanfilippo's linenoise.
 // https://github.com/antirez/linenoise
 // Reference:

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 /* A repl library that you can include in your own code to get a runtime
  * interface to your program.
  *

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var smalloc = process.binding('smalloc');
 var kMaxLength = smalloc.kMaxLength;
 var util = require('util');

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 module.exports = Stream;
 
 var EE = require('events').EventEmitter;

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 function assertEncoding(encoding) {
   if (encoding && !Buffer.isEncoding(encoding)) {
     throw new Error('Unknown encoding: ' + encoding);

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 // the sys module was renamed to 'util'.
 // this shim remains to keep old programs working.
 module.exports = require('util');

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var Timer = process.binding('timer_wrap').Timer;
 var L = require('_linklist');
 var assert = require('assert').ok;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var net = require('net');
 var url = require('url');
 var util = require('util');

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var inherits = require('util').inherits;
 var net = require('net');
 var TTY = process.binding('tty_wrap').TTY;

--- a/lib/url.js
+++ b/lib/url.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var punycode = require('punycode');
 var util = require('util');
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (!isString(f)) {

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var binding = process.binding('contextify');
 var Script = binding.ContextifyScript;
 var util = require('util');

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+'use strict';
+
 var Transform = require('_stream_transform');
 
 var binding = process.binding('zlib');

--- a/src/node.js
+++ b/src/node.js
@@ -24,6 +24,9 @@
 // This file is invoked by node::Load in src/node.cc, and responsible for
 // bootstrapping the node.js core. Special caution is given to the performance
 // of the startup process, so many dependencies are invoked lazily.
+
+'use strict';
+
 (function(process) {
   this.global = this;
 


### PR DESCRIPTION
This is a follow-up commit for b233131901dea47132b0748d8e4d6bfcbba28abe.

It enables strict mode in all built-in modules. This will break existing code, but the goal is to progressively fix as many issues as possible that can arise when using `--use-strict`.

It could probably break code that loads these modules within a browser, since any of the `'use strict';` directive would turn all code into strict mode. I'm not sure how much we support this use case though, any information on that would be much appreciated.
