### PR TITLE
doc: Change the link for v8 docs to v8dox.com

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -8,7 +8,7 @@ knowledge of several libraries:
    creating objects, calling functions, etc.  Documented mostly in the
    `v8.h` header file (`deps/v8/include/v8.h` in the Node source
    tree), which is also available
-   [online](http://izs.me/v8-docs/main.html).
+   [online](http://v8dox.com/).
 
  - [libuv](https://github.com/joyent/libuv), C event loop library.
    Anytime one needs to wait for a file descriptor to become readable,


### PR DESCRIPTION
No offense to @izs, but the doxygen he put up 3.5 years ago isn't
accurate for node 0.12 nor io.js. I'm trying to keep up and have
multiple sets of doxygen of v8 available at http://v8dox.com/
