### PR TITLE
test: make cluster tests more time tolerant

### DIFF
--- a/test/simple/test-cluster-master-error.js
+++ b/test/simple/test-cluster-master-error.js
@@ -114,7 +114,7 @@ if (cluster.isWorker) {
     existMaster = !!code;
 
     // Give the workers time to shut down
-    setTimeout(checkWorkers, 200);
+    setTimeout(checkWorkers, 1000);
 
     function checkWorkers() {
       // When master is dead all workers should be dead to

--- a/test/simple/test-cluster-master-kill.js
+++ b/test/simple/test-cluster-master-kill.js
@@ -82,7 +82,7 @@ if (cluster.isWorker) {
     // check worker process status
     setTimeout(function() {
       alive = isAlive(pid);
-    }, 200);
+    }, 1000);
   });
 
   process.once('exit', function() {


### PR DESCRIPTION
On AIX we were seeing failures in the below Node tests:

simple/test-cluster-master-error.js
with an assertion failure:
AssertionError: The workers did not die after an error in the master

and
simple/test-cluster-master-kill.js
with an assertion failure:
AssertionError: worker was alive after master died

The root cause for both the failures are same: the worker nodes of the
cluster was found to be alive when it was not expected to be. The isAlive
check is performed upon the master's exit, in both the cases.

A 200ms leeway is provided for the workers to actually terminate.

In AIX, the workers were actually terminating, but they took more
time - as much as 800ms (normal) to 1000ms (in rare cases).

Based on a C test we ran, it is found that the exit routines in AIX
is a bit more longer than that in Linux. There are a number of cleanup
activities performed in exit() system call, and depending on when the
signal handlers are shutdown in that sequence, the process will be
deemed as dead or alive, from another process's perspective -
process.kill(pid) is what is used in the test case to check the
liveliness of the worker, and when the kill() call is issued, even if the
target process is in it's exit sequences, if the signal handlers are not
shut down, it will respond to external signals, causing those calls to pass.

This pull request is to essentially increase the wait timeout to 1000ms for AIX.
in order to allow the node tests simple/test-cluster-master-error.js and
simple/test-cluster-master-kill.js to pass.
