### PR TITLE
Add dns.resolveURI(), support for DNS URI records

### DIFF
--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -71,6 +71,7 @@
         'src/ares_parse_soa_reply.c',
         'src/ares_parse_srv_reply.c',
         'src/ares_parse_txt_reply.c',
+        'src/ares_parse_uri_reply.c',
         'src/ares_platform.h',
         'src/ares_private.h',
         'src/ares_process.c',

--- a/deps/cares/include/ares.h
+++ b/deps/cares/include/ares.h
@@ -544,6 +544,14 @@ struct ares_soa_reply {
   unsigned int minttl;
 };
 
+struct ares_uri_reply {
+  struct ares_uri_reply  *next;
+  char                   *target;
+  unsigned short          priority;
+  unsigned short          weight;
+};
+
+
 /*
 ** Parse the buffer, starting at *abuf and of length alen bytes, previously
 ** obtained from an ares_search call.  Put the results in *host, if nonnull.
@@ -594,6 +602,10 @@ CARES_EXTERN int ares_parse_naptr_reply(const unsigned char* abuf,
 CARES_EXTERN int ares_parse_soa_reply(const unsigned char* abuf,
 				      int alen,
 				      struct ares_soa_reply** soa_out);
+
+CARES_EXTERN int ares_parse_uri_reply(const unsigned char* abuf,
+                                      int alen,
+                                      struct ares_uri_reply** uri_out);
 
 CARES_EXTERN void ares_free_string(void *str);
 

--- a/deps/cares/src/ares_data.c
+++ b/deps/cares/src/ares_data.c
@@ -36,6 +36,9 @@
 **   ares_get_servers()
 **   ares_parse_srv_reply()
 **   ares_parse_txt_reply()
+**   ares_parse_naptr_reply()
+**   ares_parse_soa_reply()
+**   ares_parse_uri_reply()
 */
 
 void ares_free_data(void *dataptr)
@@ -111,7 +114,14 @@ void ares_free_data(void *dataptr)
           free(ptr->data.soa_reply.nsname);
         if (ptr->data.soa_reply.hostmaster)
           free(ptr->data.soa_reply.hostmaster);
-	break;
+        break;
+
+      case ARES_DATATYPE_URI_REPLY:
+        if (ptr->data.uri_reply.next)
+          ares_free_data(ptr->data.uri_reply.next);
+        if (ptr->data.uri_reply.target)
+          free(ptr->data.uri_reply.target);
+        break;
 
       default:
         return;
@@ -188,6 +198,13 @@ void *ares_malloc_data(ares_datatype type)
         ptr->data.soa_reply.expire = 0;
         ptr->data.soa_reply.minttl = 0;
 	break;
+
+      case ARES_DATATYPE_URI_REPLY:
+        ptr->data.uri_reply.next = NULL;
+        ptr->data.uri_reply.target = NULL;
+        ptr->data.uri_reply.priority = 0;
+        ptr->data.uri_reply.weight = 0;
+        break;
 
       default:
         free(ptr);

--- a/deps/cares/src/ares_data.h
+++ b/deps/cares/src/ares_data.h
@@ -22,6 +22,7 @@ typedef enum {
   ARES_DATATYPE_MX_REPLY,    /* struct ares_mx_reply   - introduced in 1.7.2 */
   ARES_DATATYPE_NAPTR_REPLY,/* struct ares_naptr_reply - introduced in 1.7.6 */
   ARES_DATATYPE_SOA_REPLY,    /* struct ares_soa_reply - introduced in 1.9.0 */
+  ARES_DATATYPE_URI_REPLY,    /* struct ares_uri_reply - patch to node.js */
 #if 0
   ARES_DATATYPE_ADDR6TTL,     /* struct ares_addrttl   */
   ARES_DATATYPE_ADDRTTL,      /* struct ares_addr6ttl  */
@@ -61,6 +62,7 @@ struct ares_data {
     struct ares_mx_reply    mx_reply;
     struct ares_naptr_reply naptr_reply;
     struct ares_soa_reply soa_reply;
+    struct ares_uri_reply uri_reply;
   } data;
 };
 

--- a/deps/cares/src/ares_parse_uri_reply.c
+++ b/deps/cares/src/ares_parse_uri_reply.c
@@ -1,0 +1,193 @@
+
+/* Copyright 1998 by the Massachusetts Institute of Technology.
+ * Copyright (C) 2009 by Jakub Hrozek <jhrozek@redhat.com>
+ * Copyright (C) 2015 by Anthony Kirby <anthony@anthony.org>
+ *
+ * Permission to use, copy, modify, and distribute this
+ * software and its documentation for any purpose and without
+ * fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright
+ * notice and this permission notice appear in supporting
+ * documentation, and that the name of M.I.T. not be used in
+ * advertising or publicity pertaining to distribution of the
+ * software without specific, written prior permission.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is"
+ * without express or implied warranty.
+ */
+
+#include "ares_setup.h"
+
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+#  include <arpa/inet.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#else
+#  include "nameser.h"
+#endif
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#  include <arpa/nameser_compat.h>
+#endif
+
+#include "ares.h"
+#include "ares_dns.h"
+#include "ares_data.h"
+#include "ares_private.h"
+
+/* nameser.h frequently omits new DNS record types
+ *  so define constant for URI record
+ *
+ * (reference: RR types as defined by IANA, published at:
+ *  http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml)
+ */
+#ifndef T_URI
+  #define T_URI 256
+#endif
+
+
+int
+ares_parse_uri_reply (const unsigned char *abuf, int alen,
+                      struct ares_uri_reply **uri_out)
+{
+  unsigned int qdcount, ancount, i;
+  const unsigned char *aptr, *vptr;
+  int status, rr_type, rr_class, rr_len, uri_len;
+  long len;
+  char *qname = NULL, *rr_name = NULL;
+  struct ares_uri_reply *uri_head = NULL;
+  struct ares_uri_reply *uri_last = NULL;
+  struct ares_uri_reply *uri_curr;
+
+  /* Set *uri_out to NULL for all failure cases. */
+  *uri_out = NULL;
+
+  /* Give up if abuf doesn't have room for a header. */
+  if (alen < HFIXEDSZ)
+    return ARES_EBADRESP;
+
+  /* Fetch the question and answer count from the header. */
+  qdcount = DNS_HEADER_QDCOUNT (abuf);
+  ancount = DNS_HEADER_ANCOUNT (abuf);
+  if (qdcount != 1)
+    return ARES_EBADRESP;
+  if (ancount == 0)
+    return ARES_ENODATA;
+
+  /* Expand the name from the question, and skip past the question. */
+  aptr = abuf + HFIXEDSZ;
+  status = ares_expand_name (aptr, abuf, alen, &qname, &len);
+  if (status != ARES_SUCCESS)
+    return status;
+
+  if (aptr + len + QFIXEDSZ > abuf + alen)
+    {
+      free (qname);
+      return ARES_EBADRESP;
+    }
+  aptr += len + QFIXEDSZ;
+
+  /* Examine each answer resource record (RR) in turn. */
+  for (i = 0; i < ancount; i++)
+    {
+      /* Decode the RR up to the data field. */
+      status = ares_expand_name (aptr, abuf, alen, &rr_name, &len);
+      if (status != ARES_SUCCESS)
+        {
+          break;
+        }
+      aptr += len;
+      if (aptr + RRFIXEDSZ > abuf + alen)
+        {
+          status = ARES_EBADRESP;
+          break;
+        }
+      rr_type = DNS_RR_TYPE (aptr);
+      rr_class = DNS_RR_CLASS (aptr);
+      rr_len = DNS_RR_LEN (aptr);
+      aptr += RRFIXEDSZ;
+      if (aptr + rr_len > abuf + alen)
+        {
+          status = ARES_EBADRESP;
+          break;
+        }
+
+      /* Check if we are really looking at a URI record */
+      if (rr_class == C_IN && rr_type == T_URI)
+        {
+          /* parse the URI record itself */
+          if (rr_len < 4)
+            {
+              status = ARES_EBADRESP;
+              break;
+            }
+
+          /* Allocate storage for this URI answer appending it to the list */
+          uri_curr = ares_malloc_data(ARES_DATATYPE_URI_REPLY);
+          if (!uri_curr)
+            {
+              status = ARES_ENOMEM;
+              break;
+            }
+          uri_curr->target = NULL;
+          if (uri_last)
+            {
+              uri_last->next = uri_curr;
+            }
+          else
+            {
+              uri_head = uri_curr;
+            }
+          uri_last = uri_curr;
+
+          vptr = aptr;
+          uri_curr->priority = DNS__16BIT(vptr);
+          vptr += sizeof(unsigned short);
+          uri_curr->weight = DNS__16BIT(vptr);
+          vptr += sizeof(unsigned short);
+
+          /* Allocate storage for the URI target */
+          uri_len = rr_len-4;
+          uri_curr->target = malloc(uri_len + 1);
+          if (!uri_curr->target)
+            {
+              status = ARES_ENOMEM;
+              break;
+            }
+          /* copy to target */
+          memcpy(uri_curr->target, vptr, uri_len);
+          uri_curr->target[uri_len] = 0;
+        }
+
+      /* Don't lose memory in the next iteration */
+      free (rr_name);
+      rr_name = NULL;
+
+      /* Move on to the next record */
+      aptr += rr_len;
+    }
+
+  if (qname)
+    free (qname);
+  if (rr_name)
+    free (rr_name);
+
+  /* clean up on error */
+  if (status != ARES_SUCCESS)
+    {
+      if (uri_head)
+        ares_free_data (uri_head);
+      return status;
+    }
+
+  /* everything looks fine, return the data */
+  *uri_out = uri_head;
+
+  return ARES_SUCCESS;
+}

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -198,6 +198,13 @@ The same as `dns.resolve()`, but only for canonical name records (`CNAME`
 records). `addresses` is an array of the canonical name records available for
 `hostname` (e.g., `['bar.example.com']`).
 
+## dns.resolveUri(hostname, callback)
+
+The same as `dns.resolve()`, but only for URI records (`URI` records).
+`addresses` is an array of the SRV records available for `hostname`. Properties
+of URI records are priority, weight and target (e.g.,
+`[{'priority': 10, 'weight': 5, 'target': 'http://tools.ietf.org/html/draft-faltstrom-uri'}, ...]`).
+
 ## dns.reverse(ip, callback)
 
 Reverse resolves an ip address to an array of hostnames.

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -239,6 +239,7 @@ exports.resolveTxt = resolveMap.TXT = resolver('queryTxt');
 exports.resolveSrv = resolveMap.SRV = resolver('querySrv');
 exports.resolveNaptr = resolveMap.NAPTR = resolver('queryNaptr');
 exports.resolveSoa = resolveMap.SOA = resolver('querySoa');
+exports.resolveUri = resolveMap.URI = resolver('queryUri');
 exports.reverse = resolveMap.PTR = resolver('getHostByAddr');
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -213,6 +213,7 @@ namespace node {
   V(subjectaltname_string, "subjectaltname")                                  \
   V(sys_string, "sys")                                                        \
   V(syscall_string, "syscall")                                                \
+  V(target_string, "target")                                    \
   V(tick_callback_string, "_tickCallback")                                    \
   V(tick_domain_cb_string, "_tickDomainCallback")                             \
   V(timeout_string, "timeout")                                                \

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -309,6 +309,30 @@ TEST(function test_resolveTxt(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolveUri(done) {
+	  var req = dns.resolveUri('single.draft-faltstrom-uri.uk', function(err, result) {
+	    if (err) throw err;
+
+	    assert.ok(result.length > 0);
+
+	    for (var i = 0; i < result.length; i++) {
+	      var item = result[i];
+	      assert.ok(item);
+	      assert.ok(typeof item === 'object');
+
+	      assert.ok(item.target);
+	      assert.ok(typeof item.target === 'string');
+	      assert.equal(item.target, 'http://tools.ietf.org/html/draft-faltstrom-uri');
+
+	      assert.ok(typeof item.priority === 'number');
+	      assert.ok(typeof item.weight === 'number');
+	    }
+
+	    done();
+	  });
+
+	  checkWrap(req);
+	});
 
 TEST(function test_lookup_ipv4_explicit(done) {
   var req = dns.lookup('www.google.com', 4, function(err, ip, family) {


### PR DESCRIPTION
This patch adds  support for URI records, as described at:
 http://tools.ietf.org/html/draft-faltstrom-uri
An RR value (= 256) was assigned by IANA in 2011, and URI records are
 supported by recent versions of BIND.

The change includes modification to the c-ares dependency.  I've also
 submitted an identical patch to the c-ares project (http://c-ares.haxx.se)
 but it doesn't seem very active, nor does node seem to be pulling all their
 changes, so I suggest it's appropriate to patch node/deps/cares directly.
