### PR TITLE
tty: no readline when TERM==dumb

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -142,7 +142,8 @@
           useGlobal: true,
           ignoreUndefined: false
         };
-        if (parseInt(process.env['NODE_NO_READLINE'], 10)) {
+        if (parseInt(process.env['NODE_NO_READLINE'], 10) ||
+            process.env['TERM'] === 'dumb') {
           opts.terminal = false;
         }
         if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {


### PR DESCRIPTION
To stop the REPL from spitting ANSI control codes on
terminals which don't support them. (Fixes #5344)

This is a rebase and style fix of #5602.
