### PR TITLE
URL: Fix resolving from non-file to file URLs.

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -510,7 +510,9 @@ Url.prototype.resolveObject = function(relative) {
     }
 
     result.protocol = relative.protocol;
-    if (!relative.host && !hostlessProtocol[relative.protocol]) {
+    if (!relative.host &&
+        !/file:?/.test(relative.protocol) &&
+        !hostlessProtocol[relative.protocol]) {
       var relPath = (relative.pathname || '').split('/');
       while (relPath.length && !(relative.host = relPath.shift()));
       if (!relative.host) relative.host = '';

--- a/test/simple/test-url.js
+++ b/test/simple/test-url.js
@@ -1202,7 +1202,9 @@ var relativeTests = [
   ['http://example.com/b//c//d;p?q#blarg',
    'http:/a/b/c/d',
    'http://example.com/a/b/c/d'],
-  ['/foo/bar/baz', '/../etc/passwd', '/etc/passwd']
+  ['/foo/bar/baz', '/../etc/passwd', '/etc/passwd'],
+  ['http://localhost', 'file:///Users/foo', 'file:///Users/foo'],
+  ['http://localhost', 'file://foo/Users', 'file://foo/Users']
 ];
 relativeTests.forEach(function(relativeTest) {
   var a = url.resolve(relativeTest[0], relativeTest[1]),


### PR DESCRIPTION
When resolving a reference URL with the 'file' scheme an no host
against a base URL without the 'file' scheme, the first path element
of the reference URL is used as the host for the target URL. This
results in an invalid target URL.

This change makes an exception for file URLs so that the host is not
mangled during URL resolution.
