### PR TITLE
events: fix: shared object references

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -118,6 +118,10 @@ Execute each of the listeners in order with the supplied arguments.
 
 Returns `true` if event had listeners, `false` otherwise.
 
+**Note:** Objects are passed by reference, meaning that the same object can be 
+passed to multiple listeners. If a listener needs to modify a shared object, a 
+copy of the object should be made.
+
 
 ### Class Method: EventEmitter.listenerCount(emitter, event)
 


### PR DESCRIPTION
Fixes the issue: https://github.com/joyent/node/issues/25466

When emitting to multiple listeners for the same event type, the for
loop iteration over these listeners shares the same arguments. This
means (for objects), the copy is only shallow, and changes made by one
listener are overwritten on the object for the next listener.

For example, if we pass an object with arrays: as below

``` js
EventEmitter.emit("event", {
  data: [{
      users: [9237895]
  }]
});
```

And the first listener sets the users array as null like so:

``` js
EventEmitter.on('event', function(packet) {
    var data = packet.data[0];
    data.users = null;
});
```

The second event listener will ALWAYS show the array as null. This is
because only a shallow copy of the arguments is made and not a deep
copy.

This fixes that issue, by enforcing a deep copy and removing all
references from the new arguments array passed to each listener.

Link to code used to reproduce this issue:
https://ghostbin.com/paste/v4ova

Link to issue:
https://github.com/joyent/node/issues/25466
