### PR TITLE
test: Extend timeout due to failure on AIX

### DIFF
--- a/test/simple/test-tls-wrap-timeout.js
+++ b/test/simple/test-tls-wrap-timeout.js
@@ -44,7 +44,7 @@ var server = tls.createServer(options, function(c) {
 
 server.listen(common.PORT, function() {
   var socket = net.connect(common.PORT, function() {
-    socket.setTimeout(120, assert.fail);
+    socket.setTimeout(500, assert.fail);
 
     var tsocket = tls.connect({
       socket: socket,


### PR DESCRIPTION
The loopback on AIX is slower by default than on other platforms
and we've seen a number of tests fail on AIX for this reason. This
looks to be another instance.  Changing the test to bind to the
host ip instead of the loopback makes it pass reliably.

This change extends the timeout so that it passes reliably on AIX
even with the slower loopback behaviour

```
modified:   test/simple/test-tls-wrap-timeout.js
```
