### PR TITLE
Only apply drain listener when callback provided

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -450,9 +450,11 @@ Zlib.prototype.flush = function(kind, callback) {
       this.once('end', callback);
   } else if (ws.needDrain) {
     var self = this;
-    this.once('drain', function() {
-      self.flush(callback);
-    });
+    if (callback) {
+      this.once('drain', function() {
+        self.flush(callback);
+      });
+    }
   } else {
     this._flushFlag = kind;
     this.write(new Buffer(0), '', callback);


### PR DESCRIPTION
When using the [compression](https://github.com/expressjs/compression) middleware in express with Server-Sent Events, I've noticed a `possible EventEmitter memory leak detected. 11 drain listeners added.` message appearing from Gzip.addListener:

``` term
at Gzip.addListener (events.js:179:15)
at Gzip.Readable.on (_stream_readable.js:671:33)
at Gzip.once (events.js:204:8)
at Gzip.Zlib.flush (zlib.js:451:10)
at ServerResponse.flush (/app/node_modules/compression/index.js:63:16)
```

The error can be reproduced using the SSE example on the expressjs/compression [readme](https://github.com/expressjs/compression#server-sent-events).

When `stream.flush()` is called without a callback, an empty listener is being added. Since flush may be called multiple times to push SSE's down to the client, multiple noop listeners are being added. This in turn causes the `memory leak detected` message.

Judging by [line 449](https://github.com/joyent/node/blob/6036e4f5a833b27fb474f3bf891c405606fdce19/lib/zlib.js#L449), an attempt has been made to avoid this situation, however, not all code paths have had the empty listener check applied.
