### PR TITLE
buffer: align chunks on 8-byte boundary

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -86,6 +86,12 @@ function Buffer(subject, encoding) {
                             poolOffset,
                             poolOffset + this.length);
     poolOffset += this.length;
+
+    // Ensure aligned slices
+    if (poolOffset & 0x7) {
+      poolOffset |= 0x7;
+      poolOffset++;
+    }
   } else {
     alloc(this, this.length);
   }


### PR DESCRIPTION
When slicing global pool - ensure that the underlying buffer's data ptr
is 8-byte alignment to do not ruin expectations of 3rd party C++ addons.

NOTE: 0.10 node.js always returned aligned pointers and v0.12 should do
this too for compatibility.

Suggested reviewer: @trevnorris @bnoordhuis 

Cross-reference to PR in io.js: https://github.com/iojs/io.js/pull/1126
