### PR TITLE
WIP: Verify core events and patterns

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -63,6 +63,8 @@ function Agent(options) {
     var name = self.getName(options);
     debug('agent.on(free)', name);
 
+    // This seems an absurd check, we should not be firing this event after
+    // it has been closed/destroyed
     if (!socket.destroyed &&
         self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -42,6 +42,29 @@ var Agent = require('_http_agent');
 function ClientRequest(options, cb) {
   var self = this;
   OutgoingMessage.call(self);
+  this.strictEERegister({
+    connect: {
+      maxCount: 1,
+      after: ['socket'],
+    },
+    close: {
+      maxCount: 1,
+      after: ['error', 'upgrade', 'aborted', 'finish', 'end'],
+    },
+    error: {
+      maxCount: 1,
+      notAfter: ['close'],
+    },
+    continue: {
+      maxCount: 1,
+      notAfter: ['error', 'close'],
+      after: ['socket'],
+    },
+    response: {
+      notAfter: ['error', 'close'],
+      maxCount: 1,
+    },
+  }, true);
 
   if (util.isString(options)) {
     options = url.parse(options);

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -38,6 +38,15 @@ exports.readStop = readStop;
 /* Abstract base class for ServerRequest and ClientResponse. */
 function IncomingMessage(socket) {
   Stream.Readable.call(this);
+  this.strictEERegister({
+    aborted: {
+      maxCount: 1,
+      notAfter: ['error', 'close', 'end'],
+    },
+    timeout: {
+      notAfter: ['error', 'close'],
+    },
+  });
 
   // XXX This implementation is kind of all over the place
   // When the parser emits body chunks, they go in this list.

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -62,7 +62,18 @@ utcDate._onTimeout = function() {
 
 
 function OutgoingMessage() {
-  Stream.call(this);
+  Stream.Writable.call(this);
+  this.strictEERegister({
+    socket: {
+      notAfter: ['close', 'error', 'finish'],
+    },
+    upgrade: {
+      maxCount: 1,
+    },
+    timeout: {
+      notAfter: ['error', 'close'],
+    },
+  });
 
   this.output = [];
   this.outputEncodings = [];
@@ -90,7 +101,7 @@ function OutgoingMessage() {
   this._headers = null;
   this._headerNames = {};
 }
-util.inherits(OutgoingMessage, Stream);
+util.inherits(OutgoingMessage, Stream.Writable);
 
 
 exports.OutgoingMessage = OutgoingMessage;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -100,6 +100,15 @@ var STATUS_CODES = exports.STATUS_CODES = {
 
 function ServerResponse(req) {
   OutgoingMessage.call(this);
+  this.strictEERegister({
+    close: {
+      maxCount: 1,
+      after: ['abort', 'error', '_socketClose'],
+    },
+    _socketClose: {
+      maxCount: 1,
+    },
+  }, true);
 
   if (req.method === 'HEAD') this._hasBody = false;
 
@@ -237,6 +246,27 @@ ServerResponse.prototype.writeHeader = function() {
 function Server(requestListener) {
   if (!(this instanceof Server)) return new Server(requestListener);
   net.Server.call(this, { allowHalfOpen: true });
+
+  this.strictEERegister({
+    checkContinue: {
+      notAfter: ['close', 'error'],
+      after: ['listening', 'connection'],
+    },
+    request: {
+      notAfter: ['close', 'error'],
+    },
+    socket: {
+      notAfter: ['close', 'error'],
+    },
+    timeout: {
+      after: ['listening', 'connection'],
+      notAfter: ['error', 'close'],
+    },
+    upgrade: {
+      after: ['listening', 'connection'],
+      notAfter: ['close', 'error'],
+    },
+  });
 
   if (requestListener) {
     this.addListener('request', requestListener);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -152,7 +152,10 @@ function onServerResponseClose() {
   // Ergo, we need to deal with stale 'close' events and handle the case
   // where the ServerResponse object has already been deconstructed.
   // Fortunately, that requires only a single if check. :-)
-  if (this._httpMessage) this._httpMessage.emit('close');
+  if (this._httpMessage) {
+    this._httpMessage.emit('_socketClose');
+    this._httpMessage.emit('close');
+  }
 }
 
 ServerResponse.prototype.assignSocket = function(socket) {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -22,7 +22,7 @@
 module.exports = Readable;
 Readable.ReadableState = ReadableState;
 
-var EE = require('events').EventEmitter;
+var EE = require('events').StrictEE;
 var Stream = require('stream');
 var Buffer = require('buffer').Buffer;
 var util = require('util');
@@ -106,6 +106,24 @@ function Readable(options) {
   this.readable = true;
 
   Stream.call(this);
+  this.strictEERegister({
+    data: {
+      notAfter: ['close', 'end', 'error'],
+    },
+    end: {
+      maxCount: 1,
+      notAfter: ['error', 'close'],
+    },
+    pause: {
+      notAfter: ['end', 'error', 'close'],
+    },
+    readable: {
+      notAfter: ['end', 'error', 'close'],
+    },
+    resume: {
+      notAfter: ['end', 'error', 'close'],
+    },
+  }, true);
 }
 
 // Manually shove something into the read() buffer.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -738,6 +738,9 @@ function resume(stream, state) {
 }
 
 function resume_(stream, state) {
+  if (state.ended)
+    return;
+
   if (!state.reading) {
     debug('resume read 0');
     stream.read(0);
@@ -752,7 +755,8 @@ function resume_(stream, state) {
 
 Readable.prototype.pause = function() {
   debug('call pause flowing=%j', this._readableState.flowing);
-  if (false !== this._readableState.flowing) {
+  if (false !== this._readableState.flowing &&
+      !this._readableState.ended) {
     debug('pause');
     this._readableState.flowing = false;
     this.emit('pause');

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -155,6 +155,27 @@ function Writable(options) {
   this.writable = true;
 
   Stream.call(this);
+  this.strictEERegister({
+    drain: {
+      notAfter: ['finish', 'close', 'error'],
+    },
+    finish: {
+      maxCount: 1,
+      after: ['prefinish'],
+      notAfter: ['close', 'error'],
+    },
+    pipe: {
+      notAfter: ['close', 'error', 'finish'],
+    },
+    prefinish: {
+      maxCount: 1,
+      notAfter: ['close', 'error', 'finish'],
+    },
+    unpipe: {
+      after: ['pipe'],
+      notAfter: ['close', 'error'],
+    },
+  }, true);
 }
 
 // Otherwise people can pipe Writable streams, which is just wrong.

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -465,6 +465,9 @@ TLSSocket.prototype._finishInit = function() {
     this.servername = this.ssl.getServername();
   }
 
+  if (this._secureEstablished)
+    return;
+
   debug('secure established');
   this._secureEstablished = true;
   if (this._tlsOptions.handshakeTimeout > 0)

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -235,6 +235,18 @@ function TLSSocket(socket, options) {
     readable: false,
     writable: false
   });
+  this.strictEERegister({
+    secure: {
+      maxCount: 1,
+    },
+    secureConnect: {
+      maxCount: 1,
+      after: ['connect', 'secure'],
+    },
+    _tlsError: {
+      maxCount: 1,
+    },
+  });
 
   if (socket) {
     this._parent = socket;
@@ -673,6 +685,12 @@ function Server(/* [options], listener */) {
         self.emit('clientError', err, socket);
       }
     });
+  });
+  this.strictEERegister({
+    secureConnection: {
+      after: ['listening', 'connection'],
+      notAfter: ['close', 'error'],
+    },
   });
 
   if (listener) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var domain;
+var assert, domain;
 var util = require('util');
 
 function EventEmitter() {
@@ -314,4 +314,164 @@ EventEmitter.listenerCount = function(emitter, type) {
   else
     ret = emitter._events[type].length;
   return ret;
+};
+
+// StrictEE
+var strictID = 0;
+var expectedEvents = {};
+
+function StrictEE(rules, override) {
+  if (EventEmitter.TrackMinCount === undefined) {
+    EventEmitter.TrackMinCount = process.NODE_STRICT_EVENTS || false;
+    process.on('exit', function StrictEEOnExit() {
+      if (EventEmitter.TrackMinCount && Object.keys(expectedEvents).length > 0) {
+        (function MinCountAssertionFailure(ee) {
+          process.abort();
+        })(expectedEvents);
+      }
+    });
+  }
+
+  if (EventEmitter.RequireEventDef === undefined) {
+    EventEmitter.RequireEventDef = process.NODE_REQUIRE_EVENTS || true;
+  }
+
+  if (assert === undefined)
+    assert = require('assert');
+
+  if (!(this instanceof StrictEE))
+    return new StrictEE(rules);
+
+  this._strictID = undefined;
+  this.strictEERegister(rules, override);
+
+  EventEmitter.call(this);
+}
+util.inherits(StrictEE, EventEmitter);
+
+
+EventEmitter.StrictEE = StrictEE;
+EventEmitter.TrackMinCount = undefined;
+EventEmitter.RequireEventDef = undefined;
+
+StrictEE.prototype.strictEERegister = function strictRegister(rules, override) {
+  var oldRules = this._strictEERules = this._strictEERules || {};
+  this._strictEvents = this._strictEvents || {};
+
+  var i, e;
+
+  for (i in rules) {
+    if (!override) {
+      var r = oldRules[i];
+      assert.strictEqual(r, undefined,
+        util.format('Event "%s" already registered, %j', i, r));
+    }
+
+    e = rules[i];
+
+    if (util.isArray(e.notAfter) && e.notAfter.indexOf('*') > -1) {
+      assert.strictEqual(e.notAfter.length, 1,
+        util.format(
+          'Event "%s" notAfter wild card must only have one entry, not %j',
+          i, e.notAfter));
+    }
+
+    if (EventEmitter.TrackMinCount && util.isNumber(e.minCount)) {
+      if (!this._strictID)
+        this._strictID = ++strictID;
+
+      var ee = expectedEvents[strictID] = expectedEvents[strictID] || { __: this };
+
+      ee[i] = e.minCount;
+    }
+  }
+
+  this._strictEERules = util._extend(oldRules, rules);
+};
+
+StrictEE.prototype.emit = function strictEmit(type) {
+  var strictRule = this._strictEERules[type];
+
+  if (!strictRule) {
+    if (EventEmitter.RequireEventDef)
+      assert.ok(false, util.format('Event "%s" was not defined, fired %j',
+        type, Object.keys(this._strictEvents)));
+    else
+      return EventEmitter.prototype.emit.apply(this, arguments);
+  }
+
+  var keys;
+
+  if (util.isArray(strictRule.notAfter) && strictRule.notAfter.length === 1 &&
+      strictRule.notAfter[0] === '*') {
+    keys = Object.keys(this._strictEvents);
+    assert.strictEqual(keys.length, 0,
+      util.format('Event "%s" must come first but came after %j', type, keys));
+  }
+
+  var strictEvent = this._strictEvents[type] || {};
+
+  strictEvent.count = 1 + (strictEvent.count || 0);
+
+  if (util.isNumber(strictRule.maxCount)) {
+    assert.ok(strictEvent.count <= strictRule.maxCount,
+      util.format('Event "%s" fired %d times, more than %d',
+                  type, strictEvent.count, strictRule.maxCount));
+  }
+
+  if (util.isNumber(strictRule.minCount)) {
+    assert.ok(this._strictID, 'Object must have a strictID');
+    var oee = expectedEvents[this._strictID];
+    if (oee) {
+      var ee = oee[type];
+      if (ee) {
+        if (--ee === 0)
+          delete oee[type];
+      }
+
+      if (Object.keys(oee) === 1)
+        delete expectedEvents[this._strictID];
+    }
+  }
+
+  var found, i, e;
+
+  if (util.isArray(strictRule.notAfter)) {
+    found = false;
+
+    for (i in strictRule.notAfter) {
+      if (i === '*') continue;
+
+      e = strictRule.notAfter[i];
+      if (this._strictEvents[e]) {
+        found = e;
+        break;
+      }
+    }
+
+    assert.strictEqual(found, false,
+      util.format('Event "%s" must **not** fire after "%s", fired %j',
+        type, found, Object.keys(this._strictEvents)));
+  }
+
+  if (util.isArray(strictRule.after)) {
+    found = false;
+
+    for (i in strictRule.after) {
+      e = strictRule.after[i];
+      if (this._strictEvents[e]) {
+        found = true;
+        break;
+      }
+    }
+
+    console.error(this);
+    assert.strictEqual(found, true,
+      util.format('Event "%s" must fire after at least one of %j, fired %j',
+                  type, strictRule.after, Object.keys(this._strictEvents)));
+  }
+
+  this._strictEvents[type] = strictEvent;
+
+  return EventEmitter.prototype.emit.apply(this, arguments);
 };

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1567,6 +1567,12 @@ function ReadStream(path, options) {
   }, options || {});
 
   Readable.call(this, options);
+  this.strictEERegister({
+    open: {
+      maxCount: 1,
+      notAfter: ['close', 'error'],
+    },
+  });
 
   this.path = path;
   this.fd = options.hasOwnProperty('fd') ? options.fd : null;
@@ -1733,6 +1739,12 @@ function WriteStream(path, options) {
   options = options || {};
 
   Writable.call(this, options);
+  this.strictEERegister({
+    open: {
+      maxCount: 1,
+      notAfter: ['error', 'close'],
+    },
+  });
 
   this.path = path;
   this.fd = null;
@@ -1814,7 +1826,13 @@ WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 // SyncWriteStream is internal. DO NOT USE.
 // Temporary hack for process.stdout and process.stderr when piped to files.
 function SyncWriteStream(fd, options) {
-  Stream.call(this);
+  Stream.Writable.call(this);
+  this.strictEERegister({
+    open: {
+      maxOpen: 1,
+      notAfter: ['error', 'close'],
+    },
+  });
 
   options = options || {};
 
@@ -1825,7 +1843,7 @@ function SyncWriteStream(fd, options) {
       options.autoClose : true;
 }
 
-util.inherits(SyncWriteStream, Stream);
+util.inherits(SyncWriteStream, Stream.Writable);
 
 
 // Export

--- a/lib/https.js
+++ b/lib/https.js
@@ -34,6 +34,26 @@ function Server(opts, requestListener) {
   }
 
   tls.Server.call(this, opts, http._connectionListener);
+  this.strictEERegister({
+    checkContinue: {
+      notAfter: ['close', 'error'],
+      after: ['listening', 'connection'],
+    },
+    request: {
+      notAfter: ['close', 'error'],
+    },
+    socket: {
+      notAfter: ['close', 'error'],
+    },
+    timeout: {
+      after: ['listening', 'connection'],
+      notAfter: ['error', 'close'],
+    },
+    upgrade: {
+      after: ['listening', 'connection'],
+      notAfter: ['close', 'error'],
+    },
+  });
 
   this.httpAllowHalfOpen = false;
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -524,6 +524,7 @@ Socket.prototype._destroy = function(exception, cb) {
   // to make it re-entrance safe in case Socket.prototype.destroy()
   // is called within callbacks
   this.destroyed = true;
+  this.emit('destroy', exception);
   fireErrorCallbacks();
 
   if (this.server) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -197,6 +197,38 @@ function Socket(options) {
       this.read(0);
     }
   }
+
+  this.strictEERegister({
+    agentRemove: {
+      notAfter: ['close', 'error'],
+    },
+    // aborted comes from http
+    connect: {
+      maxCount: 1,
+      notAfter: ['data', 'error', 'end', 'finish', 'close'],
+    },
+    destroy: {
+      //maxCount: 1,
+      notAfter: ['close'],
+    },
+    // XXX
+    // used by httpAgent, and inexplicably we can't actually say it doesn't
+    // happen after any of the events you might consider being final.
+    free: {
+      //notAfter: ['error', 'finish', 'end', 'close'],
+    },
+    lookup: {
+      maxCount: 1,
+      notAfter: ['connect', 'data', 'error', 'end', 'finish', 'close'],
+    },
+    timeout: {
+      notAfter: ['error', 'end', 'close'],
+    },
+    _socketEnd: {
+      maxCount: 1,
+      notAfter: ['error', 'end', 'close'],
+    },
+  });
 }
 util.inherits(Socket, stream.Duplex);
 
@@ -856,6 +888,7 @@ Socket.prototype.connect = function(options, cb) {
     return Socket.prototype.connect.apply(this, args);
   }
 
+  // XXX this logic is suspect
   if (this.destroyed) {
     this._readableState.reading = false;
     this._readableState.ended = false;
@@ -866,6 +899,7 @@ Socket.prototype.connect = function(options, cb) {
     this._writableState.errorEmitted = false;
     this.destroyed = false;
     this._handle = null;
+    this._strictEvents = {};
   }
 
   var self = this;
@@ -1004,7 +1038,32 @@ function afterConnect(status, handle, req, readable, writable) {
 
 function Server(/* [ options, ] listener */) {
   if (!(this instanceof Server)) return new Server(arguments[0], arguments[1]);
-  events.EventEmitter.call(this);
+  events.StrictEE.call(this, {
+    clientError: {
+      after: ['listening'],
+      notAfter: ['error', 'close'],
+    },
+    close: {
+      after: ['listening', 'error'],
+      maxCount: 1,
+    },
+    connect: {
+      after: ['listening'],
+      notAfter: ['error', 'close'],
+    },
+    connection: {
+      after: ['listening'],
+      notAfter: ['close', 'error'],
+    },
+    error: {
+      notAfter: ['close'],
+      maxCount: 1,
+    },
+    listening: {
+      notAfter: ['close', 'error'],
+      maxCount: 1,
+    },
+  });
 
   var self = this;
 
@@ -1044,7 +1103,7 @@ function Server(/* [ options, ] listener */) {
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
-util.inherits(Server, events.EventEmitter);
+util.inherits(Server, events.StrictEE);
 exports.Server = Server;
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -148,6 +148,7 @@ function Socket(options) {
   else if (util.isUndefined(options))
     options = {};
 
+  this._originalOptions = options;
   stream.Duplex.call(this, options);
 
   if (options.handle) {
@@ -891,13 +892,7 @@ Socket.prototype.connect = function(options, cb) {
 
   // XXX this logic is suspect
   if (this.destroyed) {
-    this._readableState.reading = false;
-    this._readableState.ended = false;
-    this._readableState.endEmitted = false;
-    this._writableState.ended = false;
-    this._writableState.ending = false;
-    this._writableState.finished = false;
-    this._writableState.errorEmitted = false;
+    stream.Duplex.call(this, this._originalOptions);
     this.destroyed = false;
     this._handle = null;
     this._strictEvents = {};

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -21,7 +21,7 @@
 
 module.exports = Stream;
 
-var EE = require('events').EventEmitter;
+var EE = require('events').StrictEE;
 var util = require('util');
 
 util.inherits(Stream, EE);
@@ -40,7 +40,17 @@ Stream.Stream = Stream;
 // part of this class) is overridden in the Readable class.
 
 function Stream() {
-  EE.call(this);
+  EE.call(this, {
+    close: {
+      maxCount: 1,
+      //aborted comes from http semantics
+      after: ['error', 'end', 'finish', 'destroy', 'aborted'],
+    },
+    error: {
+      maxCount: 1,
+      notAfter: ['close', 'end', 'finish'],
+    },
+  }, true);
 }
 
 Stream.prototype.pipe = function(dest, options) {


### PR DESCRIPTION
Before we can start stamping out what it means to be "compatible" with Node.js, we have to start by writing down how we think Node.js works today, and then verifying that scenario. (cc @dshaw @trevnorris @jasnell @mdawsonibm As we've all had conversations about API compatibility in the past)

Since we're event driven the key abstraction/data structure that impacts all of Node.js is `EventEmitter`. While we have spent the time to get that useful and fast, we haven't spent as much time making sure how Node.js presents its interfaces via the `EventEmitter` are meeting our expectations.

There are many places we can improve Node.js, but one of our friction points today (internally and externally) involves around what events will happen, when, and in what order.

This branch/PR adds the notion of a `StrictEE` implementation of `EventEmitter` that provides facilities to describe your events.

Instead of inheriting from plain old `EE` you inherit from `StrictEE`, and then when constructing you pass in an object which defines the events and the orders that can be passed in.

I myself am not convinced if this should be used in production, there is definitely plenty of low hanging fruit for improving its performance (it should create way fewer object literals). But really, I think (unless the user has asked for "strict mode") normal operating procedure should be that most of the strict checks are `noop`s.

Instead, I think this is critical while running our test suite, and verifying our software (and our downstream users code).

A definition of a rule looks like this currently:

``` javascript
{
  myEvent: {
    minCount: 1,
    maxCount: 2,
    after: ['event1', 'event2', 'event3'],
    notAfter: ['event4', 'event5'],
  },
}
```

and running our test suite you can grep the output and get something like this:

```
   2 #AssertionError: Event "close" must fire after at least one of ["error","end","finish","destroy","aborted"], fired []
   2 #AssertionError: Event "close" must fire after at least one of ["error","upgrade","aborted","finish","end"], fired ["socket","drain","response"]
   2 #AssertionError: Event "close" must fire after at least one of ["listening","error"], fired []
   2 #AssertionError: Event "listening" fired 2 times, more than 1
   2 #AssertionError: Event "unpipe" must **not** fire after "error", fired ["pipe","error"]
```

It's a very simple description, `after` is better defined: "after any", and `notAfter` is "not after any", and there is a mechanism for counting the times which an event has fired. We probably want the concept of `afterAll`.

In practice `minCount` is not used anywhere, and its overhead and potential to leak (in its current implementation) should discourage use of this without also growing some concept of a finalization step that could be used to verify this instead of the current global data structure.

You can also use `obj.strictEERegister` to extend rule definitions in child classes.

There probably should also be an `obj.strictEEReset` mode that resets the "state machine" for reuse (this already found an issue in `net.connect` re-usage).

This is currently based on v0.12 because I found it helpful while debugging other current bugs. In its current state it's a public API addition that wouldn't be suitable for v0.12.1, but I do think it's useful to finish this work on the current stable branch and rename APIs and any additional events such that we can continue to squash bugs.

Other obvious oversights include missing tests and documentation.

I'm publishing this PR as I'm looking for help from someone in the community who wants to come and help complete this. As a result, you'll end up with a lot of more knowledge about how Node.js actually works. I myself learned quite a bit bootstrapping into this. For everyone else, we'll have described and along the way documented quite a bit of how Node.js works, which will make it easier for the next person to come and contribute a fix.
