### PR TITLE
repl: fix tab completion for a non-global context

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -571,9 +571,7 @@ REPLServer.prototype.complete = function(line, callback) {
       if (!expr) {
         // If context is instance of vm.ScriptContext
         // Get global vars synchronously
-        if (this.useGlobal ||
-            this.context.constructor &&
-            this.context.constructor.name === 'Context') {
+        if (this.useGlobal || vm.isContext(this.context)) {
           var contextProto = this.context;
           while (contextProto = Object.getPrototypeOf(contextProto)) {
             completionGroups.push(Object.getOwnPropertyNames(contextProto));

--- a/test/simple/test-repl-tab-complete.js
+++ b/test/simple/test-repl-tab-complete.js
@@ -211,3 +211,13 @@ testMe.complete(' ', function(error, data) {
 testMe.complete('toSt', function(error, data) {
   assert.deepEqual(data, [['toString'], 'toSt']);
 });
+
+putIn.run(['.clear']);
+
+// make sure tab completion works on context properties
+putIn.run([
+  'var custom = "test";'
+]);
+testMe.complete('cus', function(error, data) {
+  assert.deepEqual(data, [['custom'], 'cus']);
+});


### PR DESCRIPTION
a context is not an instance of 'Context' from v0.11.7
