### PR TITLE
Fixed Typo in events.js

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -208,7 +208,7 @@ EventEmitter.prototype.once = function once(type, listener) {
   return this;
 };
 
-// emits a 'removeListener' event iff the listener was removed
+// emits a 'removeListener' event if the listener was removed
 EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
   var list, position, length, i;


### PR DESCRIPTION
In lib/events.js there is a typo error in the comments. 
