### PR TITLE
Fixed architecture for kernel > 3.8 + Fixed SIGILL on Raspberry Pi

### DIFF
--- a/deps/v8/src/base/cpu.cc
+++ b/deps/v8/src/base/cpu.cc
@@ -377,6 +377,15 @@ CPU::CPU() : stepping_(0),
       }
       delete[] processor;
     }
+
+    // elf_platform moved to the model name field in Linux v3.8.
+    if (architecture_ == 7) {
+      char* processor = cpu_info.ExtractField("model name");
+      if (HasListItem(processor, "(v6l)")) {
+        architecture_ = 6;
+      }
+      delete[] processor;
+    }
   }
 
   // Try to extract the list of CPU features from ELF hwcaps.


### PR DESCRIPTION
Same as the official patch: https://github.com/v8/v8-git-mirror/blob/master/src/base/cpu.cc#L483-L499
This will fix architecture identification for Linux kernel > 3.8 according to the new elf_platform standard.
