### PR TITLE
REPL bug fixes

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -315,7 +315,9 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       self.bufferedCommand = '';
 
       // If we got any output - print it (if no error)
-      if (!e && (!self.ignoreUndefined || !util.isUndefined(ret))) {
+      if (!e &&
+          arguments.length === 2 &&
+          (!self.ignoreUndefined || !util.isUndefined(ret))) {
         self.context._ = ret;
         self.outputStream.write(self.writer(ret) + '\n');
       }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -196,7 +196,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
   self.setPrompt(!util.isUndefined(prompt) ? prompt : '> ');
 
-  this.commands = {};
+  this.commands = Object.create(null);
   defineDefaultCommands(this);
 
   // figure out which "writer" function to use

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -330,7 +330,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       }
     }
 
-    if (!skipCatchall) {
+    if (!skipCatchall && (cmd || (!cmd && self.bufferedCommand))) {
       var evalCmd = self.bufferedCommand + cmd;
       if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
         // It's confusing for `{ a : 1 }` to be interpreted as a block

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -154,6 +154,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self._domain.on('error', function(e) {
     debug('domain error');
     self.outputStream.write((e.stack || e) + '\n');
+    self._currentStringLiteral = null;
     self.bufferedCommand = '';
     self.lines.level = [];
     self.displayPrompt();
@@ -180,6 +181,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.outputStream = output;
 
   self.resetContext();
+  self._currentStringLiteral = null;
   self.bufferedCommand = '';
   self.lines.level = [];
 
@@ -221,6 +223,10 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   });
 
   var sawSIGINT = false;
+  Object.defineProperty(self, '_currentStringLiteral', {
+    value: null
+  });
+
   self.on('SIGINT', function() {
     var empty = self.line.length === 0;
     self.clearLine();
@@ -237,16 +243,78 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       sawSIGINT = false;
     }
 
+    self._currentStringLiteral = null;
     self.bufferedCommand = '';
     self.lines.level = [];
     self.displayPrompt();
   });
 
+  function parseForStringLiteral(line) {
+    var previous = null, current = null;
+
+    for (var i = 0; i < line.length; i += 1) {
+      if (previous === '\\') {
+        // if it is a valid escaping, then skip processing
+        previous = current;
+        continue;
+      }
+
+      current = line.charAt(i);
+      if (current === self._currentStringLiteral) {
+        self._currentStringLiteral = null;
+      } else if (current === '\'' ||
+                 current === '"' &&
+                 self._currentStringLiteral === null) {
+        self._currentStringLiteral = current;
+      }
+      previous = current;
+    }
+  }
+
+  function getFinisherFunction(cmd, defaultFn) {
+    if ((self._currentStringLiteral === null &&
+         cmd.charAt(cmd.length - 1) === '\\') ||
+        (self._currentStringLiteral !== null &&
+         cmd.charAt(cmd.length - 1) !== '\\')) {
+
+      // If the line continuation is used outside string literal or if the
+      // string continuation happens with out line continuation, then fail hard
+      return function(e, ret) {
+        var error = e instanceof Recoverable ? e.err : e;
+        var args = [error];
+
+        if (arguments.length === 2) {
+          // adding second argument only if it is actually passed. Otherwise
+          // `undefined` will be printed when invalid REPL commands are used.
+          args.push(ret);
+        }
+
+        return defaultFn.apply(this, args);
+      };
+    }
+    return defaultFn;
+  }
   self.on('line', function(cmd) {
     debug('line %j', cmd);
     sawSIGINT = false;
     var skipCatchall = false;
-    cmd = trimWhitespace(cmd);
+
+    var wasWithinStrLiteral = self._currentStringLiteral !== null;
+    parseForStringLiteral(cmd);
+    var isWithinStrLiteral = self._currentStringLiteral !== null;
+
+    if (!wasWithinStrLiteral && !isWithinStrLiteral) {
+      // Current line has nothing to do with String literals, trim both the ends
+      cmd = cmd.replace(/^\s+|\s+$/g, '');
+    } else if (wasWithinStrLiteral && !isWithinStrLiteral) {
+      // was part of a string literal, but it is over now. So trim only the end
+      cmd = cmd.replace(/\s+$/, '');
+    } else if (isWithinStrLiteral && !wasWithinStrLiteral) {
+      // was not part of a string literal, but it is now. So trim the beginning
+      cmd = cmd.replace(/^\s+/, '');
+    }
+
+    var finisherFn = getFinisherFunction(cmd, finish);
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
@@ -278,9 +346,9 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       }
 
       debug('eval %j', evalCmd);
-      self.eval(evalCmd, self.context, 'repl', finish);
+      self.eval(evalCmd, self.context, 'repl', finisherFn);
     } else {
-      finish(null);
+      finisherFn(null);
     }
 
     function finish(e, ret) {
@@ -291,6 +359,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
+        self._currentStringLiteral = null;
         self.bufferedCommand = '';
         self.displayPrompt();
         return;
@@ -312,6 +381,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
       }
 
       // Clear buffer if no SyntaxErrors
+      self._currentStringLiteral = null;
       self.bufferedCommand = '';
 
       // If we got any output - print it (if no error)
@@ -823,6 +893,7 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
     action: function() {
+      this._currentStringLiteral = null;
       this.bufferedCommand = '';
       this.displayPrompt();
     }
@@ -837,6 +908,7 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('clear', {
     help: clearMessage,
     action: function() {
+      this._currentStringLiteral = null;
       this.bufferedCommand = '';
       if (!this.useGlobal) {
         this.outputStream.write('Clearing context...\n');
@@ -901,18 +973,6 @@ function defineDefaultCommands(repl) {
     }
   });
 }
-
-
-function trimWhitespace(cmd) {
-  var trimmer = /^\s*(.+)\s*$/m,
-      matches = trimmer.exec(cmd);
-
-  if (matches && matches.length === 2) {
-    return matches[1];
-  }
-  return '';
-}
-
 
 function regexpEscape(s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -235,6 +235,13 @@ function error_test() {
     // using REPL command "help" within a string literal should still work
     { client: client_unix, send: '\'thefourth\\\n.help\neye\'',
       expect: /'thefourtheye'/ },
+    // empty lines in the REPL should be allowed
+    { client: client_unix, send: '\n\n\n',
+      expect: prompt_unix + prompt_unix + prompt_unix },
+    // empty lines in the string literals should not affect the string
+    { client: client_unix, send: '\'the\\\n\\\nfourtheye\'\n',
+      expect: prompt_multiline + prompt_multiline +
+              '\'thefourtheye\'\n' + prompt_unix },
   ]);
 }
 

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -209,6 +209,32 @@ function error_test() {
     // a REPL command
     { client: client_unix, send: '.toString',
       expect: 'Invalid REPL keyword\n' + prompt_unix },
+    // fail when we are not inside a String and a line continuation is used
+    { client: client_unix, send: '[] \\',
+      expect: /^SyntaxError: Unexpected token ILLEGAL/ },
+    // do not fail when a String is created with line continuation
+    { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
+      expect: prompt_multiline + prompt_multiline + '\'thefourtheye\'' },
+    // Don't fail when a partial String is created and line continuation is used
+    // with whitespace characters at the end of the string. We are to ignore it.
+    // This test is to make sure that we properly remove the whitespace
+    // characters at the end of line, unlike the buggy `trimWhitespace` function
+    { client: client_unix, send: '  \t    .break  \t  ',
+      expect: prompt_unix },
+    // multiline strings preserve whitespace characters in them
+    { client: client_unix, send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
+      expect: prompt_multiline + prompt_multiline +
+              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix},
+    // more than one multiline strings also should preserve whitespace chars
+    { client: client_unix, send: '\'the \\\n   fourth\' + \'\t\t\\\n  eye  \'',
+      expect: prompt_multiline + prompt_multiline +
+              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix},
+    // using REPL commands within a string literal should still work
+    { client: client_unix, send: '\'\\\n.break',
+      expect: prompt_unix },
+    // using REPL command "help" within a string literal should still work
+    { client: client_unix, send: '\'thefourth\\\n.help\neye\'',
+      expect: /'thefourtheye'/ },
   ]);
 }
 

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -205,6 +205,10 @@ function error_test() {
     // the error message
     { client: client_unix, send: '.invalid_repl_command',
       expect: 'Invalid REPL keyword\n' + prompt_unix },
+    // this makes sure that we don't crash when we use an inherited property as
+    // a REPL command
+    { client: client_unix, send: '.toString',
+      expect: 'Invalid REPL keyword\n' + prompt_unix },
   ]);
 }
 

--- a/test/simple/test-repl.js
+++ b/test/simple/test-repl.js
@@ -200,7 +200,11 @@ function error_test() {
     { client: client_unix, send: 'url.format("http://google.com")',
       expect: 'http://google.com/' },
     { client: client_unix, send: 'var path = 42; path',
-      expect: '42' }
+      expect: '42' },
+    // this makes sure that we don't print `undefined` when we actually print
+    // the error message
+    { client: client_unix, send: '.invalid_repl_command',
+      expect: 'Invalid REPL keyword\n' + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
There are four bug fixes.
#### 1. Better line continuation feature

As it is, REPL doesn't honour the line continuation feature very well.
This patch
1. keeps track of the beginning of the string literals and if they
   don't end or current line doesn't end with line continuation, then
   error out.
2. monitors if the line continuation character is used without the
   string literal and errors out if that happens.

This also fixes: #6070

---
#### 2. Removing `undefined` when unknown REPL command is used

When an invalid REPL keyword is used, we actually print `undefined` as
well in the console.

```
> process.version
'v0.12.7'
> .invalid_repl_command
Invalid REPL keyword
undefined
```

This patch prevents printing `undefined` in this case.

```
> process.version
'v0.13.0-pre'
> .invalid_repl_command
Invalid REPL keyword
```

---
#### 3. preventing REPL crash with inherited properties

When an inherited property is used as a REPL keyword, the REPL crashes.

```
> process.version
'v0.12.7'
> .toString
repl.js:706
    cmd.action.call(this, rest);
            ^
TypeError: Cannot read property 'call' of undefined
    at REPLServer.parseREPLKeyword (repl.js:706:15)
    at REPLServer.<anonymous> (repl.js:255:16)
    at REPLServer.emit (events.js:107:17)
    at REPLServer.Interface._onLine (readline.js:214:10)
    at REPLServer.Interface._line (readline.js:553:8)
    at REPLServer.Interface._ttyWrite (readline.js:830:14)
    at ReadStream.onkeypress (readline.js:109:10)
    at ReadStream.emit (events.js:110:17)
    at readline.js:1175:14
    at Array.forEach (native)
```

This patch makes the internal `commands` object inherit from `null` so
that there will be no inherited properties.

```
> process.version
'v0.13.0-pre'
> .toString
Invalid REPL keyword
>
```

---
#### 4. Better empty line handling

In REPL, if we try to evaluate an empty line, we get `undefined`.

```
> process.version
'v0.12.7'
>
undefined
>
undefined
>
```

This patch prevents `undefined` from printing if the string is empty.

```
> process.version
'v0.13.0-pre'
>
>
>
```

cc @misterdjules 
