### PR TITLE
Update sample code in api doc, net.markdown

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -160,7 +160,13 @@ would be to wait a second and then try again. This can be done with
       if (e.code == 'EADDRINUSE') {
         console.log('Address in use, retrying...');
         setTimeout(function () {
-          server.close();
+          try {
+            server.close();//this may throw Error if server not running
+            //fs.unlinkSync(PATH);//this is for Unix domain socket
+          } catch (e) {
+            console.log(e);
+          }
+          
           server.listen(PORT, HOST);
         }, 1000);
       }


### PR DESCRIPTION
In this document,the sample code for `net.listen()` issue is not running well.
if server code runs first time, and get an error EADDRINUSE,the sample code `server.close()` will throw `Not running`
and if when  listen with Unix domain socket`server.listen(path)`,the sample code will not run well yet.
use fs.unlinkSync() is a better case.
