### PR TITLE
doc: fix typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -925,7 +925,7 @@ maintained libraries. The externally maintained libraries used by Node are:
      #	---------COPYING.libtabe ---- BEGIN--------------------
      #
      #	/*
-     #	 * Copyrighy (c) 1999 TaBE Project.
+     #	 * Copyright (c) 1999 TaBE Project.
      #	 * Copyright (c) 1999 Pai-Hsiang Hsiao.
      #	 * All rights reserved.
      #	 *


### PR DESCRIPTION
"Copyright" misspelled
