### PR TITLE
test,win: disable test-tls-server-verify for CI

### DIFF
--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -6,6 +6,7 @@ test-cluster-basic                : PASS,FLAKY
 
 [$system==win32]
 test-timers-first-fire            : PASS,FLAKY
+test-tls-server-verify            : PASS,FLAKY
 
 [$system==linux]
 test-fs-readfile-error            : PASS,FLAKY


### PR DESCRIPTION
test-tls-server-verify takes a lont time to execute and times
out on the Jenkins machines.
