### PR TITLE
configure: remove unused variable 'byteorder'

### DIFF
--- a/configure
+++ b/configure
@@ -891,7 +891,6 @@ def configure_intl(o):
         sys.exit(1)
 
   # ICU mode. (icu-generic.gyp)
-  byteorder = sys.byteorder
   o['variables']['icu_gyp_path'] = 'tools/icu/icu-generic.gyp'
   # ICU source dir relative to root
   o['variables']['icu_path'] = icu_full_path


### PR DESCRIPTION
A separate PR, according to https://github.com/joyent/node/pull/25282#issuecomment-101307222.
