### PR TITLE
buffer: add method readBits for reading slices of a byte

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -509,6 +509,21 @@ function checkOffset(offset, ext, length) {
 }
 
 
+Buffer.prototype.readBits = function(position, offset, bitLength, noAssert) {
+  position = position >>> 0;
+  offset = offset >>> 0;
+  bitLength = bitLength >>> 0;
+  if (!noAssert) {
+    if (position < 0 || position >= this.length)
+      throw new RangeError('index out of range');
+    if (bitLength > 8)
+      throw new RangeError('bit length out of range');
+  }
+
+  return (this[position] >> offset) & ((1 << bitLength) - 1);
+};
+
+
 Buffer.prototype.readUIntLE = function(offset, byteLength, noAssert) {
   offset = offset >>> 0;
   byteLength = byteLength >>> 0;

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -1187,3 +1187,7 @@ assert.throws(function() {
 
 // Regression test for https://github.com/iojs/io.js/issues/649.
 assert.throws(function() { Buffer(1422561062959).toString('utf8'); });
+
+var b = new Buffer(1).fill(1);
+assert.equal(b.readBits(0, 0, 4), 1);
+assert.equal(b.readBits(0, 4, 4), 0);


### PR DESCRIPTION
# Overview

The readBits method allows for reading bits that might be inside of a byte,
most commonly, a nibble.  Bits are fairly common in the hardware world and
often times a byte can be segmented multiple times.  readBits allows you to
read the byte and deem valuable information from it.  Generally this will
only be in the form of an integer value.
## Usage

Say I have a buffer, where in position 12, there is a nibble.  The first part of the nibble is 9 and the second part is 0.

```
var buffer = new Buffer('0000000000000000000000000900', 'hex');
buffer.readBits(12, 0, 4); // 9
buffer.readBits(12, 4, 8); // 0
```

The reason for this, is because it is drastically easier than writing and wiring the following on top of the buffer, which can lead to errors and becomes far more difficult from a readability point of view.

```
var buffer = new Buffer('0000000000000000000000000900', 'hex');
(buffer[12] >> 0) & ((1 << 4) - 1); // 9
(buffer[12] >> 4) & ((1 << 4) - 1); // 0
```
