### PR TITLE
fix install source path for openssl headers

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -161,7 +161,7 @@ def files(action):
 
   if 'false' == variables.get('node_shared_openssl'):
     action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
-    subdir_files('deps/openssl/include/openssl', 'include/node/openssl/', action)
+    subdir_files('deps/openssl/openssl/include/openssl', 'include/node/openssl/', action)
 
   if 'false' == variables.get('node_shared_v8'):
     subdir_files('deps/v8/include', 'include/node/', action)

--- a/tools/install.py
+++ b/tools/install.py
@@ -160,8 +160,8 @@ def files(action):
     subdir_files('deps/uv/include', 'include/node/', action)
 
   if 'false' == variables.get('node_shared_openssl'):
-    action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
     subdir_files('deps/openssl/openssl/include/openssl', 'include/node/openssl/', action)
+    action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
 
   if 'false' == variables.get('node_shared_v8'):
     subdir_files('deps/v8/include', 'include/node/', action)


### PR DESCRIPTION
Seems node 0.12.x and node 0.10.x / jxcore use the same install script. This must be broken for a very long time. Moving the commit from https://github.com/jxcore/jxcore/commit/fc1023f48d046f5731cb5899581b9353db5c7607
