### PR TITLE
v8: fix let bindings in for loops

### DIFF
--- a/deps/v8/test/mjsunit/harmony/regress/regress-3683.js
+++ b/deps/v8/test/mjsunit/harmony/regress/regress-3683.js
@@ -1,0 +1,84 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Flags: --harmony-scoping
+
+"use strict";
+
+// Simplest case
+var count = 0;
+for (let x = 0; x < 10;) {
+  x++;
+  count++;
+  continue;
+}
+assertEquals(10, count);
+
+// Labeled
+count = 0;
+label: for (let x = 0; x < 10;) {
+  while (true) {
+    x++;
+    count++;
+    continue label;
+  }
+}
+assertEquals(10, count);
+
+// Simple and labeled
+count = 0;
+label: for (let x = 0; x < 10;) {
+  x++;
+  count++;
+  continue label;
+}
+assertEquals(10, count);
+
+// Shadowing loop variable in same scope as continue
+count = 0;
+for (let x = 0; x < 10;) {
+  x++;
+  count++;
+  {
+    let x = "hello";
+    continue;
+  }
+}
+assertEquals(10, count);
+
+// Nested let-bound for loops, inner continue
+count = 0;
+for (let x = 0; x < 10;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++;
+    continue;
+  }
+}
+assertEquals(20, count);
+
+// Nested let-bound for loops, outer continue
+count = 0;
+for (let x = 0; x < 10;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++;
+  }
+  continue;
+}
+assertEquals(20, count);
+
+// Nested let-bound for loops, labeled continue
+count = 0;
+outer: for (let x = 0; x < 10;) {
+  x++;
+  for (let y = 0; y < 2;) {
+    y++;
+    count++;
+    if (y == 2) continue outer;
+  }
+}
+assertEquals(20, count);

--- a/test/simple/test-let-bindings-for-loop-harmony.js
+++ b/test/simple/test-let-bindings-for-loop-harmony.js
@@ -1,0 +1,38 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * This is a regression test for the issue described at:
+ * https://github.com/joyent/node/issues/9113.
+ *
+ * This problem has been fixed by floating a patch on V8, this test makes
+ * sure that the appropriate patch is floated even after future V8 upgrades.
+ *
+ * If the bug is reproduced, this test stalls and the tests suite makes it
+ * time out eventually (currently after one minute). Otherwise it exits after
+ * the for loop completes its execution.
+ */
+var spawn = require('child_process').spawn;
+var args = ['--harmony',
+            '--use-strict',
+            '-e',
+            'for (let i = 0; i < 3; ++i) { if (i == 1) { continue; } }'];
+var child = spawn(process.execPath, args);


### PR DESCRIPTION
This PR:
- Adds [the floating patch that fixes let bindings and continue statements in for loops](https://github.com/joyent/node/commit/072460265226c047369558b23e9ff2748965bf6c).
- Adds [a test](https://github.com/joyent/node/commit/00ca880a7013d75820bdf087698930d6fc11cb92) that makes sure that this patch is floated in future V8 upgrades if needed.

They are in two separate commits so that every time we float the patch, we don't float the test too.

This PR is based off [another PR that downgrades V8 to the actual proper stable version for node v0.12](https://github.com/joyent/node/pull/18206), which is the reason why there are more commits than the two highlighted above.

Once #18206 lands, this PR will be rebased on top of v0.12 and will only include these two commits.

Fixes #9113 and #14411.

/cc @joyent/node-coreteam  and especially @mhdawson.
