### PR TITLE
dgram and net: better error messages

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -37,6 +37,7 @@ var cluster = null;
 var dns = null;
 
 var errnoException = util._errnoException;
+var exceptionWithHostPort = util._exceptionWithHostPort;
 
 function lookup(address, family, callback) {
   if (!dns)
@@ -198,7 +199,8 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
     if (cluster.isWorker && !exclusive) {
       cluster._getServer(self, ip, port, self.type, -1, function(err, handle) {
         if (err) {
-          self.emit('error', errnoException(err, 'bind'));
+          var ex = exceptionWithHostPort(err, 'bind', ip, port);
+          self.emit('error', ex);
           self._bindState = BIND_STATE_UNBOUND;
           return;
         }
@@ -221,7 +223,8 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
 
       var err = self._handle.bind(ip, port || 0, flags);
       if (err) {
-        self.emit('error', errnoException(err, 'bind'));
+        var ex = exceptionWithHostPort(err, 'bind', ip, port);
+        self.emit('error', ex);
         self._bindState = BIND_STATE_UNBOUND;
         // Todo: close?
         return;
@@ -322,6 +325,8 @@ Socket.prototype.send = function(buffer,
       var req = new SendWrap();
       req.buffer = buffer;  // Keep reference alive.
       req.length = length;
+      req.address = address;
+      req.port = port;
       if (callback) {
         req.callback = callback;
         req.oncomplete = afterSend;
@@ -336,7 +341,8 @@ Socket.prototype.send = function(buffer,
       if (err && callback) {
         // don't emit as error, dgram_legacy.js compatibility
         process.nextTick(function() {
-          callback(errnoException(err, 'send'));
+          var ex = exceptionWithHostPort(err, 'send', address, port);
+          callback(ex);
         });
       }
     }
@@ -345,7 +351,10 @@ Socket.prototype.send = function(buffer,
 
 
 function afterSend(err) {
-  this.callback(err ? errnoException(err, 'send') : null, this.length);
+  if (err) {
+    err = exceptionWithHostPort(err, 'send', this.address, this.port);
+  }
+  this.callback(err, this.length);
 }
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -892,7 +892,7 @@ Socket.prototype.connect = function(options, cb) {
   } else {
     var dns = require('dns');
     var host = options.host || 'localhost';
-    var port = options.port | 0;
+    var port = 0;
     var localAddress = options.localAddress;
     var localPort = options.localPort;
     var dnsopts = {
@@ -906,8 +906,16 @@ Socket.prototype.connect = function(options, cb) {
     if (localPort && !util.isNumber(localPort))
       throw new TypeError('localPort should be a number: ' + localPort);
 
-    if (port <= 0 || port > 65535)
-      throw new RangeError('port should be > 0 and < 65536: ' + port);
+    if (typeof options.port === 'number')
+      port = options.port;
+    else if (typeof options.port === 'string')
+      port = options.port.trim() === '' ? -1 : +options.port;
+    else if (options.port !== undefined)
+      throw new TypeError('port should be a number or string: ' + options.port);
+
+    if (port < 0 || port > 65535 || isNaN(port))
+      throw new RangeError('port should be >= 0 and < 65536: ' +
+                           options.port);
 
     if (dnsopts.family !== 4 && dnsopts.family !== 6)
       dnsopts.hints = dns.ADDRCONFIG | dns.V4MAPPED;

--- a/lib/net.js
+++ b/lib/net.js
@@ -37,6 +37,7 @@ var WriteWrap = process.binding('stream_wrap').WriteWrap;
 var Buffer = require('buffer').Buffer;
 var cluster;
 var errnoException = util._errnoException;
+var exceptionWithHostPort = util._exceptionWithHostPort;
 
 function noop() {}
 
@@ -772,7 +773,7 @@ function afterWrite(status, handle, req, err) {
   }
 
   if (status < 0) {
-    var ex = errnoException(status, 'write', err);
+    var ex = exceptionWithHostPort(status, 'write', req.address, req.port);
     debug('write failure', ex);
     self._destroy(ex, req.cb);
     return;
@@ -818,7 +819,8 @@ function connect(self, address, port, addressType, localAddress, localPort) {
     err = bind(localAddress, localPort);
 
     if (err) {
-      self._destroy(errnoException(err, 'bind'));
+      var ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
+      self._destroy(ex);
       return;
     }
   }
@@ -839,7 +841,15 @@ function connect(self, address, port, addressType, localAddress, localPort) {
   }
 
   if (err) {
-    self._destroy(errnoException(err, 'connect'));
+    var sockname = self._getsockname();
+    var details;
+
+    if (sockname) {
+      details = sockname.address + ':' + sockname.port;
+    }
+
+    var ex = exceptionWithHostPort(err, 'connect', address, port, details);
+    self._destroy(ex);
   }
 }
 
@@ -989,7 +999,17 @@ function afterConnect(status, handle, req, readable, writable) {
 
   } else {
     self._connecting = false;
-    self._destroy(errnoException(status, 'connect'));
+    var details;
+    if (req.localAddress && req.localPort) {
+      details = req.localAddress + ':' + req.localPort;
+    }
+    var ex = exceptionWithHostPort(status,
+                                   'connect',
+                                   req.address,
+                                   req.port,
+                                   details);
+
+    self._destroy(ex);
   }
 }
 
@@ -1118,7 +1138,8 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
     debug('_listen2: create a handle');
     var rval = createServerHandle(address, port, addressType, fd);
     if (util.isNumber(rval)) {
-      var error = errnoException(rval, 'listen');
+      console.log('>>>>', address, port);
+      var error = exceptionWithHostPort(rval, 'listen', address, port);
       process.nextTick(function() {
         self.emit('error', error);
       });
@@ -1135,7 +1156,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   var err = _listen(self._handle, backlog);
 
   if (err) {
-    var ex = errnoException(err, 'listen');
+    var ex = exceptionWithHostPort(err, 'listen', address, port);
     self._handle.close();
     self._handle = null;
     process.nextTick(function() {
@@ -1183,8 +1204,10 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
         err = uv.UV_EADDRINUSE;
     }
 
-    if (err)
-      return self.emit('error', errnoException(err, 'bind'));
+    if (err) {
+      var ex = exceptionWithHostPort(err, 'bind', address, port);
+      return self.emit('error', ex);
+    }
 
     self._handle = handle;
     self._listen2(address, port, addressType, backlog, fd);

--- a/lib/net.js
+++ b/lib/net.js
@@ -37,6 +37,7 @@ var WriteWrap = process.binding('stream_wrap').WriteWrap;
 var Buffer = require('buffer').Buffer;
 var cluster;
 var errnoException = util._errnoException;
+var exceptionWithHostPort = util._exceptionWithHostPort;
 
 function noop() {}
 
@@ -772,7 +773,7 @@ function afterWrite(status, handle, req, err) {
   }
 
   if (status < 0) {
-    var ex = errnoException(status, 'write', err);
+    var ex = exceptionWithHostPort(status, 'write', req.address, req.port);
     debug('write failure', ex);
     self._destroy(ex, req.cb);
     return;
@@ -818,7 +819,8 @@ function connect(self, address, port, addressType, localAddress, localPort) {
     err = bind(localAddress, localPort);
 
     if (err) {
-      self._destroy(errnoException(err, 'bind'));
+      var ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
+      self._destroy(ex);
       return;
     }
   }
@@ -839,7 +841,15 @@ function connect(self, address, port, addressType, localAddress, localPort) {
   }
 
   if (err) {
-    self._destroy(errnoException(err, 'connect'));
+    var sockname = self._getsockname();
+    var details;
+
+    if (sockname) {
+      details = sockname.address + ':' + sockname.port;
+    }
+
+    var ex = exceptionWithHostPort(err, 'connect', address, port, details);
+    self._destroy(ex);
   }
 }
 
@@ -997,7 +1007,17 @@ function afterConnect(status, handle, req, readable, writable) {
 
   } else {
     self._connecting = false;
-    self._destroy(errnoException(status, 'connect'));
+    var details;
+    if (req.localAddress && req.localPort) {
+      details = req.localAddress + ':' + req.localPort;
+    }
+    var ex = exceptionWithHostPort(status,
+                                   'connect',
+                                   req.address,
+                                   req.port,
+                                   details);
+
+    self._destroy(ex);
   }
 }
 
@@ -1126,7 +1146,8 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
     debug('_listen2: create a handle');
     var rval = createServerHandle(address, port, addressType, fd);
     if (util.isNumber(rval)) {
-      var error = errnoException(rval, 'listen');
+      console.log('>>>>', address, port);
+      var error = exceptionWithHostPort(rval, 'listen', address, port);
       process.nextTick(function() {
         self.emit('error', error);
       });
@@ -1143,7 +1164,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   var err = _listen(self._handle, backlog);
 
   if (err) {
-    var ex = errnoException(err, 'listen');
+    var ex = exceptionWithHostPort(err, 'listen', address, port);
     self._handle.close();
     self._handle = null;
     process.nextTick(function() {
@@ -1191,8 +1212,10 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
         err = uv.UV_EADDRINUSE;
     }
 
-    if (err)
-      return self.emit('error', errnoException(err, 'bind'));
+    if (err) {
+      var ex = exceptionWithHostPort(err, 'bind', address, port);
+      return self.emit('error', ex);
+    }
 
     self._handle = handle;
     self._listen2(address, port, addressType, backlog, fd);

--- a/lib/util.js
+++ b/lib/util.js
@@ -749,3 +749,27 @@ exports._errnoException = function(err, syscall, original) {
   e.syscall = syscall;
   return e;
 };
+
+exports._exceptionWithHostPort = function(err,
+                                          syscall,
+                                          address,
+                                          port,
+                                          additional) {
+  var details;
+  if (port && port > 0) {
+    details = address + ':' + port;
+  } else {
+    details = address;
+  }
+
+  if (additional) {
+    details += ' - Local (' + additional + ')';
+  }
+
+  var ex = exports._errnoException(err, syscall, details);
+  //ex.address = address;
+  //if (port) {
+  //  ex.port = port;
+  //}
+  return ex;
+};

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -428,7 +428,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
-  assert(args[2]->Uint32Value());
+  assert(args[2]->IsUint32());
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(args[1]);
@@ -460,7 +460,7 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
-  assert(args[2]->Uint32Value());
+  assert(args[2]->IsUint32());
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(args[1]);

--- a/test/simple/test-dgram-error-message-address.js
+++ b/test/simple/test-dgram-error-message-address.js
@@ -23,16 +23,33 @@ var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 
-// Send a too big datagram. The destination doesn't matter because it's
-// not supposed to get sent out anyway.
-var buf = Buffer(256 * 1024);
-var sock = dgram.createSocket('udp4');
-sock.send(buf, 0, buf.length, 12345, '127.0.0.1', common.mustCall(cb));
-function cb(err) {
-  assert(err instanceof Error);
-  assert.equal(err.code, 'EMSGSIZE');
-  // assert.equal(err.address, '127.0.0.1');
-  // assert.equal(err.port, 12345);
-  assert.equal(err.message, 'send EMSGSIZE 127.0.0.1:12345');
-  sock.close();
-}
+// IPv4 Test
+var socket_ipv4 = dgram.createSocket('udp4');
+
+socket_ipv4.on('listening', assert.fail);
+
+socket_ipv4.on('error', common.mustCall(function(e) {
+  assert.equal(e.message, 'bind EADDRNOTAVAIL 1.1.1.1:' + common.PORT);
+  // assert.equal(e.address, '1.1.1.1');
+  // assert.equal(e.port, common.PORT);
+  assert.equal(e.code, 'EADDRNOTAVAIL');
+  socket_ipv4.close();
+}));
+
+socket_ipv4.bind(common.PORT, '1.1.1.1');
+
+// IPv6 Test
+var socket_ipv6 = dgram.createSocket('udp6');
+var family_ipv6 = 'IPv6';
+
+socket_ipv6.on('listening', assert.fail);
+
+socket_ipv6.on('error', common.mustCall(function(e) {
+  assert.equal(e.message, 'bind EADDRNOTAVAIL 111::1:' + common.PORT);
+  // assert.equal(e.address, '111::1');
+  // assert.equal(e.port, common.PORT);
+  assert.equal(e.code, 'EADDRNOTAVAIL');
+  socket_ipv6.close();
+}));
+
+socket_ipv6.bind(common.PORT, '111::1');

--- a/test/simple/test-net-create-connection.js
+++ b/test/simple/test-net-create-connection.js
@@ -24,33 +24,99 @@ var assert = require('assert');
 var net = require('net');
 
 var tcpPort = common.PORT;
+var expectedConnections = 7;
 var clientConnected = 0;
 var serverConnected = 0;
 
 var server = net.createServer(function(socket) {
   socket.end();
-  if (++serverConnected === 4) {
+  if (++serverConnected === expectedConnections) {
     server.close();
   }
 });
+
 server.listen(tcpPort, 'localhost', function() {
   function cb() {
     ++clientConnected;
+  }
+
+  function fail(opts, errtype, msg) {
+    assert.throws(function() {
+      var client = net.createConnection(opts, cb);
+    }, function (err) {
+      return err instanceof errtype && msg === err.message;
+    });
   }
 
   net.createConnection(tcpPort).on('connect', cb);
   net.createConnection(tcpPort, 'localhost').on('connect', cb);
   net.createConnection(tcpPort, cb);
   net.createConnection(tcpPort, 'localhost', cb);
+  net.createConnection(tcpPort + '', 'localhost', cb);
+  net.createConnection({port: tcpPort + ''}).on('connect', cb);
+  net.createConnection({port: '0x' + tcpPort.toString(16)}, cb);
 
-  assert.throws(function () {
-    net.createConnection({
-      port: 'invalid!'
-    }, cb);
-  });
+  fail({
+    port: true
+  }, TypeError, 'port should be a number or string: true');
+
+  fail({
+    port: false
+  }, TypeError, 'port should be a number or string: false');
+
+  fail({
+    port: []
+  }, TypeError, 'port should be a number or string: ');
+
+  fail({
+    port: {}
+  }, TypeError, 'port should be a number or string: [object Object]');
+
+  fail({
+    port: null
+  }, TypeError, 'port should be a number or string: null');
+
+  fail({
+    port: ''
+  }, RangeError, 'port should be >= 0 and < 65536: ');
+
+  fail({
+    port: ' '
+  }, RangeError, 'port should be >= 0 and < 65536:  ');
+
+  fail({
+    port: '0x'
+  }, RangeError, 'port should be >= 0 and < 65536: 0x');
+
+  fail({
+    port: '-0x1'
+  }, RangeError, 'port should be >= 0 and < 65536: -0x1');
+
+  fail({
+    port: NaN
+  }, RangeError, 'port should be >= 0 and < 65536: NaN');
+
+  fail({
+    port: Infinity
+  }, RangeError, 'port should be >= 0 and < 65536: Infinity');
+
+  fail({
+    port: -1
+  }, RangeError, 'port should be >= 0 and < 65536: -1');
+
+  fail({
+    port: 65536
+  }, RangeError, 'port should be >= 0 and < 65536: 65536');
+});
+
+// Try connecting to random ports, but do so once the server is closed
+server.on('close', function() {
+  function nop() {}
+
+  net.createConnection({port: 0}).on('error', nop);
+  net.createConnection({port: undefined}).on('error', nop);
 });
 
 process.on('exit', function() {
-  assert.equal(clientConnected, 4);
+  assert.equal(clientConnected, expectedConnections);
 });
-

--- a/test/simple/test-net-localerror.js
+++ b/test/simple/test-net-localerror.js
@@ -23,27 +23,17 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-  connect({
-    host: 'localhost',
-    port: common.PORT,
-    localPort: 'foobar',
-  }, 'localPort should be a number: foobar');
+connect({
+  host: 'localhost',
+  port: common.PORT,
+  localPort: 'foobar',
+}, 'localPort should be a number: foobar');
 
-  connect({
-    host: 'localhost',
-    port: common.PORT,
-    localAddress: 'foobar',
-  }, 'localAddress should be a valid IP: foobar');
-
-  connect({
-    host: 'localhost',
-    port: 65536
-  }, 'port should be > 0 and < 65536: 65536');
-
-  connect({
-    host: 'localhost',
-    port: 0
-  }, 'port should be > 0 and < 65536: 0');
+connect({
+  host: 'localhost',
+  port: common.PORT,
+  localAddress: 'foobar',
+}, 'localAddress should be a valid IP: foobar');
 
 function connect(opts, msg) {
   assert.throws(function() {

--- a/test/simple/test-net-server-errmsg.js
+++ b/test/simple/test-net-server-errmsg.js
@@ -20,19 +20,17 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var common = require('../common');
+var net = require('net');
 var assert = require('assert');
-var dgram = require('dgram');
 
-// Send a too big datagram. The destination doesn't matter because it's
-// not supposed to get sent out anyway.
-var buf = Buffer(256 * 1024);
-var sock = dgram.createSocket('udp4');
-sock.send(buf, 0, buf.length, 12345, '127.0.0.1', common.mustCall(cb));
-function cb(err) {
-  assert(err instanceof Error);
-  assert.equal(err.code, 'EMSGSIZE');
-  // assert.equal(err.address, '127.0.0.1');
-  // assert.equal(err.port, 12345);
-  assert.equal(err.message, 'send EMSGSIZE 127.0.0.1:12345');
-  sock.close();
-}
+var server1 = net.createServer();
+var server2 = net.createServer();
+
+server1.listen(common.PORT, 'localhost', function(err) { assert(!err); });
+
+server2.on('error', function(err) {
+  assert.equal(err.message, 'listen EADDRINUSE 127.0.0.1:' + common.PORT);
+  server1.close();
+});
+
+server2.listen(common.PORT, 'localhost', function() {});


### PR DESCRIPTION
Port of the io.js util._exceptionWithHostPort addition.
Slight change to omit the ex.address and ex.port from the generated
error to avoid the API change. These are commented out for now so
they can be added back in easily later. Pulled over the changes made
to dgram and net to use this. Added an additional
test-net-server-errmsg
test as additional verification

see: https://github.com/iojs/io.js/pull/250 for reference.

Addresses: https://github.com/joyent/node/issues/9294

/cc @joyent/node-coreteam
