### PR TITLE
Reconcile v0.12 with new CI 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,11 @@ docopen: out/doc/api/all.html
 docclean:
 	-rm -rf out/doc
 
+run-ci:
+	$(PYTHON) ./configure --without-snapshot $(CONFIG_FLAGS)
+	$(MAKE)
+	$(MAKE) test-ci
+
 RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)
 VERSION=v$(RAWVER)
 NODE_DOC_VERSION=$(VERSION)
@@ -443,4 +448,9 @@ cpplint:
 
 lint: jslint cpplint
 
-.PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean check uninstall install install-includes install-bin all staticlib dynamiclib test test-all test-addons build-addons website-upload pkg blog blogclean tar binary release-only bench-http-simple bench-idle bench-all bench bench-misc bench-array bench-buffer bench-net bench-http bench-fs bench-tls
+.PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean \
+	check uninstall install install-includes install-bin all staticlib \
+	dynamiclib test test-all test-addons build-addons website-upload pkg \
+	blog blogclean tar binary release-only bench-http-simple bench-idle \
+	bench-all bench bench-misc bench-array bench-buffer bench-net \
+	bench-http bench-fs bench-tls run-ci

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ test-all-http1: test-build
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
+test-ci:
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release --arch=$(DESTCPU) simple message internet
+
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ NINJA ?= ninja
 DESTDIR ?=
 SIGN ?=
 PREFIX ?= /usr/local
+FLAKY_TESTS ?= run
 
 NODE ?= ./node
 
@@ -128,7 +129,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci:
-	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release --arch=$(DESTCPU) simple message internet
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release --arch=$(DESTCPU) --flaky-tests=$(FLAKY_TESTS) simple message internet
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release

--- a/tools/test.py
+++ b/tools/test.py
@@ -1375,7 +1375,7 @@ def Main():
 
   ch = logging.StreamHandler(sys.stdout)
   logger.addHandler(ch)
-  logger.setLevel('INFO')
+  logger.setLevel(logging.INFO)
   if options.logfile:
     fh = logging.FileHandler(options.logfile)
     logger.addHandler(fh)

--- a/tools/test.py
+++ b/tools/test.py
@@ -68,7 +68,9 @@ class ProgressIndicator(object):
     self.remaining = len(cases)
     self.total = len(cases)
     self.failed = [ ]
+    self.flaky_failed = [ ]
     self.crashed = 0
+    self.flaky_crashed = 0
     self.terminate = False
     self.lock = threading.Lock()
 
@@ -129,9 +131,14 @@ class ProgressIndicator(object):
         return
       self.lock.acquire()
       if output.UnexpectedOutput():
-        self.failed.append(output)
-        if output.HasCrashed():
-          self.crashed += 1
+        if FLAKY in output.test.outcomes and self.flaky_tests_mode == "dontcare":
+          self.flaky_failed.append(output)
+          if output.HasCrashed():
+            self.flaky_crashed += 1
+        else:
+          self.failed.append(output)
+          if output.HasCrashed():
+            self.crashed += 1
       else:
         self.succeeded += 1
       self.remaining -= 1

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -61,7 +61,8 @@ if /i "%1"=="test-simple"   set test=test-simple&goto arg-ok
 if /i "%1"=="test-message"  set test=test-message&goto arg-ok
 if /i "%1"=="test-gc"       set test=test-gc&set buildnodeweak=1&goto arg-ok
 if /i "%1"=="test-all"      set test=test-all&set buildnodeweak=1&goto arg-ok
-if /i "%1"=="test"          set test=test&goto arg-ok
+if /i "%1"=="test-ci"       set test=test-ci&set nosnapshot=1&goto arg-ok
+if /i "%1"=="test"          set test=test&set jslint=1&goto arg-ok
 @rem Include small-icu support with MSI installer
 if /i "%1"=="msi"           set msi=1&set licensertf=1&set download_arg="--download=all"&set i18n_arg=small-icu&goto arg-ok
 if /i "%1"=="upload"        set upload=1&goto arg-ok
@@ -81,7 +82,6 @@ goto next-arg
 
 :args-done
 if defined upload goto upload
-if defined jslint goto jslint
 
 if defined build_release (
   set nosnapshot=1
@@ -197,12 +197,15 @@ if errorlevel 1 echo Failed to sign msi&goto exit
 
 :run
 @rem Run tests if requested.
-if "%test%"=="" goto exit
+if "%test%"=="" goto jslint
 
 if "%config%"=="Debug" set test_args=--mode=debug
 if "%config%"=="Release" set test_args=--mode=release
 
+set test_args=%test_args% --arch=%target_arch% 
+
 if "%test%"=="test" set test_args=%test_args% simple message
+if "%test%"=="test-ci" set test_args=%test_args% -p tap --logfile test.tap simple message internet
 if "%test%"=="test-internet" set test_args=%test_args% internet
 if "%test%"=="test-pummel" set test_args=%test_args% pummel
 if "%test%"=="test-simple" set test_args=%test_args% simple
@@ -224,8 +227,7 @@ goto exit
 :run-tests
 echo running 'python tools/test.py %test_args%'
 python tools/test.py %test_args%
-if "%test%"=="test" goto jslint
-goto exit
+goto jslint
 
 :create-msvs-files-failed
 echo Failed to create vc project files. 
@@ -243,6 +245,7 @@ scp Release\node.pdb node@nodejs.org:~/web/nodejs.org/dist/v%NODE_VERSION%/node.
 goto exit
 
 :jslint
+if not defined jslint goto exit
 echo running jslint
 set PYTHONPATH=tools/closure_linter/
 python tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -38,6 +38,7 @@ set noperfctr_msi_arg=
 set i18n_arg=
 set download_arg=
 set build_release=
+set flaky_tests_arg=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -72,6 +73,7 @@ if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
 if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="build-release" set build_release=1&goto arg-ok
+if /i "%1"=="ignore-flaky"  set flaky_tests_arg=--flaky-tests=dontcare&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -205,7 +207,7 @@ if "%config%"=="Release" set test_args=--mode=release
 set test_args=%test_args% --arch=%target_arch% 
 
 if "%test%"=="test" set test_args=%test_args% simple message
-if "%test%"=="test-ci" set test_args=%test_args% -p tap --logfile test.tap simple message internet
+if "%test%"=="test-ci" set test_args=%test_args% -p tap --logfile test.tap %flaky_tests_arg% simple message internet 
 if "%test%"=="test-internet" set test_args=%test_args% internet
 if "%test%"=="test-pummel" set test_args=%test_args% pummel
 if "%test%"=="test-simple" set test_args=%test_args% simple


### PR DESCRIPTION
..continued from https://github.com/joyent/node/pull/25541

As part of CI reconciliation, these commits make v0.12 work with the jobs at https://jenkins-iojs.nodesource.com/ 

This PR addresses all review feedback from https://github.com/joyent/node/pull/25541. In particular:
- I left out the commit that changed the default for snapshots, based on feedback from @misterdjules . Instead, I introduced a new run-ci makefile rule which invokes configure internally with --without-snapshot. On Windows, the same is accomplished by calling vcbuild test-ci
- I made it so that Jenkins jobs can control whether to care about flaky tests or not, with an environment variable on *nix and a vcbuild argument on Windows.
