### PR TITLE
configure: add --without-mdb flag (fix issue #6439)

### DIFF
--- a/configure
+++ b/configure
@@ -282,6 +282,11 @@ parser.add_option('--without-etw',
     dest='without_etw',
     help='build without ETW')
 
+parser.add_option('--without-mdb',
+    action='store_true',
+    dest='without_mdb',
+    help='build without mdb')
+
 parser.add_option('--without-npm',
     action='store_true',
     dest='without_npm',
@@ -554,7 +559,7 @@ def configure_node(o):
   # if we're on illumos based systems wrap the helper library into the
   # executable
   if flavor == 'solaris':
-    o['variables']['node_use_mdb'] = 'true'
+    o['variables']['node_use_mdb'] = b(not options.without_mdb)
   else:
     o['variables']['node_use_mdb'] = 'false'
 


### PR DESCRIPTION
We need a way to disable node_use_mdb on non Illumos derivated, because of
missing libproc.h.

Example:
    ./configure --dest-cpu=x64  --dest-os=solaris --prefix=/opt/node --without-mdb
    creating  ./icu_config.gypi
    { 'target_defaults': { 'cflags': [],
                           'default_configuration': 'Release',
                           'defines': [],
                           'include_dirs': [],
                           'libraries': []},
      'variables': { 'clang': 0,
                     'gcc_version': 48,
                     'host_arch': 'ia32',
                     'icu_small': 'false',
                     'node_install_npm': 'true',
                     'node_prefix': '/opt/node',
                     'node_shared_cares': 'false',
                     'node_shared_http_parser': 'false',
                     'node_shared_libuv': 'false',
                     'node_shared_openssl': 'false',
                     'node_shared_v8': 'false',
                     'node_shared_zlib': 'false',
                     'node_tag': '',
                     'node_use_dtrace': 'true',
                     'node_use_etw': 'false',
                     'node_use_mdb': 'false',
                     'node_use_openssl': 'true',
                     'node_use_perfctr': 'false',
                     'openssl_no_asm': 0,
                     'python': '/usr/bin/python',
                     'target_arch': 'x64',
                     'uv_library': 'static_library',
                     'uv_parent_path': '/deps/uv/',
                     'uv_use_dtrace': 'true',
                     'v8_enable_gdbjit': 0,
                     'v8_enable_i18n_support': 0,
                     'v8_no_strict_aliasing': 1,
                     'v8_optimized_debug': 0,
                     'v8_random_seed': 0,
                     'v8_use_snapshot': 'true',
                     'want_separate_host_toolset': 1}}
    creating  ./config.gypi
    creating  ./config.mk
