### PR TITLE
Update README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ endif
 TARBALL=$(TARNAME).tar.gz
 BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)
 BINARYTAR=$(BINARYNAME).tar.gz
+BINARYDOC=$(BINARYNAME)/share/doc/$(TARNAME)
 PKG=out/$(TARNAME).pkg
 PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker
 
@@ -345,9 +346,10 @@ $(BINARYTAR): release-only
 	$(PYTHON) ./configure --prefix=/ --download=all --with-intl=small-icu \
 		--without-snapshot --dest-cpu=$(DESTCPU) --tag=$(TAG) $(CONFIG_FLAGS)
 	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
-	cp README.md $(BINARYNAME)
-	cp LICENSE $(BINARYNAME)
-	cp ChangeLog $(BINARYNAME)
+	mkdir -p $(BINARYDOC)
+	cp README.md $(BINARYDOC)
+	cp LICENSE $(BINARYDOC)
+	cp ChangeLog $(BINARYDOC)
 	tar -cf $(BINARYNAME).tar $(BINARYNAME)
 	rm -rf $(BINARYNAME)
 	gzip -f -9 $(BINARYNAME).tar

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Or system-wide with:
 
 ```sh
 cd /usr/local && tar --strip-components 1 -xzf \
-                    /path/to/node-<version>-<platform>-<arch>.tar.gz
+                    /path/to/node-<version>-<platform>-<arch>.tar.gz \
+                    --exclude='node-*/ChangeLog' \
+                    --exclude='node-*/LICENSE' \
+                    --exclude='node-*/README.md'
 ```
 
 ### To run the tests:

--- a/README.md
+++ b/README.md
@@ -53,11 +53,8 @@ tar xzf /path/to/node-<version>-<platform>-<arch>.tar.gz
 Or system-wide with:
 
 ```sh
-cd /usr/local && tar --strip-components 1 -xzf \
-                    /path/to/node-<version>-<platform>-<arch>.tar.gz \
-                    --exclude='node-*/ChangeLog' \
-                    --exclude='node-*/LICENSE' \
-                    --exclude='node-*/README.md'
+tar -xzC /usr/local --strip-components 1 \
+                    -f /path/to/node-<version>-<platform>-<arch>.tar.gz
 ```
 
 ### To run the tests:


### PR DESCRIPTION
Edited linux system wide instructions to avoid installing the doc files inside /usr/local when extracting the binary tarball.
