### PR TITLE
configure: fix empty prefix

### DIFF
--- a/configure
+++ b/configure
@@ -1020,7 +1020,7 @@ config = {
   'PYTHON': sys.executable,
 }
 
-if options.prefix:
+if options.prefix != None:
   config['PREFIX'] = options.prefix
 
 config = '\n'.join(map('='.join, config.iteritems())) + '\n'


### PR DESCRIPTION
autoconf-based configure scripts (which this one is modeled after)
support to pass an empty prefix via --prefix=.
this is required for systems that have binaries directly in /bin
rather than /usr/bin etc (one example is sabotage linux).

the fix is easy: rather than testing options.prefix for "if var",
which treats an empty string the same as "None", we check for
"if var not None".

fixes #5197
