### PR TITLE
Removes making copy of options in http.request

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -47,8 +47,6 @@ function ClientRequest(options, cb) {
 
   if (util.isString(options)) {
     options = url.parse(options);
-  } else {
-    options = util._extend({}, options);
   }
 
   var agent = options.agent;


### PR DESCRIPTION
Introduces solution from https://github.com/iojs/io.js/commit/06cfff935012ed2826cac56284cea982630cbc27 to node. 

> The `options` object is never overwritten, so making a copy is not necessary.
#14569

Also running the sample code from the aforementioned issue before this fix results in node 0.12.0:

```
BODY: inner
BODY: root
```

After the fix:

```
BODY: inner
BODY: inner
```

In io.js 1.6.0:

```
BODY: inner
BODY: inner
```
