### PR TITLE
v8: don't busy loop in cpu profiler thread

### DIFF
--- a/deps/v8/src/cpu-profiler.cc
+++ b/deps/v8/src/cpu-profiler.cc
@@ -112,10 +112,18 @@ void ProfilerEventsProcessor::Run() {
     timer.Start();
     // Keep processing existing events until we need to do next sample.
     do {
-      if (FoundSampleForNextCodeEvent == ProcessOneSample()) {
+      switch (ProcessOneSample()) {
+      case FoundSampleForNextCodeEvent:
         // All ticks of the current last_processed_code_event_id_ are
         // processed, proceed to the next code event.
         ProcessCodeEvent();
+        break;
+      case NoSamplesInQueue:
+        base::Thread::YieldCPU();
+        break;
+      default:
+        // carry on processing samples
+        break;
       }
     } while (!timer.HasExpired(period_));
 


### PR DESCRIPTION
The change in v0.10 (issue #8789) to sleep instead of
busy looping in the profiler processing thread is not
effective in v0.12 due to alterations in V8 to the
main loop in the processing thread.

As part of this V8 change, the responsibility for taking
stack samples been added to this loop to allow for the
sampling interval to be configured via the API.

This resulted in removing the previously present call to
YieldCPU().

The purpose of this commit is to recreate a similar fix in
v0.12 to the one provided for v0.10 in issue #8789.

The call to YieldCPU is reintroduced to the loop in the case
where there is no work to perform. Since YieldCPU was previously
modified to nanosleep (rather than sched_yield) on posix platforms,
and that change has been carried forward to 0.12, this will result
in a sleep for a period rounding up to the scheduler's granularity
on posix.

In v0.12 this could delay samples by the sleep period which would
be accurate on the unpatched code (since the loop now manages the
time at which samples are taken).
## Additional:

This change (like issue #8789) is a patch to deps/v8 rather than node itself.
My understanding is that this was accepted previously because the v8 version (3.14) used by node (in 0.10) was significantly backlevel that it would not be patched upstream. I assume this is the case with 0.12 as well (which uses V8 3.28).

I have raised a V8 issue to address the problem on the latest V8 level (https://code.google.com/p/v8/issues/detail?id=3967).
