### PR TITLE
test: relax timing constraints for child process

### DIFF
--- a/test/simple/test-child-process-spawnsync.js
+++ b/test/simple/test-child-process-spawnsync.js
@@ -41,7 +41,7 @@ var ret = spawnSync('sleep', ['1']);
 var stop = process.hrtime(start);
 assert.strictEqual(ret.status, 0, 'exit status should be zero');
 console.log('sleep exited', stop);
-assert.strictEqual(stop[0], 1, 'sleep should not take longer or less than 1 second');
+assert.ok(stop[0] >= 1, 'sleep should not take less than 1 second');
 
 // Error test when command does not exist
 var ret_err = spawnSync('command_does_not_exist');


### PR DESCRIPTION
In windows we were seeing failures in the Node test:

test-child-process-spawnsync.js

assert.js:86
throw new assert.AssertionError({
ˆ
AssertionError: sleep should not take longer or less than 1 second

at Object.<anonymous> (test\simple\test-child-process-spawnsync.js:44:8)
at Module._compile (module.js:460:26)
at Object.Module._extensions..js (module.js:478:10)
at Module.load (module.js:355:32)
at Function.Module._load (module.js:310:12)
at Function.Module.runMain (module.js:501:10)
at startup (node.js:129:16) # at node.js:814:3

This is easily reproducible by adding additional load to 
the system while the test runs.
We see that the additional load can cause the sleep
to wakeup after 2 seconds or more instead of the usual/expected
1 second.

While the intent of the test is to test 
the functionality of spawnSync and the child process 
in general, in effect it is testing the system command sleep,
and further, it's responsiveness.

Since from the name the purpose of the test seems to be
unrelated to the sleep behavior, I believe a more meaningful
assertion would be to see the time taken is more than 1 second.

And hence the pull request.
