### PR TITLE
tls: throw an error on getLegacyCipher

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -204,6 +204,34 @@ Reverting back to the defaults used by older releases can weaken the security
 of your applications. The legacy cipher suites should only be used if absolutely
 necessary.
 
+NOTE: Due to an error in Node.js v0.10.38, the default cipher list only applied
+to servers using TLS. The default cipher list would _not_ be used by clients.
+This behavior has been changed in v0.10.39 and v0.12.x and the default cipher
+list is now used by both the server and client when using TLS. However, when
+using `--enable-legacy-cipher-list=v0.10.38`, Node.js is reverted back to the
+v0.10.38 behavior of only using the default cipher list on the server.
+
+### Cipher List Precedence
+
+Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive.
+
+If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
+are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
+
+The `--cipher-list` and `--enable-legacy-cipher-list` command line options
+will override the environment variables. If both happen to be specified, the
+right-most (second one specified) will take precedence. For instance, in the
+example:
+
+    node --cipher-list=ABC --enable-legacy-cipher-list=v0.10.38
+
+The v0.10.38 default cipher list will be used.
+
+    node --enable-legacy-cipher-list=v0.10.38 --cipher-list=ABC
+
+The custom cipher list will be used.
+
 ## tls.getCiphers()
 
 Returns an array with the names of the supported SSL ciphers.
@@ -215,10 +243,16 @@ Example:
 
 ## tls.getLegacyCiphers(version)
 
-Returns the legacy default cipher suite for the specified Node.js release.
+Returns a default cipher list used in a previous version of Node.js. The
+version parameter must be a string whose value identifies previous Node.js
+release version. The only values currently supported are `v0.10.38`,
+`v0.10.39`, and `v0.12.2`.
 
-Example:
-    var cipher_suite = tls.getLegacyCiphers('v0.10.38');
+A TypeError will be thrown if: (a) the `version` is any type other than a
+string, (b) the `version` parameter is not specified, or (c) additional
+parameters are passed in. An Error will be thrown if the `version` parameter is
+passed in as a string but the value does not correlate to any known Node.js
+release for which a default cipher list is available.
 
 ## tls.createServer(options[, secureConnectionListener])
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -134,6 +134,75 @@ the character "E" appended to the traditional abbreviations):
 Ephemeral methods may have some performance drawbacks, because key generation
 is expensive.
 
+## Modifying the Default Cipher Suite
+
+Node.js is built with a default suite of enabled and disabled ciphers.
+Currently, the default cipher suite is:
+
+    ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:
+    !RC4:!MD5:!aNULL
+
+This default can be overridden entirely using the `--cipher-list` command line
+switch or `NODE_CIPHER_LIST` environment variable. For instance:
+
+    node --cipher-list=ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384
+
+Setting the environment variable would have the same effect:
+
+    NODE_CIPHER_LIST=ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384
+
+CAUTION: The default cipher suite has been carefully selected to reflect current
+security best practices and risk mitigation. Changing the default cipher suite
+can have a significant impact on the security of an application. The
+`--cipher-list` and `NODE_CIPHER_LIST` options should only be used if
+absolutely necessary.
+
+### Using Legacy Default Cipher Suite ###
+
+It is possible for the built-in default cipher suite to change from one release
+of Node.js to another. For instance, v0.10.38 uses a different default than
+v0.12.2. Such changes can cause issues with applications written to assume
+certain specific defaults. To help buffer applications against such changes,
+the `--enable-legacy-cipher-list` command line switch or `NODE_LEGACY_CIPHER_LIST`
+environment variable can be set to specify a specific preset default:
+
+    # Use the v0.10.38 defaults
+    node --enable-legacy-cipher-list=v0.10.38
+    // or
+    NODE_LEGACY_CIPHER_LIST=v0.10.38
+
+    # Use the v0.12.2 defaults
+    node --enable-legacy-cipher-list=v0.12.2
+    // or
+    NODE_LEGACY_CIPHER_LIST=v0.12.2
+
+Currently, the values supported for the `enable-legacy-cipher-list` switch and
+`NODE_LEGACY_CIPHER_LIST` environment variable include:
+
+    v0.10.38 - To enable the default cipher suite used in v0.10.38
+
+      ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH
+
+    v0.10.39 - To enable the default cipher suite used in v0.10.39
+
+      ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH
+
+    v0.12.2 - To enable the default cipher suite used in v0.12.2
+
+      ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:
+      HIGH:!MD5:!aNULL
+
+These legacy cipher suites are also made available for use via the
+`getLegacyCiphers()` method:
+
+    var tls = require('tls');
+    console.log(tls.getLegacyCiphers('v0.10.38'));
+
+CAUTION: Changes to the default cipher suite are typically made in order to
+strengthen the default security for applications running within Node.js.
+Reverting back to the defaults used by older releases can weaken the security
+of your applications. The legacy cipher suites should only be used if absolutely
+necessary.
 
 ## tls.getCiphers()
 
@@ -144,6 +213,12 @@ Example:
     var ciphers = tls.getCiphers();
     console.log(ciphers); // ['AES128-SHA', 'AES256-SHA', ...]
 
+## tls.getLegacyCiphers(version)
+
+Returns the legacy default cipher suite for the specified Node.js release.
+
+Example:
+    var cipher_suite = tls.getLegacyCiphers('v0.10.38');
 
 ## tls.createServer(options[, secureConnectionListener])
 
@@ -177,7 +252,7 @@ automatically set as a listener for the [secureConnection][] event.  The
     prioritize the non-CBC cipher.
 
     Defaults to
-    `ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL`.
+    `ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL`.
     Consult the [OpenSSL cipher list format documentation] for details
     on the format.
 
@@ -187,10 +262,7 @@ automatically set as a listener for the [secureConnection][] event.  The
     of OpenSSL.  Note that it is still possible for a TLS v1.2 client
     to negotiate a weaker cipher unless `honorCipherOrder` is enabled.
 
-    `RC4` is used as a fallback for clients that speak on older version of
-    the TLS protocol.  `RC4` has in recent years come under suspicion and
-    should be considered compromised for anything that is truly sensitive.
-    It is speculated that state-level actors possess the ability to break it.
+    `RC4` is explicitly switched off by default due to known vulnerabilities.
 
     **NOTE**: Previous revisions of this section suggested `AES256-SHA` as an
     acceptable cipher. Unfortunately, `AES256-SHA` is a CBC cipher and therefore

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -827,6 +827,16 @@ function legacyConnect(hostname, options, NPN, context) {
   return pair;
 }
 
+function usingV1038Ciphers() {
+  var argv = process.execArgv;
+  if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
+       process.env['NODE_LEGACY_CIPHER_LIST'] === 'v0.10.38') &&
+      tls.DEFAULT_CIPHERS === tls.getLegacyCiphers('v0.10.38')) {
+    return true;
+  }
+  return false;
+}
+
 exports.connect = function(/* [port, host], options, cb */) {
   var args = normalizeConnectArgs(arguments);
   var options = args[0];
@@ -834,9 +844,19 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED,
-    ciphers: tls.DEFAULT_CIPHERS,
     checkServerIdentity: tls.checkServerIdentity
   };
+
+  if (!usingV1038Ciphers()) {
+    // only set the default ciphers if we are _not_ using the
+    // v0.10.38 legacy cipher list. Node v0.10.38 had a bug
+    // that failed to set the default ciphers on the default
+    // options. This has been fixed in v0.10.39 and above.
+    // However, when the user explicitly tells node to revert
+    // back to using the v0.10.38 cipher list, node should
+    // revert back to the original v0.10.38 behavior.
+    defaults.ciphers = tls.DEFAULT_CIPHERS;
+  }
 
   options = util._extend(defaults, options || {});
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var _crypto = process.binding('crypto');
+
 var net = require('net');
 var url = require('url');
 var util = require('util');
@@ -33,16 +35,14 @@ exports.CLIENT_RENEG_WINDOW = 600;
 
 exports.SLAB_BUFFER_SIZE = 10 * 1024 * 1024;
 
-exports.DEFAULT_CIPHERS =
-    // TLS 1.2
-    'ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:' +
-    // TLS 1.0
-    'RC4:HIGH:!MD5:!aNULL';
+exports.DEFAULT_CIPHERS = _crypto.DEFAULT_CIPHER_LIST;
+
+exports.getLegacyCiphers = _crypto.getLegacyCiphers;
 
 exports.DEFAULT_ECDH_CURVE = 'prime256v1';
 
 exports.getCiphers = function() {
-  var names = process.binding('crypto').getSSLCiphers();
+  var names = _crypto.getSSLCiphers();
   // Drop all-caps names in favor of their lowercase aliases,
   var ctx = {};
   names.forEach(function(name) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2938,9 +2938,7 @@ static void PrintHelp() {
          "  --enable-ssl3        enable ssl3\n"
          "  --cipher-list=val    specify the default TLS cipher list\n"
          "  --enable-legacy-cipher-list=val \n"
-         "                       set to v0.10.38 to use the v0.10.38 list,\n"
-         "                       set to v0.10.39 to use the v0.10.39 list.\n"
-         "                       set to v0.12.2 to use the v0.12.2 list.\n"
+         "                       val = v0.10.38, v0.10.39, or v0.12.2\n"
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2959,10 +2957,8 @@ static void PrintHelp() {
 #endif
 #endif
          "NODE_CIPHER_LIST       Override the default TLS cipher list\n"
-         "NODE_LEGACY_CIPHER_LIST\n"
-         "                       Set to v0.10.38 to use the v0.10.38 list.\n"
-         "                       Set to v0.10.39 to use the v0.10.39 list.\n"
-         "                       Set to v0.12.2 to use the v0.12.2 list.\n"
+         "NODE_LEGACY_CIPHER_LIST=val\n"
+         "                       val = v0.10.38, v0.10.39, or v0.12.2\n"
          "\n"
          "Documentation can be found at http://nodejs.org/\n");
 }
@@ -3002,7 +2998,6 @@ static void ParseArgs(int* argc,
   unsigned int new_argc = 1;
   new_v8_argv[0] = argv[0];
   new_argv[0] = argv[0];
-  bool using_legacy_cipher_list = false;
 
   unsigned int index = 1;
   while (index < nargs && argv[index][0] == '-') {
@@ -3059,14 +3054,11 @@ static void ParseArgs(int* argc,
       new_v8_argv[new_v8_argc] = "--help";
       new_v8_argc += 1;
     } else if (strncmp(arg, "--cipher-list=", 14) == 0) {
-      if (!using_legacy_cipher_list) {
-        DEFAULT_CIPHER_LIST = arg + 14;
-      }
+      DEFAULT_CIPHER_LIST = arg + 14;
     } else if (strncmp(arg, "--enable-legacy-cipher-list=", 28) == 0) {
       // use the original v0.10.x/v0.12.x cipher lists
       const char * legacy_list = legacy_cipher_list(arg+28);
       if (legacy_list != NULL) {
-        using_legacy_cipher_list = true;
         DEFAULT_CIPHER_LIST = legacy_list;
       } else {
         fprintf(stderr, "Error: An unknown legacy cipher list was specified\n");
@@ -3423,6 +3415,24 @@ void Init(int* argc,
   V8::SetFlagsFromString(NODE_V8_OPTIONS, sizeof(NODE_V8_OPTIONS) - 1);
 #endif
 
+  // set the cipher list from the environment variable first,
+  // the command line switch will override if specified.
+  const char * cipher_list = getenv("NODE_CIPHER_LIST");
+  if (cipher_list != NULL) {
+    DEFAULT_CIPHER_LIST = cipher_list;
+  }
+  const char * leg_cipher_id = getenv("NODE_LEGACY_CIPHER_LIST");
+  if (leg_cipher_id != NULL) {
+    const char * leg_cipher_list =
+      legacy_cipher_list(leg_cipher_id);
+    if (leg_cipher_list != NULL) {
+      DEFAULT_CIPHER_LIST = leg_cipher_list;
+    } else {
+      fprintf(stderr, "Error: An unknown legacy cipher list was specified\n");
+      exit(9);
+    }
+  }
+
   // Parse a few arguments which are specific to Node.
   int v8_argc;
   const char** v8_argv;
@@ -3438,27 +3448,6 @@ void Init(int* argc,
       break;
     }
   }
-
-  const char * cipher_list = getenv("NODE_CIPHER_LIST");
-  if (cipher_list != NULL) {
-    DEFAULT_CIPHER_LIST = cipher_list;
-  }
-  // Allow the NODE_LEGACY_CIPHER_LIST envar to override the other
-  // cipher list options. NODE_LEGACY_CIPHER_LIST=v0.10.38 will use
-  // the cipher list from v0.10.38, NODE_LEGACY_CIPHER_LIST=v0.12.2 will
-  // use the cipher list from v0.12.2
-  const char * leg_cipher_id = getenv("NODE_LEGACY_CIPHER_LIST");
-  if (leg_cipher_id != NULL) {
-    const char * leg_cipher_list =
-      legacy_cipher_list(leg_cipher_id);
-    if (leg_cipher_list != NULL) {
-      DEFAULT_CIPHER_LIST = leg_cipher_list;
-    } else {
-      fprintf(stderr, "Error: An unknown legacy cipher list was specified\n");
-      exit(9);
-    }
-  }
-
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
   if (icu_data_dir == NULL) {

--- a/src/node.h
+++ b/src/node.h
@@ -223,6 +223,19 @@ NODE_EXTERN void RunAtExit(Environment* env);
   }                                                                           \
   while (0)
 
+#define NODE_DEFINE_STRING_CONSTANT(target, constant)                         \
+  do {                                                                        \
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();                         \
+    v8::Local<v8::String> constant_name =                                     \
+        v8::String::NewFromUtf8(isolate, #constant);                          \
+    v8::Local<v8::String> constant_value =                                    \
+        v8::String::NewFromUtf8(isolate, constant);                           \
+    v8::PropertyAttribute constant_attributes =                               \
+        static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);    \
+    (target)->ForceSet(constant_name, constant_value, constant_attributes);   \
+  } while (0)
+
+
 // Used to be a macro, hence the uppercase name.
 template <typename TypeName>
 inline void NODE_SET_METHOD(const TypeName& recv,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4861,15 +4861,17 @@ const char* ToCString(const String::Utf8Value& value) {
 void DefaultCiphers(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
+
+  if (args.Length() != 1 || !args[0]->IsString()) {
+    return env->ThrowTypeError("A single string parameter is required");
+  }
   v8::String::Utf8Value key(args[0]);
   const char * list = legacy_cipher_list(ToCString(key));
   if (list != NULL) {
     args.GetReturnValue().Set(
       v8::String::NewFromUtf8(args.GetIsolate(), list));
   } else {
-    args.GetReturnValue().Set(
-      v8::String::NewFromUtf8(args.GetIsolate(),
-                             DEFAULT_CIPHER_LIST_HEAD));
+    env->ThrowError("Unknown legacy cipher list");
   }
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -77,6 +77,7 @@ namespace node {
 
 bool SSL2_ENABLE = false;
 bool SSL3_ENABLE = false;
+const char * DEFAULT_CIPHER_LIST = DEFAULT_CIPHER_LIST_HEAD;
 
 namespace crypto {
 
@@ -4851,6 +4852,26 @@ static void array_push_back(const TypeName* md,
   ctx->arr->Set(ctx->arr->Length(), OneByteString(ctx->env()->isolate(), from));
 }
 
+// borrowed from v8
+// (see http://v8.googlecode.com/svn/trunk/samples/shell.cc)
+const char* ToCString(const String::Utf8Value& value) {
+  return *value ? *value : "<string conversion failed>";
+}
+
+void DefaultCiphers(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope scope(env->isolate());
+  v8::String::Utf8Value key(args[0]);
+  const char * list = legacy_cipher_list(ToCString(key));
+  if (list != NULL) {
+    args.GetReturnValue().Set(
+      v8::String::NewFromUtf8(args.GetIsolate(), list));
+  } else {
+    args.GetReturnValue().Set(
+      v8::String::NewFromUtf8(args.GetIsolate(),
+                             DEFAULT_CIPHER_LIST_HEAD));
+  }
+}
 
 void GetCiphers(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
@@ -5171,6 +5192,8 @@ void InitCrypto(Handle<Object> target,
 
   NODE_DEFINE_CONSTANT(target, SSL3_ENABLE);
   NODE_DEFINE_CONSTANT(target, SSL2_ENABLE);
+  NODE_DEFINE_STRING_CONSTANT(target, DEFAULT_CIPHER_LIST);
+  NODE_SET_METHOD(target, "getLegacyCiphers", DefaultCiphers);
 }
 
 }  // namespace crypto

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -38,6 +38,7 @@
 
 #include "v8.h"
 
+#include <string.h>
 #include <openssl/ssl.h>
 #include <openssl/ec.h>
 #include <openssl/ecdh.h>
@@ -59,10 +60,40 @@
 # define NODE__HAVE_TLSEXT_STATUS_CB
 #endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
 
+#define DEFAULT_CIPHER_LIST_V10_38 "ECDHE-RSA-AES128-SHA256:"                  \
+                                "AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH"
+
+#define DEFAULT_CIPHER_LIST_V10_39 "ECDHE-RSA-AES128-SHA256:"                  \
+                                "AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH"
+
+#define DEFAULT_CIPHER_LIST_V12_2 "ECDHE-RSA-AES128-SHA256:"                   \
+                                "DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:" \
+                                "HIGH:!MD5:!aNULL"
+
+#define DEFAULT_CIPHER_LIST_HEAD "ECDHE-RSA-AES128-SHA256:"                    \
+                                "DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:"\
+                                "!RC4:!MD5:!aNULL"
+
+static inline const char * legacy_cipher_list(const char * ver) {
+  if (ver == NULL) {
+    return NULL;
+  }
+  if (strncmp(ver, "v0.10.38", 8) == 0) {
+    return DEFAULT_CIPHER_LIST_V10_38;
+  } else if (strncmp(ver, "v0.10.39", 8) == 0) {
+    return DEFAULT_CIPHER_LIST_V10_39;
+  } else if (strncmp(ver, "v0.12.2", 7) == 0) {
+    return DEFAULT_CIPHER_LIST_V12_2;
+  } else {
+    return NULL;
+  }
+}
+
 namespace node {
 
 extern bool SSL2_ENABLE;
 extern bool SSL3_ENABLE;
+extern const char * DEFAULT_CIPHER_LIST;
 
 namespace crypto {
 

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -1,0 +1,69 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var spawn = require('child_process').spawn;
+var assert = require('assert');
+var tls = require('tls');
+
+function doTest(checklist, env, useswitch) {
+  var options;
+  if (env && useswitch === 1) {
+    options = {env:env};
+  }
+  var args = ['-e', 'console.log(require(\'tls\').DEFAULT_CIPHERS)'];
+
+  switch(useswitch) {
+    case 1:
+      // Test --cipher-test
+      args.unshift('--cipher-list=' + env);
+      break;
+    case 2:
+      // Test --enable-legacy-cipher-list
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      break;
+    case 3:
+      // Test NODE_LEGACY_CIPHER_LIST
+      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
+      break;
+    default:
+      // Test NODE_CIPHER_LIST
+      if (env) options = {env:env};
+  }
+
+  var out = '';
+  spawn(process.execPath, args, options).
+    stdout.
+      on('data', function(data) {
+        out += data;
+      }).
+      on('end', function() {
+        assert.equal(out.trim(), checklist);
+      });
+}
+
+doTest(tls.DEFAULT_CIPHERS); // test the default
+doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
+doTest('ABC', 'ABC', 1); // test the --cipher-list switch
+
+['v0.10.38', 'v0.10.39', 'v0.12.2'].forEach(function(ver) {
+  doTest(tls.getLegacyCiphers(ver), ver, 2);
+  doTest(tls.getLegacyCiphers(ver), ver, 3);
+});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -22,32 +22,18 @@
 var spawn = require('child_process').spawn;
 var assert = require('assert');
 var tls = require('tls');
+var crypto = process.binding('crypto');
+var common = require('../common');
+var fs = require('fs');
 
-function doTest(checklist, env, useswitch) {
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+
+function doTest(checklist, additional_args, env) {
   var options;
-  if (env && useswitch === 1) {
-    options = {env:env};
-  }
-  var args = ['-e', 'console.log(require(\'tls\').DEFAULT_CIPHERS)'];
-
-  switch(useswitch) {
-    case 1:
-      // Test --cipher-test
-      args.unshift('--cipher-list=' + env);
-      break;
-    case 2:
-      // Test --enable-legacy-cipher-list
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      break;
-    case 3:
-      // Test NODE_LEGACY_CIPHER_LIST
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
-      break;
-    default:
-      // Test NODE_CIPHER_LIST
-      if (env) options = {env:env};
-  }
-
+  if (env) options = {env:env};
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)']);
   var out = '';
   spawn(process.execPath, args, options).
     stdout.
@@ -59,11 +45,216 @@ function doTest(checklist, env, useswitch) {
       });
 }
 
-doTest(tls.DEFAULT_CIPHERS); // test the default
-doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
-doTest('ABC', 'ABC', 1); // test the --cipher-list switch
+// test that the command line switchs takes precedence
+// over the environment variables
+function doTestPrecedence() {
+  // test that --cipher-list takes precedence over NODE_CIPHER_LIST
+  doTest('ABC', ['--cipher-list=ABC'], {'NODE_CIPHER_LIST': 'XYZ'});
 
-['v0.10.38', 'v0.10.39', 'v0.12.2'].forEach(function(ver) {
-  doTest(tls.getLegacyCiphers(ver), ver, 2);
-  doTest(tls.getLegacyCiphers(ver), ver, 3);
+  // test that --enable-legacy-cipher-list takes precedence
+  // over NODE_CIPHER_LIST
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {'NODE_CIPHER_LIST': 'XYZ'});
+
+  // test that --cipher-list takes precedence over NODE_LEGACY_CIPHER_LIST
+  doTest('ABC',
+         ['--cipher-list=ABC'],
+         {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+
+  // test that --enable-legacy-cipher-list takes precence over both envars
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {
+           'NODE_LEGACY_CIPHER_LIST': 'v0.10.39',
+           'NODE_CIPHER_LIST': 'XYZ'
+         });
+
+  // test the right-most command line option takes precedence
+  doTest(V1038Ciphers,
+         [
+           '--cipher-list=XYZ',
+           '--enable-legacy-cipher-list=v0.10.38'
+         ]);
+
+   // test the right-most command line option takes precedence
+   doTest('XYZ',
+          [
+            '--enable-legacy-cipher-list=v0.10.38',
+            '--cipher-list=XYZ'
+          ]);
+
+    // test the right-most command line option takes precedence
+    doTest('XYZ',
+           [
+             '--cipher-list=ABC',
+             '--enable-legacy-cipher-list=v0.10.39',
+             '--cipher-list=XYZ'
+           ]);
+
+    // test that NODE_LEGACY_CIPHER_LIST takes precedence over
+    // NODE_CIPHER_LIST
+    doTest(V1038Ciphers, [],
+           {
+             'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+             'NODE_CIPHER_LIST': 'ABC'
+           });
+}
+
+// Start running the tests...
+doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
+
+// Test the NODE_CIPHER_LIST environment variable
+doTest('ABC', [], {'NODE_CIPHER_LIST':'ABC'});
+
+// Test the --cipher-list command line switch
+doTest('ABC', ['--cipher-list=ABC']);
+
+// Test the --enable-legacy-cipher-list and NODE_LEGACY_CIPHER_LIST envar
+['v0.10.38','v0.10.39','v0.12.2'].forEach(function(arg) {
+  var checklist = tls.getLegacyCiphers(arg);
+  // command line switch
+  doTest(checklist, ['--enable-legacy-cipher-list=' + arg]);
+  // environment variable
+  doTest(checklist, [], {'NODE_LEGACY_CIPHER_LIST': arg});
+});
+
+// Test the precedence order for the various options
+doTestPrecedence();
+
+// Test that we throw properly
+// invalid value
+assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
+// no parameters
+assert.throws(function() {tls.getLegacyCiphers();}, TypeError);
+// not a string parameter
+assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
+// too many parameters
+assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
+// ah, just right
+assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});
+assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.39');});
+assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.12.2');});
+
+// Test to ensure default ciphers are not set when v0.10.38 legacy cipher
+// switch is used. This is a bit involved... we need to first set up the
+// TLS server, then spawn a second node instance using the v0.10.38 cipher,
+// then connect and check to make sure the options are correct. Since there
+// is no direct way of testing it, an alternate createCredentials shim is
+// created that intercepts the call to createCredentials and checks the output.
+// The following server code was adopted from test-tls-connect-simple.
+// This test spins up a server in order to test that the client will still
+// connect successfully with the default ciphers not set.
+
+// note that the following function is written out to a string and
+// passed in as an argument to a child node instance.
+var fail_if_default_ciphers_set = (
+  function() {
+    var tls = require('tls');
+    var used_monkey_patch = false;
+    var orig_createSecureContext = tls.createSecureContext;
+    tls.createSecureContext = function(details) {
+      used_monkey_patch = true;
+      // since node was started with the --enable-legacy-cipher-list
+      // switch equal to v0.10.38, the options.ciphers should be
+      // undefined. If it's not undefined, we have a problem and
+      // the test fails
+      if (details.ciphers !== undefined) {
+        console.error(details.ciphers);
+        process.exit(1);
+      }
+      return orig_createSecureContext(details);
+    };
+    var socket = tls.connect({
+      port: 0,
+      rejectUnauthorized: false
+    }, function() {
+      socket.end();
+      if (!used_monkey_patch) {
+        console.error('monkey patched createSecureContext not used');
+      }
+    });
+  }
+).toString();
+
+// Verifies that the default cipher list is set.
+// like fail_if_default_ciphers_set, this is serialized
+// out to a string and passed to a new node instance
+var fail_if_default_ciphers_not_set = (
+  function() {
+    var tls = require('tls');
+    var used_monkey_patch = false;
+    var orig_createSecureContext = tls.createSecureContext;
+    tls.createSecureContext = function(details) {
+      used_monkey_patch = true;
+      // node is not started with --enable-legacy-cipher-list
+      if (!details.ciphers) {
+        console.error('default ciphers are not set');
+        process.exit(1);
+      }
+      return orig_createSecureContext(details);
+    };
+    var socket = tls.connect({
+      port: 0,
+      rejectUnauthorized: false
+    }, function() {
+      socket.end();
+      if (!used_monkey_patch) {
+        console.error('monkey patched createSecureContext not used');
+      }
+    });
+  }
+).toString();
+
+var test_count = 0;
+
+function doDefaultCipherTest(test, additional_args, env) {
+  var options = {};
+  if (env) options.env = env;
+  var out = '', err = '';
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', require('util').format('(%s)()', test).replace(
+      'port: 0', 'port: ' + common.PORT)
+  ]);
+  var child = spawn(process.execPath, args, options);
+  child.stderr.
+    on('data', function(data) {
+      err += data;
+    }).
+    on('end', function() {
+      if (err !== '') {
+        assert.fail(err.substr(0,err.length-1));
+      }
+    });
+}
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+var server = tls.Server(options, function(socket) {
+  test_count++;
+  if (test_count === 4) server.close();
+});
+server.listen(common.PORT, function() {
+  // checks to make sure the default ciphers are *not* set
+  // because the --enable-legacy-cipher-list switch is set to
+  // v0.10.38
+  doDefaultCipherTest(fail_if_default_ciphers_set,
+                      ['--enable-legacy-cipher-list=v0.10.38']);
+
+  // checks to make sure the default ciphers are *not* set
+  // because the NODE_LEGACY_CIPHER_LIST envar is set to v0.10.38
+  doDefaultCipherTest(fail_if_default_ciphers_set,
+                      [], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+
+  // this variant checks to ensure that the default cipher list IS set
+  doDefaultCipherTest(fail_if_default_ciphers_not_set, [], {});
+
+  // test that setting the cipher list explicitly to the v0.10.38
+  // string without using the legacy cipher switch causes the
+  // default ciphers to be set.
+  doDefaultCipherTest(fail_if_default_ciphers_not_set,
+                      ['--cipher-list=' + V1038Ciphers], {});
 });

--- a/test/simple/test-tls-getcipher.js
+++ b/test/simple/test-tls-getcipher.js
@@ -49,7 +49,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
     rejectUnauthorized: false
   }, function() {
     var cipher = client.getCipher();
-    assert.equal(cipher.name, cipher_list[0]);
+    assert.equal(cipher.name, cipher_list[1]);
     assert(cipher_version_pattern.test(cipher.version));
     client.end();
     server.close();


### PR DESCRIPTION
throw an error on unknown getLegacyCipher input
rather than returning the default. Makes the
behavior more explicit and matches up with the
behavior on the command line switches.
