### PR TITLE
http: emit abort event from ClientRequest

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -855,7 +855,14 @@ Emitted when the server sends a '100 Continue' HTTP response, usually because
 the request contained 'Expect: 100-continue'. This is an instruction that
 the client should send the request body.
 
-### request.flushHeaders()
+### Event: 'abort'
+
+`function () { }`
+
+Emitted when the request has been aborted by the client. This event is only
+emitted on the first call to `abort()`.
+
+### request.flush()
 
 Flush the request headers.
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -189,6 +189,15 @@ ClientRequest.prototype._implicitHeader = function() {
 };
 
 ClientRequest.prototype.abort = function() {
+  if (this.aborted !== undefined)
+    return;
+
+  var self = this;
+
+  process.nextTick(function() {
+    self.emit('abort');
+  });
+
   // Mark as aborting so we can avoid sending queued request data
   // This is used as a truthy flag elsewhere. The use of Date.now is for
   // debugging purposes only.

--- a/test/simple/test-http-client-abort-event.js
+++ b/test/simple/test-http-client-abort-event.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+var http = require('http');
+var common = require('../common');
+var server = http.createServer(function(req, res) {
+  res.end();
+});
+var count = 0;
+server.listen(common.PORT, function() {
+  var req = http.request({
+    port: common.PORT
+  }, function() {
+    assert(false, 'should not receive data');
+  });
+
+  req.on('abort', function() {
+    // should only be emitted once
+    count++;
+    server.close();
+  });
+
+  req.end();
+  req.abort();
+  req.abort();
+});
+
+process.on('exit', function() {
+  assert.equal(count, 1);
+})


### PR DESCRIPTION
`ClientRequest` will now emit an `abort` event the first time `abort()` is called.

cc: @tjfontaine 
Closes #9278 
