### PR TITLE
v8: back-port JitCodeEvent patch from upstream

### DIFF
--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -1485,7 +1485,11 @@ void Logger::LogCodeObject(Object* object) {
         tag = Logger::STUB_TAG;
         break;
       case Code::BUILTIN:
-        description = "A builtin from the snapshot";
+        description =
+            Isolate::Current()->builtins()->Lookup(code_object->entry());
+        if (description == NULL) {
+          description = "A builtin from the snapshot";
+        }
         tag = Logger::BUILTIN_TAG;
         break;
       case Code::KEYED_LOAD_IC:

--- a/src/node.cc
+++ b/src/node.cc
@@ -1427,7 +1427,7 @@ static Handle<Value> Umask(const Arguments& args) {
       node::Utf8Value str(args[0]);
 
       // Parse the octal string.
-      for (int i = 0; i < str.length(); i++) {
+      for (size_t i = 0; i < str.length(); i++) {
         char c = (*str)[i];
         if (c > '7' || c < '0') {
           return ThrowException(Exception::TypeError(


### PR DESCRIPTION
Original commit log follows:

```
Meaningful name for builtins in JitCodeEvent API.

Report builtins by name (e.g. "Builtin:ArgumentsAdaptorTrampoline")
instead of labeling everything "Builtin:A builtin from the snapshot"

Review URL: https://codereview.chromium.org/1216833002
```

R=@sam-github?
