### PR TITLE
test: Unmark tests that are no longer flaky

### DIFF
--- a/test/internet/internet.status
+++ b/test/internet/internet.status
@@ -3,4 +3,3 @@ prefix internet
 test-dns                          : PASS,FLAKY
 
 [$system==solaris]
-test-http-dns-fail                : PASS,FLAKY

--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -1,6 +1,5 @@
 prefix simple
 
-test-crypto-domains               : PASS,FLAKY
 test-debug-signal-cluster         : PASS,FLAKY
 test-cluster-basic                : PASS,FLAKY
 test-microtask-queue-run          : PASS,FLAKY
@@ -10,10 +9,6 @@ test-microtask-queue-run-domain   : PASS,FLAKY
 test-timers-first-fire            : PASS,FLAKY
 
 [$system==linux]
-test-fs-readfile-error            : PASS,FLAKY
-test-net-GH-5504                  : PASS,FLAKY
-test-stdin-script-child           : PASS,FLAKY
-test-util-debug                   : PASS,FLAKY
 
 [$system==macos]
 test-fs-watch                     : PASS,FLAKY


### PR DESCRIPTION
- `test-crypto-domains` was fixed by joyent/node@2afa3d8a03f1f0798d83dc57abc252bb78b7e591
- (EDIT:) All tests under linux appear to be fixed and have not failed recently on Jenkins
- (EDIT:) `test-http-dns-fail` was fixed by the DNS configuration change mentioned in joyent/node#8056

Fixes #25656
Fixes #25673

/cc @joyent/node-collaborators 
