### PR TITLE
[cluster.js] removeHandlesForWorker() on both 'exit' and 'disconnect' events.

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -365,7 +365,8 @@ function masterInit() {
        * worker a second time just in case 'disconnect'
        * event isn't emitted.
        */
-      removeHandlesForWorker(worker);
+      if (worker.state != 'disconnected')
+        removeHandlesForWorker(worker);
 
       /*
        * Remove the worker from the workers list only

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -361,6 +361,13 @@ function masterInit() {
 
     worker.process.once('exit', function(exitCode, signalCode) {
       /*
+       * Remove the handles associated with this
+       * worker a second time just in case 'disconnect'
+       * event isn't emitted.
+       */
+      removeHandlesForWorker(worker);
+
+      /*
        * Remove the worker from the workers list only
        * if it has disconnected, otherwise we might
        * still want to access it.


### PR DESCRIPTION
[cluster.js][worker] Calls removeHandlesForWorker(worker) on both 'exit' and 'disconnect' event instead of just 'disconnect' because sometimes it happens that 'disconnect' event isn't emitted at all in which case some handles will be left and when all workers will be dead an exception raised "AssertionError: Resource leak detected".

Hello, I have previously posted this issue : https://github.com/joyent/node/issues/9409
I finally came up with this piece of code which intentionally triggers the excpetion :

``` javascript
var http    = require('http');
var cluster = require('cluster');

if (cluster.isMaster) {

  cluster.on('disconnect', function(worker, code, signal) {
    console.log('worker ' + worker.process.pid + ' disconnected');
  });
  cluster.on('exit', function(worker, code, signal) {
    console.log('worker ' + worker.process.pid + ' died');
  });

  var worker = cluster.fork();
  worker.process.removeAllListeners('disconnect');

  setInterval(function keepAlive() {}, 1000);

} else {
  console.log('Hello, Im the worker with pid', process.pid);

  setTimeout(function() {
    process.exit(0);
  }, 2000);

  http.createServer(function(req, res) {
    res.writeHead(200);
    res.end("hello world\n");
  }).listen(8000);
}
```

And finally I found the solution which is to double check that the handles are removed when a worker dies even if it does not emit the 'disconnect' event but only the 'exit' event as it happens sometimes.
Calling removeHandlesForWorker() twice isn't much of a problem because it does nothing if the worker has already been removed from that handle.
Thanks.
