### PR TITLE
Check this.connection._httpMessage for null

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -561,7 +561,9 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   // There is the first message on the outgoing queue, and we've sent
   // everything to the socket.
   debug('outgoing message end.');
-  if (this.output.length === 0 && this.connection._httpMessage === this) {
+  if (this.output.length === 0 && 
+    this.connection &&
+    this.connection._httpMessage === this) {
     this._finish();
   }
 


### PR DESCRIPTION
When using express-ws, I've noticed a TypeError is thrown in early terminating router middleware. Here is code to reproduce the error: 

```
var app = require('express')();
var expressWs = require('express-ws')(app);

// Terminating middleware
app.use('/ws', function(req, res, next) {
  try {
    return res.status(500).end();
  } catch(ex) {
    console.log(ex.name, ex.message);
  }
});

app.ws('/ws', function(ws, req) { });

app.listen(8888);
```

Package versions:

```
express: 4.13.1
express-ws: 0.2.6
```
