### PR TITLE
build: make release process usable by multiple users

### DIFF
--- a/tools/getstability.py
+++ b/tools/getstability.py
@@ -1,4 +1,4 @@
-import os,re
+import os, re, sys
 
 node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
     'node_version.h')
@@ -13,7 +13,13 @@ for line in f:
   if re.match('#define NODE_PATCH_VERSION', line):
     patch = line.split()[2]
 
-if int(minor) % 2 == 0:
+major_minor = major + '.' + minor
+if major_minor == '0.10':
+  print 'maintenance'
+elif major_minor == '0.12':
   print 'stable'
-else:
+elif minor % 2 != 0:
   print 'unstable'
+else:
+  print 'Unknown stability status, exiting'
+  sys.exit(1)

--- a/tools/node-release-post-build.sh
+++ b/tools/node-release-post-build.sh
@@ -13,18 +13,41 @@ fi
 stability="$(python tools/getstability.py)"
 NODE_STABC="$(tr '[:lower:]' '[:upper:]' <<< ${stability:0:1})${stability:1}"
 NODE_STABL="$stability"
+GITHUB_USERNAME=
+
+function usage
+{
+  echo "usage: sh tools/node-release-post-build.sh -u gh_username"
+  exit 1
+}
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -u | --github-username ) shift
+                             GITHUB_USERNAME=$1
+                             ;;
+    * )                      usage
+                             exit 1
+  esac
+  shift
+done
+
+if [ "$GITHUB_USERNAME" = "" ];
+then
+  usage
+fi
 
 echo "Building for $stability"
 
-scp tj@nodejs.org:archive/node/tmp/v$(python tools/getnodeversion.py)/SHASUM* .
+scp staging@nodejs.org:archive/node/tmp/v$(python tools/getnodeversion.py)/SHASUM* .
 FILES="SHASUMS SHASUMS256"
 for i in $FILES ; do gpg -s $i.txt; gpg --clearsign $i.txt; done
-scp SHASUM* tj@nodejs.org:archive/node/tmp/v$(python tools/getnodeversion.py)/
+scp SHASUM* staging@nodejs.org:archive/node/tmp/v$(python tools/getnodeversion.py)/
  
 ssh nodejs.org mkdir -p "dist/v$(python tools/getnodeversion.py)/{x64,docs}"
 ssh nodejs.org ln -s ../dist/v$(python tools/getnodeversion.py)/docs docs/v$(python tools/getnodeversion.py)
 
-ssh root@nodejs.org mv /home/tj/archive/node/tmp/v$(python tools/getnodeversion.py)/* /home/node/dist/v$(python tools/getnodeversion.py)/
+ssh root@nodejs.org mv /home/staging/archive/node/tmp/v$(python tools/getnodeversion.py)/* /home/node/dist/v$(python tools/getnodeversion.py)/
 ssh root@nodejs.org chown -R node:other /home/node/dist/v$(python tools/getnodeversion.py)
 
 # tag the release
@@ -32,7 +55,7 @@ ssh root@nodejs.org chown -R node:other /home/node/dist/v$(python tools/getnodev
 git tag -sm "$(bash tools/changelog-head.sh)" v$(python tools/getnodeversion.py)
  
 # push to github
-git push git@github.com:joyent/node v$(python tools/getnodeversion.py)-release --tags 
+git push git@github.com:$GITHUB_USERNAME/node v$(python tools/getnodeversion.py)-release --tags
 
 # blog post and email
 make email.md
@@ -51,16 +74,18 @@ make email.md
   echo ""
   cat email.md ) > ../node-website/doc/blog/release/v$(python tools/getnodeversion.py).md
 
-if [ "$stability" = "stable" ];
+if [ "$stability" = "unstable" ];
 then
-  ## this needs to happen here because the website depends on the current node
-  ## node version
-  ## this will get the api docs in the right place
-  make website-upload
-  BRANCH="v$(python tools/getnodeversion.py | sed -E 's#\.[0-9]+$##')"
-  echo $(python tools/getnodeversion.py) > ../node-website/STABLE
-else
   BRANCH="master"
+else
+  ## This needs to happen here because the website depends on the current node
+  ## node version.
+  if [ "$stability" = "stable" ]
+  then
+    echo $(python tools/getnodeversion.py) > ../node-website/STABLE
+  fi
+
+  BRANCH="v$(python tools/getnodeversion.py | sed -E 's#\.[0-9]+$##')"
 fi
 
 echo "Merging back into $BRANCH"
@@ -74,6 +99,6 @@ git merge --no-ff v$(python tools/getnodeversion.py)-release
 vim src/node_version.h
 git commit -am "Now working on "$(python tools/getnodeversion.py)
 
-git push git@github.com:joyent/node $BRANCH
+git push git@github.com:$GITHUB_USERNAME/node $BRANCH
 
 echo "Now go do the website stuff"


### PR DESCRIPTION
This is a first step in making the release process easier to use by multiple users.

Instead of using `/home/tj` on `nodejs.org` as a staging directory, it uses `/home/staging`, which we also can control access to via ssh keys.

Instead of pushing tags and branches directly to joyent/node, it pushes them to the personal fork of the person doing the release, so there's a chance to fix errors and mistakes before pushing tags and releases branches to the reference repository.

Finally it also now distinguishes between stable, maintenance and unstable versions to mirror the current v0.10/v0.12/v0.13 release lines.

These changes are in sync with the latest changes I made recently to the [nodejs-release Jenkins job](http://jenkins.nodejs.org/job/nodejs-release/) and [Node.js release guide](https://github.com/joyent/node/wiki/Node.js-release-guide).

/cc @joyent/node-collaborators
