### PR TITLE
src: fix backport for SIGINT crash fix on FreeBSD

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2790,7 +2790,7 @@ static void SignalExit(int signo) {
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = SIG_DFL;
-  CHECK_EQ(sigaction(signo, &sa, nullptr), 0);
+  CHECK_EQ(sigaction(signo, &sa, NULL), 0);
 #endif
   raise(signo);
 }


### PR DESCRIPTION
61fe1fe21ba281b05b90a632e2dad29eefb14a0a backported
b64983d77cc3ed2e4b585f3bfc8ed23802389a52 from io.js, but failed to
change nullptr to NULL, which lead to a build break on FreeBSD since the
current build system doesn't enable support for C++11.

This change replaces nullptr by NULL, and has been tested on
FreeBSD 10.1-RELEASE-p8.

Fixes #9326.
