### PR TITLE
crypto: remove hoisted function

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -594,11 +594,11 @@ exports.pbkdf2Sync = function(password, salt, iterations, keylen, digest) {
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
   var encoding = exports.DEFAULT_ENCODING;
 
-  function next(er, ret) {
+  var next = function(er, ret) {
     if (ret)
       ret = ret.toString(encoding);
     callback(er, ret);
-  }
+  };
 
   password = toBuf(password);
   salt = toBuf(salt);


### PR DESCRIPTION
Heya,

Re: LearnBoost/mongoose#2281, crypto and strict mode don't play nicely together:

```
$ node -v
v0.12.0
$ node --use_strict
> var c = require('crypto');
crypto.js:604
    function next(er, ret) {
    ^^^^^^^^
SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.
    at runInThisContext (node.js:741:18)
    at NativeModule.compile (node.js:804:14)
    at Function.NativeModule.require (node.js:774:18)
    at Function.Module._load (module.js:295:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at repl:1:9
    at REPLServer.defaultEval (repl.js:132:27)
    at bound (domain.js:254:14)
    at REPLServer.runBound [as eval] (domain.js:267:12)
> 
(^C again to quit)
> 
```

This'll fix that particular issue
