### PR TITLE
test: relax the timing window in test-child-process-fork-net2.js

### DIFF
--- a/test/simple/test-child-process-fork-net2.js
+++ b/test/simple/test-child-process-fork-net2.js
@@ -149,13 +149,13 @@ if (process.argv[2] === 'child') {
 
   server.listen(common.PORT, '127.0.0.1');
 
-  var timeElasped = 0;
+  var timeElapsed = 0;
   var closeServer = function() {
     console.error('[m] closeServer');
     var startTime = Date.now();
     server.on('close', function() {
       console.error('[m] emit(close)');
-      timeElasped = Date.now() - startTime;
+      timeElapsed = Date.now() - startTime;
     });
 
     console.error('[m] calling server.close');
@@ -174,7 +174,7 @@ if (process.argv[2] === 'child') {
     assert.equal(disconnected, count);
     assert.equal(connected, count);
     assert.ok(closeEmitted);
-    assert.ok(timeElasped >= 190 && timeElasped <= 1000,
-              'timeElasped was not between 190 and 1000 ms');
+    assert.ok(timeElapsed >= 190 && timeElapsed <= 5000,
+              'timeElapsed (' + timeElapsed + ') was not between 190 and 5000 ms');
   });
 }


### PR DESCRIPTION
In Linux, simple/test-child-process-fork-net2.js fails intermittently.

assert.js:86
  throw new assert.AssertionError({
        ˆ
AssertionError: timeElasped was not between 190 and 1000 ms
    at process.<anonymous> (/home/gireesh/linux/2015/node/test/simple/test-child-process-fork-net2.js:177:12)
    at process.emit (events.js:129:20)

In SuSE Linux system, under network high load situations, this failure is
consistently reproducible.

The test case tests whether the TCP connections which were established between
the processes terminate in a timely and clean manner. After some iterations of
data transfer on established connections, the server is closed. The server does
not get closed immediately, instead waits for all the active connections to
terminate. A timed (200ms) callback closes the connections, which eventually
closes the server.

The start is the time when the server close is invoked.
The end is the time when the server is actually closed(onClose call back invoked).

Given that there is a minimum delay of 200ms before the connections are
terminated, expecting the elapsed time above 190 is reasonable and fair,
but looks like the leeway of 800ms for the upper bounds seem to be too
stringent, and breaking some scenarios of network load.

The pull request is to:
1. Relax the upper bounds of time elapse for the connections  to close
   for it to work consistently across varying network load situations.
2. Show the actual time elapsed in the fail message for easy comprehension,
3. Correct a variable name for its intended meeting - possibly a typo.
