### PR TITLE
Deprecate RC4 ciphers from the default ciphers list

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -135,20 +135,20 @@ absolutely necessary.
 
 It is possible for the built-in default cipher suite to change from one release
 of Node.js to another. For instance, v0.10.39 uses a different default than
-v0.10.38. Such changes can cause issues with applications written to assume
+v0.10.40. Such changes can cause issues with applications written to assume
 certain specific defaults. To help buffer applications against such changes,
 the `--enable-legacy-cipher-list` command line switch or `NODE_LEGACY_CIPHER_LIST`
 environment variable can be set to specify a specific preset default:
 
-    # Use the v0.10.38 defaults
-    node --enable-legacy-cipher-list=v0.10.38
+    # Use the v0.10.40 defaults
+    node --enable-legacy-cipher-list=v0.10.40
     // or
-    NODE_LEGACY_CIPHER_LIST=v0.10.38
+    NODE_LEGACY_CIPHER_LIST=v0.10.40
 
 Currently, the values supported for the `enable-legacy-cipher-list` switch and
 `NODE_LEGACY_CIPHER_LIST` environment variable include:
 
-    v0.10.38 - To enable the default cipher suite used in v0.10.38
+    v0.10.40 - To enable the default cipher suite used in v0.10.40
 
       ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH
 
@@ -156,7 +156,7 @@ These legacy cipher suites are also made available for use via the
 `getLegacyCiphers()` method:
 
     var tls = require('tls');
-    console.log(tls.getLegacyCiphers('v0.10.38'));
+    console.log(tls.getLegacyCiphers('v0.10.40'));
 
 CAUTION: Changes to the default cipher suite are typically made in order to
 strengthen the default security for applications running within Node.js.
@@ -164,12 +164,12 @@ Reverting back to the defaults used by older releases can weaken the security
 of your applications. The legacy cipher suites should only be used if absolutely
 necessary.
 
-NOTE: Due to an error in Node.js v0.10.38, the default cipher list only applied
+NOTE: Due to an error in Node.js v0.10.40, the default cipher list only applied
 to servers using TLS. The default cipher list would _not_ be used by clients.
 This behavior has been changed in v0.10.39 and the default cipher list is now
 used by both the server and client when using TLS. However, when using
-`--enable-legacy-cipher-list=v0.10.38`, Node.js is reverted back to the
-v0.10.38 behavior of only using the default cipher list on the server.
+`--enable-legacy-cipher-list=v0.10.40`, Node.js is reverted back to the
+v0.10.40 behavior of only using the default cipher list on the server.
 
 ### Cipher List Precedence
 
@@ -184,11 +184,11 @@ will override the environment variables. If both happen to be specified, the
 right-most (second one specified) will take precedence. For instance, in the
 example:
 
-    node --cipher-list=ABC --enable-legacy-cipher-list=v0.10.38
+    node --cipher-list=ABC --enable-legacy-cipher-list=v0.10.40
 
-The v0.10.38 default cipher list will be used.
+The v0.10.40 default cipher list will be used.
 
-    node --enable-legacy-cipher-list=v0.10.38 --cipher-list=ABC
+    node --enable-legacy-cipher-list=v0.10.40 --cipher-list=ABC
 
 The custom cipher list will be used.
 
@@ -206,7 +206,7 @@ Example:
 
 Returns a default cipher list used in a previous version of Node.js. The
 version parameter must be a string whose value identifies previous Node.js
-release version. The only value currently supported is `v0.10.38`.
+release version. The only value currently supported is `v0.10.40`.
 
 A TypeError will be thrown if: (a) the `version` is any type other than a
 string, (b) the `version` parameter is not specified, or (c) additional

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -109,6 +109,60 @@ handshake extensions allowing you:
   * SNI - to use one TLS server for multiple hostnames with different SSL
     certificates.
 
+## Modifying the Default Cipher Suite
+
+Node.js is built with a default suite of enabled and disabled ciphers.
+Currently, the default cipher suite is:
+
+    ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH
+
+This default can be overridden entirely using the `--cipher-list` command line
+switch or `NODE_CIPHER_LIST` environment variable. For instance:
+
+    node --cipher-list=ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384
+
+Setting the environment variable would have the same effect:
+
+    NODE_CIPHER_LIST=ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384
+
+CAUTION: The default cipher suite has been carefully selected to reflect current
+security best practices and risk mitigation. Changing the default cipher suite
+can have a significant impact on the security of an application. The
+`--cipher-list` and `NODE_CIPHER_LIST` options should only be used if
+absolutely necessary.
+
+### Using Legacy Default Cipher Suite ###
+
+It is possible for the built-in default cipher suite to change from one release
+of Node.js to another. For instance, v0.10.39 uses a different default than
+v0.10.38. Such changes can cause issues with applications written to assume
+certain specific defaults. To help buffer applications against such changes,
+the `--enable-legacy-cipher-list` command line switch or `NODE_LEGACY_CIPHER_LIST`
+environment variable can be set to specify a specific preset default:
+
+    # Use the v0.10.38 defaults
+    node --enable-legacy-cipher-list=v0.10.38
+    // or
+    NODE_LEGACY_CIPHER_LIST=v0.10.38
+
+Currently, the values supported for the `enable-legacy-cipher-list` switch and
+`NODE_LEGACY_CIPHER_LIST` environment variable include:
+
+    v0.10.38 - To enable the default cipher suite used in v0.10.38
+
+      ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH
+
+These legacy cipher suites are also made available for use via the
+`getLegacyCiphers()` method:
+
+    var tls = require('tls');
+    console.log(tls.getLegacyCiphers('v0.10.38'));
+
+CAUTION: Changes to the default cipher suite are typically made in order to
+strengthen the default security for applications running within Node.js.
+Reverting back to the defaults used by older releases can weaken the security
+of your applications. The legacy cipher suites should only be used if absolutely
+necessary.
 
 ## tls.getCiphers()
 
@@ -151,13 +205,13 @@ automatically set as a listener for the [secureConnection][] event.  The
     conjunction with the `honorCipherOrder` option described below to
     prioritize the non-CBC cipher.
 
-    Defaults to `AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH`.
+    Defaults to `ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH`.
     Consult the [OpenSSL cipher list format documentation] for details on the
     format. ECDH (Elliptic Curve Diffie-Hellman) ciphers are not yet supported.
 
 
     `AES128-GCM-SHA256` is used when node.js is linked against OpenSSL 1.0.1
-    or newer and the client speaks TLS 1.2, RC4 is used as a secure fallback.
+    or newer and the client speaks TLS 1.2.
 
     **NOTE**: Previous revisions of this section suggested `AES256-SHA` as an
     acceptable cipher. Unfortunately, `AES256-SHA` is a CBC cipher and therefore
@@ -333,7 +387,7 @@ Here is an example of a client of echo server as described previously:
       // These are necessary only if using the client certificate authentication
       key: fs.readFileSync('client-key.pem'),
       cert: fs.readFileSync('client-cert.pem'),
-    
+
       // This is necessary only if the server uses the self-signed certificate
       ca: [ fs.readFileSync('server-cert.pem') ]
     };
@@ -525,7 +579,7 @@ A ClearTextStream is the `clear` member of a SecurePair object.
 
 ### Event: 'secureConnect'
 
-This event is emitted after a new connection has been successfully handshaked. 
+This event is emitted after a new connection has been successfully handshaked.
 The listener will be called no matter if the server's certificate was
 authorized or not. It is up to the user to test `cleartextStream.authorized`
 to see if the server certificate was signed by one of the specified CAs.
@@ -550,14 +604,14 @@ some properties corresponding to the field of the certificate.
 
 Example:
 
-    { subject: 
+    { subject:
        { C: 'UK',
          ST: 'Acknack Ltd',
          L: 'Rhys Jones',
          O: 'node.js',
          OU: 'Test TLS Certificate',
          CN: 'localhost' },
-      issuer: 
+      issuer:
        { C: 'UK',
          ST: 'Acknack Ltd',
          L: 'Rhys Jones',

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -174,8 +174,7 @@ v0.10.38 behavior of only using the default cipher list on the server.
 ### Cipher List Precedence
 
 Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
-`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive. Only
-_one_ should be used at a time.
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive.
 
 If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
 are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -164,6 +164,35 @@ Reverting back to the defaults used by older releases can weaken the security
 of your applications. The legacy cipher suites should only be used if absolutely
 necessary.
 
+NOTE: Due to an error in Node.js v0.10.38, the default cipher list only applied
+to servers using TLS. The default cipher list would _not_ be used by clients.
+This behavior has been changed in v0.10.39 and the default cipher list is now
+used by both the server and client when using TLS. However, when using
+`--enable-legacy-cipher-list=v0.10.38`, Node.js is reverted back to the
+v0.10.38 behavior of only using the default cipher list on the server.
+
+### Cipher List Precedence
+
+Note that the `--enable-legacy-cipher-list`, `NODE_LEGACY_CIPHER_LIST`,
+`--cipher-list` and `NODE_CIPHER_LIST` options are mutually exclusive. Only
+_one_ should be used at a time.
+
+If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
+are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
+
+The `--cipher-list` and `--enable-legacy-cipher-list` command line options
+will override the environment variables. If both happened to be specified, the
+right-most (second one specified) will take precedence. For instance, in the
+example:
+
+    node --cipher-list=ABC --enable-legacy-cipher-list=v0.10.38
+
+The v0.10.38 default cipher list will be used.
+
+    node --enable-legacy-cipher-list=v0.10.38 --cipher-list=ABC
+
+The custom cipher list will be used.
+
 ## tls.getCiphers()
 
 Returns an array with the names of the supported SSL ciphers.
@@ -173,6 +202,18 @@ Example:
     var ciphers = tls.getCiphers();
     console.log(ciphers); // ['AES128-SHA', 'AES256-SHA', ...]
 
+
+## tls.getLegacyCiphers(version)
+
+Returns a default cipher list used in a previous version of Node.js. The
+version parameter must be a string whose value identifies previous Node.js
+release version. The only value currently supported is `v0.10.38`.
+
+A TypeError will be thrown if: (a) the `version` is any type other than a
+string, (b) the `version` parameter is not specified, or (c) additional
+parameters are passed in. An Error will be thrown if the `version` parameter is
+passed in as a string but the value does not correlate to any known Node.js
+release for which a default cipher list is available.
 
 ## tls.createServer(options, [secureConnectionListener])
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -181,7 +181,7 @@ If the `NODE_CIPHER_LIST` and `NODE_LEGACY_CIPHER_LIST` environment variables
 are both specified, the `NODE_LEGACY_CIPHER_LIST` setting will take precedence.
 
 The `--cipher-list` and `--enable-legacy-cipher-list` command line options
-will override the environment variables. If both happened to be specified, the
+will override the environment variables. If both happen to be specified, the
 right-most (second one specified) will take precedence. For instance, in the
 example:
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -134,7 +134,11 @@ exports.createCredentials = function(options, context) {
 
   if (options.cert) c.context.setCert(options.cert);
 
-  if (options.ciphers) c.context.setCiphers(options.ciphers);
+  if (options.ciphers) {
+    c.context.setCiphers(options.ciphers);
+  } else {
+    c.context.setCiphers(binding.DEFAULT_CIPHER_LIST);
+  }
 
   if (options.ca) {
     if (Array.isArray(options.ca)) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -135,9 +135,9 @@ exports.createCredentials = function(options, context) {
 
   if (options.ciphers) {
     c.context.setCiphers(options.ciphers);
-  } else if (!(process._usingV1038Ciphers() && options.ciphers === undefined)) {
+  } else if (!(process._usingV1040Ciphers() && options.ciphers === undefined)) {
     // Set the ciphers to the default ciphers list unless
-    // --enable-legacy-cipher-list=v0.10.38 was passed on the command line and
+    // --enable-legacy-cipher-list=v0.10.40 was passed on the command line and
     // no ciphers value was passed explicitly. In that case, we want to
     // preserve the previous buggy behavior that existed in v0.10.x until
     // v0.10.39, otherwise, a lot of client code might be broken. Server

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -41,6 +41,7 @@ var constants = process.binding('constants');
 
 var stream = require('stream');
 var util = require('util');
+var tls = require('tls');
 
 // This is here because many functions accepted binary strings without
 // any explicit encoding in older versions of node, and we don't want
@@ -114,7 +115,6 @@ function Credentials(secureProtocol, flags, context) {
 
 exports.Credentials = Credentials;
 
-
 exports.createCredentials = function(options, context) {
   if (!options) options = {};
 
@@ -136,7 +136,14 @@ exports.createCredentials = function(options, context) {
 
   if (options.ciphers) {
     c.context.setCiphers(options.ciphers);
-  } else {
+  } else if (!(tls.usingV1038Ciphers() && options.ciphers === undefined)) {
+    // Set the ciphers to the default ciphers list unless
+    // --enable-legacy-cipher-list=v0.10.38 was passed on the command line and
+    // no ciphers value was passed explicitly. In that case, we want to
+    // preserve the previous buggy behavior that existed in v0.10.x until
+    // v0.10.39, otherwise, a lot of client code might be broken. Server
+    // side TLS/HTTPS code always sets a default cipher list explicitly so it
+    // never reaches this, even for versions < v0.10.39.
     c.context.setCiphers(binding.DEFAULT_CIPHER_LIST);
   }
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -41,7 +41,6 @@ var constants = process.binding('constants');
 
 var stream = require('stream');
 var util = require('util');
-var tls = require('tls');
 
 // This is here because many functions accepted binary strings without
 // any explicit encoding in older versions of node, and we don't want
@@ -136,7 +135,7 @@ exports.createCredentials = function(options, context) {
 
   if (options.ciphers) {
     c.context.setCiphers(options.ciphers);
-  } else if (!(tls.usingV1038Ciphers() && options.ciphers === undefined)) {
+  } else if (!(process._usingV1038Ciphers() && options.ciphers === undefined)) {
     // Set the ciphers to the default ciphers list unless
     // --enable-legacy-cipher-list=v0.10.38 was passed on the command line and
     // no ciphers value was passed explicitly. In that case, we want to

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1330,6 +1330,20 @@ function normalizeConnectArgs(listArgs) {
   return (cb) ? [options, cb] : [options];
 }
 
+// return true if the --enable-legacy-cipher-list command line
+// switch, or the NODE_LEGACY_CIPHER_LIST environment variable
+// are set to v0.10.38 and the DEFAULT_CIPHERS equal the v0.10.38
+// list.
+function usingV1038Ciphers() {
+  var argv = process.execArgv;
+  if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
+       process.env['NODE_LEGACY_CIPHER_LIST'] === 'v0.10.38') &&
+      DEFAULT_CIPHERS === _crypto.getLegacyCiphers('v0.10.38')) {
+        return true;
+  }
+  return false;
+}
+
 exports.connect = function(/* [port, host], options, cb */) {
   var args = normalizeConnectArgs(arguments);
   var options = args[0];
@@ -1338,7 +1352,8 @@ exports.connect = function(/* [port, host], options, cb */) {
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
-  if (DEFAULT_CIPHERS != _crypto.getLegacyCiphers('v0.10.38')) {
+  if (!usingV1038Ciphers()) {
+    // only set the default ciphers
     defaults.ciphers = DEFAULT_CIPHERS;
   }
   options = util._extend(defaults, options || {});

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1330,21 +1330,6 @@ function normalizeConnectArgs(listArgs) {
   return (cb) ? [options, cb] : [options];
 }
 
-// Returns true if the --enable-legacy-cipher-list command line
-// switch, or the NODE_LEGACY_CIPHER_LIST environment variable
-// are set to v0.10.38 and the DEFAULT_CIPHERS equal the v0.10.38
-// list.
-function usingV1038Ciphers() {
-  var argv = process.execArgv;
-  if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
-       process.env['NODE_LEGACY_CIPHER_LIST'] === 'v0.10.38') &&
-      DEFAULT_CIPHERS === _crypto.getLegacyCiphers('v0.10.38')) {
-        return true;
-  }
-  return false;
-}
-exports.usingV1038Ciphers = usingV1038Ciphers;
-
 exports.connect = function(/* [port, host], options, cb */) {
   var args = normalizeConnectArgs(arguments);
   var options = args[0];
@@ -1353,7 +1338,7 @@ exports.connect = function(/* [port, host], options, cb */) {
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
-  if (!usingV1038Ciphers()) {
+  if (!process._usingV1038Ciphers()) {
     // only set the default ciphers if we are _not_ using the
     // v0.10.38 legacy cipher list. Node v0.10.38 had a bug
     // that failed to set the default ciphers on the default

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1353,7 +1353,13 @@ exports.connect = function(/* [port, host], options, cb */) {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
   if (!usingV1038Ciphers()) {
-    // only set the default ciphers
+    // only set the default ciphers if we are _not_ using the
+    // v0.10.38 legacy cipher list. Node v0.10.38 had a bug
+    // that failed to set the default ciphers on the default
+    // options. This has been fixed in v0.10.39 and above.
+    // However, when the user explicitly tells node to revert
+    // back to using the v0.10.38 cipher list, node should
+    // revert back to the original v0.10.38 behavior.
     defaults.ciphers = DEFAULT_CIPHERS;
   }
   options = util._extend(defaults, options || {});

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1330,7 +1330,7 @@ function normalizeConnectArgs(listArgs) {
   return (cb) ? [options, cb] : [options];
 }
 
-// return true if the --enable-legacy-cipher-list command line
+// Returns true if the --enable-legacy-cipher-list command line
 // switch, or the NODE_LEGACY_CIPHER_LIST environment variable
 // are set to v0.10.38 and the DEFAULT_CIPHERS equal the v0.10.38
 // list.
@@ -1343,6 +1343,7 @@ function usingV1038Ciphers() {
   }
   return false;
 }
+exports.usingV1038Ciphers = usingV1038Ciphers;
 
 exports.connect = function(/* [port, host], options, cb */) {
   var args = normalizeConnectArgs(arguments);

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var _crypto = process.binding('crypto');
+
 var crypto = require('crypto');
 var util = require('util');
 var net = require('net');
@@ -31,8 +33,9 @@ var constants = require('constants');
 
 var Timer = process.binding('timer_wrap').Timer;
 
-var DEFAULT_CIPHERS = 'ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:' + // TLS 1.2
-                      'RC4:HIGH:!MD5:!aNULL:!EDH';                   // TLS 1.0
+var DEFAULT_CIPHERS = _crypto.DEFAULT_CIPHER_LIST;
+
+exports.getLegacyCiphers = _crypto.getLegacyCiphers;
 
 // Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
 // every {CLIENT_RENEG_WINDOW} seconds. An error event is emitted if more
@@ -44,7 +47,7 @@ exports.CLIENT_RENEG_WINDOW = 600;
 exports.SLAB_BUFFER_SIZE = 10 * 1024 * 1024;
 
 exports.getCiphers = function() {
-  var names = process.binding('crypto').getSSLCiphers();
+  var names = _crypto.getSSLCiphers();
   // Drop all-caps names in favor of their lowercase aliases,
   var ctx = {};
   names.forEach(function(name) {
@@ -65,7 +68,7 @@ if (process.env.NODE_DEBUG && /tls/.test(process.env.NODE_DEBUG)) {
 
 var Connection = null;
 try {
-  Connection = process.binding('crypto').Connection;
+  Connection = _crypto.Connection;
 } catch (e) {
   throw new Error('node.js not compiled with openssl crypto support.');
 }
@@ -1335,6 +1338,9 @@ exports.connect = function(/* [port, host], options, cb */) {
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
+  if (DEFAULT_CIPHERS != _crypto.getLegacyCiphers('v0.10.38')) {
+    defaults.ciphers = DEFAULT_CIPHERS;
+  }
   options = util._extend(defaults, options || {});
 
   options.secureOptions = crypto._getSecureOptions(options.secureProtocol,

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1338,14 +1338,14 @@ exports.connect = function(/* [port, host], options, cb */) {
   var defaults = {
     rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED
   };
-  if (!process._usingV1038Ciphers()) {
+  if (!process._usingV1040Ciphers()) {
     // only set the default ciphers if we are _not_ using the
-    // v0.10.38 legacy cipher list. Node v0.10.38 had a bug
+    // v0.10.40 legacy cipher list. Node v0.10.40 had a bug
     // that failed to set the default ciphers on the default
     // options. This has been fixed in v0.10.39 and above.
     // However, when the user explicitly tells node to revert
-    // back to using the v0.10.38 cipher list, node should
-    // revert back to the original v0.10.38 behavior.
+    // back to using the v0.10.40 cipher list, node should
+    // revert back to the original v0.10.40 behavior.
     defaults.ciphers = DEFAULT_CIPHERS;
   }
   options = util._extend(defaults, options || {});

--- a/src/node.cc
+++ b/src/node.cc
@@ -2567,7 +2567,7 @@ static void PrintHelp() {
          "  --enable-ssl2        enable ssl2\n"
          "  --enable-ssl3        enable ssl3\n"
          "  --cipher-list=val    specify the default TLS cipher list\n"
-         "  --enable-legacy-cipher-list=v0.10.38 \n"
+         "  --enable-legacy-cipher-list=v0.10.40 \n"
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2580,7 +2580,7 @@ static void PrintHelp() {
          "                       global contexts.\n"
          "NODE_DISABLE_COLORS    Set to 1 to disable colors in the REPL\n"
          "NODE_CIPHER_LIST       Override the default TLS cipher list\n"
-         "NODE_LEGACY_CIPHER_LIST=v0.10.38\n"
+         "NODE_LEGACY_CIPHER_LIST=v0.10.40\n"
          "\n"
          "Documentation can be found at http://nodejs.org/\n");
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -2567,8 +2567,7 @@ static void PrintHelp() {
          "  --enable-ssl2        enable ssl2\n"
          "  --enable-ssl3        enable ssl3\n"
          "  --cipher-list=val    specify the default TLS cipher list\n"
-         "  --enable-legacy-cipher-list=val \n"
-         "                       set to v0.10.38 to use the v0.10.38 list\n"
+         "  --enable-legacy-cipher-list=v0.10.38 \n"
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2581,8 +2580,7 @@ static void PrintHelp() {
          "                       global contexts.\n"
          "NODE_DISABLE_COLORS    Set to 1 to disable colors in the REPL\n"
          "NODE_CIPHER_LIST       Override the default TLS cipher list\n"
-         "NODE_LEGACY_CIPHER_LIST\n"
-         "                       Set to v0.10.38 to use the v0.10.38 list\n"
+         "NODE_LEGACY_CIPHER_LIST=v0.10.38\n"
          "\n"
          "Documentation can be found at http://nodejs.org/\n");
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -2588,8 +2588,6 @@ static void PrintHelp() {
 // Parse node command line arguments.
 static void ParseArgs(int argc, char **argv) {
   int i;
-  int cipher_list_options = 0;
-  bool using_cipher_list_option = false;
 
   // TODO use parse opts
   for (i = 1; i < argc; i++) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2662,7 +2662,7 @@ static void ParseArgs(int argc, char **argv) {
       DEFAULT_CIPHER_LIST = arg + 14;
       argv[i] = const_cast<char*>("");
     } else if (strncmp(arg, "--enable-legacy-cipher-list=", 28) == 0) {
-      const char * legacy_list = legacy_cipher_list(arg+28);
+      const char * legacy_list = crypto::LegacyCipherList(arg+28);
       if (legacy_list != NULL) {
         DEFAULT_CIPHER_LIST = legacy_list;
       } else {
@@ -2957,7 +2957,7 @@ char** Init(int argc, char *argv[]) {
   const char * leg_cipher_id = getenv("NODE_LEGACY_CIPHER_LIST");
   if (leg_cipher_id != NULL) {
     const char * leg_cipher_list =
-      legacy_cipher_list(leg_cipher_id);
+      crypto::LegacyCipherList(leg_cipher_id);
     if (leg_cipher_list != NULL) {
       DEFAULT_CIPHER_LIST = leg_cipher_list;
     } else {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2566,6 +2566,9 @@ static void PrintHelp() {
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
          "  --enable-ssl2        enable ssl2\n"
          "  --enable-ssl3        enable ssl3\n"
+         "  --cipher-list=val    specify the default TLS cipher list\n"
+         "  --enable-legacy-cipher-list=val \n"
+         "                       set to v0.10.38 to use the v0.10.38 list\n"
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2577,6 +2580,9 @@ static void PrintHelp() {
          "NODE_MODULE_CONTEXTS   Set to 1 to load modules in their own\n"
          "                       global contexts.\n"
          "NODE_DISABLE_COLORS    Set to 1 to disable colors in the REPL\n"
+         "NODE_CIPHER_LIST       Override the default TLS cipher list\n"
+         "NODE_LEGACY_CIPHER_LIST\n"
+         "                       Set to v0.10.38 to use the v0.10.38 list\n"
          "\n"
          "Documentation can be found at http://nodejs.org/\n");
 }
@@ -2584,6 +2590,7 @@ static void PrintHelp() {
 // Parse node command line arguments.
 static void ParseArgs(int argc, char **argv) {
   int i;
+  bool using_legacy_cipher_list = false;
 
   // TODO use parse opts
   for (i = 1; i < argc; i++) {
@@ -2652,6 +2659,21 @@ static void ParseArgs(int argc, char **argv) {
     } else if (strcmp(arg, "--throw-deprecation") == 0) {
       argv[i] = const_cast<char*>("");
       throw_deprecation = true;
+    } else if (strncmp(arg, "--cipher-list=", 14) == 0) {
+      if (!using_legacy_cipher_list) {
+        DEFAULT_CIPHER_LIST = arg + 14;
+      }
+      argv[i] = const_cast<char*>("");
+    } else if (strncmp(arg, "--enable-legacy-cipher-list=", 28) == 0) {
+      const char * legacy_list = legacy_cipher_list(arg+28);
+      if (legacy_list != NULL) {
+        using_legacy_cipher_list = true;
+        DEFAULT_CIPHER_LIST = legacy_list;
+      } else {
+        fprintf(stderr, "Error: An unknown legacy cipher list was specified\n");
+        exit(9);
+      }
+      argv[i] = const_cast<char*>("");
     } else if (argv[i][0] != '-') {
       break;
     }
@@ -2944,6 +2966,25 @@ char** Init(int argc, char *argv[]) {
     memcpy(v8argv, argv, sizeof(*argv) * option_end_index);
     v8argv[option_end_index] = const_cast<char*>("--expose_debug_as");
     v8argv[option_end_index + 1] = const_cast<char*>("v8debug");
+  }
+
+  const char * cipher_list = getenv("NODE_CIPHER_LIST");
+  if (cipher_list != NULL) {
+    DEFAULT_CIPHER_LIST = cipher_list;
+  }
+  // Allow the NODE_LEGACY_CIPHER_LIST envar to override the other
+  // cipher list options. NODE_LEGACY_CIPHER_LIST=v0.10.38 will use
+  // the cipher list from v0.10.38
+  const char * leg_cipher_id = getenv("NODE_LEGACY_CIPHER_LIST");
+  if (leg_cipher_id != NULL) {
+    const char * leg_cipher_list =
+      legacy_cipher_list(leg_cipher_id);
+    if (leg_cipher_list != NULL) {
+      DEFAULT_CIPHER_LIST = leg_cipher_list;
+    } else {
+      fprintf(stderr, "Error: An unknown legacy cipher list was specified\n");
+      exit(9);
+    }
   }
 
   // For the normal stack which moves from high to low addresses when frames

--- a/src/node.js
+++ b/src/node.js
@@ -46,6 +46,8 @@
     startup.globalTimeouts();
     startup.globalConsole();
 
+    startup.setupLegacyCiphers();
+
     startup.processAssert();
     startup.processConfig();
     startup.processNextTick();
@@ -166,6 +168,25 @@
     process.binding('buffer').setFastBufferConstructor(global.Buffer);
     process.domain = null;
     process._exiting = false;
+  };
+
+  startup.setupLegacyCiphers = function setupLegacyCiphers() {
+    process._usingV1038Ciphers = function _usingV1038Ciphers() {
+      // Returns true if the --enable-legacy-cipher-list command line
+      // switch, or the NODE_LEGACY_CIPHER_LIST environment variable
+      // are set to v0.10.38 and the DEFAULT_CIPHERS equal the v0.10.38
+      // list.
+      var crypto = process.binding('crypto');
+
+      var argv = process.execArgv;
+      if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
+           process.env.NODE_LEGACY_CIPHER_LIST === 'v0.10.38') &&
+          crypto.DEFAULT_CIPHER_LIST === crypto.getLegacyCiphers('v0.10.38')) {
+            return true;
+      }
+
+      return false;
+    };
   };
 
   startup.globalTimeouts = function() {

--- a/src/node.js
+++ b/src/node.js
@@ -171,17 +171,17 @@
   };
 
   startup.setupLegacyCiphers = function setupLegacyCiphers() {
-    process._usingV1038Ciphers = function _usingV1038Ciphers() {
+    process._usingV1040Ciphers = function _usingV1040Ciphers() {
       // Returns true if the --enable-legacy-cipher-list command line
       // switch, or the NODE_LEGACY_CIPHER_LIST environment variable
-      // are set to v0.10.38 and the DEFAULT_CIPHERS equal the v0.10.38
+      // are set to v0.10.40 and the DEFAULT_CIPHERS equal the v0.10.40
       // list.
       var crypto = process.binding('crypto');
 
       var argv = process.execArgv;
-      if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.38') > -1 ||
-           process.env.NODE_LEGACY_CIPHER_LIST === 'v0.10.38') &&
-          crypto.DEFAULT_CIPHER_LIST === crypto.getLegacyCiphers('v0.10.38')) {
+      if ((argv.indexOf('--enable-legacy-cipher-list=v0.10.40') > -1 ||
+           process.env.NODE_LEGACY_CIPHER_LIST === 'v0.10.40') &&
+          crypto.DEFAULT_CIPHER_LIST === crypto.getLegacyCiphers('v0.10.40')) {
             return true;
       }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4199,12 +4199,18 @@ const char* ToCString(const node::Utf8Value& value) {
 
 Handle<Value> DefaultCiphers(const Arguments& args) {
   HandleScope scope;
+  unsigned int len = args.Length();
+  if (len != 1 || !args[0]->IsString()) {
+    return ThrowException(Exception::TypeError(String::New("A single string parameter is required")));
+  }
   node::Utf8Value key(args[0]);
   const char * list = legacy_cipher_list(ToCString(key));
-  if (list == NULL) {
-    list = DEFAULT_CIPHER_LIST_HEAD;
+  if (list != NULL) {
+    return scope.Close(v8::String::New(list));
+  } else {
+    return ThrowException(Exception::Error(String::New(
+      "Unknown legacy cipher list")));
   }
-  return scope.Close(v8::String::New(list));
 }
 
 Handle<Value> GetCiphers(const Arguments& args) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -62,7 +62,7 @@ static const int X509_NAME_FLAGS = ASN1_STRFLGS_ESC_CTRL
                                  | XN_FLAG_SEP_MULTILINE
                                  | XN_FLAG_FN_SN;
 
-#define DEFAULT_CIPHER_LIST_V10_38 "ECDHE-RSA-AES128-SHA256:"         \
+#define DEFAULT_CIPHER_LIST_V10_40 "ECDHE-RSA-AES128-SHA256:"         \
                                 "AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH"
 
 #define DEFAULT_CIPHER_LIST_HEAD "ECDHE-RSA-AES128-SHA256:"           \
@@ -4207,8 +4207,8 @@ const char* LegacyCipherList(const char * ver) {
   if (ver == NULL) {
     return NULL;
   }
-  if (strncmp(ver, "v0.10.38", 8) == 0) {
-    return DEFAULT_CIPHER_LIST_V10_38;
+  if (strncmp(ver, "v0.10.40", 8) == 0) {
+    return DEFAULT_CIPHER_LIST_V10_40;
   } else {
     return NULL;
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -71,6 +71,7 @@ const char* root_certs[] = {
 
 bool SSL2_ENABLE = false;
 bool SSL3_ENABLE = false;
+const char * DEFAULT_CIPHER_LIST = DEFAULT_CIPHER_LIST_HEAD;
 
 namespace crypto {
 
@@ -802,7 +803,7 @@ size_t ClientHelloParser::Write(const uint8_t* data, size_t len) {
   HandleScope scope;
 
   assert(state_ != kEnded);
-  
+
   // Just accumulate data, everything will be pushed to BIO later
   if (state_ == kPaused) return 0;
 
@@ -4190,6 +4191,21 @@ static void array_push_back(const TypeName* md,
   arr->Set(arr->Length(), String::New(from));
 }
 
+// borrowed from v8
+// (see http://v8.googlecode.com/svn/trunk/samples/shell.cc)
+const char* ToCString(const node::Utf8Value& value) {
+  return *value ? *value : "<string conversion failed>";
+}
+
+Handle<Value> DefaultCiphers(const Arguments& args) {
+  HandleScope scope;
+  node::Utf8Value key(args[0]);
+  const char * list = legacy_cipher_list(ToCString(key));
+  if (list == NULL) {
+    list = DEFAULT_CIPHER_LIST_HEAD;
+  }
+  return scope.Close(v8::String::New(list));
+}
 
 Handle<Value> GetCiphers(const Arguments& args) {
   HandleScope scope;
@@ -4264,6 +4280,13 @@ void InitCrypto(Handle<Object> target) {
 
   NODE_DEFINE_CONSTANT(target, SSL3_ENABLE);
   NODE_DEFINE_CONSTANT(target, SSL2_ENABLE);
+
+  (target)->ForceSet(
+      v8::String::New("DEFAULT_CIPHER_LIST"),
+      v8::String::New(DEFAULT_CIPHER_LIST),
+      static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
+
+  NODE_SET_METHOD(target, "getLegacyCiphers", DefaultCiphers);
 }
 
 }  // namespace crypto

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4201,7 +4201,9 @@ Handle<Value> DefaultCiphers(const Arguments& args) {
   HandleScope scope;
   unsigned int len = args.Length();
   if (len != 1 || !args[0]->IsString()) {
-    return ThrowException(Exception::TypeError(String::New("A single string parameter is required")));
+    return ThrowException(
+      Exception::TypeError(
+        String::New("A single string parameter is required")));
   }
   node::Utf8Value key(args[0]);
   const char * list = legacy_cipher_list(ToCString(key));

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -44,24 +44,6 @@
 
 #define EVP_F_EVP_DECRYPTFINAL 101
 
-#define DEFAULT_CIPHER_LIST_V10_38 "ECDHE-RSA-AES128-SHA256:"         \
-                                "AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH"
-
-#define DEFAULT_CIPHER_LIST_HEAD "ECDHE-RSA-AES128-SHA256:"           \
-                                "AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH"
-
-static inline const char * legacy_cipher_list(const char * ver) {
-  if (ver == NULL) {
-    return NULL;
-  }
-  if (strncmp(ver, "v0.10.38", 8) == 0) {
-    return DEFAULT_CIPHER_LIST_V10_38;
-  } else {
-    return NULL;
-  }
-}
-
-
 namespace node {
 
 extern bool SSL2_ENABLE;
@@ -314,6 +296,7 @@ class Connection : ObjectWrap {
   friend class SecureContext;
 };
 
+const char* LegacyCipherList(const char * ver);
 bool EntropySource(unsigned char* buffer, size_t length);
 void InitCrypto(v8::Handle<v8::Object> target);
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -27,6 +27,7 @@
 #include "node_object_wrap.h"
 #include "v8.h"
 
+#include <string.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -43,10 +44,29 @@
 
 #define EVP_F_EVP_DECRYPTFINAL 101
 
+#define DEFAULT_CIPHER_LIST_V10_38 "ECDHE-RSA-AES128-SHA256:"         \
+                                "AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH"
+
+#define DEFAULT_CIPHER_LIST_HEAD "ECDHE-RSA-AES128-SHA256:"           \
+                                "AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH"
+
+static inline const char * legacy_cipher_list(const char * ver) {
+  if (ver == NULL) {
+    return NULL;
+  }
+  if (strncmp(ver, "v0.10.38", 8) == 0) {
+    return DEFAULT_CIPHER_LIST_V10_38;
+  } else {
+    return NULL;
+  }
+}
+
+
 namespace node {
 
 extern bool SSL2_ENABLE;
 extern bool SSL3_ENABLE;
+extern const char * DEFAULT_CIPHER_LIST;
 
 namespace crypto {
 

--- a/test/external/ssl-options/test.js
+++ b/test/external/ssl-options/test.js
@@ -26,7 +26,7 @@ var RC4_MD5_CIPHER = 'RC4-MD5';
 //
 // This specific cipher is used to test that it can be used with current
 // versions of Node.js *only* when both ends explicitly  specify RC4-SHA
-// as the cipher they want to use, or if --enable-legacy-cipher-list=v0.10.38
+// as the cipher they want to use, or if --enable-legacy-cipher-list=v0.10.40
 // is passed at least to the client or the server.
 //
 // Note also that RC4-SHA is a SSLv3 cipher, not a SSLv2 cipher contrary to
@@ -37,7 +37,7 @@ var CMD_LINE_OPTIONS = [
   null,
   "--enable-ssl2",
   "--enable-ssl3",
-  "--enable-legacy-cipher-list=v0.10.38"
+  "--enable-legacy-cipher-list=v0.10.40"
 ];
 
 var SERVER_SSL_PROTOCOLS = [
@@ -188,13 +188,13 @@ function testSSLv2Setups(serverSetup, clientSetup) {
 
     // It is also the case if the server passes explicitly RC4-MD%
     // but the client doesn't pass any cipher and passes
-    // --enable-legacy-cipher-list=v0.10.38 on the command line. This basically
+    // --enable-legacy-cipher-list=v0.10.40 on the command line. This basically
     // keeps the buggy be behavior of clients not using the default ciphers
     // list when not explicitly passing any cipher, and as a result
     // allowing RC4 and MD5 to be used.
     if (serverSetup.ciphers === RC4_MD5_CIPHER &&
         clientSetup.ciphers === undefined &&
-        clientSetup.cmdLine === '--enable-legacy-cipher-list=v0.10.38')
+        clientSetup.cmdLine === '--enable-legacy-cipher-list=v0.10.40')
       return true;
 
     // In all other cases, when using SSLv2 on both sides,
@@ -222,7 +222,7 @@ function testRC4LegacyCiphers(serverSetup, clientSetup) {
   // To be able to use a RC4 cipher suite, either both ends specify it (like
   // for the test using RC4-MD5), or one end pass it explicitly and the other
   // uses the default ciphers list while passing the
-  // --enable-legacy-cipher-list=v0.10.38 command line option
+  // --enable-legacy-cipher-list=v0.10.40 command line option
   // We're using RC4-SHA as our test cipher suite, because SHA is allowed by
   // default and not RC4, so we know that we're only testing disabling/enabling
   // RC4.
@@ -236,12 +236,12 @@ function testRC4LegacyCiphers(serverSetup, clientSetup) {
 
     if (serverSetup.ciphers === RC4_SHA_CIPHER &&
         usesDefaultCiphers(clientSetup) &&
-        clientSetup.cmdLine === '--enable-legacy-cipher-list=v0.10.38')
+        clientSetup.cmdLine === '--enable-legacy-cipher-list=v0.10.40')
       return true;
 
     if (clientSetup.ciphers === RC4_SHA_CIPHER &&
         usesDefaultCiphers(serverSetup) &&
-        serverSetup.cmdLine === '--enable-legacy-cipher-list=v0.10.38')
+        serverSetup.cmdLine === '--enable-legacy-cipher-list=v0.10.40')
       return true;
 
     // Otherwise, if only one end passes a RC4 cipher suite explicitly,

--- a/test/external/ssl-options/test.js
+++ b/test/external/ssl-options/test.js
@@ -169,26 +169,17 @@ function testSetupsCompatible(serverSetup, clientSetup) {
     return false;
   }
 
-  if (isSsl2Protocol(serverSetup.secureProtocol) ||
-      isSsl2Protocol(clientSetup.secureProtocol)) {
-
-      /*
-       * It seems that in order to be able to use SSLv2, at least the server
-       * *needs* to advertise at least one cipher compatible with it.
-       */
-      if (serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS) {
-        return false;
-      }
-
-      /*
-       * If only either one of the client or server specify SSLv2 as their
-       * protocol, then *both* of them *need* to advertise at least one cipher
-       * that is compatible with SSLv2.
-       */
-      if ((!isSsl2Protocol(serverSetup.secureProtocol) || !isSsl2Protocol(clientSetup.secureProtocol)) &&
-        (clientSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS || serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS)) {
-        return false;
-      }
+  var ssl2Used = isSsl2Protocol(serverSetup.secureProtocol) ||
+                 isSsl2Protocol(clientSetup.secureProtocol);
+  if (ssl2Used &&
+      ((serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS) ||
+      (clientSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS))) {
+    /*
+     * Default ciphers are not compatible with SSLv2. Both client *and*
+     * server need to specify a SSLv2 compatible cipher to be able to use
+     * SSLv2.
+     */
+    return false;
   }
 
   return true;
@@ -340,7 +331,8 @@ function runClient(port, secureProtocol, secureOptions, ciphers) {
                         {
                           rejectUnauthorized: false,
                           secureProtocol: secureProtocol,
-                          secureOptions: secureOptions
+                          secureOptions: secureOptions,
+                          ciphers: ciphers
                         },
                         function() {
 

--- a/test/external/ssl-options/test.js
+++ b/test/external/ssl-options/test.js
@@ -11,9 +11,34 @@ var debug     = require('debug')('test-node-ssl');
 
 var common = require('../../common');
 
-var SSL2_COMPATIBLE_CIPHERS = 'RC4-MD5';
+// RC4-MD5 is a SSLv2 cipher that can only be used if both ends explictly
+// specify it as allowed. Indeed, MD5 is not available in the default ciphers
+// list.
+// It is a SSLv2 cipher, we use it to test that SSLv2 connections work.
+var RC4_MD5_CIPHER = 'RC4-MD5';
 
-var CMD_LINE_OPTIONS = [ null, "--enable-ssl2", "--enable-ssl3" ];
+// The 'RC4-SHA' cipher is one of the RC4 ciphers that is supported by
+// versions of Node.js < v0.10.40 (before the deprecation of RC4),
+// since both RC4 and SHA are included in the default ciphers list.
+//
+// 'RC4-SHA' is not supported by default with Node.js versions >= 0.10.40
+// since RC4 was deprecated at that time.
+//
+// This specific cipher is used to test that it can be used with current
+// versions of Node.js *only* when both ends explicitly  specify RC4-SHA
+// as the cipher they want to use, or if --enable-legacy-cipher-list=v0.10.38
+// is passed at least to the client or the server.
+//
+// Note also that RC4-SHA is a SSLv3 cipher, not a SSLv2 cipher contrary to
+// RC4-MD5.
+var RC4_SHA_CIPHER = 'RC4-SHA';
+
+var CMD_LINE_OPTIONS = [
+  null,
+  "--enable-ssl2",
+  "--enable-ssl3",
+  "--enable-legacy-cipher-list=v0.10.38"
+];
 
 var SERVER_SSL_PROTOCOLS = [
   null,
@@ -137,6 +162,66 @@ function secureProtocolCompatibleWithSecureOptions(secureProtocol, secureOptions
   return true;
 }
 
+function testSSLv2Setups(serverSetup, clientSetup) {
+  // SSLv2 has to be explicitly specified on both sides to work
+  if (isSsl2Protocol(serverSetup.secureProtocol) &&
+      !isSsl2Protocol(clientSetup.secureProtocol))
+    return false;
+
+  if (isSsl2Protocol(clientSetup.secureProtocol) &&
+    !isSsl2Protocol(serverSetup.secureProtocol))
+    return false;
+
+  var ssl2UsedOnBothSides = isSsl2Protocol(serverSetup.secureProtocol) &&
+                            isSsl2Protocol(clientSetup.secureProtocol);
+  if (ssl2UsedOnBothSides &&
+      ((serverSetup.ciphers !== RC4_MD5_CIPHER) ||
+      (clientSetup.ciphers !== RC4_MD5_CIPHER))) {
+    /*
+     * Default ciphers are not compatible with SSLv2. Both client *and*
+     * server need to specify a SSLv2 compatible cipher to be able to use
+     * SSLv2.
+     */
+    return false;
+  }
+
+  return true;
+}
+
+function usesDefaultCiphers(setup) {
+  assert(typeof setup === 'object', 'setup parameter must be an object');
+  return setup.ciphers == null;
+}
+
+function testRC4LegacyCiphers(serverSetup, clientSetup) {
+
+  // To be able to use a RC4 cipher suite, either both ends specify it (like
+  // for the test using RC4-MD5), or one end pass it explicitly and the other
+  // uses the default ciphers list while passing the
+  // --enable-legacy-cipher-list=v0.10.38 command line option
+  // We're using RC4-SHA as our test cipher suite, because SHA is allowed by
+  // default and not RC4, so we know that we're only testing disabling/enabling
+  // RC4.
+
+  if (serverSetup.ciphers === RC4_SHA_CIPHER) {
+    if (clientSetup.ciphers !== RC4_SHA_CIPHER &&
+        (!usesDefaultCiphers(clientSetup) ||
+         clientSetup.cmdLine !== '--enable-legacy-cipher-list=v0.10.38')) {
+        return false;
+      }
+  }
+
+  if (clientSetup.ciphers === RC4_SHA_CIPHER) {
+    if (serverSetup.ciphers !== RC4_SHA_CIPHER &&
+        (!usesDefaultCiphers(serverSetup) ||
+         serverSetup.cmdLine !== '--enable-legacy-cipher-list=v0.10.38')) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function testSetupsCompatible(serverSetup, clientSetup) {
   debug('Determing test result for:');
   debug(serverSetup);
@@ -169,16 +254,11 @@ function testSetupsCompatible(serverSetup, clientSetup) {
     return false;
   }
 
-  var ssl2Used = isSsl2Protocol(serverSetup.secureProtocol) ||
-                 isSsl2Protocol(clientSetup.secureProtocol);
-  if (ssl2Used &&
-      ((serverSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS) ||
-      (clientSetup.ciphers !== SSL2_COMPATIBLE_CIPHERS))) {
-    /*
-     * Default ciphers are not compatible with SSLv2. Both client *and*
-     * server need to specify a SSLv2 compatible cipher to be able to use
-     * SSLv2.
-     */
+  if (!testSSLv2Setups(serverSetup, clientSetup)) {
+    return false;
+  }
+
+  if (!testRC4LegacyCiphers(serverSetup, clientSetup)) {
     return false;
   }
 
@@ -224,8 +304,14 @@ function createTestsSetups() {
 
           if (isSsl2Protocol(serverSecureProtocol)) {
             var setupWithSsl2Ciphers = xtend(serverSetup);
-            setupWithSsl2Ciphers.ciphers = SSL2_COMPATIBLE_CIPHERS;
+            setupWithSsl2Ciphers.ciphers = RC4_MD5_CIPHER;
             serversSetup.push(setupWithSsl2Ciphers);
+          }
+
+          if (isSsl3Protocol(serverSecureProtocol)) {
+            var setupWithSsl3Ciphers = xtend(serverSetup);
+            setupWithSsl3Ciphers.ciphers = RC4_SHA_CIPHER;
+            serversSetup.push(setupWithSsl3Ciphers);
           }
         }
       });
@@ -246,8 +332,14 @@ function createTestsSetups() {
 
           if (isSsl2Protocol(clientSecureProtocol)) {
             var setupWithSsl2Ciphers = xtend(clientSetup);
-            setupWithSsl2Ciphers.ciphers = SSL2_COMPATIBLE_CIPHERS;
+            setupWithSsl2Ciphers.ciphers = RC4_MD5_CIPHER;
             clientsSetup.push(setupWithSsl2Ciphers);
+          }
+
+          if (isSsl3Protocol(clientSecureProtocol)) {
+            var setupWithSsl3Ciphers = xtend(clientSetup);
+            setupWithSsl3Ciphers.ciphers = RC4_SHA_CIPHER;
+            clientsSetup.push(setupWithSsl3Ciphers);
           }
         }
       });

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -19,84 +19,21 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var spawn = require('child_process').spawn;
+var spawn  = require('child_process').spawn;
 var assert = require('assert');
-var tls = require('tls');
+var tls    = require('tls');
 var crypto = process.binding('crypto');
+var common = require('../common');
+var fs     = require('fs');
 
-function doTest(checklist, env, useswitch) {
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+
+function doTest(checklist, additional_args, env) {
   var options;
-  if (env && useswitch === 1) {
-    options = {env:env};
-  }
-  var args = ['-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)'];
-
-  switch(useswitch) {
-    case 1:
-      // Test --cipher-test
-      args.unshift('--cipher-list=' + env);
-      break;
-    case 2:
-      // Test --enable-legacy-cipher-list
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      break;
-    case 3:
-      // Test NODE_LEGACY_CIPHER_LIST
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
-      break;
-    case 4:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--cipher-list=' + env);
-      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
-      break;
-    case 5:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
-      break;
-    case 6:
-      // Test right-most option takes precedence
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      args.unshift('--cipher-list=XYZ');
-      break;
-    case 7:
-      // Test right-most option takes precedence
-      args.unshift('--cipher-list=' + env);
-      args.unshift('--enable-legacy-cipher-list=v0.10.38');
-      break;
-    case 8:
-      // Test NODE_LEGACY_CIPHER_LIST takes precendence over NODE_CIPHER_LIST
-      options = {env:{
-        "NODE_LEGACY_CIPHER_LIST": env,
-        "NODE_CIPHER_LIST": "ABC"
-      }};
-      break;
-    case 9:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--cipher-list=' + env);
-      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": "v0.10.38"}};
-      break;
-    case 10:
-      // Test command line switch takes precedence over environment variable
-      args.unshift('--enable-legacy-cipher-list=' + env);
-      if (env) options = {
-        env:{
-          "NODE_LEGACY_CIPHER_LIST": "v0.10.38",
-          "NODE_CIPHER_LIST": "XYZ"
-        }
-      };
-      break;
-    case 11:
-      // Test right-most option takes precedence, multiple of same option
-      args.unshift('--cipher-list=' + env);
-      args.unshift('--enable-legacy-cipher-list=v0.10.38');
-      args.unshift('--cipher-list=' + 'XYZ');
-      break;
-    default:
-      // Test NODE_CIPHER_LIST
-      if (env) options = {env:env};
-  }
-
+  if (env) options = {env:env};
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)']);
   var out = '';
   spawn(process.execPath, args, options).
     stdout.
@@ -108,27 +45,88 @@ function doTest(checklist, env, useswitch) {
       });
 }
 
-var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+// test that the command line switchs takes precedence
+// over the environment variables
+function doTestPrecedence() {
+  // test that --cipher-list takes precedence over NODE_CIPHER_LIST
+  doTest('ABC', ['--cipher-list=ABC'], {'NODE_CIPHER_LIST': 'XYZ'});
+
+  // test that --enable-legacy-cipher-list takes precedence
+  // over NODE_CIPHER_LIST
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {'NODE_CIPHER_LIST': 'XYZ'});
+
+  // test that --cipher-list takes precedence over NODE_LEGACY_CIPHER_LIST
+  doTest('ABC',
+         ['--cipher-list=ABC'],
+         {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+
+
+  // test that --enable-legacy-cipher-list takes precence over both envars
+  doTest(V1038Ciphers,
+         ['--enable-legacy-cipher-list=v0.10.38'],
+         {
+           'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+           'NODE_CIPHER_LIST': 'XYZ'
+         });
+
+  // test the right-most command line option takes precedence
+  doTest(V1038Ciphers,
+         [
+           '--cipher-list=XYZ',
+           '--enable-legacy-cipher-list=v0.10.38'
+         ]);
+
+   // test the right-most command line option takes precedence
+   doTest('XYZ',
+          [
+            '--enable-legacy-cipher-list=v0.10.38',
+            '--cipher-list=XYZ'
+          ]);
+
+    // test the right-most command line option takes precedence
+    doTest('XYZ',
+           [
+             '--cipher-list=XYZ',
+             '--enable-legacy-cipher-list=v0.10.38',
+             '--cipher-list=XYZ'
+           ]);
+
+    // test that NODE_LEGACY_CIPHER_LIST takes precedence over
+    // NODE_CIPHER_LIST
+
+    doTest(V1038Ciphers, [],
+           {
+             'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+             'NODE_CIPHER_LIST': 'ABC'
+           });
+
+}
+
+// Start running the tests...
 
 doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
-doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
-doTest('ABC', 'ABC', 1); // test the --cipher-list switch
 
-// test precedence order
-doTest('ABC', 'ABC', 4);
-doTest(V1038Ciphers, 'v0.10.38', 5);
-doTest(V1038Ciphers, 'v0.10.38', 6);
-doTest('ABC', 'ABC', 7);
-doTest(V1038Ciphers, 'v0.10.38', 8);
-doTest('ABC', 'ABC', 9);
-doTest(V1038Ciphers, 'v0.10.38', 10);
-doTest('YYY', 'YYY', 11);
+// Test the NODE_CIPHER_LIST environment variable
+doTest('ABC', [], {'NODE_CIPHER_LIST':'ABC'});
 
-['v0.10.38'].forEach(function(ver) {
-  doTest(tls.getLegacyCiphers(ver), ver, 2);
-  doTest(tls.getLegacyCiphers(ver), ver, 3);
+// Test the --cipher-list command line switch
+doTest('ABC', ['--cipher-list=ABC']);
+
+// Test the --enable-legacy-cipher-list and NODE_LEGACY_CIPHER_LIST envar
+['v0.10.38'].forEach(function(arg) {
+  var checklist = tls.getLegacyCiphers(arg);
+  // command line switch
+  doTest(checklist, ['--enable-legacy-cipher-list=' + arg]);
+  // environment variable
+  doTest(checklist, [], {'NODE_LEGACY_CIPHER_LIST': arg});
 });
 
+// Test the precedence order for the various options
+doTestPrecedence();
+
+// Test that we throw properly
 // invalid value
 assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
 // no parameters
@@ -139,3 +137,93 @@ assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
 assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
 // ah, just right
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});
+
+
+
+// Test to ensure default ciphers are not set when v0.10.38 legacy cipher
+// switch is used. This is a bit involved... we need to first set up the
+// TLS server, then spawn a second node instance using the v0.10.38 cipher,
+// then connect and check to make sure the options are correct. Since there
+// is no direct way of testing it, an alternate createCredentials shim is
+// created that intercepts the call to createCredentials and checks the output.
+// The following server code was adopted from test-tls-connect-simple.
+
+// note that the following function is written out to a string and
+// passed in as an argument to a child node instance.
+var script = (
+  function() {
+    var tls = require('tls');
+    var orig_createCredentials = require('crypto').createCredentials;
+    require('crypto').createCredentials = function(options) {
+      if (options.ciphers !== undefined) {
+        console.error(options.ciphers);
+        process.exit(1);
+      }
+      return orig_createCredentials(options);
+    };
+    var socket = tls.connect({
+      port: 0,
+      rejectUnauthorized: false
+    }, function() {
+      socket.end();
+    });
+  }
+).toString();
+
+var test_count = 0;
+
+function doDefaultCipherTest(additional_args, env, failexpected) {
+  var options = {};
+  if (env) options.env = env;
+  var out = '', err = '';
+  additional_args = additional_args || [];
+  var args = additional_args.concat([
+    '-e', require('util').format('(%s)()', script).replace(
+      'port: 0', 'port: ' + common.PORT)
+  ]);
+  var child = spawn(process.execPath, args, options);
+  child.stdout.
+    on('data', function(data) {
+      out += data;
+    }).
+    on('end', function() {
+      if (failexpected && err === '') {
+        // if we get here, there's a problem because the default cipher
+        // list was not set when it should have been
+        assert.fail('options.cipher list was not set');
+      }
+    });
+  child.stderr.
+    on('data', function(data) {
+      err += data;
+    }).
+    on('end', function() {
+      if (err !== '') {
+        if (!failexpected) {
+          assert.fail(err.substr(0,err.length-1));
+        }
+      }
+    });
+  child.on('close', function() {
+    test_count++;
+    if (test_count === 4) server.close();
+  });
+}
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+var server = tls.Server(options, function(socket) {});
+server.listen(common.PORT, function() {
+  doDefaultCipherTest(['--enable-legacy-cipher-list=v0.10.38']);
+  doDefaultCipherTest([], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+  // this variant checks to ensure that the default cipher list IS set
+  var test_uses_default_cipher_list = true;
+  doDefaultCipherTest([], {}, test_uses_default_cipher_list);
+  // test that setting the cipher list explicitly to the v0.10.38
+  // string without using the legacy cipher switch causes the
+  // default ciphers to be set.
+  doDefaultCipherTest(['--cipher-list=' + V1038Ciphers], {},
+                      test_uses_default_cipher_list);
+});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -71,6 +71,27 @@ function doTest(checklist, env, useswitch) {
         "NODE_CIPHER_LIST": "ABC"
       }};
       break;
+    case 9:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--cipher-list=' + env);
+      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": "v0.10.38"}};
+      break;
+    case 10:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      if (env) options = {
+        env:{
+          "NODE_LEGACY_CIPHER_LIST": "v0.10.38",
+          "NODE_CIPHER_LIST": "XYZ"
+        }
+      };
+      break;
+    case 11:
+      // Test right-most option takes precedence, multiple of same option
+      args.unshift('--cipher-list=' + env);
+      args.unshift('--enable-legacy-cipher-list=v0.10.38');
+      args.unshift('--cipher-list=' + 'XYZ');
+      break;
     default:
       // Test NODE_CIPHER_LIST
       if (env) options = {env:env};
@@ -99,6 +120,9 @@ doTest(V1038Ciphers, 'v0.10.38', 5);
 doTest(V1038Ciphers, 'v0.10.38', 6);
 doTest('ABC', 'ABC', 7);
 doTest(V1038Ciphers, 'v0.10.38', 8);
+doTest('ABC', 'ABC', 9);
+doTest(V1038Ciphers, 'v0.10.38', 10);
+doTest('YYY', 'YYY', 11);
 
 ['v0.10.38'].forEach(function(ver) {
   doTest(tls.getLegacyCiphers(ver), ver, 2);

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -26,7 +26,7 @@ var crypto = process.binding('crypto');
 var common = require('../common');
 var fs = require('fs');
 
-var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.40');
 
 function doTest(checklist, additional_args, env) {
   var options;
@@ -54,13 +54,13 @@ function doTestPrecedence() {
   // test that --enable-legacy-cipher-list takes precedence
   // over NODE_CIPHER_LIST
   doTest(V1038Ciphers,
-         ['--enable-legacy-cipher-list=v0.10.38'],
+         ['--enable-legacy-cipher-list=v0.10.40'],
          {'NODE_CIPHER_LIST': 'XYZ'});
 
   // test that --cipher-list takes precedence over NODE_LEGACY_CIPHER_LIST
   doTest('ABC',
          ['--cipher-list=ABC'],
-         {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+         {'NODE_LEGACY_CIPHER_LIST': 'v0.10.40'});
 
   // test that --enable-legacy-cipher-list takes precence over both envars
   // note: in this release, there's only one legal value for the legacy
@@ -68,9 +68,9 @@ function doTestPrecedence() {
   //       are supported, this test should be changed to test that the
   //       command line switch actually does override
   doTest(V1038Ciphers,
-         ['--enable-legacy-cipher-list=v0.10.38'],
+         ['--enable-legacy-cipher-list=v0.10.40'],
          {
-           'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+           'NODE_LEGACY_CIPHER_LIST': 'v0.10.40',
            'NODE_CIPHER_LIST': 'XYZ'
          });
 
@@ -78,13 +78,13 @@ function doTestPrecedence() {
   doTest(V1038Ciphers,
          [
            '--cipher-list=XYZ',
-           '--enable-legacy-cipher-list=v0.10.38'
+           '--enable-legacy-cipher-list=v0.10.40'
          ]);
 
    // test the right-most command line option takes precedence
    doTest('XYZ',
           [
-            '--enable-legacy-cipher-list=v0.10.38',
+            '--enable-legacy-cipher-list=v0.10.40',
             '--cipher-list=XYZ'
           ]);
 
@@ -92,7 +92,7 @@ function doTestPrecedence() {
     doTest('XYZ',
            [
              '--cipher-list=ABC',
-             '--enable-legacy-cipher-list=v0.10.38',
+             '--enable-legacy-cipher-list=v0.10.40',
              '--cipher-list=XYZ'
            ]);
 
@@ -100,7 +100,7 @@ function doTestPrecedence() {
     // NODE_CIPHER_LIST
     doTest(V1038Ciphers, [],
            {
-             'NODE_LEGACY_CIPHER_LIST': 'v0.10.38',
+             'NODE_LEGACY_CIPHER_LIST': 'v0.10.40',
              'NODE_CIPHER_LIST': 'ABC'
            });
 }
@@ -115,7 +115,7 @@ doTest('ABC', [], {'NODE_CIPHER_LIST':'ABC'});
 doTest('ABC', ['--cipher-list=ABC']);
 
 // Test the --enable-legacy-cipher-list and NODE_LEGACY_CIPHER_LIST envar
-['v0.10.38'].forEach(function(arg) {
+['v0.10.40'].forEach(function(arg) {
   var checklist = tls.getLegacyCiphers(arg);
   // command line switch
   doTest(checklist, ['--enable-legacy-cipher-list=' + arg]);
@@ -136,11 +136,11 @@ assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
 // too many parameters
 assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
 // ah, just right
-assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});
+assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.40');});
 
-// Test to ensure default ciphers are not set when v0.10.38 legacy cipher
+// Test to ensure default ciphers are not set when v0.10.40 legacy cipher
 // switch is used. This is a bit involved... we need to first set up the
-// TLS server, then spawn a second node instance using the v0.10.38 cipher,
+// TLS server, then spawn a second node instance using the v0.10.40 cipher,
 // then connect and check to make sure the options are correct. Since there
 // is no direct way of testing it, an alternate createCredentials shim is
 // created that intercepts the call to createCredentials and checks the
@@ -159,7 +159,7 @@ var fail_if_default_ciphers_set = (
     require('crypto').createCredentials = function(options) {
       used_monkey_patch = true;
       // since node was started with the --enable-legacy-cipher-list
-      // switch equal to v0.10.38, the options.ciphers should be
+      // switch equal to v0.10.40, the options.ciphers should be
       // undefined. If it's not undefined, we have a problem and
       // the test fails
       if (options.ciphers !== undefined) {
@@ -253,19 +253,19 @@ var server = tls.Server(options, function(socket) {
 server.listen(common.PORT, function() {
   // checks to make sure the default ciphers are *not* set
   // because the --enable-legacy-cipher-list switch is set to
-  // v0.10.38
+  // v0.10.40
   doDefaultCipherTest(fail_if_default_ciphers_set,
-                      ['--enable-legacy-cipher-list=v0.10.38']);
+                      ['--enable-legacy-cipher-list=v0.10.40']);
 
   // checks to make sure the default ciphers are *not* set
-  // because the NODE_LEGACY_CIPHER_LIST envar is set to v0.10.38
+  // because the NODE_LEGACY_CIPHER_LIST envar is set to v0.10.40
   doDefaultCipherTest(fail_if_default_ciphers_set,
-                      [], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.38'});
+                      [], {'NODE_LEGACY_CIPHER_LIST': 'v0.10.40'});
 
   // this variant checks to ensure that the default cipher list IS set
   doDefaultCipherTest(fail_if_default_ciphers_not_set, [], {});
 
-  // test that setting the cipher list explicitly to the v0.10.38
+  // test that setting the cipher list explicitly to the v0.10.40
   // string without using the legacy cipher switch causes the
   // default ciphers to be set.
   doDefaultCipherTest(fail_if_default_ciphers_not_set,

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -1,0 +1,70 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var spawn = require('child_process').spawn;
+var assert = require('assert');
+var tls = require('tls');
+var crypto = process.binding('crypto');
+
+function doTest(checklist, env, useswitch) {
+  var options;
+  if (env && useswitch === 1) {
+    options = {env:env};
+  }
+  var args = ['-e', 'console.log(process.binding(\'crypto\').DEFAULT_CIPHER_LIST)'];
+
+  switch(useswitch) {
+    case 1:
+      // Test --cipher-test
+      args.unshift('--cipher-list=' + env);
+      break;
+    case 2:
+      // Test --enable-legacy-cipher-list
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      break;
+    case 3:
+      // Test NODE_LEGACY_CIPHER_LIST
+      if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
+      break;
+    default:
+      // Test NODE_CIPHER_LIST
+      if (env) options = {env:env};
+  }
+
+  var out = '';
+  spawn(process.execPath, args, options).
+    stdout.
+      on('data', function(data) {
+        out += data;
+      }).
+      on('end', function() {
+        assert.equal(out.trim(), checklist);
+      });
+}
+
+doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
+doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
+doTest('ABC', 'ABC', 1); // test the --cipher-list switch
+
+['v0.10.38'].forEach(function(ver) {
+  doTest(tls.getLegacyCiphers(ver), ver, 2);
+  doTest(tls.getLegacyCiphers(ver), ver, 3);
+});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -106,12 +106,12 @@ doTest(V1038Ciphers, 'v0.10.38', 8);
 });
 
 // invalid value
-assert.throws(function() {tls.getLegacyCiphers('foo');});
+assert.throws(function() {tls.getLegacyCiphers('foo');}, Error);
 // no parameters
-assert.throws(function() {tls.getLegacyCiphers();});
+assert.throws(function() {tls.getLegacyCiphers();}, TypeError);
 // not a string parameter
-assert.throws(function() {tls.getLegacyCiphers(1);});
+assert.throws(function() {tls.getLegacyCiphers(1);}, TypeError);
 // too many parameters
-assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');});
+assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');}, TypeError);
 // ah, just right
 assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});

--- a/test/simple/test-tls-cipher-list.js
+++ b/test/simple/test-tls-cipher-list.js
@@ -44,6 +44,33 @@ function doTest(checklist, env, useswitch) {
       // Test NODE_LEGACY_CIPHER_LIST
       if (env) options = {env:{"NODE_LEGACY_CIPHER_LIST": env}};
       break;
+    case 4:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--cipher-list=' + env);
+      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
+      break;
+    case 5:
+      // Test command line switch takes precedence over environment variable
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      if (env) options = {env:{"NODE_CIPHER_LIST": "XYZ"}};
+      break;
+    case 6:
+      // Test right-most option takes precedence
+      args.unshift('--enable-legacy-cipher-list=' + env);
+      args.unshift('--cipher-list=XYZ');
+      break;
+    case 7:
+      // Test right-most option takes precedence
+      args.unshift('--cipher-list=' + env);
+      args.unshift('--enable-legacy-cipher-list=v0.10.38');
+      break;
+    case 8:
+      // Test NODE_LEGACY_CIPHER_LIST takes precendence over NODE_CIPHER_LIST
+      options = {env:{
+        "NODE_LEGACY_CIPHER_LIST": env,
+        "NODE_CIPHER_LIST": "ABC"
+      }};
+      break;
     default:
       // Test NODE_CIPHER_LIST
       if (env) options = {env:env};
@@ -60,11 +87,31 @@ function doTest(checklist, env, useswitch) {
       });
 }
 
+var V1038Ciphers = tls.getLegacyCiphers('v0.10.38');
+
 doTest(crypto.DEFAULT_CIPHER_LIST); // test the default
 doTest('ABC', {'NODE_CIPHER_LIST':'ABC'}); // test the envar
 doTest('ABC', 'ABC', 1); // test the --cipher-list switch
+
+// test precedence order
+doTest('ABC', 'ABC', 4);
+doTest(V1038Ciphers, 'v0.10.38', 5);
+doTest(V1038Ciphers, 'v0.10.38', 6);
+doTest('ABC', 'ABC', 7);
+doTest(V1038Ciphers, 'v0.10.38', 8);
 
 ['v0.10.38'].forEach(function(ver) {
   doTest(tls.getLegacyCiphers(ver), ver, 2);
   doTest(tls.getLegacyCiphers(ver), ver, 3);
 });
+
+// invalid value
+assert.throws(function() {tls.getLegacyCiphers('foo');});
+// no parameters
+assert.throws(function() {tls.getLegacyCiphers();});
+// not a string parameter
+assert.throws(function() {tls.getLegacyCiphers(1);});
+// too many parameters
+assert.throws(function() {tls.getLegacyCiphers('abc', 'extra');});
+// ah, just right
+assert.doesNotThrow(function() {tls.getLegacyCiphers('v0.10.38');});

--- a/test/simple/test-tls-clients-default-ciphers.js
+++ b/test/simple/test-tls-clients-default-ciphers.js
@@ -1,0 +1,122 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * This is a regression test that highlights a problem where tls.connect would
+ * not use the default ciphers suite when no ciphers was passed.
+ *
+ * This test makes sure that when connecting to a server that uses only the RC4
+ * cipher, which was removed recently from the default ciphers suite, calls to
+ * tls.connect that don't pass any ciphers fail to connect properly.
+ */
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var https = require('https');
+var path = require('path');
+var fs = require('fs');
+
+var KEYPATH = path.join(common.fixturesDir, 'keys', 'agent2-key.pem');
+var KEY = fs.readFileSync(KEYPATH).toString();
+
+var CERTPATH = path.join(common.fixturesDir, 'keys', 'agent2-cert.pem');
+var CERT = fs.readFileSync(CERTPATH).toString();
+
+var SERVER_OPTIONS = {
+  key: KEY,
+  cert: CERT,
+  // RC4 was removed recently from the default ciphers list
+  // due to security vulnerabilities. Set the server to only use this
+  // cipher so that this test can make sure that tls clients
+  // can't connect to it when they use default ciphers.
+  ciphers: 'RC4-MD5',
+};
+
+/*
+ * Uses "clientFn" with default ciphers to connect to TLS/HTTPS server
+ * on port "port". Calls "callback" with an object as parameter
+ * that has one property "allClientsFailed" that is true
+ * if all clients connections/requests failed, false otherwise.
+ */
+function testClientWithDefaultCiphers(clientFn, port, callback) {
+  // Use different forms of passing default ciphers to
+  // tls connect: no 'ciphers' property, 'ciphers' with value 'null' and
+  // 'ciphers' with value 'undefined'. Although we would think that these
+  // semantically similar ways of passing no ciphers would trigger the same
+  // behavior, in reality the implementation behaves differently, and
+  // thus we need to keep all these forms in the test.
+  var CLIENT_OPTIONS = [
+    {
+      rejectUnauthorized: false,
+      ciphers: null
+    },
+    {
+      rejectUnauthorized: false,
+      ciphers: undefined
+    },
+    {
+      rejectUnauthorized: false,
+    }
+  ];
+
+  var nbClientErrors = 0;
+  var callbackCalled = false;
+
+  CLIENT_OPTIONS.forEach(function(clientOptionsObject) {
+    clientOptionsObject.port = port;
+
+    var conn = clientFn(clientOptionsObject, function onConnect() {
+      callbackCalled = true;
+      return callback({ allClientsFailed: false });
+    });
+
+    conn.on('error', function onClientError(err) {
+      ++nbClientErrors;
+      if (nbClientErrors === CLIENT_OPTIONS.length && !callbackCalled) {
+        callbackCalled = true;
+        return callback({ allClientsFailed: true });
+      }
+    });
+  });
+}
+
+// Test that tls.connect uses default ciphers on the client properly
+var tlsServer = new tls.Server(SERVER_OPTIONS);
+tlsServer.listen(common.PORT, function () {
+  testClientWithDefaultCiphers(tls.connect, common.PORT, function onTestsDone(results) {
+    assert(results.allClientsFailed,
+           'All TLS clients using default ciphers to server only ' +
+           'supporting RC4 cipher should have failed');
+    tlsServer.close();
+  });
+});
+
+// Test that https.get uses default ciphers on the client properly
+var httpsServer = new https.Server(SERVER_OPTIONS);
+httpsServer.listen(common.PORT + 1, function () {
+  testClientWithDefaultCiphers(https.get, common.PORT + 1, function onTestsDone(results) {
+    assert(results.allClientsFailed,
+           'All HTTPS clients using default ciphers to server only ' +
+           'supporting RC4 cipher should have failed');
+    httpsServer.close();
+  });
+});

--- a/test/simple/test-tls-getcipher.js
+++ b/test/simple/test-tls-getcipher.js
@@ -49,7 +49,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
     rejectUnauthorized: false
   }, function() {
     var cipher = client.getCipher();
-    assert.equal(cipher.name, cipher_list[0]);
+    assert.equal(cipher.name, cipher_list[1]);
     assert(cipher_version_pattern.test(cipher.version));
     client.end();
     server.close();


### PR DESCRIPTION
This PR consolidates previous PRs from @jasnell (https://github.com/joyent/node/pull/14413, https://github.com/joyent/node/pull/14572) and myself (https://github.com/joyent/node/pull/23947) and allows us to have one single place where we can take a look at the current status of deprecating RC4 from the default ciphers list used by node v0.10.x, discuss it, and make changes.

The list of commits hasn't been squashed to preserve the history behind these changes. If this PR lands, its commits will be squashed. Before that, we want to make sure we understand all the implications of these changes.
