### PR TITLE
add CLI option to syntax check script, fixes #9426

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -49,6 +49,8 @@ and servers.
 
   -p, --print            print result of --eval
 
+  -c, --check            syntax check script without executing
+
   -i, --interactive      always enter the REPL even if stdin
                          does not appear to be a terminal
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -124,6 +124,7 @@ using v8::kExternalUint32Array;
 
 static bool print_eval = false;
 static bool force_repl = false;
+static bool syntax_check_only = false;
 static bool trace_deprecation = false;
 static bool throw_deprecation = false;
 static const char* eval_string = NULL;
@@ -2685,6 +2686,11 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "_print_eval", True(env->isolate()));
   }
 
+  // -c, --check
+  if (syntax_check_only) {
+    READONLY_PROPERTY(process, "_syntax_check_only", True(env->isolate()));
+  }
+
   // -i, --interactive
   if (force_repl) {
     READONLY_PROPERTY(process, "_forceRepl", True(env->isolate()));
@@ -2911,6 +2917,7 @@ static void PrintHelp() {
          "  -v, --version        print node's version\n"
          "  -e, --eval script    evaluate script\n"
          "  -p, --print          evaluate script and print result\n"
+         "  -c, --check          syntax check script without executing\n"
          "  -i, --interactive    always enter the REPL even if stdin\n"
          "                       does not appear to be a terminal\n"
          "  --no-deprecation     silence deprecation warnings\n"
@@ -3029,6 +3036,8 @@ static void ParseArgs(int* argc,
           eval_string += 1;
         }
       }
+    } else if (strcmp(arg, "--check") == 0 || strcmp(arg, "-c") == 0) {
+      syntax_check_only = true;
     } else if (strcmp(arg, "--interactive") == 0 || strcmp(arg, "-i") == 0) {
       force_repl = true;
     } else if (strcmp(arg, "--no-deprecation") == 0) {

--- a/src/node.js
+++ b/src/node.js
@@ -96,6 +96,15 @@
       var path = NativeModule.require('path');
       process.argv[1] = path.resolve(process.argv[1]);
 
+      // check if user passed `-c` or `--check` arguments to Node.
+      if (process._syntax_check_only != null) {
+        var vm = NativeModule.require('vm');
+        var fs = NativeModule.require('fs');
+        var source = fs.readFileSync(process.argv[1], 'utf8').replace(/^#.*/, '');
+        new vm.Script(source, {filename: process.argv[1], displayErrors: true});
+        process.exit(0);
+      }
+
       // If this is a worker in cluster mode, start up the communication
       // channel.
       if (process.env.NODE_UNIQUE_ID) {

--- a/test/fixtures/syntax/bad_syntax.js
+++ b/test/fixtures/syntax/bad_syntax.js
@@ -1,0 +1,1 @@
+var foo bar;

--- a/test/fixtures/syntax/bad_syntax_shebang.js
+++ b/test/fixtures/syntax/bad_syntax_shebang.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+var foo bar;

--- a/test/fixtures/syntax/good_syntax.js
+++ b/test/fixtures/syntax/good_syntax.js
@@ -1,0 +1,1 @@
+var foo = 'bar';

--- a/test/fixtures/syntax/good_syntax_shebang.js
+++ b/test/fixtures/syntax/good_syntax_shebang.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+var foo = 'bar';

--- a/test/simple/test-cli-syntax.js
+++ b/test/simple/test-cli-syntax.js
@@ -1,0 +1,76 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var spawnSync = require('child_process').spawnSync;
+var path = require('path');
+
+var common = require('../common');
+
+var node = process.argv[0];
+
+// test both sets of arguments that check syntax
+var syntax_args = [
+  ['-c'],
+  ['--check']
+];
+
+// test good syntax with and without shebang
+[
+  'syntax/good_syntax.js',
+  'syntax/good_syntax_shebang.js'
+].forEach(function(file) {
+  file = path.join(common.fixturesDir, file);
+
+  // loop each possible option, `-c` or `--check`
+  syntax_args.forEach(function(args) {
+    var _args = args.concat([file]);
+    console.log('calling %s %s', node, _args.join(' '));
+    var c = spawnSync(node, _args, {encoding: 'utf8'});
+
+    // no output should be produced
+    assert.equal(c.stdout, '', 'stdout produced');
+    assert.equal(c.stderr, '', 'stderr produced');
+    assert.equal(c.status, 0, 'code == ' + c.status);
+    console.log('ok');
+  });
+});
+
+// test bad syntax with and without shebang
+[
+  'syntax/bad_syntax.js',
+  'syntax/bad_syntax_shebang.js'
+].forEach(function(file) {
+  file = path.join(common.fixturesDir, file);
+
+  // loop each possible option, `-c` or `--check`
+  syntax_args.forEach(function(args) {
+    var _args = args.concat([file]);
+    console.log('calling %s %s', node, _args.join(' '));
+    var c = spawnSync(node, _args, {encoding: 'utf8'});
+
+    // no output should be produced
+    assert.equal(c.stdout, '', 'stdout produced');
+    assert(c.stderr, 'stderr not produced');
+    assert.equal(c.status, 1, 'code == ' + c.status);
+    console.log('ok');
+  });
+});


### PR DESCRIPTION
discussion in https://github.com/joyent/node/issues/9426

This is my first contribution to node core so I may have missed a few files when trying to add this functionality... but in my testing everything worked as expected.

```
$ cat ./good.js
var a = 'foo';
$ ./out/Release/node -c ./good.js
$ echo $?
0
```

```
$ cat ./bad.js
var a foo;
$ ./out/Release/node -c ./bad.js
/Users/dave/dev/node/bad.js:1
var a foo;
      ^^^
SyntaxError: Unexpected identifier
    at startup (node.js:104:54)
    at node.js:826:3
$ echo $?
1
```
