### PR TITLE
http: fix assert on data/end after socket error

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -264,7 +264,6 @@ function socketCloseListener() {
 
 function socketErrorListener(err) {
   var socket = this;
-  var parser = socket.parser;
   var req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
@@ -275,10 +274,18 @@ function socketErrorListener(err) {
     req.socket._hadError = true;
   }
 
+  // Handle any pending data
+  socket.read();
+
+  var parser = socket.parser;
   if (parser) {
     parser.finish();
     freeParser(parser, req, socket);
   }
+
+  // Ensure that no further data will come out of the socket
+  socket.removeListener('data', socketOnData);
+  socket.removeListener('end', socketOnEnd);
   socket.destroy();
 }
 

--- a/test/parallel/test-http-client-read-in-error.js
+++ b/test/parallel/test-http-client-read-in-error.js
@@ -1,0 +1,42 @@
+var net = require('net');
+var http = require('http');
+var util = require('util');
+
+function Agent() {
+  http.Agent.call(this);
+}
+util.inherits(Agent, http.Agent);
+
+Agent.prototype.createConnection = function() {
+  var self = this;
+  var socket = new net.Socket();
+
+  socket.on('error', function() {
+    socket.push('HTTP/1.1 200\r\n\r\n');
+  });
+
+  socket.on('newListener', function onNewListener(name) {
+    if (name !== 'error')
+      return;
+    socket.removeListener('newListener', onNewListener);
+
+    // Let other listeners to be set up too
+    process.nextTick(function() {
+      self.breakSocket(socket);
+    });
+  });
+
+  return socket;
+};
+
+Agent.prototype.breakSocket = function breakSocket(socket) {
+  socket.emit('error', new Error('Intentional error'));
+};
+
+var agent = new Agent();
+
+http.request({
+  agent: agent
+}).once('error', function() {
+  console.log('ignore');
+});


### PR DESCRIPTION
This change is a backport of 1a3ca8223e08d82051655d7d7e2ea31b439f1bf1
from io.js.

Original commit message:

  Read all pending data out of the socket on `error` event and ensure that
  no `data`/`end` handlers will be invoked on `socket.destroy()`.
  Otherwise following assertion happens:

```
  AssertionError: null == true
      at TLSSocket.socketOnData (_http_client.js:308:3)
      at TLSSocket.emit (events.js:107:17)
      at TLSSocket.Readable.read (_stream_readable.js:373:10)
      at TLSSocket.socketCloseListener (_http_client.js:229:10)
      at TLSSocket.emit (events.js:129:20)
      at TCP.close (net.js:476:12)
```

  Fix: https://github.com/joyent/node/issues/9348
  PR-URL: https://github.com/iojs/io.js/pull/1103
  Reviewed-By: Rod Vagg rod@vagg.org
  Reviewed-By: Nicu Micleușanu micnic90@gmail.com

Fixes #9348.
