### PR TITLE
Update child_process.markdown, fix VIP example

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -308,9 +308,10 @@ socket to a "special" child process. Other sockets will go to a "normal" process
       if (socket.remoteAddress === '74.125.127.100') {
         special.send('socket', socket);
         return;
-      }
+      } else {
       // just the usual dudes
-      normal.send('socket', socket);
+        normal.send('socket', socket);
+      }
     });
     server.listen(1337);
 


### PR DESCRIPTION
The original logic would have sent the socket to both child processes instead of just one. By adding the else statement, it should now only send to one child process.
