### PR TITLE
v8: cherry-pick JitCodeEvent patch from upstream

### DIFF
--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -1648,7 +1648,7 @@ void Logger::LogCodeObject(Object* object) {
       tag = Logger::REG_EXP_TAG;
       break;
     case Code::BUILTIN:
-      description = "A builtin from the snapshot";
+      description = isolate_->builtins()->name(code_object->builtin_index());
       tag = Logger::BUILTIN_TAG;
       break;
     case Code::HANDLER:


### PR DESCRIPTION
Original commit log follows:

```
Meaningful name for builtins in JitCodeEvent API.

Report builtins by name (e.g. "Builtin:ArgumentsAdaptorTrampoline")
instead of labeling everything "Builtin:A builtin from the snapshot"

Review URL: https://codereview.chromium.org/1216833002
```

R=@sam-github?
