### PR TITLE
win: bring back xp/2k3 support

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -135,8 +135,21 @@
       },
       'VCLinkerTool': {
         'conditions': [
+          ['target_arch=="ia32"', {
+            'TargetMachine' : 1, # /MACHINE:X86
+            'target_conditions': [
+              ['_type=="executable"', {
+                'AdditionalOptions': [ '/SubSystem:Console,"5.01"' ],
+              }],
+            ],
+          }],
           ['target_arch=="x64"', {
-            'TargetMachine' : 17 # /MACHINE:X64
+            'TargetMachine' : 17, # /MACHINE:AMD64
+            'target_conditions': [
+              ['_type=="executable"', {
+                'AdditionalOptions': [ '/SubSystem:Console,"5.02"' ],
+              }],
+            ],
           }],
         ],
         'GenerateDebugInformation': 'true',
@@ -144,11 +157,6 @@
         'DataExecutionPrevention': 2, # enable DEP
         'AllowIsolation': 'true',
         'SuppressStartupBanner': 'true',
-        'target_conditions': [
-          ['_type=="executable"', {
-            'SubSystem': 1, # console executable
-          }],
-        ],
       },
     },
     'msvs_disabled_warnings': [4351, 4355, 4800],

--- a/node.gyp
+++ b/node.gyp
@@ -378,9 +378,6 @@
         }],
       ],
       'msvs_settings': {
-        'VCLinkerTool': {
-          'SubSystem': 1, # /subsystem:console
-        },
         'VCManifestTool': {
           'EmbedManifest': 'true',
           'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'


### PR DESCRIPTION
Issue: https://github.com/joyent/node/issues/25348
The gyp/project files don't explicitly specify a subsystem version,
which results in the default being used. The default differs between
linked versions, and it changed from VS 2010 to VS 2012 and later.

Backport e8d08503c7821e8c92e9fa236ed7328e9bdfe62a from io.js.
Original commit message follows:

Chrome still runs on Windows XP, so there is no reason that iojs
couldn't.

PR: https://github.com/iojs/io.js/pull/512
Reviewed-by: Ben Noordhuis info@bnoordhuis.nl
(cherry picked from commit e8d08503c7821e8c92e9fa236ed7328e9bdfe62a)
