### PR TITLE
fix the bug when ./configure --without-ssl (fix the pr #18456)

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3010,11 +3010,15 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--version") == 0 || strcmp(arg, "-v") == 0) {
       printf("%s\n", NODE_VERSION);
       exit(0);
-    } else if (strcmp(arg, "--enable-ssl2") == 0) {
+    } 
+#if HAVE_OPENSSL
+    else if (strcmp(arg, "--enable-ssl2") == 0) {
       SSL2_ENABLE = true;
     } else if (strcmp(arg, "--enable-ssl3") == 0) {
       SSL3_ENABLE = true;
-    } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+    }
+#endif	
+    else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);
     } else if (strcmp(arg, "--eval") == 0 ||


### PR DESCRIPTION
When ./configure --without-ssl and make, it will report no definition of SSL2_ENABLE and SSL3
_ENABLE. Because they are declared in "node_crypto.h", and "node_crypto.h" will not be included here when without ssl

#if HAVE_OPENSSL
#include "node_crypto.h"
#endif

fix the pr #18456 