### PR TITLE
tls: properly handle multi-value RDNs in certificate subject/issuer

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -220,10 +220,10 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
 };
 
 // Example:
-// C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1\nemailAddress=ry@clouds.org
+// C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1 + emailAddress=ry@clouds.org
 exports.parseCertString = function parseCertString(s) {
   var out = {};
-  var parts = s.split('\n');
+  var parts = s.split(/\n| \+ /);
   for (var i = 0, len = parts.length; i < len; i++) {
     var sepIndex = parts[i].indexOf('=');
     if (sepIndex > 0) {


### PR DESCRIPTION
Without this, checkServerIdentity will never succeed if a server
certificate's CN is part of a multi-value RDN.  A multi-value RDN is
sometimes used by CAs in this manner to list an emailAddress, UID,
serialNumber, or other identifier in the DN.
