### PR TITLE
net: do not set V4MAPPED on FreeBSD

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -259,8 +259,9 @@ The following flags can be passed as hints to `dns.lookup`.
 of addresses supported by the current system. For example, IPv4 addresses
 are only returned if the current system has at least one IPv4 address
 configured. Loopback addresses are not considered.
-- `dns.V4MAPPED`: If the IPv6 family was specified, but no IPv6 addresses
-were found, then return IPv4 mapped IPv6 addresses.
+- `dns.V4MAPPED`: If the IPv6 family was specified, but no IPv6 addresses were
+found, then return IPv4 mapped IPv6 addresses. Note that it is not supported
+on some operating systems (e.g FreeBSD 10.1).
 
 ## Implementation considerations
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -917,8 +917,18 @@ Socket.prototype.connect = function(options, cb) {
       throw new RangeError('port should be >= 0 and < 65536: ' +
                            options.port);
 
-    if (dnsopts.family !== 4 && dnsopts.family !== 6)
-      dnsopts.hints = dns.ADDRCONFIG | dns.V4MAPPED;
+    if (dnsopts.family !== 4 && dnsopts.family !== 6) {
+      dnsopts.hints = dns.ADDRCONFIG;
+      // The AI_V4MAPPED hint is not supported on FreeBSD, and getaddrinfo
+      // returns EAI_BADFLAGS. However, it seems to be supported on most other
+      // systems. See
+      // http://lists.freebsd.org/pipermail/freebsd-bugs/2008-February/028260.html
+      // and
+      // https://svnweb.freebsd.org/base/head/lib/libc/net/getaddrinfo.c?r1=172052&r2=175955
+      // for more information on the lack of support for FreeBSD.
+      if (process.platform !== 'freebsd')
+        dnsopts.hints |= dns.V4MAPPED;
+    }
 
     debug('connect: find host ' + host);
     debug('connect: dns options ' + dnsopts);


### PR DESCRIPTION
V4MAPPED is not supported on recent FreeBSD versions, at least on 10.1.
Thus, do not set this flag in net.connect on FreeBSD.

Fixes #8540.
