### PR TITLE
Fix improper sample code in http.markdown

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -557,6 +557,8 @@ Example:
 
     http.get("http://www.google.com/index.html", function(res) {
       console.log("Got response: " + res.statusCode);
+      // consume response body
+      res.resume();
     }).on('error', function(e) {
       console.log("Got error: " + e.message);
     });


### PR DESCRIPTION
You must consume the data from the response object. #8443
This sample code hangs up after consuming http agent's slots.
