### PR TITLE
net: setKeepAlive now throws an exception on error

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -359,8 +359,11 @@ Socket.prototype.setNoDelay = function(enable) {
 
 
 Socket.prototype.setKeepAlive = function(setting, msecs) {
-  if (this._handle && this._handle.setKeepAlive)
-    this._handle.setKeepAlive(setting, ~~(msecs / 1000));
+  if (this._handle && this._handle.setKeepAlive) {
+    var err = this._handle.setKeepAlive(setting, ~~(msecs / 1000));
+    if (err)
+      throw errnoException(err, 'setKeepAlive');
+  }
 };
 
 

--- a/test/simple/test-net-keepalive.js
+++ b/test/simple/test-net-keepalive.js
@@ -28,6 +28,14 @@ var echoServer = net.createServer(function(connection) {
   serverConnection = connection;
   connection.setTimeout(0);
   assert.notEqual(connection.setKeepAlive, undefined);
+
+  // very low keepalive values should throw an error
+  assert.throws(function() {
+    // minimum keepalive times may vary with the platform
+    // so use something very low
+    connection.setKeepAlive(true, 1);
+  });
+
   // send a keepalive packet after 1000 ms
   connection.setKeepAlive(true, 1000);
   connection.on('end', function() {


### PR DESCRIPTION
socket.setKeepAlive now throws an error if the operation fails.
For example setting the keep alive time too small, or calling
the function on a closed socket.

Fixes #21080
