### PR TITLE
fs.watch error message includes filename

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1160,7 +1160,7 @@ function FSWatcher() {
   this._handle.onchange = function(status, event, filename) {
     if (status < 0) {
       self._handle.close();
-      self.emit('error', errnoException(status, 'watch'));
+      self.emit('error', errnoException(status, 'watch ' + filename));
     } else {
       self.emit('change', event, filename);
     }
@@ -1175,7 +1175,7 @@ FSWatcher.prototype.start = function(filename, persistent, recursive) {
                                recursive);
   if (err) {
     this._handle.close();
-    throw errnoException(err, 'watch');
+    throw errnoException(err, 'watch ' + filename);
   }
 };
 

--- a/test/simple/test-fs-watch-error.js
+++ b/test/simple/test-fs-watch-error.js
@@ -1,0 +1,30 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var fs = require('fs');
+
+try {
+  fs.watch('non-existant-file')
+} catch (error) {
+  assert(error);
+  assert(/non-existant-file/.test(error));
+}

--- a/test/simple/test-fs-watch-error.js
+++ b/test/simple/test-fs-watch-error.js
@@ -23,7 +23,7 @@ var assert = require('assert');
 var fs = require('fs');
 
 try {
-  fs.watch('non-existant-file')
+  fs.watch('non-existent-file');
 } catch (error) {
   assert(error);
   assert(/non-existant-file/.test(error));

--- a/test/simple/test-fs-watch-error.js
+++ b/test/simple/test-fs-watch-error.js
@@ -26,5 +26,5 @@ try {
   fs.watch('non-existent-file');
 } catch (error) {
   assert(error);
-  assert(/non-existant-file/.test(error));
+  assert(/non-existent-file/.test(error));
 }


### PR DESCRIPTION
If the file does not exist or if the file is not accessible (throws EACCES, what I actually ran into) the error thrown did not include the filename.
