### PR TITLE
prevented overwriting encoding when chunk is a buffer in writeOrBuffer

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -266,7 +266,7 @@ function decodeChunk(state, chunk, encoding) {
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, chunk, encoding, cb) {
   chunk = decodeChunk(state, chunk, encoding);
-  if (util.isBuffer(chunk))
+  if (!encoding && util.isBuffer(chunk))
     encoding = 'buffer';
   var len = state.objectMode ? 1 : chunk.length;
 


### PR DESCRIPTION
_stream_writable ignores the incoming encoding in writeOrBuffer if the chunk is a Buffer. That led to "unknown encoding' errors later, despite the chunk initially having a good encoding. 

FWIW, upstream was a process.stdin with encoding to utf8. That encoding was getting lost in writeOrBuffer.
