### PR TITLE
tls: Use OpenSSL default trusted CA list and allow configuration of the trusted CA path

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -77,8 +77,9 @@ dictionary with keys:
   <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT>
   for details on the format.
 
-If no 'ca' details are given, then node.js will use the default
-publicly trusted list of CAs as given in
+If no `ca` is provided, the OpenSSL default trusted CA list will be used.  If
+OpenSSL is not configured with a default trusted CA list, then node.js will use
+a hard-coded list of publicly trusted CAs based on
 <http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>.
 
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -70,6 +70,11 @@ dictionary with keys:
 * `cert` : A string holding the PEM encoded certificate
 * `ca` : Either a string or list of strings of PEM encoded CA
   certificates to trust.
+* `caFile` : A string holding the path to a file containing PEM
+  encoded CA certificates to trust.
+* `caPath` : A string holding the path to a directory containing PEM
+  encoded CA certificates to trust.  This directory must be prepared
+  using the OpenSSL c\_rehash utility.
 * `crl` : Either a string or list of strings of PEM encoded CRLs
   (Certificate Revocation List)
 * `ciphers`: A string describing the ciphers to use or exclude.
@@ -77,9 +82,9 @@ dictionary with keys:
   <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT>
   for details on the format.
 
-If no `ca` is provided, the OpenSSL default trusted CA list will be used.  If
-OpenSSL is not configured with a default trusted CA list, then node.js will use
-a hard-coded list of publicly trusted CAs based on
+If no `ca`, `caFile`, or `caPath` is provided, the OpenSSL default trusted CA
+list will be used.  If OpenSSL is not configured with a default trusted CA list,
+then node.js will use a hard-coded list of publicly trusted CAs based on
 <http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>.
 
 

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -125,8 +125,13 @@ The following options from [tls.connect()][] can also be specified. However, a
 - `key`: Private key to use for SSL. Default `null`.
 - `passphrase`: A string of passphrase for the private key or pfx. Default `null`.
 - `cert`: Public x509 certificate to use. Default `null`.
-- `ca`: An authority certificate or array of authority certificates to check
-  the remote host against.
+- `ca`: A string or array of strings containing PEM encoded CA certificates to
+  check the remote host against.
+- `caFile`: A string containing the path to a file containing PEM encoded CA
+  certificates to check the remote host against.
+- `caPath`: A string containing the path to a directory containing PEM encoded
+  CA certificates to check the remote host against.  This directory must be
+  prepared using the OpenSSL c\_rehash utility.
 - `ciphers`: A string describing the ciphers to use or exclude. Consult
   <http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for
   details on the format.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -247,10 +247,14 @@ automatically set as a listener for the [secureConnection][] event.  The
     PEM format. (Could be an array of certs). (Required)
 
   - `ca`: An array of strings or `Buffer`s of trusted certificates in PEM
-    format.  If this is omitted the OpenSSL default trusted CA list will be
-    used.  If OpenSSL is not configured with a default trusted CA list, then
-    node.js will use a hard-coded list of well known root CAs.  These are used
-    to authorize connections.
+    format.
+
+  - `caFile`: A string containing the path to a file that contains trusted
+    certificates in PEM format.
+
+  - `caPath`: A string containing the path to a directory that contains trusted
+    certificates.  This directory must be prepared using the OpenSSL c\_rehash
+    utility.
 
   - `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate
     Revocation List)
@@ -340,6 +344,12 @@ automatically set as a listener for the [secureConnection][] event.  The
   - `secureOptions`: Set server options. For example, to disable the SSLv3
     protocol set the `SSL_OP_NO_SSLv3` flag. See [SSL_CTX_set_options]
     for all available options.
+
+If no `ca`, `caFile`, or `caPath` is specified, the OpenSSL default trusted CA
+list will be used.  If OpenSSL is not configured with a default trusted CA list,
+then a hard-coded list of publicly trusted CAs based on
+<http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>
+will be used.
 
 Here is a simple example echo server:
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -247,8 +247,10 @@ automatically set as a listener for the [secureConnection][] event.  The
     PEM format. (Could be an array of certs). (Required)
 
   - `ca`: An array of strings or `Buffer`s of trusted certificates in PEM
-    format. If this is omitted several well known "root" CAs will be used,
-    like VeriSign. These are used to authorize connections.
+    format.  If this is omitted the OpenSSL default trusted CA list will be
+    used.  If OpenSSL is not configured with a default trusted CA list, then
+    node.js will use a hard-coded list of well known root CAs.  These are used
+    to authorize connections.
 
   - `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate
     Revocation List)

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -114,7 +114,9 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   // NOTE: It's important to add CA before the cert to be able to load
   // cert's issuer in C++ code.
-  if (options.ca) {
+  if (options.caFile || options.caPath) {
+    c.context.addRootCerts(options.caFile, options.caPath);
+  } else if (options.ca) {
     if (util.isArray(options.ca)) {
       for (var i = 0, len = options.ca.length; i < len; i++) {
         c.context.addCACert(options.ca[i]);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -603,6 +603,8 @@ function Server(/* [options], listener */) {
     passphrase: self.passphrase,
     cert: self.cert,
     ca: self.ca,
+    caFile: self.caFile,
+    caPath: self.caPath,
     ciphers: self.ciphers,
     ecdhCurve: self.ecdhCurve,
     dhparam: self.dhparam,
@@ -719,6 +721,8 @@ Server.prototype.setOptions = function(options) {
   if (options.passphrase) this.passphrase = options.passphrase;
   if (options.cert) this.cert = options.cert;
   if (options.ca) this.ca = options.ca;
+  if (options.caFile) this.caFile = options.caFile;
+  if (options.caPath) this.caPath = options.caPath;
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
   if (options.crl) this.crl = options.crl;
   if (options.ciphers) this.ciphers = options.ciphers;

--- a/lib/https.js
+++ b/lib/https.js
@@ -101,6 +101,14 @@ Agent.prototype.getName = function(options) {
     name += options.ca;
 
   name += ':';
+  if (options.caFile)
+    name += options.caFile;
+
+  name += ':';
+  if (options.caPath)
+    name += options.caPath;
+
+  name += ':';
   if (options.cert)
     name += options.cert;
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -699,6 +699,9 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
 
   assert(sc->ca_store_ == NULL);
 
+  if (SSL_CTX_set_default_verify_paths(sc->ctx_))
+    return;
+
   if (!root_cert_store) {
     root_cert_store = X509_STORE_new();
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -699,6 +699,29 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
 
   assert(sc->ca_store_ == NULL);
 
+  if (args.Length() == 2) {
+    char* caFile = NULL;
+    char* caPath = NULL;
+    if (args[0]->IsString()) {
+      String::Utf8Value file(args[0]);
+      caFile = *file;
+    } else if (!args[0]->IsUndefined() && !args[0]->IsNull()) {
+      return sc->env()->ThrowTypeError("Bad parameter");
+    }
+    if (args[1]->IsString()) {
+      String::Utf8Value path(args[1]);
+      caPath = *path;
+    } else if (!args[1]->IsUndefined() && !args[1]->IsNull()) {
+      return sc->env()->ThrowTypeError("Bad parameter");
+    }
+    if (!SSL_CTX_load_verify_locations(sc->ctx_, caFile, caPath))
+      return sc->env()->ThrowTypeError("Error loading CA certificates from caFile or caPath");
+    return;
+  }
+
+  if (args.Length() != 0)
+    return sc->env()->ThrowTypeError("Bad parameter");
+
   if (SSL_CTX_set_default_verify_paths(sc->ctx_))
     return;
 


### PR DESCRIPTION
Please see the commit messages for additional explanation.  These are actually two separate changes - I would have split this into two separate pull requests except that the changes are adjacent in the source code, and the documentation for the changes is interdependent, so I couldn't split this into two pull requests without causing merge conflicts between them.
