### PR TITLE
configure: added --with-arm-fpu option

### DIFF
--- a/configure
+++ b/configure
@@ -232,6 +232,12 @@ parser.add_option('--with-arm-float-abi',
     help='specifies which floating-point ABI to use. Valid values are: '
          'soft, softfp, hard')
 
+parser.add_option('--with-arm-fpu',
+    action='store',
+    dest='arm_fpu',
+    help='specifies which vector floating point unit to use. Valid values are: '
+         'vfpv3, vfpv3-d16, neon')
+
 parser.add_option('--with-dtrace',
     action='store_true',
     dest='with_dtrace',
@@ -490,6 +496,11 @@ def configure_arm(o):
   else:
     arm_float_abi = 'default'
 
+  if options.arm_fpu:
+    arm_fpu = options.arm_fpu
+  else:
+    arm_fpu = 'vfpv3'
+
   if is_arch_armv7():
     o['variables']['arm_version'] = '7'
   elif is_arch_armv6():
@@ -497,7 +508,7 @@ def configure_arm(o):
   else:
     o['variables']['arm_version'] = 'default'
 
-  o['variables']['arm_fpu'] = 'vfpv3'  # V8 3.18 no longer supports VFP2.
+  o['variables']['arm_fpu'] = arm_fpu
   o['variables']['arm_neon'] = int(is_arm_neon())
   o['variables']['arm_thumb'] = 0      # -marm
   o['variables']['arm_float_abi'] = arm_float_abi


### PR DESCRIPTION
The configure script is currently using arm-fpu='vfpv3' as the hardcoded default.

This patch will add a --with-arm-fpu option that will allow the choice of other FPU hardware. Otherwise we would get an "Illegal instruction" error on runtime when using the v8 engine in ARM hardware that has a different floating point unit (I was having this problem on an at91sama5 microcontroller).

It might be advisable to use as default value "default" instead of "vfpv3". For consistency and to avoid having to update the default value in the future if v8 ever decides to drop support of vfpv3 like it did with vfpv2. 

But since this would change the current default behavior ("default" currently falls back to "vfpv3-d16" in the version of v8 you are using), I would like to know your opinion about it, perhaps you have good reasons to have "vfpv3" as the default arm_fpu, instead of "vfpv3-d16".
