### PR TITLE
stream_wrap: Fix issue with null file handles

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -224,6 +224,10 @@ void StreamWrap::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
+  if ( NULL == wrap) {
+    args.GetReturnValue().Set(UV_EBADF);
+    return;
+  }
 
   assert(args[0]->IsObject());
   assert(Buffer::HasInstance(args[1]));
@@ -282,6 +286,11 @@ void StreamWrap::WriteStringImpl(const FunctionCallbackInfo<Value>& args) {
   int err;
 
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
+
+  if ( NULL == wrap) {
+    args.GetReturnValue().Set(UV_EBADF);
+    return;
+  }
 
   assert(args[0]->IsObject());
   assert(args[1]->IsString());
@@ -547,6 +556,10 @@ void StreamWrap::SetBlocking(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(env->isolate());
 
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
+  if ( NULL == wrap) {
+    args.GetReturnValue().Set(UV_EBADF);
+    return;
+  }
 
   assert(args.Length() > 0);
   int err = uv_stream_set_blocking(wrap->stream(), args[0]->IsTrue());

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -411,6 +411,14 @@ void StreamWrap::Writev(const FunctionCallbackInfo<Value>& args) {
 
   StreamWrap* wrap = Unwrap<StreamWrap>(args.Holder());
 
+  if ( NULL == wrap) {
+    // wrap is set to NULL when the handle for the request
+    // is closed. Since the handle is no longer valid return
+    // UV_EBADF to indicate this
+    args.GetReturnValue().Set(UV_EBADF);
+    return;
+  }
+
   assert(args[0]->IsObject());
   assert(args[1]->IsArray());
 


### PR DESCRIPTION
Fixes #25365. Essentially, a file I/O request is generated and queued, in a different thread the stream is closed and handle set to null. When a worker thread then tries to execute the request it gets a null handle
