### PR TITLE
security: use https for downloading certdata

### DIFF
--- a/tools/mk-ca-bundle.pl
+++ b/tools/mk-ca-bundle.pl
@@ -36,7 +36,7 @@ use MIME::Base64;
 use strict;
 use vars qw($opt_h $opt_i $opt_l $opt_q $opt_t $opt_v $opt_w);
 
-my $url = 'http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1';
+my $url = 'https://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1';
 # If the OpenSSL commandline is not in search path you can configure it here!
 my $openssl = 'openssl';
 


### PR DESCRIPTION
This makes sure that the code used to download the cert store data
from Mozilla is over a secure channel. 

An MITM attacker could inject his own CA root cert to the trust, 
eventually making this list futile and ultimately make all 
deployments of Nodejs trust his cert.
