### PR TITLE
cluster: only assign debug port if in valid range.

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -307,17 +307,19 @@ function masterInit() {
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;
 
-    for (var i = 0; i < execArgv.length; i++) {
-      var match = execArgv[i].match(/^(--debug|--debug-brk)(=\d+)?$/);
+    if (1024 < debugPort < 65535) {
+      for (var i = 0; i < execArgv.length; i++) {
+        var match = execArgv[i].match(/^(--debug|--debug-brk)(=\d+)?$/);
 
-      if (match) {
-        execArgv[i] = match[1] + '=' + debugPort;
-        hasDebugArg = true;
+        if (match) {
+          execArgv[i] = match[1] + '=' + debugPort;
+          hasDebugArg = true;
+        }
       }
-    }
 
     if (!hasDebugArg)
       execArgv = ['--debug-port=' + debugPort].concat(execArgv);
+    }
 
     return fork(cluster.settings.exec, cluster.settings.args, {
       env: workerEnv,

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -307,7 +307,7 @@ function masterInit() {
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;
 
-    if (1024 < debugPort < 65535) {
+    if !(debug_port < 1024 || debug_port > 65535) { // If port in range according to node.cc:2903
       for (var i = 0; i < execArgv.length; i++) {
         var match = execArgv[i].match(/^(--debug|--debug-brk)(=\d+)?$/);
 


### PR DESCRIPTION
See: https://github.com/joyent/node/issues/8159

Per above discussion, cluster.fork() currently sends --debug-port to
forked processes regardless of whether debug is enabled, and more
importantly, without any bounds checking. This will rather unexpectedly
crash any Node process that forks enough times.

This patch simply bounds checks --debug-port and doesn't set arg if out
of bounds (V8 requires 1024 < debug-port < 65535). This will prevent
surprises to callers of cluster.fork() while waiting for the debug part
of node to be rewritten as mentioned in issue discussion above.
