### PR TITLE
win,msi: change InstallScope to perMachine

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -18,7 +18,7 @@
            Manufacturer="$(var.ProductAuthor)"
            UpgradeCode="1d60944c-b9ce-4a71-a7c0-0384eb884baa">
 
-    <Package InstallerVersion="200" Compressed="yes"/>
+    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine"/>
 
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -31,6 +31,11 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"/>
 
     <Property Id="INSTALLDIR">
+      <RegistrySearch Id="InstallPathRegistryLM"
+                      Type="raw"
+                      Root="HKLM"
+                      Key="$(var.RegistryKeyPath)"
+                      Name="InstallPath"/>
       <RegistrySearch Id="InstallPathRegistry"
                       Type="raw"
                       Root="HKCU"
@@ -44,8 +49,9 @@
              Description="Install the core Node.js runtime (node.exe)."
              Absent="disallow">
       <ComponentRef Id="NodeExecutable"/>
+      <ComponentRef Id="NodeRegistryEntries"/>
       <ComponentRef Id="NodeVarsScript"/>
-      <ComponentRef Id="NodeStartMenuAndRegistryEntries"/>
+      <ComponentRef Id="NodeStartMenu"/>
       <ComponentGroupRef Id="Product.Generated"/>
 
       <Feature Id="NodePerfCtrSupport"
@@ -115,6 +121,20 @@
         <File Id="node.exe" KeyPath="yes" Source="$(var.SourceDir)\node.exe"/>
       </Component>
 
+      <Component Id="NodeRegistryEntries">
+        <RegistryValue Root="HKLM"
+                       Key="$(var.RegistryKeyPath)"
+                       Name="InstallPath"
+                       Type="string"
+                       Value="[INSTALLDIR]"
+                       KeyPath="yes"/>
+        <RegistryValue Root="HKLM"
+                       Key="$(var.RegistryKeyPath)"
+                       Name="Version"
+                       Type="string"
+                       Value="$(var.ProductVersion)"/>
+      </Component>
+
       <Component Id="NodeVarsScript">
         <File Id="nodevars.bat" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\nodevars.bat"/>
       </Component>
@@ -137,18 +157,13 @@
     </DirectoryRef>
 
     <DirectoryRef Id="ApplicationProgramsFolder">
-      <Component Id="NodeStartMenuAndRegistryEntries">
+      <Component Id="NodeStartMenu">
         <RegistryValue Root="HKCU"
-                       Key="$(var.RegistryKeyPath)"
-                       Name="InstallPath"
-                       Type="string"
-                       Value="[INSTALLDIR]"
+                       Key="$(var.RegistryKeyPath)\Components"
+                       Name="NodeStartMenuShortcuts"
+                       Type="integer"
+                       Value="1"
                        KeyPath="yes"/>
-        <RegistryValue Root="HKCU"
-                       Key="$(var.RegistryKeyPath)"
-                       Name="Version"
-                       Type="string"
-                       Value="$(var.ProductVersion)"/>
         <Shortcut Id="NodeVarsScriptShortcut"
                   Name="Node.js command prompt"
                   Target="[%ComSpec]"


### PR DESCRIPTION
Currently, installing with the MSI always asks for Administrator permissions, as mentioned in #7629 . Explicitly installing per machine only adds the benefit that shortcuts are placed in ProgramData thus being accessible to all users and also solving #5849 .

The second commit moves the installation path in the registry to Local Machine. The registry stores HKLM in different places for 32 and 64 bit applications, so the installer will not suggest the old path when upgrading from 32 to 64 bit version, solving #5592 and #25087 .
