### PR TITLE
http: fix crash when setting a header value to a non-string with a newline

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -302,7 +302,7 @@ function storeHeader(self, state, field, value) {
   // Protect against response splitting. The if statement is there to
   // minimize the performance impact in the common case.
   if (/[\r\n]/.test(value))
-    value = value.replace(/[\r\n]+[ \t]*/g, '');
+    value = ('' + value).replace(/[\r\n]+[ \t]*/g, '');
 
   state.messageHeader += field + ': ' + value + CRLF;
 

--- a/test/simple/test-http-multi-line-nonstring-header.js
+++ b/test/simple/test-http-multi-line-nonstring-header.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  res.setHeader('Test-Header-String', 'foo\nbar');
+  res.setHeader('Test-Header-Buffer', new Buffer('foo\nbar'));
+  res.end('Test');
+});
+
+var responses_recvd = 0;
+
+server.listen(common.PORT, function() {
+  http.get({
+    port: common.PORT,
+    path: '/hello',
+  }, function(res) {
+    assert.equal(200, res.statusCode);
+    responses_recvd += 1;
+    res.setEncoding('utf8');
+    assert.equal(res.headers['test-header-string'], 'foobar');
+    assert.equal(res.headers['test-header-buffer'], 'foobar');
+    server.close();
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(responses_recvd, 1);
+});


### PR DESCRIPTION
From conversation [here](https://groups.google.com/forum/#!topic/nodejs/S5aV7V_PRqw), it seems storeHeader() happily converts any value to a string, unless the value, when converted to a string, has a newline in it, in which case is crashes.  This should fix that to also convert to a string when stripping newlines.
