### PR TITLE
url: % is a valid host character in IPv6 addresses

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -282,6 +282,15 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
           }
         }
       }
+    } else {
+      // IPv6 hostname
+      
+      // for link local addresses:
+      // - make sure the zone id is present after the %
+      // - make sure the hostname does not end in '%]'
+      if (this.hostname.indexOf('%]') !== -1) {
+        this.hostname.replace('%', '');
+      }
     }
 
     if (this.hostname.length > hostnameMaxLen) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -70,6 +70,7 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     // are the ones that are *expected* to be seen, so we fast-path
     // them.
     nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
+    nonHostCharsIPv6 = ['/', '?', ';', '#'].concat(autoEscape),
     hostEndingChars = ['/', '?', '#'],
     hostnameMaxLen = 255,
     hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/,
@@ -216,11 +217,19 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       rest = rest.slice(atSign + 1);
       this.auth = decodeURIComponent(auth);
     }
+    
+    // if hostname begins with [ and is followed by ]
+    // assume that it's an IPv6 address.
+    // :: is the smallest IPv6 address possible, so ] must be > 2 positions to the right of [
+    var ipv6Hostname = rest[0] === '[' &&
+        rest.indexOf(']') > 2;
 
     // the host is the remaining to the left of the first non-host char
+    // use the appropriate non-host char set
+    var invalidHostChars = ipv6Hostname ? nonHostCharsIPv6 : nonHostChars;
     hostEnd = -1;
-    for (var i = 0; i < nonHostChars.length; i++) {
-      var hec = rest.indexOf(nonHostChars[i]);
+    for (var i = 0; i < invalidHostChars.length; i++) {
+      var hec = rest.indexOf(invalidHostChars[i]);
       if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
         hostEnd = hec;
     }
@@ -237,11 +246,6 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // we've indicated that there is a hostname,
     // so even if it's empty, it has to be present.
     this.hostname = this.hostname || '';
-
-    // if hostname begins with [ and ends with ]
-    // assume that it's an IPv6 address.
-    var ipv6Hostname = this.hostname[0] === '[' &&
-        this.hostname[this.hostname.length - 1] === ']';
 
     // validate a little.
     if (!ipv6Hostname) {

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -889,6 +889,22 @@ var parseTests = {
       pathname: '/',
       path: '/',
       href: 'http://[fe80::1%lo0]:51877/' 
+  },
+  
+  // in IPv6 link-local addresses, % must be followed by something
+  'http://[fe80::1%]:51877/': {
+      protocol: 'http:',
+      slashes: true,
+      auth: null,
+      host: '[fe80::1]:51877',
+      port: 51877,
+      hostname: 'fe80::1',
+      hash: null,
+      search: null,
+      query: null,
+      pathname: '/',
+      path: '/',
+      href: 'http://[fe80::1]:51877/' 
   }
 
 };

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -873,6 +873,22 @@ var parseTests = {
     pathname: '/:npm/npm',
     path: '/:npm/npm',
     href: 'git+ssh://git@github.com/:npm/npm'
+  },
+  
+  // % is a valid host character in IPv6 link-local addresses
+  'http://[fe80::1%lo0]:51877/': {
+      protocol: 'http:',
+      slashes: true,
+      auth: null,
+      host: '[fe80::1%lo0]:51877',
+      port: 51877,
+      hostname: 'fe80::1%lo0',
+      hash: null,
+      search: null,
+      query: null,
+      pathname: '/',
+      path: '/',
+      href: 'http://[fe80::1%lo0]:51877/' 
   }
 
 };


### PR DESCRIPTION
% is a valid host character in IPv6 link-local addresses.

The % separates the address from the zone within the hostname section of the URL.

This fixes issue #9404 
