### PR TITLE
win,msi: change InstallScope to perMachine

### DIFF
--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -14,6 +14,7 @@ test-fs-readfile-error            : PASS,FLAKY
 test-net-GH-5504                  : PASS,FLAKY
 test-stdin-script-child           : PASS,FLAKY
 test-util-debug                   : PASS,FLAKY
+test-signal-unregister            : PASS,FLAKY
 
 [$system==macos]
 test-fs-watch                     : PASS,FLAKY

--- a/tools/msvs/msi/custom_actions.c
+++ b/tools/msvs/msi/custom_actions.c
@@ -1,9 +1,59 @@
-
 #define WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
 #include <msiquery.h>
 #include <wcautil.h>
+
+#define GUID_BUFFER_SIZE 39 // {8-4-4-4-12}\0
+
+
+UINT WINAPI SetInstallScope(MSIHANDLE hInstall) {
+  HRESULT hr = S_OK;
+  UINT er = ERROR_SUCCESS;
+  TCHAR upgrade_code[GUID_BUFFER_SIZE];
+  DWORD upgrade_code_len = GUID_BUFFER_SIZE;
+  DWORD iProductIndex;
+  TCHAR product_code[GUID_BUFFER_SIZE];
+  TCHAR assignment_type[2];
+  DWORD assignment_type_len = 2;
+
+  hr = WcaInitialize(hInstall, "SetInstallScope");
+  ExitOnFailure(hr, "Failed to initialize");
+
+  er = MsiGetProperty(hInstall, TEXT("UpgradeCode"), upgrade_code,
+                      &upgrade_code_len);
+  ExitOnWin32Error(er, hr, "Failed to get UpgradeCode property");
+
+  for (iProductIndex = 0;; iProductIndex++) {
+    er = MsiEnumRelatedProducts(upgrade_code, 0, iProductIndex, product_code);
+    if (er == ERROR_NO_MORE_ITEMS) break;
+    ExitOnWin32Error(er, hr, "Failed to get related product code");
+
+    er = MsiGetProductInfo(product_code, INSTALLPROPERTY_ASSIGNMENTTYPE,
+                           assignment_type, &assignment_type_len);
+    ExitOnWin32Error(er, hr, "Failed to get the assignment type property "
+                     "from related product");
+
+    // '0' = per-user; '1' = per-machine
+    if (assignment_type[0] == '0') {
+      /* When old versions which were installed as per-user are detected, the
+       * installation scope has to be set to per-user to be able to do an
+       * upgrade. If not, two versions will be installed side-by-side: one as
+       * per-user and the other as per-machine.
+       *
+       * If we wanted to disable backward compatibility, the installer should
+       * abort here, and request the previous version to be manually
+       * uninstalled before installing this one.
+       */
+      er = MsiSetProperty(hInstall, TEXT("ALLUSERS"), TEXT(""));
+      ExitOnWin32Error(er, hr, "Failed to set the install scope to per-user");
+      break;
+    }
+  }
+
+LExit:
+  return WcaFinalize(ERROR_SUCCESS);
+}
 
 
 UINT WINAPI BroadcastEnvironmentUpdate(MSIHANDLE hInstall) {

--- a/tools/msvs/msi/custom_actions.def
+++ b/tools/msvs/msi/custom_actions.def
@@ -1,4 +1,5 @@
 LIBRARY "custom_actions"
 
 EXPORTS
+SetInstallScope
 BroadcastEnvironmentUpdate

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -18,7 +18,7 @@
            Manufacturer="$(var.ProductAuthor)"
            UpgradeCode="1d60944c-b9ce-4a71-a7c0-0384eb884baa">
 
-    <Package InstallerVersion="200" Compressed="yes"/>
+    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine"/>
 
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
@@ -249,16 +249,27 @@
       </Component>
     </DirectoryRef>
 
-    <Binary Id='BroadcastEnvironmentUpdate'
+    <Binary Id='CustomActionsDLL'
             SourceFile='$(var.custom_actions.TargetDir)$(var.custom_actions.TargetName).dll' />
 
+    <CustomAction Id="SetInstallScope"
+                  BinaryKey="CustomActionsDLL"
+                  DllEntry="SetInstallScope"
+                  Execute="immediate"
+                  Return="check" />
+
     <CustomAction Id="BroadcastEnvironmentUpdate"
-                  BinaryKey="BroadcastEnvironmentUpdate"
+                  BinaryKey="CustomActionsDLL"
                   DllEntry="BroadcastEnvironmentUpdate"
                   Execute="immediate"
                   Return="check" />
 
+    <InstallUISequence>
+      <Custom Action='SetInstallScope' Before='FindRelatedProducts'/>
+    </InstallUISequence>
+
     <InstallExecuteSequence>
+      <Custom Action='SetInstallScope' Before='FindRelatedProducts'/>
       <Custom Action='BroadcastEnvironmentUpdate' After='InstallFinalize'/>
     </InstallExecuteSequence>
 

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -33,6 +33,14 @@
     <Property Id="INSTALLDIR">
       <RegistrySearch Id="InstallPathRegistry"
                       Type="raw"
+                      Root="HKLM"
+                      Key="$(var.RegistryKeyPath)"
+                      Name="InstallPath"/>
+      <!-- Also need to search under HKCU to support upgrading from old
+           versions. If we wanted to disable backward compatibility, this
+           second search could be deleted. -->
+      <RegistrySearch Id="InstallPathRegistryCU"
+                      Type="raw"
                       Root="HKCU"
                       Key="$(var.RegistryKeyPath)"
                       Name="InstallPath"/>
@@ -44,8 +52,9 @@
              Description="Install the core Node.js runtime (node.exe)."
              Absent="disallow">
       <ComponentRef Id="NodeExecutable"/>
+      <ComponentRef Id="NodeRegistryEntries"/>
       <ComponentRef Id="NodeVarsScript"/>
-      <ComponentRef Id="NodeStartMenuAndRegistryEntries"/>
+      <ComponentRef Id="NodeStartMenu"/>
       <ComponentRef Id="AppData" />
       <ComponentGroupRef Id="Product.Generated"/>
 
@@ -117,6 +126,20 @@
         <File Id="node.exe" KeyPath="yes" Source="$(var.SourceDir)\node.exe"/>
       </Component>
 
+      <Component Id="NodeRegistryEntries">
+        <RegistryValue Root="HKLM"
+                       Key="$(var.RegistryKeyPath)"
+                       Name="InstallPath"
+                       Type="string"
+                       Value="[INSTALLDIR]"
+                       KeyPath="yes"/>
+        <RegistryValue Root="HKLM"
+                       Key="$(var.RegistryKeyPath)"
+                       Name="Version"
+                       Type="string"
+                       Value="$(var.ProductVersion)"/>
+      </Component>
+
       <Component Id="NodeVarsScript">
         <File Id="nodevars.bat" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\nodevars.bat"/>
       </Component>
@@ -139,18 +162,15 @@
     </DirectoryRef>
 
     <DirectoryRef Id="ApplicationProgramsFolder">
-      <Component Id="NodeStartMenuAndRegistryEntries">
+      <Component Id="NodeStartMenu">
+        <!-- RegistryValue needed because every Component must have a KeyPath.
+             Because of ICE43, the Root must be HKCU. -->
         <RegistryValue Root="HKCU"
-                       Key="$(var.RegistryKeyPath)"
-                       Name="InstallPath"
-                       Type="string"
-                       Value="[INSTALLDIR]"
+                       Key="$(var.RegistryKeyPath)\Components"
+                       Name="NodeStartMenuShortcuts"
+                       Type="integer"
+                       Value="1"
                        KeyPath="yes"/>
-        <RegistryValue Root="HKCU"
-                       Key="$(var.RegistryKeyPath)"
-                       Name="Version"
-                       Type="string"
-                       Value="$(var.ProductVersion)"/>
         <Shortcut Id="NodeVarsScriptShortcut"
                   Name="Node.js command prompt"
                   Target="[%ComSpec]"


### PR DESCRIPTION
Currently, installing with the MSI always asks for Administrator permissions, as mentioned in #7629 . Explicitly installing per machine only adds the benefit that shortcuts are placed in ProgramData thus being accessible to all users and also solving #5849 .

The second commit moves the installation path in the registry to Local Machine. The registry stores HKLM in different places for 32 and 64 bit applications, so the installer will not suggest the old path when upgrading from 32 to 64 bit version, solving #5592 and #25087 .

/cc @piscisaureus 
