### PR TITLE
openssl: arm64 compile fix

### DIFF
--- a/deps/openssl/config/opensslconf.h
+++ b/deps/openssl/config/opensslconf.h
@@ -205,7 +205,7 @@
  /* If this is set to 'unsigned int' on a DEC Alpha, this gives about a
   * %20 speed up (longs are 8 bytes, int's are 4). */
 # undef DES_LONG
-# if defined(_M_X64) || defined(__x86_64__) || defined(__arm__) || defined(__mips__)
+# if defined(_M_X64) || defined(__x86_64__) || defined(__ARM_ARCH_64__) || defined(__arm__) || defined(__mips__)
 #  define DES_LONG unsigned int
 # elif defined(_M_IX86) || defined(__i386__)
 #  define DES_LONG unsigned long
@@ -233,7 +233,7 @@
 # undef EIGHT_BIT
 # if (defined(_M_X64) || defined(__x86_64__)) && defined(_WIN32)
 #  define SIXTY_FOUR_BIT
-# elif (defined(_M_X64) || defined(__x86_64__)) && !defined(_WIN32)
+# elif (defined(_M_X64) || defined(__x86_64__) || defined(__ARM_ARCH_64__)) && !defined(_WIN32)
 #  define SIXTY_FOUR_BIT_LONG
 # elif defined(_M_IX86) || defined(__i386__) || defined(__arm__) || defined(__mips__)
 #  define THIRTY_TWO_BIT


### PR DESCRIPTION
Compiling openssl was failing on arm64 platform.
