### PR TITLE
domains: fix stack clearing after error handled

### DIFF
--- a/test/simple/test-domain-top-level-error-handler-clears-stack.js
+++ b/test/simple/test-domain-top-level-error-handler-clears-stack.js
@@ -1,0 +1,41 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var domain = require('domain');
+
+/*
+ * Make sure that the domains stack is cleared after a top-level domain
+ * error handler exited gracefully.
+ */
+var d = domain.create();
+
+d.on('error', function() {
+  process.nextTick(function() {
+    if (domain._stack.length !== 1) {
+      process.exit(1);
+    }
+  });
+});
+
+d.run(function() {
+  throw new Error('Error from domain');
+});


### PR DESCRIPTION
caeb67735baa8e069902e23f21d01033907c4f33 introduced a regression where
the domains stack would not be cleared after an error had been handled
by the top-level domain.

This change clears the domains stack regardless of the position of the
active domain in the stack.
