### PR TITLE
tls: throw an error on getLegacyCipher

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -174,8 +174,7 @@ v0.10.38 behavior of only using the default cipher list on the server.
 ### Cipher List Precedence
 
 Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
-`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive. Only
-_one_ should be used at a time.
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive.
 
 If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
 are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -164,6 +164,35 @@ Reverting back to the defaults used by older releases can weaken the security
 of your applications. The legacy cipher suites should only be used if absolutely
 necessary.
 
+NOTE: Due to an error in Node.js v0.10.38, the default cipher list only applied
+to servers using TLS. The default cipher list would _not_ be used by clients.
+This behavior has been changed in v0.10.39 and the default cipher list is now
+used by both the server and client when using TLS. However, when using
+`--enable-legacy-cipher-list=v0.10.38`, Node.js is reverted back to the
+v0.10.38 behavior of only using the default cipher list on the server.
+
+### Cipher List Precedence
+
+Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive. Only
+_one_ should be used at a time.
+
+If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
+are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
+
+The `--cipher-list` and `--enable-legacy-cipher-list` command line options
+will override the environment variables. If both happened to be specified, the
+right-most (second one specified) will take precedence. For instance, in the
+example:
+
+    node --cipher-list=ABC --enable-legacy-cipher-list=v0.10.38
+
+The v0.10.38 default cipher list will be used.
+
+    node --enable-legacy-cipher-list=v0.10.38 --cipher-list=ABC
+
+The custom cipher list will be used.
+
 ## tls.getCiphers()
 
 Returns an array with the names of the supported SSL ciphers.
@@ -173,6 +202,18 @@ Example:
     var ciphers = tls.getCiphers();
     console.log(ciphers); // ['AES128-SHA', 'AES256-SHA', ...]
 
+
+## tls.getLegacyCiphers(version)
+
+Returns a default cipher list used in a previous version of Node.js. The
+version parameter must be a string whose value identifies previous Node.js
+release version. The only value currently supported is `v0.10.38`.
+
+A TypeError will be thrown if: (a) the `version` is any type other than a
+string, (b) the `version` parameter is not specified, or (c) additional
+parameters are passed in. An Error will be thrown if the `version` parameter is
+passed in as a string but the value does not correlate to any known Node.js
+release for which a default cipher list is available.
 
 ## tls.createServer(options, [secureConnectionListener])
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -181,7 +181,7 @@ If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
 are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
 
 The `--cipher-list` and `--enable-legacy-cipher-list` command line options
-will override the environment variables. If both happened to be specified, the
+will override the environment variables. If both happen to be specified, the
 right-most (second one specified) will take precedence. For instance, in the
 example:
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1330,6 +1330,20 @@ function normalizeConnectArgs(listArgs) {
   return (cb) ? [options, cb] : [options];
 }
 
+// return true if the --enable-legacy-cipher-list command line
+// switch, or the NODE_LEGACY_CIPHER_LIST environment variable
+// are set to v0.10.38 and the DEFAULT_CIPHERS equal the v0.10.38
+// list.
+function usingV1038Ciphers() {
+  var argv = process.execArgv;
+  if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
+       process.env['NODE_LEGACY_CIPHER_LIST'] === 'v0.10.38') &&
+      DEFAULT_CIPHERS === _crypto.getLegacyCiphers('v0.10.38')) {
+        return true;
+  }
+  return false;
+}
+
 exports.connect = function(/* [port, host], options, cb */) {
   var args = normalizeConnectArgs(arguments);
   var options = args[0];
@@ -1338,7 +1352,8 @@ exports.connect = function(/* [port, host], options, cb */) {
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
-  if (DEFAULT_CIPHERS != _crypto.getLegacyCiphers('v0.10.38')) {
+  if (!usingV1038Ciphers()) {
+    // only set the default ciphers
     defaults.ciphers = DEFAULT_CIPHERS;
   }
   options = util._extend(defaults, options || {});

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1353,7 +1353,13 @@ exports.connect = function(/* [port, host], options, cb */) {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
   if (!usingV1038Ciphers()) {
-    // only set the default ciphers
+    // only set the default ciphers if we are _not_ using the
+    // v0.10.38 legacy cipher list. Node v0.10.38 had a bug
+    // that failed to set the default ciphers on the default
+    // options. This has been fixed in v0.10.39 and above.
+    // However, when the user explicitly tells node to revert
+    // back to using the v0.10.38 cipher list, node should
+    // revert back to the original v0.10.38 behavior.
     defaults.ciphers = DEFAULT_CIPHERS;
   }
   options = util._extend(defaults, options || {});

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4199,12 +4199,18 @@ const char* ToCString(const node::Utf8Value& value) {
 
 Handle<Value> DefaultCiphers(const Arguments& args) {
   HandleScope scope;
+  unsigned int len = args.Length();
+  if (len != 1 || !args[0]->IsString()) {
+    return ThrowException(Exception::TypeError(String::New("A single string parameter is required")));
+  }
   node::Utf8Value key(args[0]);
   const char * list = legacy_cipher_list(ToCString(key));
-  if (list == NULL) {
-    list = DEFAULT_CIPHER_LIST_HEAD;
+  if (list != NULL) {
+    return scope.Close(v8::String::New(list));
+  } else {
+    return ThrowException(Exception::Error(String::New(
+      "Unknown legacy cipher list")));
   }
-  return scope.Close(v8::String::New(list));
 }
 
 Handle<Value> GetCiphers(const Arguments& args) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4201,7 +4201,9 @@ Handle<Value> DefaultCiphers(const Arguments& args) {
   HandleScope scope;
   unsigned int len = args.Length();
   if (len != 1 || !args[0]->IsString()) {
-    return ThrowException(Exception::TypeError(String::New("A single string parameter is required")));
+    return ThrowException(
+      Exception::TypeError(
+        String::New("A single string parameter is required")));
   }
   node::Utf8Value key(args[0]);
   const char * list = legacy_cipher_list(ToCString(key));

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -19,84 +19,21 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var spawn = require('child_process').spawn;
+var spawn  = require('child_process').spawn;
 var assert = require('assert');
-var tls = require('tls');
+var tls    = require('tls');
 var crypto = process.binding('crypto');
+var common = require('../common');
+var fs     = require('fs');
 
-function doTest(checklist, env, useswitch) {
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+
+function doTest(checklist, additional_args, env) {
   var options;
-  if (env && useswitch === 1) {
-    options = {env:env};
-  }
-  var args = ['-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)'];
-
-  switch(useswitch) {
-    case 1:
-      // Test --cipher-test
-      args.unshift('--cipher-list=' + env);
-      break;
-    case 2:
-      // Test --enable-legacy-cipher-list
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      break;
-    case 3:
-      // Test NODE_LEGACY_CIPHER_LIST
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
-      break;
-    case 4:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--cipher-list=' + env);
-      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
-      break;
-    case 5:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
-      break;
-    case 6:
-      // Test right-most option takes precedence
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      args.unshift('--cipher-list=XYZ');
-      break;
-    case 7:
-      // Test right-most option takes precedence
-      args.unshift('--cipher-list=' + env);
-      args.unshift('--enable-legacy-cipher-list=v0.10.38');
-      break;
-    case 8:
-      // Test NODE_LEGACY_CIPHER_LIST takes precendence over NODE_CIPHER_LIST
-      options = {env:{
-        "NODE_LEGACY_CIPHER_LIST": env,
-        "NODE_CIPHER_LIST": "ABC"
-      }};
-      break;
-    case 9:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--cipher-list=' + env);
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": "v0.10.38"}};
-      break;
-    case 10:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      if (env) options = {
-        env:{
-          "NODE_LEGACY_CIPHER_LIST": "v0.10.38",
-          "NODE_CIPHER_LIST": "XYZ"
-        }
-      };
-      break;
-    case 11:
-      // Test right-most option takes precedence, multiple of same option
-      args.unshift('--cipher-list=' + env);
-      args.unshift('--enable-legacy-cipher-list=v0.10.38');
-      args.unshift('--cipher-list=' + 'XYZ');
-      break;
-    default:
-      // Test NODE_CIPHER_LIST
-      if (env) options = {env:env};
-  }
-
+  if (env) options = {env:env};
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)']);
   var out = '';
   spawn(process.execPath, args, options).
     stdout.
@@ -108,27 +45,88 @@ function doTest(checklist, env, useswitch) {
       });
 }
 
-var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+// test that the command line switchs takes precedence
+// over the environment variables
+function doTestPrecedence() {
+  // test that --cipher-list takes precedence over NODE_CIPHER_LIST
+  doTest('ABC', ['--cipher-list=ABC'], {'NODE_CIPHER_LIST': 'XYZ'});
+
+  // test that --enable-legacy-cipher-list takes precedence
+  // over NODE_CIPHER_LIST
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {'NODE_CIPHER_LIST': 'XYZ'});
+
+  // test that --cipher-list takes precedence over NODE_LEGACY_CIPHER_LIST
+  doTest('ABC',
+         ['--cipher-list=ABC'],
+         {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+
+
+  // test that --enable-legacy-cipher-list takes precence over both envars
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {
+           'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+           'NODE_CIPHER_LIST': 'XYZ'
+         });
+
+  // test the right-most command line option takes precedence
+  doTest(V1038Ciphers,
+         [
+           '--cipher-list=XYZ',
+           '--enable-legacy-cipher-list=v0.10.38'
+         ]);
+
+   // test the right-most command line option takes precedence
+   doTest('XYZ',
+          [
+            '--enable-legacy-cipher-list=v0.10.38',
+            '--cipher-list=XYZ'
+          ]);
+
+    // test the right-most command line option takes precedence
+    doTest('XYZ',
+           [
+             '--cipher-list=XYZ',
+             '--enable-legacy-cipher-list=v0.10.38',
+             '--cipher-list=XYZ'
+           ]);
+
+    // test that NODE_LEGACY_CIPHER_LIST takes precedence over
+    // NODE_CIPHER_LIST
+
+    doTest(V1038Ciphers, [],
+           {
+             'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+             'NODE_CIPHER_LIST': 'ABC'
+           });
+
+}
+
+// Start running the tests...
 
 doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
-doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
-doTest('ABC', 'ABC', 1); // test the --cipher-list switch
 
-// test precedence order
-doTest('ABC', 'ABC', 4);
-doTest(V1038Ciphers, 'v0.10.38', 5);
-doTest(V1038Ciphers, 'v0.10.38', 6);
-doTest('ABC', 'ABC', 7);
-doTest(V1038Ciphers, 'v0.10.38', 8);
-doTest('ABC', 'ABC', 9);
-doTest(V1038Ciphers, 'v0.10.38', 10);
-doTest('YYY', 'YYY', 11);
+// Test the NODE_CIPHER_LIST environment variable
+doTest('ABC', [], {'NODE_CIPHER_LIST':'ABC'});
 
-['v0.10.38'].forEach(function(ver) {
-  doTest(tls.getLegacyCiphers(ver), ver, 2);
-  doTest(tls.getLegacyCiphers(ver), ver, 3);
+// Test the --cipher-list command line switch
+doTest('ABC', ['--cipher-list=ABC']);
+
+// Test the --enable-legacy-cipher-list and NODE_LEGACY_CIPHER_LIST envar
+['v0.10.38'].forEach(function(arg) {
+  var checklist = tls.getLegacyCiphers(arg);
+  // command line switch
+  doTest(checklist, ['--enable-legacy-cipher-list=' + arg]);
+  // environment variable
+  doTest(checklist, [], {'NODE_LEGACY_CIPHER_LIST': arg});
 });
 
+// Test the precedence order for the various options
+doTestPrecedence();
+
+// Test that we throw properly
 // invalid value
 assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
 // no parameters
@@ -139,3 +137,93 @@ assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
 assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
 // ah, just right
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});
+
+
+
+// Test to ensure default ciphers are not set when v0.10.38 legacy cipher
+// switch is used. This is a bit involved... we need to first set up the
+// TLS server, then spawn a second node instance using the v0.10.38 cipher,
+// then connect and check to make sure the options are correct. Since there
+// is no direct way of testing it, an alternate createCredentials shim is
+// created that intercepts the call to createCredentials and checks the output.
+// The following server code was adopted from test-tls-connect-simple.
+
+// note that the following function is written out to a string and
+// passed in as an argument to a child node instance.
+var script = (
+  function() {
+    var tls = require('tls');
+    var orig_createCredentials = require('crypto').createCredentials;
+    require('crypto').createCredentials = function(options) {
+      if (options.ciphers !== undefined) {
+        console.error(options.ciphers);
+        process.exit(1);
+      }
+      return orig_createCredentials(options);
+    };
+    var socket = tls.connect({
+      port: 0,
+      rejectUnauthorized: false
+    }, function() {
+      socket.end();
+    });
+  }
+).toString();
+
+var test_count = 0;
+
+function doDefaultCipherTest(additional_args, env, failexpected) {
+  var options = {};
+  if (env) options.env = env;
+  var out = '', err = '';
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', require('util').format('(%s)()', script).replace(
+      'port: 0', 'port: ' + common.PORT)
+  ]);
+  var child = spawn(process.execPath, args, options);
+  child.stdout.
+    on('data', function(data) {
+      out += data;
+    }).
+    on('end', function() {
+      if (failexpected && err === '') {
+        // if we get here, there's a problem because the default cipher
+        // list was not set when it should have been
+        assert.fail('options.cipher list was not set');
+      }
+    });
+  child.stderr.
+    on('data', function(data) {
+      err += data;
+    }).
+    on('end', function() {
+      if (err !== '') {
+        if (!failexpected) {
+          assert.fail(err.substr(0,err.length-1));
+        }
+      }
+    });
+  child.on('close', function() {
+    test_count++;
+    if (test_count === 4) server.close();
+  });
+}
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+var server = tls.Server(options, function(socket) {});
+server.listen(common.PORT, function() {
+  doDefaultCipherTest(['--enable-legacy-cipher-list=v0.10.38']);
+  doDefaultCipherTest([], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+  // this variant checks to ensure that the default cipher list IS set
+  var test_uses_default_cipher_list = true;
+  doDefaultCipherTest([], {}, test_uses_default_cipher_list);
+  // test that setting the cipher list explicitly to the v0.10.38
+  // string without using the legacy cipher switch causes the
+  // default ciphers to be set.
+  doDefaultCipherTest(['--cipher-list=' + V1038Ciphers], {},
+                      test_uses_default_cipher_list);
+});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -71,6 +71,27 @@ function doTest(checklist, env, useswitch) {
         "NODE_CIPHER_LIST": "ABC"
       }};
       break;
+    case 9:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--cipher-list=' + env);
+      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": "v0.10.38"}};
+      break;
+    case 10:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      if (env) options = {
+        env:{
+          "NODE_LEGACY_CIPHER_LIST": "v0.10.38",
+          "NODE_CIPHER_LIST": "XYZ"
+        }
+      };
+      break;
+    case 11:
+      // Test right-most option takes precedence, multiple of same option
+      args.unshift('--cipher-list=' + env);
+      args.unshift('--enable-legacy-cipher-list=v0.10.38');
+      args.unshift('--cipher-list=' + 'XYZ');
+      break;
     default:
       // Test NODE_CIPHER_LIST
       if (env) options = {env:env};
@@ -99,6 +120,9 @@ doTest(V1038Ciphers, 'v0.10.38', 5);
 doTest(V1038Ciphers, 'v0.10.38', 6);
 doTest('ABC', 'ABC', 7);
 doTest(V1038Ciphers, 'v0.10.38', 8);
+doTest('ABC', 'ABC', 9);
+doTest(V1038Ciphers, 'v0.10.38', 10);
+doTest('YYY', 'YYY', 11);
 
 ['v0.10.38'].forEach(function(ver) {
   doTest(tls.getLegacyCiphers(ver), ver, 2);

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -106,12 +106,12 @@ doTest(V1038Ciphers, 'v0.10.38', 8);
 });
 
 // invalid value
-assert.throws(function() {tls.getLegacyCiphers('foo');});
+assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
 // no parameters
-assert.throws(function() {tls.getLegacyCiphers();});
+assert.throws(function() {tls.getLegacyCiphers();}, TypeError);
 // not a string parameter
-assert.throws(function() {tls.getLegacyCiphers(1);});
+assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
 // too many parameters
-assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');});
+assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
 // ah, just right
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -44,6 +44,33 @@ function doTest(checklist, env, useswitch) {
       // Test NODE_LEGACY_CIPHER_LIST
       if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
       break;
+    case 4:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--cipher-list=' + env);
+      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
+      break;
+    case 5:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
+      break;
+    case 6:
+      // Test right-most option takes precedence
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      args.unshift('--cipher-list=XYZ');
+      break;
+    case 7:
+      // Test right-most option takes precedence
+      args.unshift('--cipher-list=' + env);
+      args.unshift('--enable-legacy-cipher-list=v0.10.38');
+      break;
+    case 8:
+      // Test NODE_LEGACY_CIPHER_LIST takes precendence over NODE_CIPHER_LIST
+      options = {env:{
+        "NODE_LEGACY_CIPHER_LIST": env,
+        "NODE_CIPHER_LIST": "ABC"
+      }};
+      break;
     default:
       // Test NODE_CIPHER_LIST
       if (env) options = {env:env};
@@ -60,11 +87,31 @@ function doTest(checklist, env, useswitch) {
       });
 }
 
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+
 doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
 doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
 doTest('ABC', 'ABC', 1); // test the --cipher-list switch
+
+// test precedence order
+doTest('ABC', 'ABC', 4);
+doTest(V1038Ciphers, 'v0.10.38', 5);
+doTest(V1038Ciphers, 'v0.10.38', 6);
+doTest('ABC', 'ABC', 7);
+doTest(V1038Ciphers, 'v0.10.38', 8);
 
 ['v0.10.38'].forEach(function(ver) {
   doTest(tls.getLegacyCiphers(ver), ver, 2);
   doTest(tls.getLegacyCiphers(ver), ver, 3);
 });
+
+// invalid value
+assert.throws(function() {tls.getLegacyCiphers('foo');});
+// no parameters
+assert.throws(function() {tls.getLegacyCiphers();});
+// not a string parameter
+assert.throws(function() {tls.getLegacyCiphers(1);});
+// too many parameters
+assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');});
+// ah, just right
+assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});


### PR DESCRIPTION
throw an error on unknown getLegacyCipher input
rather than returning the default. Makes the
behavior more explicit and matches up with the
behavior on the command line switches.
