### PR TITLE
test: Fix test-npm Makefile target for npm 2.8.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,8 @@ test-npm: node
 	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
 	     npm_config_prefix="$(shell pwd)/npm-prefix" \
 	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     PATH="../../:${PATH}" node cli.js run-script test-all && \
+	     PATH="../../:${PATH}" node cli.js run-script test-legacy && \
+	     PATH="../../:${PATH}" node cli.js run-script test && \
 	     PATH="../../:${PATH}" node cli.js prune --prod && \
 	     cd ../.. && \
 	     rm -rf npm-cache npm-tmp npm-prefix


### PR DESCRIPTION
Changes in npm 2.8.4 broke the test-npm target.  This change
updates to allow the tests to run once again
