### PR TITLE
Fix keepAlive/maxSockets #9074

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -86,7 +86,7 @@ function Agent(options) {
         if (self.sockets[name])
           count += self.sockets[name].length;
 
-        if (count >= self.maxSockets || freeLen >= self.maxFreeSockets) {
+        if (count > self.maxSockets || freeLen >= self.maxFreeSockets) {
           self.removeSocket(socket, options);
           socket.destroy();
         } else {


### PR DESCRIPTION
Total number of sockets (used + free) must be less than or equal to maxSockets parameters. So the "count" variable must be greater than maxSockets, and not greater than or equal to maxSockets.
