### PR TITLE
docs: port is optional for socket.bind()

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -156,19 +156,21 @@ a packet might travel, and that generally sending a datagram greater than
 the (receiver) `MTU` won't work (the packet gets silently dropped, without
 informing the source that the data did not reach its intended recipient).
 
-### socket.bind(port[, address][, callback])
+### socket.bind([port][, address][, callback])
 
-* `port` Integer
+* `port` Integer, Optional
 * `address` String, Optional
 * `callback` Function with no parameters, Optional. Callback when
   binding is done.
 
 For UDP sockets, listen for datagrams on a named `port` and optional
-`address`. If `address` is not specified, the OS will try to listen on
-all addresses.  After binding is done, a "listening" event is emitted
-and the `callback`(if specified) is called. Specifying both a
-"listening" event listener and `callback` is not harmful but not very
-useful.
+`address`.
+If `port` is not specified, the OS will try to bind to a random port.
+If `address` is not specified, the OS will try to listen on all addresses.
+After binding is done, a "listening" event is emitted and the `callback`
+(if specified) is called.
+Specifying both a "listening" event listenerand `callback` is not harmful
+but not very useful.
 
 A bound datagram socket keeps the node process running to receive
 datagrams.


### PR DESCRIPTION
Same as #5686,  but I lost that fork, so I'm resubmitting it.
