### PR TITLE
test: Environment varible to specify directory for pipes

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -28,6 +28,11 @@ exports.testDir = path.dirname(__filename);
 exports.fixturesDir = path.join(exports.testDir, 'fixtures');
 exports.libDir = path.join(exports.testDir, '../lib');
 exports.tmpDir = path.join(exports.testDir, 'tmp');
+if (process.env.NODE_PIPE_DIR === undefined) {
+  exports.pipeTmpDir = exports.tmpDir;
+} else {
+  exports.pipeTmpDir = path.join(process.env.NODE_PIPE_DIR, 'NodePipeTmp');
+}
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 
 exports.opensslCli = path.join(path.dirname(process.execPath), 'openssl-cli');
@@ -35,7 +40,7 @@ if (process.platform === 'win32') {
   exports.PIPE = '\\\\.\\pipe\\libuv-test';
   exports.opensslCli += '.exe';
 } else {
-  exports.PIPE = exports.tmpDir + '/test.sock';
+  exports.PIPE = exports.pipeTmpDir + '/test.sock';
 }
 if (!fs.existsSync(exports.opensslCli))
   exports.opensslCli = false;

--- a/test/simple/test-cluster-eaccess.js
+++ b/test/simple/test-cluster-eaccess.js
@@ -27,7 +27,12 @@ var path = require('path');
 var fs = require('fs');
 var net = require('net');
 
-var socketPath = path.join(common.fixturesDir, 'socket-path');
+var socketPath = common.PIPE;
+if (process.platform === 'win32') {
+  // for windows pipes are handled specially and we can't write to
+  // common.PIPE with fs.writeFileSync like we can on other platforms
+  socketPath = path.join(common.fixturesDir, 'socket-path');
+}
 
 if (cluster.isMaster) {
   var worker = cluster.fork();

--- a/test/simple/test-net-pipe-connect-errors.js
+++ b/test/simple/test-net-pipe-connect-errors.js
@@ -31,7 +31,9 @@ var accessErrorFired = false;
 
 // Test if ENOTSOCK is fired when trying to connect to a file which is not
 // a socket.
-var emptyTxt = path.join(common.fixturesDir, 'empty.txt');
+var emptyTxt = path.join(common.pipeTmpDir, 'empty.txt');
+fs.closeSync(fs.openSync(emptyTxt, 'w'));
+
 var notSocketClient = net.createConnection(emptyTxt, function() {
   assert.ok(false);
 });

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -48,16 +48,22 @@ class SimpleTestCase(test.TestCase):
     self.mode = mode
     self.tmpdir = join(dirname(self.config.root), 'tmp')
     self.additional_flags = additional
+    if "NODE_PIPE_DIR" in os.environ:
+      self.pipeTmpDir = join(os.environ["NODE_PIPE_DIR"], 'NodePipeTmp')
   
   def AfterRun(self, result):
     # delete the whole tmp dir
     try:
       rmtree(self.tmpdir)
+      if self.pipeTmpDir:
+        rmtree(self.pipeTmpDir);
     except:
       pass
     # make it again.
     try:
       mkdir(self.tmpdir)
+      if self.pipeTmpDir:
+        mkdir(self.pipeTmpDir);
     except:
       pass
 
@@ -65,6 +71,8 @@ class SimpleTestCase(test.TestCase):
     # delete the whole tmp dir
     try:
       rmtree(self.tmpdir)
+      if self.pipeTmpDir:
+        rmtree(self.pipeTmpDir);
     except:
       pass
     # make it again.
@@ -72,6 +80,8 @@ class SimpleTestCase(test.TestCase):
     while not os.path.exists(self.tmpdir):
       try:
         mkdir(self.tmpdir)
+        if self.pipeTmpDir:
+          mkdir(self.pipeTmpDir);
       except:
         pass
   


### PR DESCRIPTION
At the uv layer pipes are connected with uv_pipe_connect.
The current spec for this method indicates that the maximum
length is limited to the size of length of
sizeof(sockaddr_un.sun_path), typically between 92 and
108 bytes. Anything longer than that just gets truncated.

The simple testsuite currently creates pipes in directories
under the directory where node was built.  In our jenkins
jobs this sometimes ends up being a deep enough path that
the path for the pipes is getting truncated.  The result
is that tests using pipes fail with errors that don't
make it obvious what the problem is.

Even if the errors were helpful, we still need a way
to avoid the truncation.

This patch adds the environment variable NODE_PIPE_DIR.
If set the tests create pipes in this directory instead of
the current defaults.  In addition the test harness is
updated to remove/delete this directory before/after
each test is run.

```
modified:   test/common.js
modified:   test/simple/test-net-pipe-connect-errors.js
modified:   test/testpy/__init__.py
modified:   test/simple/test-cluster-eaccess.js
```
