### PR TITLE
docs: Fix default options for fs.createWriteStream()

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -820,7 +820,7 @@ Returns a new WriteStream object (See `Writable Stream`).
 `options` is an object with the following defaults:
 
     { flags: 'w',
-      encoding: null,
+      defaultEncoding: 'utf8',
       fd: null,
       mode: 0666 }
 


### PR DESCRIPTION
The documentation for createWriteStream() references an
'encoding' property that has a default value of null. However,
this property is never referenced by createWriteStream() or
WritableState(). Instead a 'defaultEncoding' property is
referenced in WritableState() with a default of 'utf8' if no value
is supplied.

This fix updates the documentation to rename the 'encoding'
property to 'defaultEncoding' and indicate its default value of
'utf8'.
