### PR TITLE
tls: Closing parent socket also closes the tls sock

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -228,6 +228,7 @@ function onocspresponse(resp) {
 function TLSSocket(socket, options) {
   // Disallow wrapping TLSSocket in TLSSocket
   assert(!(socket instanceof TLSSocket));
+  var self = this;
 
   net.Socket.call(this, {
     handle: socket && socket._handle,
@@ -238,6 +239,9 @@ function TLSSocket(socket, options) {
 
   if (socket) {
     this._parent = socket;
+    socket._destroy = function(exception) {
+      self._destroy(exception);
+    };
     // To prevent assertion in afterConnect()
     this._connecting = socket._connecting;
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -468,12 +468,10 @@ Socket.prototype._destroy = function(exception, cb) {
     return;
   }
 
-  self._connecting = false;
-
-  this.readable = this.writable = false;
-
-  for (var s = this; s !== null; s = s._parent)
+  for (var s = this; s !== null; s = s._parent) {
     timers.unenroll(s);
+    s._connecting = s.readable = s.writable = false;
+  }
 
   debug('close');
   if (this._handle) {
@@ -482,16 +480,20 @@ Socket.prototype._destroy = function(exception, cb) {
     var isException = exception ? true : false;
     this._handle.close(function() {
       debug('emit close');
-      self.emit('close', isException);
+      for (var s = self; s !== null; s = s._parent)
+        s.emit('close', isException);
     });
     this._handle.onread = noop;
-    this._handle = null;
+    for (var s = this; s !== null; s = s._parent)
+      s._handle = null;
   }
 
   // we set destroyed to true before firing error callbacks in order
   // to make it re-entrance safe in case Socket.prototype.destroy()
   // is called within callbacks
-  this.destroyed = true;
+  for (var s = this; s !== null; s = s._parent)
+    s.destroyed = true;
+
   fireErrorCallbacks();
 
   if (this.server) {

--- a/test/simple/test-tls-destroy-socket.js
+++ b/test/simple/test-tls-destroy-socket.js
@@ -1,0 +1,55 @@
+if (!process.versions.openssl) {
+  console.error('Skipping because node compiled without OpenSSL.');
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+var fs = require('fs');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+};
+
+var normalSock = null;
+var hasError = false;
+var tlsCloseCount = 0;
+var sockCloseCount = 0;
+
+var server = tls.createServer(options, function(secureSock) {
+  secureSock.on('error', function() {
+    hasError = true;
+  });
+  secureSock.on('close', function() {
+    tlsCloseCount++;
+  });
+  normalSock.on('close', function() {
+    sockCloseCount++;
+  });
+
+  normalSock.destroy();
+  secureSock.write('Test!', function(err) {
+    assert(err);
+  });
+});
+
+server.on('connection', function(sock) {
+  normalSock = sock;
+});
+
+server.listen(common.PORT, function() {
+  var c = tls.connect(common.PORT, {rejectUnauthorized: false});
+  c.on('error', function() {}); // ignore socket hangup error
+
+  c.on('end', function() {
+    server.close();
+  });
+
+  process.on('exit', function() {
+    assert(hasError);
+    assert.equal(tlsCloseCount, 1);
+    assert.equal(sockCloseCount, 1);
+  });
+});


### PR DESCRIPTION
Fixes #25365 .  At the moment if you close the parent socket of a a TLS socket the TLS socket is not aware of this and will segfault when you attempt to perform and IO operation on it.  Further, if you close the parent socket and then the TLS socket, the parent socket will emit the close event twice (and the TLS socket wont fire at all). If you change the order the results are reversed, ie. closing the TLS then the parent socket will result in the TLS socket firing the close event twice and the parent socket wont fire at all. 

This patch moves toward linking the parent and tls sockets. Calling `destroy()` on either of the the sockets causes both sockets to be destroyed and the close event emitted for both of them
