### PR TITLE
test: immunize data flow from packet size and order

### DIFF
--- a/test/simple/test-child-process-stdout-flush-exit.js
+++ b/test/simple/test-child-process-stdout-flush-exit.js
@@ -52,14 +52,17 @@ if (process.argv[2] === 'child') {
 
   // check if we receive both 'hello' at start and 'goodbye' at end
   child.stdout.setEncoding('utf8');
+  var messageSequence = 0;
   child.stdout.on('data', function (data) {
-    if (data.slice(0, 6) == 'hello\n') {
+    if ((0 == messageSequence) && (data.slice(0, 6) == 'hello\n')) {
       gotHello = true;
-    } else if (data.slice(data.length - 8) == 'goodbye\n') {
+    }
+    if (data.slice(data.length - 8) == 'goodbye\n') {
       gotBye = true;
     } else {
       gotBye = false;
     }
+    messageSequence++;
   });
 
   child.on('close', function (data) {


### PR DESCRIPTION
simple/test-child-process-stdout-flush-exit.js fails with an assertion.
The root cause for this assertion is that the expected boolean value of
true for the variable gotBye was false. This is set to true when the
piped stdout stream of the child writes the end token "goodbye". So the
error message would indicate that the end token was never received by
the parent, but in fact it did. The only difference is that the first
chunk itself had both 'hello' and 'goodbye' (as well as the filler
words in between) in AIX, while Linux receives them separately.

While this issue is not reproducible in Linux, the number of bytes
received each time a callback is called is not consistent across runs,
which is ratified as the actual content size of a UNIX domain data packet
is determined outside of the node's logic, instead in OS tunables, as well
as the runtime context of data transfer (depending on contiguous free
memory available in OS data structures at the time of sending).
In addition, around 200 filler words sent in between the 'hello' and 
'goodbye' seem to indicate that the coalescence of chunks was a possibility
in Linux as well, and was devised to separate the first word from the last,
through an arbitrary delimiter.

Parser logic seem to be rigid and have assumptions about the order and size
of the data arrival. For example, it checks for 'goodbye' only when it does
not find 'hello' in it, as if they would always come separately. This
exclusiveness is what makes the test to fail in AIX.

This pull request is to make provision in the test case to address
situations wherein the data arrives together, as well as to exhibit consistent
behavior irrespective of the order and content size of the data arrival.
