### PR TITLE
path: Remove dead code in favor of unit tests

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -90,7 +90,7 @@ function win32SplitPath(filename) {
   // Separate device+slash from tail
   var result = splitDeviceRe.exec(filename),
       device = (result[1] || '') + (result[2] || ''),
-      tail = result[3] || '';
+      tail = result[3];
   // Split the tail into dir, basename and extension
   var result2 = splitTailRe.exec(tail),
       dir = result2[1],
@@ -396,9 +396,6 @@ win32.parse = function(pathString) {
     );
   }
   var allParts = win32SplitPath(pathString);
-  if (!allParts || allParts.length !== 4) {
-    throw new TypeError("Invalid path '" + pathString + "'");
-  }
   return {
     root: allParts[0],
     dir: allParts[0] + allParts[1].slice(0, -1),
@@ -596,13 +593,6 @@ posix.parse = function(pathString) {
     );
   }
   var allParts = posixSplitPath(pathString);
-  if (!allParts || allParts.length !== 4) {
-    throw new TypeError("Invalid path '" + pathString + "'");
-  }
-  allParts[1] = allParts[1] || '';
-  allParts[2] = allParts[2] || '';
-  allParts[3] = allParts[3] || '';
-
   return {
     root: allParts[0],
     dir: allParts[0] + allParts[1].slice(0, -1),

--- a/test/simple/test-path-parse-format.js
+++ b/test/simple/test-path-parse-format.js
@@ -29,6 +29,7 @@ var winPaths = [
   '\\foo\\C:',
   'file',
   '.\\file',
+  '',
 
   // unc
   '\\\\server\\share\\file_path',
@@ -52,7 +53,8 @@ var unixPaths = [
   'file',
   '.\\file',
   './file',
-  'C:\\foo'
+  'C:\\foo',
+  ''
 ];
 
 var unixSpecialCaseFormatTests = [
@@ -67,7 +69,6 @@ var errors = [
   {method: 'parse', input: [true], message: /Parameter 'pathString' must be a string, not boolean/},
   {method: 'parse', input: [1], message: /Parameter 'pathString' must be a string, not number/},
   {method: 'parse', input: [], message: /Parameter 'pathString' must be a string, not undefined/},
-  // {method: 'parse', input: [''], message: /Invalid path/}, // omitted because it's hard to trigger!
   {method: 'format', input: [null], message: /Parameter 'pathObject' must be an object, not/},
   {method: 'format', input: [''], message: /Parameter 'pathObject' must be an object, not string/},
   {method: 'format', input: [true], message: /Parameter 'pathObject' must be an object, not boolean/},
@@ -101,8 +102,13 @@ function checkErrors(path) {
 }
 
 function checkParseFormat(path, paths) {
-  paths.forEach(function(element, index, array) {
+  paths.forEach(function(element) {
     var output = path.parse(element);
+    assert.strictEqual(typeof output.root, 'string');
+    assert.strictEqual(typeof output.dir, 'string');
+    assert.strictEqual(typeof output.base, 'string');
+    assert.strictEqual(typeof output.ext, 'string');
+    assert.strictEqual(typeof output.name, 'string');
     assert.strictEqual(path.format(output), element);
     assert.strictEqual(output.dir, output.dir ? path.dirname(element) : '');
     assert.strictEqual(output.base, path.basename(element));


### PR DESCRIPTION
This PR removes dead code paths that are created by assertions that will never trigger. They may only trigger if either the `splitDeviceRe` or `splitPathRe` regular expressions or the `[win32|posix]SplitPath` functions are modified. If at some point they are modified (and for some reason the author doesn't update the code that uses those regexes/functions), current unit tests will catch most of the resulting errors and this PR adds extra tests to catch the remaining errors.
