### PR TITLE
test: fix test-process-active-wraps for IPv4

### DIFF
--- a/test/simple/test-process-active-wraps.js
+++ b/test/simple/test-process-active-wraps.js
@@ -31,12 +31,17 @@ function expect(activeHandles, activeRequests) {
 
 var handles = [];
 
+/* Start from the assumption that IPv6 is enabled, just like Node does;
+ * if it is disabled, a different number of handles will be created. */
+var isIPv6 = true;
+
 (function() {
   expect(0, 0);
   var server = net.createServer().listen(common.PORT);
-  expect(1, 0);
+  if (server.address().family !== 'IPv6') isIPv6 = false;
+  isIPv6 ? expect(1, 0) : expect(2, 0);
   server.close();
-  expect(1, 0); // server handle doesn't shut down until next tick
+  isIPv6 ? expect(1, 0) : expect(2, 0); // server handle doesn't shut down until next tick
   handles.push(server);
 })();
 
@@ -47,13 +52,13 @@ var handles = [];
     });
   };
 
-  expect(1, 0);
+  isIPv6 ? expect(1, 0) : expect(2, 0);
   var conn = net.createConnection(common.PORT);
   conn.on('lookup', onlookup);
   conn.on('error', function() { assert(false); });
-  expect(2, 1);
+  isIPv6 ? expect(2, 1) : expect(3, 1);
   conn.destroy();
-  expect(2, 1); // client handle doesn't shut down until next tick
+  isIPv6 ? expect(2, 1) : expect(3, 1); // client handle doesn't shut down until next tick
   handles.push(conn);
 })();
 


### PR DESCRIPTION
**Problem**

The test-process-active-wraps test found in test/simple/test-process-active-wraps.js fails if the machine it runs on does not have IPv6 enabled. This is due to the fact that Node first tries to use IPv6 and then falls back to using IPv4 if it is not enabled, as it can be seen in [lib/net.js#L1100-L1105](https://github.com/joyent/node/blob/9b534e2e87489d219f0d0cf5be7f9119704fe424/lib/net.js#L1100-L1105). Even though binding to an IPv6 address fails, there is an extra handle created in the process. This causes a couple of assertions in the test to fail.

**Fix**

The fix involves checking whether the server started on an IPv6 address or IPv4 address when deciding what to assert. If the protocol used is IPv4, then the numbers used for the assertions can simply be bumped by one.

As an example, this is how the code has been changed in the test:

```
...

var isIPv6 = true;

(function() {
  expect(0, 0);
  var server = net.createServer().listen(common.PORT);
  if (server.address().family !== 'IPv6') isIPv6 = false;
  isIPv6 ? expect(1, 0) : expect(2, 0);

...
```
