### PR TITLE
net: use cached peername to resolve remote props

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -568,10 +568,10 @@ function onread(nread, buffer) {
 
 
 Socket.prototype._getpeername = function() {
-  if (!this._handle || !this._handle.getpeername) {
-    return {};
-  }
   if (!this._peername) {
+    if (!this._handle || !this._handle.getpeername) {
+      return {};
+    }
     var out = {};
     var err = this._handle.getpeername(out);
     if (err) return {};  // FIXME(bnoordhuis) Throw?
@@ -857,6 +857,7 @@ Socket.prototype.connect = function(options, cb) {
     this._writableState.errorEmitted = false;
     this.destroyed = false;
     this._handle = null;
+    this._peername = null;
   }
 
   var self = this;

--- a/test/simple/test-net-remote-address-port.js
+++ b/test/simple/test-net-remote-address-port.js
@@ -41,6 +41,10 @@ var server = net.createServer(function(socket) {
   socket.on('end', function() {
     if (++conns_closed == 2) server.close();
   });
+  socket.on('close', function() {
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(socket.remoteFamily));
+  });
   socket.resume();
 });
 
@@ -53,11 +57,19 @@ server.listen(common.PORT, 'localhost', function() {
     assert.equal(common.PORT, client.remotePort);
     client.end();
   });
+  client.on('close', function() {
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(client.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(client.remoteFamily));
+  });
   client2.on('connect', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
     assert.equal(common.PORT, client2.remotePort);
     client2.end();
+  });
+  client2.on('close', function() {
+    assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
+    assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
   });
 });
 


### PR DESCRIPTION
Allows socket.remote\* properties to still be accessed even after the
socket is closed. Fixes #9287
