### PR TITLE
docs:events clarify that emitter.listener() returns a copy

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -104,7 +104,7 @@ Note that `emitter.setMaxListeners(n)` still has precedence over
 
 ### emitter.listeners(event)
 
-Returns an array of listeners for the specified event.
+Returns a copy of the array of listeners for the specified event.
 
     server.on('connection', function (stream) {
       console.log('someone connected!');


### PR DESCRIPTION
Clarifies that emitter.listener() returns a copy, not a reference
Resolves issue #9022
