### PR TITLE
tls: throw an error on getLegacyCipher

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -212,6 +212,35 @@ Reverting back to the defaults used by older releases can weaken the security
 of your applications. The legacy cipher suites should only be used if absolutely
 necessary.
 
+NOTE: Due to an error in Node.js v0.10.38, the default cipher list only applied
+to servers using TLS. The default cipher list would _not_ be used by clients.
+This behavior has been changed in v0.10.39 and v0.12.x and the default cipher
+list is now used by both the server and client when using TLS. However, when
+using `--enable-legacy-cipher-list=v0.10.38`, Node.js is reverted back to the
+v0.10.38 behavior of only using the default cipher list on the server.
+
+### Cipher List Precedence
+
+Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive. Only
+_one_ should be used at a time.
+
+If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
+are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
+
+The `--cipher-list` and `--enable-legacy-cipher-list` command line options
+will override the environment variables. If both happened to be specified, the
+right-most (second one specified) will take precedence. For instance, in the
+example:
+
+    node --cipher-list=ABC --enable-legacy-cipher-list=v0.10.38
+
+The v0.10.38 default cipher list will be used.
+
+    node --enable-legacy-cipher-list=v0.10.38 --cipher-list=ABC
+
+The custom cipher list will be used.
+
 ## tls.getCiphers()
 
 Returns an array with the names of the supported SSL ciphers.
@@ -223,10 +252,15 @@ Example:
 
 ## tls.getLegacyCiphers(version)
 
-Returns the legacy default cipher suite for the specified Node.js release.
+Returns a default cipher list used in a previous version of Node.js. The
+version parameter must be a string whose value identifies previous Node.js
+release version. The only values currently supported are `v0.10.38`, `v0.10.39`, `v0.12.2` and `v0.12.3`.
 
-Example:
-    var cipher_suite = tls.getLegacyCiphers('v0.10.38');
+A TypeError will be thrown if: (a) the `version` is any type other than a
+string, (b) the `version` parameter is not specified, or (c) additional
+parameters are passed in. An Error will be thrown if the `version` parameter is
+passed in as a string but the value does not correlate to any known Node.js
+release for which a default cipher list is available.
 
 ## tls.createServer(options[, secureConnectionListener])
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -229,7 +229,7 @@ If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
 are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
 
 The `--cipher-list` and `--enable-legacy-cipher-list` command line options
-will override the environment variables. If both happened to be specified, the
+will override the environment variables. If both happen to be specified, the
 right-most (second one specified) will take precedence. For instance, in the
 example:
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -222,8 +222,7 @@ v0.10.38 behavior of only using the default cipher list on the server.
 ### Cipher List Precedence
 
 Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
-`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive. Only
-_one_ should be used at a time.
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive.
 
 If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
 are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -829,6 +829,16 @@ function legacyConnect(hostname, options, NPN, context) {
   return pair;
 }
 
+function usingV1038Ciphers() {
+  var argv = process.execArgv;
+  if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
+       process.env['NODE_LEGACY_CIPHER_LIST'] === 'v0.10.38') &&
+      tls.DEFAULT_CIPHERS === tls.getLegacyCiphers('v0.10.38')) {
+        return true;
+  }
+  return false;
+}
+
 exports.connect = function(/* [port, host], options, cb */) {
   var args = normalizeConnectArgs(arguments);
   var options = args[0];
@@ -839,7 +849,7 @@ exports.connect = function(/* [port, host], options, cb */) {
     checkServerIdentity: tls.checkServerIdentity
   };
 
-  if (tls.DEFAULT_CIPHERS != tls.getLegacyCiphers('v0.10.38')) {
+  if (!usingV1038Ciphers()) {
     defaults.ciphers = tls.DEFAULT_CIPHERS;
   }
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -850,6 +850,13 @@ exports.connect = function(/* [port, host], options, cb */) {
   };
 
   if (!usingV1038Ciphers()) {
+    // only set the default ciphers if we are _not_ using the
+    // v0.10.38 legacy cipher list. Node v0.10.38 had a bug
+    // that failed to set the default ciphers on the default
+    // options. This has been fixed in v0.10.39 and above.
+    // However, when the user explicitly tells node to revert
+    // back to using the v0.10.38 cipher list, node should
+    // revert back to the original v0.10.38 behavior.
     defaults.ciphers = tls.DEFAULT_CIPHERS;
   }
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -836,9 +836,12 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED,
-    ciphers: tls.DEFAULT_CIPHERS,
     checkServerIdentity: tls.checkServerIdentity
   };
+
+  if (tls.DEFAULT_CIPHERS != tls.getLegacyCiphers('v0.10.38')) {
+    defaults.ciphers = tls.DEFAULT_CIPHERS;
+  }
 
   options = util._extend(defaults, options || {});
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4861,15 +4861,17 @@ const char* ToCString(const String::Utf8Value& value) {
 void DefaultCiphers(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
   HandleScope scope(env->isolate());
+
+  if (args.Length() != 1 || !args[0]->IsString()) {
+    return env->ThrowTypeError("A single string parameter is required");
+  }
   v8::String::Utf8Value key(args[0]);
   const char * list = legacy_cipher_list(ToCString(key));
   if (list != NULL) {
     args.GetReturnValue().Set(
       v8::String::NewFromUtf8(args.GetIsolate(), list));
   } else {
-    args.GetReturnValue().Set(
-      v8::String::NewFromUtf8(args.GetIsolate(),
-                             DEFAULT_CIPHER_LIST_HEAD));
+    env->ThrowError("Unknown legacy cipher list");
   }
 }
 

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -102,13 +102,13 @@ doTest(V1038Ciphers, 'v0.10.38', 8);
 });
 
 // invalid value
-assert.throws(function() {tls.getLegacyCiphers('foo');});
+assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
 // no parameters
-assert.throws(function() {tls.getLegacyCiphers();});
+assert.throws(function() {tls.getLegacyCiphers();}, TypeError);
 // not a string parameter
-assert.throws(function() {tls.getLegacyCiphers(1);});
+assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
 // too many parameters
-assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');});
+assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
 // ah, just right
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.39');});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -67,6 +67,27 @@ function doTest(checklist, env, useswitch) {
         "NODE_CIPHER_LIST": "ABC"
       }};
       break;
+    case 9:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--cipher-list=' + env);
+      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": "v0.10.38"}};
+      break;
+    case 10:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      if (env) options = {
+        env:{
+          "NODE_LEGACY_CIPHER_LIST": "v0.10.39",
+          "NODE_CIPHER_LIST": "XYZ"
+        }
+      };
+      break;
+    case 11:
+      // Test right-most option takes precedence, multiple of same option
+      args.unshift('--cipher-list=' + env);
+      args.unshift('--enable-legacy-cipher-list=v0.10.38');
+      args.unshift('--cipher-list=' + 'XYZ');
+      break;
     default:
       // Test NODE_CIPHER_LIST
       if (env) options = {env:env};
@@ -95,6 +116,9 @@ doTest(V1038Ciphers, 'v0.10.38', 5);
 doTest(V1038Ciphers, 'v0.10.38', 6);
 doTest('ABC', 'ABC', 7);
 doTest(V1038Ciphers, 'v0.10.38', 8);
+doTest('ABC', 'ABC', 9);
+doTest(V1038Ciphers, 'v0.10.38', 10);
+doTest('YYY', 'YYY', 11);
 
 ['v0.10.38', 'v0.10.39', 'v0.12.2', 'v0.12.3'].forEach(function(ver) {
   doTest(tls.getLegacyCiphers(ver), ver, 2);

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -19,80 +19,21 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var spawn = require('child_process').spawn;
+var spawn  = require('child_process').spawn;
 var assert = require('assert');
-var tls = require('tls');
+var tls    = require('tls');
+var crypto = process.binding('crypto');
+var common = require('../common');
+var fs     = require('fs');
 
-function doTest(checklist, env, useswitch) {
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+
+function doTest(checklist, additional_args, env) {
   var options;
-  var args = ['-e', 'console.log(require(\'tls\').DEFAULT_CIPHERS)'];
-
-  switch(useswitch) {
-    case 1:
-      // Test --cipher-list
-      args.unshift('--cipher-list=' + env);
-      break;
-    case 2:
-      // Test --enable-legacy-cipher-list
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      break;
-    case 3:
-      // Test NODE_LEGACY_CIPHER_LIST
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
-      break;
-    case 4:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--cipher-list=' + env);
-      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
-      break;
-    case 5:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
-      break;
-    case 6:
-      // Test right-most option takes precedence
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      args.unshift('--cipher-list=XYZ');
-      break;
-    case 7:
-      // Test right-most option takes precedence
-      args.unshift('--cipher-list=' + env);
-      args.unshift('--enable-legacy-cipher-list=v0.10.38');
-      break;
-    case 8:
-      // Test NODE_LEGACY_CIPHER_LIST takes precendence over NODE_CIPHER_LIST
-      options = {env:{
-        "NODE_LEGACY_CIPHER_LIST": env,
-        "NODE_CIPHER_LIST": "ABC"
-      }};
-      break;
-    case 9:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--cipher-list=' + env);
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": "v0.10.38"}};
-      break;
-    case 10:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      if (env) options = {
-        env:{
-          "NODE_LEGACY_CIPHER_LIST": "v0.10.39",
-          "NODE_CIPHER_LIST": "XYZ"
-        }
-      };
-      break;
-    case 11:
-      // Test right-most option takes precedence, multiple of same option
-      args.unshift('--cipher-list=' + env);
-      args.unshift('--enable-legacy-cipher-list=v0.10.38');
-      args.unshift('--cipher-list=' + 'XYZ');
-      break;
-    default:
-      // Test NODE_CIPHER_LIST
-      if (env) options = {env:env};
-  }
-
+  if (env) options = {env:env};
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)']);
   var out = '';
   spawn(process.execPath, args, options).
     stdout.
@@ -104,27 +45,88 @@ function doTest(checklist, env, useswitch) {
       });
 }
 
-var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+// test that the command line switchs takes precedence
+// over the environment variables
+function doTestPrecedence() {
+  // test that --cipher-list takes precedence over NODE_CIPHER_LIST
+  doTest('ABC', ['--cipher-list=ABC'], {'NODE_CIPHER_LIST': 'XYZ'});
 
-doTest(tls.DEFAULT_CIPHERS); // test the default
-doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
-doTest('ABC', 'ABC', 1); // test the --cipher-list switch
+  // test that --enable-legacy-cipher-list takes precedence
+  // over NODE_CIPHER_LIST
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {'NODE_CIPHER_LIST': 'XYZ'});
 
-// test precedence order
-doTest('ABC', 'ABC', 4);
-doTest(V1038Ciphers, 'v0.10.38', 5);
-doTest(V1038Ciphers, 'v0.10.38', 6);
-doTest('ABC', 'ABC', 7);
-doTest(V1038Ciphers, 'v0.10.38', 8);
-doTest('ABC', 'ABC', 9);
-doTest(V1038Ciphers, 'v0.10.38', 10);
-doTest('YYY', 'YYY', 11);
+  // test that --cipher-list takes precedence over NODE_LEGACY_CIPHER_LIST
+  doTest('ABC',
+         ['--cipher-list=ABC'],
+         {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
 
-['v0.10.38', 'v0.10.39', 'v0.12.2', 'v0.12.3'].forEach(function(ver) {
-  doTest(tls.getLegacyCiphers(ver), ver, 2);
-  doTest(tls.getLegacyCiphers(ver), ver, 3);
+
+  // test that --enable-legacy-cipher-list takes precence over both envars
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {
+           'NODE_LEGACY_CIPHER_LIST': 'v0.10.39',
+           'NODE_CIPHER_LIST': 'XYZ'
+         });
+
+  // test the right-most command line option takes precedence
+  doTest(V1038Ciphers,
+         [
+           '--cipher-list=XYZ',
+           '--enable-legacy-cipher-list=v0.10.38'
+         ]);
+
+   // test the right-most command line option takes precedence
+   doTest('XYZ',
+          [
+            '--enable-legacy-cipher-list=v0.10.38',
+            '--cipher-list=XYZ'
+          ]);
+
+    // test the right-most command line option takes precedence
+    doTest('XYZ',
+           [
+             '--cipher-list=XYZ',
+             '--enable-legacy-cipher-list=v0.10.39',
+             '--cipher-list=XYZ'
+           ]);
+
+    // test that NODE_LEGACY_CIPHER_LIST takes precedence over
+    // NODE_CIPHER_LIST
+
+    doTest(V1038Ciphers, [],
+           {
+             'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+             'NODE_CIPHER_LIST': 'ABC'
+           });
+
+}
+
+// Start running the tests...
+
+doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
+
+// Test the NODE_CIPHER_LIST environment variable
+doTest('ABC', [], {'NODE_CIPHER_LIST':'ABC'});
+
+// Test the --cipher-list command line switch
+doTest('ABC', ['--cipher-list=ABC']);
+
+// Test the --enable-legacy-cipher-list and NODE_LEGACY_CIPHER_LIST envar
+['v0.10.38','v0.10.39','v0.12.2'].forEach(function(arg) {
+  var checklist = tls.getLegacyCiphers(arg);
+  // command line switch
+  doTest(checklist, ['--enable-legacy-cipher-list=' + arg]);
+  // environment variable
+  doTest(checklist, [], {'NODE_LEGACY_CIPHER_LIST': arg});
 });
 
+// Test the precedence order for the various options
+doTestPrecedence();
+
+// Test that we throw properly
 // invalid value
 assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
 // no parameters
@@ -138,3 +140,93 @@ assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.39');});
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.12.2');});
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.12.3');});
+
+// Test to ensure default ciphers are not set when v0.10.38 legacy cipher
+// switch is used. This is a bit involved... we need to first set up the
+// TLS server, then spawn a second node instance using the v0.10.38 cipher,
+// then connect and check to make sure the options are correct. Since there
+// is no direct way of testing it, an alternate createCredentials shim is
+// created that intercepts the call to createCredentials and checks the output.
+// The following server code was adopted from test-tls-connect-simple.
+
+// note that the following function is written out to a string and
+// passed in as an argument to a child node instance.
+var script = (
+  function() {
+    var tls = require('tls');
+    //var orig_createCredentials = require('crypto').createCredentials;
+    var orig_createSecureContext = tls.createSecureContext;
+    //require('crypto').createCredentials = function(options) {
+    tls.createSecureContext = function(details) {
+      if (details.ciphers !== undefined) {
+        console.error(details.ciphers);
+        process.exit(1);
+      }
+      return orig_createSecureContext(details);
+    };
+    var socket = tls.connect({
+      port: 0,
+      rejectUnauthorized: false
+    }, function() {
+      socket.end();
+    });
+  }
+).toString();
+
+var test_count = 0;
+
+function doDefaultCipherTest(additional_args, env, failexpected) {
+  var options = {};
+  if (env) options.env = env;
+  var out = '', err = '';
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', require('util').format('(%s)()', script).replace(
+      'port: 0', 'port: ' + common.PORT)
+  ]);
+  var child = spawn(process.execPath, args, options);
+  child.stdout.
+    on('data', function(data) {
+      out += data;
+    }).
+    on('end', function() {
+      if (failexpected && err === '') {
+        // if we get here, there's a problem because the default cipher
+        // list was not set when it should have been
+        assert.fail('options.cipher list was not set');
+      }
+    });
+  child.stderr.
+    on('data', function(data) {
+      err += data;
+    }).
+    on('end', function() {
+      if (err !== '') {
+        if (!failexpected) {
+          assert.fail(err.substr(0,err.length-1));
+        }
+      }
+    });
+  child.on('close', function() {
+    test_count++;
+    if (test_count === 4) server.close();
+  });
+}
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+var server = tls.Server(options, function(socket) {});
+server.listen(common.PORT, function() {
+  doDefaultCipherTest(['--enable-legacy-cipher-list=v0.10.38']);
+  doDefaultCipherTest([], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+  // this variant checks to ensure that the default cipher list IS set
+  var test_uses_default_cipher_list = true;
+  doDefaultCipherTest([], {}, test_uses_default_cipher_list);
+  // test that setting the cipher list explicitly to the v0.10.38
+  // string without using the legacy cipher switch causes the
+  // default ciphers to be set.
+  doDefaultCipherTest(['--cipher-list=' + V1038Ciphers], {},
+                      test_uses_default_cipher_list);
+});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -88,7 +88,7 @@ function doTestPrecedence() {
     // test the right-most command line option takes precedence
     doTest('XYZ',
            [
-             '--cipher-list=XYZ',
+             '--cipher-list=ABC',
              '--enable-legacy-cipher-list=v0.10.39',
              '--cipher-list=XYZ'
            ]);
@@ -154,10 +154,12 @@ assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.12.3');});
 var script = (
   function() {
     var tls = require('tls');
-    //var orig_createCredentials = require('crypto').createCredentials;
     var orig_createSecureContext = tls.createSecureContext;
-    //require('crypto').createCredentials = function(options) {
     tls.createSecureContext = function(details) {
+      // since node was started with the --enable-legacy-cipher-list
+      // switch equal to v0.10.38, the options.ciphers should be
+      // undefined. If it's not undefined, we have a problem and
+      // the test fails
       if (details.ciphers !== undefined) {
         console.error(details.ciphers);
         process.exit(1);
@@ -175,7 +177,7 @@ var script = (
 
 var test_count = 0;
 
-function doDefaultCipherTest(additional_args, env, failexpected) {
+function doDefaultCipherTest(additional_args, env, opts) {
   var options = {};
   if (env) options.env = env;
   var out = '', err = '';
@@ -190,7 +192,7 @@ function doDefaultCipherTest(additional_args, env, failexpected) {
       out += data;
     }).
     on('end', function() {
-      if (failexpected && err === '') {
+      if (opts.failExpected && err === '') {
         // if we get here, there's a problem because the default cipher
         // list was not set when it should have been
         assert.fail('options.cipher list was not set');
@@ -202,7 +204,7 @@ function doDefaultCipherTest(additional_args, env, failexpected) {
     }).
     on('end', function() {
       if (err !== '') {
-        if (!failexpected) {
+        if (!opts.failExpected) {
           assert.fail(err.substr(0,err.length-1));
         }
       }
@@ -222,11 +224,10 @@ server.listen(common.PORT, function() {
   doDefaultCipherTest(['--enable-legacy-cipher-list=v0.10.38']);
   doDefaultCipherTest([], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
   // this variant checks to ensure that the default cipher list IS set
-  var test_uses_default_cipher_list = true;
-  doDefaultCipherTest([], {}, test_uses_default_cipher_list);
+  doDefaultCipherTest([], {}, {failExpected:true});
   // test that setting the cipher list explicitly to the v0.10.38
   // string without using the legacy cipher switch causes the
   // default ciphers to be set.
   doDefaultCipherTest(['--cipher-list=' + V1038Ciphers], {},
-                      test_uses_default_cipher_list);
+                      {failExpected:true});
 });


### PR DESCRIPTION
throw an error on unknown getLegacyCipher input
rather than returning the default. Makes the
behavior more explicit and matches up with the
behavior on the command line switches.
