### PR TITLE
cli: add -n and --printf flags

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -414,6 +414,7 @@
   function evalScript(name) {
     var Module = NativeModule.require('module');
     var path = NativeModule.require('path');
+    var util = NativeModule.require('util');
     var cwd = process.cwd();
 
     var module = new Module(name);
@@ -433,6 +434,7 @@
     }
     var result = module._compile(script, name + '-wrapper');
     if (process._print_eval) console.log(result);
+    else if (process._printf_eval) process.stdout.write(util.format(result));
   }
 
   function createWritableStdioStream(fd) {

--- a/test/simple/test-cli-eval.js
+++ b/test/simple/test-cli-eval.js
@@ -66,6 +66,22 @@ child.exec(nodejs + ' --eval "console.error(42)"',
       });
 });
 
+['--printf', '-n -e', '-ne', '-n'].forEach(function(s) {
+  var cmd = nodejs + ' ' + s + ' ';
+
+  child.exec(cmd + '42',
+      function(err, stdout, stderr) {
+        assert.equal(stdout, '42');
+        assert.equal(stderr, '');
+      });
+
+  child.exec(cmd + "'[]'",
+      function(err, stdout, stderr) {
+        assert.equal(stdout, '[]');
+        assert.equal(stderr, '');
+      });
+});
+
 // assert that module loading works
 child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
     function(status, stdout, stderr) {


### PR DESCRIPTION
This fixes issue #16525. It adds `-n` and `--printf` flags to the CLI to evaluate the script and print the result, similar to `-p` and `--print` but without a trailing newline.

This is my first contribution so feedback is welcome.
