### PR TITLE
OpenSuse Tumbleweed gcc (v. 5.1.1) -dumpversion issues

### DIFF
--- a/configure
+++ b/configure
@@ -527,8 +527,11 @@ def configure_node(o):
   o['variables']['clang'] = 1 if is_clang else 0
 
   if not is_clang and cc_version != 0:
-    o['variables']['gcc_version'] = 10 * cc_version[0] + cc_version[1]
-
+    try:
+        o['variables']['gcc_version'] = 10 * cc_version[0] + cc_version[1]
+    except IndexError:
+        o['variables']['gcc_version'] = 10 * cc_version[0]
+        
   # clang has always supported -fvisibility=hidden, right?
   if not is_clang and cc_version < (4,0,0):
     o['variables']['visibility'] = ''


### PR DESCRIPTION
Hello,
I found some difficulties when attempting to configure and compile NodeJS packages in openSUSE Tumbleweed.
The error reported when running ./configure

```
Traceback (most recent call last):
  File "./configure", line 992, in <module>
    configure_node(output)
  File "./configure", line 530, in configure_node
    o['variables']['gcc_version'] = 10 * cc_version[0] + cc_version[1]
IndexError: tuple index out of range
```

In the configure file, specifically the compiler_version function. It returned a tuple to cc_version variable. However, in OpenSUSE, if we execute:

```
henrique@aegis~>: gcc -dumpversion
5
```

It returns a single integer value, making the variable that contains the tuple store (5,), resulting in IndexError exception.

I made this change in my configure file, allowing the compilation of NodeJS in my Tumbleweed environment.

ps: Excuse me for my English, it is not my native language. I'm learning it yet. :)
