### PR TITLE
_http_server.js: fix typo in comment

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -450,7 +450,7 @@ function connectionListener(socket) {
     }
 
     // When we're finished writing the response, check if this is the last
-    // respose, if so destroy the socket.
+    // response, if so destroy the socket.
     res.on('prefinish', resOnFinish);
     function resOnFinish() {
       // Usually the first incoming element should be our request.  it may


### PR DESCRIPTION
Fix misspelling of 'response' on line 453 of _http_server.js

BEFORE:
// When we're finished writing the response, check if this is the last
 // respose, if so destroy the socket.
AFTER:
// When we're finished writing the response, check if this is the last
 // response, if so destroy the socket.

No other changes were made.
