### PR TITLE
Add the CESU-8 encoding support

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1616,6 +1616,12 @@ class V8_EXPORT String : public Primitive {
   int Utf8Length() const;
 
   /**
+  * Returns the number of bytes in the CESU-8 encoded
+  * representation of this string.
+  */
+  int Cesu8Length() const;
+
+  /**
    * Returns whether this string is known to contain only one byte data.
    * Does not read the string.
    * False negatives are possible.
@@ -1661,7 +1667,10 @@ class V8_EXPORT String : public Primitive {
     // Used by WriteUtf8 to replace orphan surrogate code units with the
     // unicode replacement character. Needs to be set to guarantee valid UTF-8
     // output.
-    REPLACE_INVALID_UTF8 = 8
+    REPLACE_INVALID_UTF8 = 8,
+    // Compatibility Encoding Scheme for UTF-16: 8-Bit
+    // a variant of UTF-8 that is described in Unicode Technical Report #26
+    ENCODE_AS_CESU_8 = 16
   };
 
   // 16-bit character codes.

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -4303,7 +4303,7 @@ class Utf8LengthHelper : public i::AllStatic {
       state_ = kInitialState;
     }
 
-    void VisitTwoByteString(const uint16_t* chars, int length) {
+    virtual void VisitTwoByteString(const uint16_t* chars, int length) {
       int utf8_length = 0;
       int last_character = unibrow::Utf16::kNoPreviousCharacter;
       for (int i = 0; i < length; i++) {
@@ -4332,10 +4332,43 @@ class Utf8LengthHelper : public i::AllStatic {
       return cons_string;
     }
 
-   private:
+   protected:
     int utf8_length_;
     uint8_t state_;
     DISALLOW_COPY_AND_ASSIGN(Visitor);
+  };
+
+  class CesuVisitor : public Visitor {
+   public:
+
+    virtual void VisitTwoByteString(const uint16_t* chars, int length) {
+      int utf8_length = 0;
+      int last_character = unibrow::Utf16::kNoPreviousCharacter;
+      for (int i = 0; i < length; i++) {
+        uint16_t c = chars[i];
+        utf8_length += unibrow::Utf8::CesuLength(c, last_character);
+        last_character = c;
+      }
+      utf8_length_ = utf8_length;
+      uint8_t state = 0;
+      if (unibrow::Utf16::IsTrailSurrogate(chars[0])) {
+        state |= kStartsWithTrailingSurrogate;
+      }
+      if (unibrow::Utf16::IsLeadSurrogate(chars[length-1])) {
+        state |= kEndsWithLeadingSurrogate;
+      }
+      state_ = state;
+    }
+
+    static i::ConsString* VisitFlat(i::String* string,
+                                    int* length,
+                                    uint8_t* state) {
+      CesuVisitor visitor;
+      i::ConsString* cons_string = i::String::VisitFlat(&visitor, string);
+      *length = visitor.utf8_length_;
+      *state = visitor.state_;
+      return cons_string;
+    }
   };
 
   static inline void MergeLeafLeft(int* length,
@@ -4438,9 +4471,107 @@ class Utf8LengthHelper : public i::AllStatic {
     return 0;
   }
 
+  static inline void CesuMergeLeafLeft(int* length,
+                                   uint8_t* state,
+                                   uint8_t leaf_state) {
+    bool edge_surrogate = StartsWithSurrogate(leaf_state);
+    if (!(*state & kLeftmostEdgeIsCalculated)) {
+      DCHECK(!(*state & kLeftmostEdgeIsSurrogate));
+      *state |= kLeftmostEdgeIsCalculated
+          | (edge_surrogate ? kLeftmostEdgeIsSurrogate : 0);
+    }
+    if (EndsWithSurrogate(leaf_state)) {
+      *state |= kEndsWithLeadingSurrogate;
+    } else {
+      *state &= ~kEndsWithLeadingSurrogate;
+    }
+  }
+
+  static inline void CesuMergeLeafRight(int* length,
+                                    uint8_t* state,
+                                    uint8_t leaf_state) {
+    bool edge_surrogate = EndsWithSurrogate(leaf_state);
+    if (!(*state & kRightmostEdgeIsCalculated)) {
+      DCHECK(!(*state & kRightmostEdgeIsSurrogate));
+      *state |= (kRightmostEdgeIsCalculated
+                 | (edge_surrogate ? kRightmostEdgeIsSurrogate : 0));
+    }
+    if (StartsWithSurrogate(leaf_state)) {
+      *state |= kStartsWithTrailingSurrogate;
+    } else {
+      *state &= ~kStartsWithTrailingSurrogate;
+    }
+  }
+
+  static inline void CesuMergeTerminal(int* length,
+                                   uint8_t state,
+                                   uint8_t* state_out) {
+    DCHECK((state & kLeftmostEdgeIsCalculated) &&
+           (state & kRightmostEdgeIsCalculated));
+    *state_out = kInitialState |
+        (state & kLeftmostEdgeIsSurrogate ? kStartsWithTrailingSurrogate : 0) |
+        (state & kRightmostEdgeIsSurrogate ? kEndsWithLeadingSurrogate : 0);
+  }
+  
+  static int CesuCalculate(i::ConsString* current, uint8_t* state_out) {
+    using namespace internal;
+    int total_length = 0;
+    uint8_t state = kInitialState;
+    while (true) {
+      i::String* left = current->first();
+      i::String* right = current->second();
+      uint8_t right_leaf_state;
+      uint8_t left_leaf_state;
+      int leaf_length;
+      ConsString* left_as_cons =
+          CesuVisitor::VisitFlat(left, &leaf_length, &left_leaf_state);
+      if (left_as_cons == NULL) {
+        total_length += leaf_length;
+        CesuMergeLeafLeft(&total_length, &state, left_leaf_state);
+      }
+      ConsString* right_as_cons =
+          CesuVisitor::VisitFlat(right, &leaf_length, &right_leaf_state);
+      if (right_as_cons == NULL) {
+        total_length += leaf_length;
+        CesuMergeLeafRight(&total_length, &state, right_leaf_state);
+        if (left_as_cons != NULL) {
+          // 1 Leaf node. Descend in place.
+          current = left_as_cons;
+          continue;
+        } else {
+          // Terminal node.
+          CesuMergeTerminal(&total_length, state, state_out);
+          return total_length;
+        }
+      } else if (left_as_cons == NULL) {
+        // 1 Leaf node. Descend in place.
+        current = right_as_cons;
+        continue;
+      }
+      // Both strings are ConsStrings.
+      // Recurse on smallest.
+      if (left->length() < right->length()) {
+        total_length += CesuCalculate(left_as_cons, &left_leaf_state);
+        CesuMergeLeafLeft(&total_length, &state, left_leaf_state);
+        current = right_as_cons;
+      } else {
+        total_length += CesuCalculate(right_as_cons, &right_leaf_state);
+        CesuMergeLeafRight(&total_length, &state, right_leaf_state);
+        current = left_as_cons;
+      }
+    }
+    UNREACHABLE();
+    return 0;
+  }
+
   static inline int Calculate(i::ConsString* current) {
     uint8_t state = kInitialState;
     return Calculate(current, &state);
+  }
+
+  static inline int CesuCalculate(i::ConsString* current) {
+    uint8_t state = kInitialState;
+    return CesuCalculate(current, &state);
   }
 
  private:
@@ -4458,11 +4589,27 @@ static int Utf8Length(i::String* str, i::Isolate* isolate) {
   return Utf8LengthHelper::Calculate(cons_string);
 }
 
+static int Cesu8Length(i::String* str, i::Isolate* isolate) {
+  int length = str->length();
+  if (length == 0) return 0;
+  uint8_t state;
+  i::ConsString* cons_string =
+      Utf8LengthHelper::CesuVisitor::VisitFlat(str, &length, &state);
+  if (cons_string == NULL) return length;
+  return Utf8LengthHelper::CesuCalculate(cons_string);
+}
+
 
 int String::Utf8Length() const {
   i::Handle<i::String> str = Utils::OpenHandle(this);
   i::Isolate* isolate = str->GetIsolate();
   return v8::Utf8Length(*str, isolate);
+}
+
+int String::Cesu8Length() const {
+  i::Handle<i::String> str = Utils::OpenHandle(this);
+  i::Isolate* isolate = str->GetIsolate();
+  return v8::Cesu8Length(*str, isolate);
 }
 
 
@@ -4472,7 +4619,8 @@ class Utf8WriterVisitor {
       char* buffer,
       int capacity,
       bool skip_capacity_check,
-      bool replace_invalid_utf8)
+      bool replace_invalid_utf8,
+      bool encode_as_cesu_8)
     : early_termination_(false),
       last_character_(unibrow::Utf16::kNoPreviousCharacter),
       buffer_(buffer),
@@ -4480,6 +4628,7 @@ class Utf8WriterVisitor {
       capacity_(capacity),
       skip_capacity_check_(capacity == -1 || skip_capacity_check),
       replace_invalid_utf8_(replace_invalid_utf8),
+      encode_as_cesu_8_(encode_as_cesu_8),
       utf16_chars_read_(0) {
   }
 
@@ -4487,13 +4636,14 @@ class Utf8WriterVisitor {
                                int last_character,
                                int remaining,
                                char* const buffer,
-                               bool replace_invalid_utf8) {
+                               bool replace_invalid_utf8,
+                               bool encode_as_cesu_8) {
     using namespace unibrow;
     DCHECK(remaining > 0);
     // We can't use a local buffer here because Encode needs to modify
     // previous characters in the stream.  We know, however, that
     // exactly one character will be advanced.
-    if (Utf16::IsSurrogatePair(last_character, character)) {
+    if (!encode_as_cesu_8 && Utf16::IsSurrogatePair(last_character, character)) {
       int written = Utf8::Encode(buffer,
                                  character,
                                  last_character,
@@ -4507,7 +4657,8 @@ class Utf8WriterVisitor {
     int written = Utf8::Encode(temp_buffer,
                                character,
                                Utf16::kNoPreviousCharacter,
-                               replace_invalid_utf8);
+                               replace_invalid_utf8,
+                               encode_as_cesu_8);
     // Won't fit.
     if (written > remaining) return 0;
     // Copy over the character from temp_buffer.
@@ -4567,7 +4718,8 @@ class Utf8WriterVisitor {
           buffer += Utf8::Encode(buffer,
                                  character,
                                  last_character,
-                                 replace_invalid_utf8_);
+                                 replace_invalid_utf8_,
+                                 encode_as_cesu_8_);
           last_character = character;
           DCHECK(capacity_ == -1 || (buffer - start_) <= capacity_);
         }
@@ -4597,7 +4749,8 @@ class Utf8WriterVisitor {
                                       last_character,
                                       remaining_capacity,
                                       buffer,
-                                      replace_invalid_utf8_);
+                                      replace_invalid_utf8_,
+                                      encode_as_cesu_8_);
       if (written == 0) {
         early_termination_ = true;
         break;
@@ -4646,6 +4799,7 @@ class Utf8WriterVisitor {
   int capacity_;
   bool const skip_capacity_check_;
   bool const replace_invalid_utf8_;
+  bool const encode_as_cesu_8_;
   int utf16_chars_read_;
   DISALLOW_IMPLICIT_CONSTRUCTORS(Utf8WriterVisitor);
 };
@@ -4685,10 +4839,12 @@ int String::WriteUtf8(char* buffer,
   const int string_length = str->length();
   bool write_null = !(options & NO_NULL_TERMINATION);
   bool replace_invalid_utf8 = (options & REPLACE_INVALID_UTF8);
+  bool encode_as_cesu_8 = (options & ENCODE_AS_CESU_8);
   int max16BitCodeUnitSize = unibrow::Utf8::kMax16BitCodeUnitSize;
   // First check if we can just write the string without checking capacity.
   if (capacity == -1 || capacity / max16BitCodeUnitSize >= string_length) {
-    Utf8WriterVisitor writer(buffer, capacity, true, replace_invalid_utf8);
+    Utf8WriterVisitor writer(buffer, capacity, true, replace_invalid_utf8,
+                             encode_as_cesu_8);
     const int kMaxRecursion = 100;
     bool success = RecursivelySerializeToUtf8(*str, &writer, kMaxRecursion);
     if (success) return writer.CompleteWrite(write_null, nchars_ref);
@@ -4716,7 +4872,8 @@ int String::WriteUtf8(char* buffer,
   }
   // Recursive slow path can potentially be unreasonable slow. Flatten.
   str = i::String::Flatten(str);
-  Utf8WriterVisitor writer(buffer, capacity, false, replace_invalid_utf8);
+  Utf8WriterVisitor writer(buffer, capacity, false, replace_invalid_utf8,
+                           encode_as_cesu_8);
   i::String::VisitFlat(&writer, *str);
   return writer.CompleteWrite(write_null, nchars_ref);
 }

--- a/deps/v8/src/unicode-inl.h
+++ b/deps/v8/src/unicode-inl.h
@@ -91,7 +91,8 @@ unsigned Utf8::EncodeOneByte(char* str, uint8_t c) {
 unsigned Utf8::Encode(char* str,
                       uchar c,
                       int previous,
-                      bool replace_invalid) {
+                      bool replace_invalid,
+                      bool encode_as_cesu_8) {
   static const int kMask = ~(1 << 6);
   if (c <= kMaxOneByteChar) {
     str[0] = c;
@@ -101,7 +102,7 @@ unsigned Utf8::Encode(char* str,
     str[1] = 0x80 | (c & kMask);
     return 2;
   } else if (c <= kMaxThreeByteChar) {
-    if (Utf16::IsSurrogatePair(previous, c)) {
+    if (!encode_as_cesu_8 && Utf16::IsSurrogatePair(previous, c)) {
       const int kUnmatchedSize = kSizeOfUnmatchedSurrogate;
       return Encode(str - kUnmatchedSize,
                     Utf16::CombineSurrogatePair(previous, c),
@@ -150,6 +151,18 @@ unsigned Utf8::Length(uchar c, int previous) {
     return 3;
   } else {
     return 4;
+  }
+}
+
+unsigned Utf8::CesuLength(uchar c, int previous) {
+  if (c <= kMaxOneByteChar) {
+    return 1;
+  } else if (c <= kMaxTwoByteChar) {
+    return 2;
+  } else if (c <= kMaxThreeByteChar) {
+    return 3;
+  } else {
+    return 6;
   }
 }
 

--- a/deps/v8/src/unicode.h
+++ b/deps/v8/src/unicode.h
@@ -125,11 +125,13 @@ class Latin1 {
 class Utf8 {
  public:
   static inline uchar Length(uchar chr, int previous);
+  static inline uchar CesuLength(uchar chr, int previous);
   static inline unsigned EncodeOneByte(char* out, uint8_t c);
   static inline unsigned Encode(char* out,
                                 uchar c,
                                 int previous,
-                                bool replace_invalid = false);
+                                bool replace_invalid = false,
+                                bool encode_as_cesu_8 = false);
   static uchar CalculateValue(const byte* str,
                               unsigned length,
                               unsigned* cursor);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -431,6 +431,11 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       ret = this.utf8Write(string, offset, length);
       break;
 
+    case 'cesu8':
+    case 'cesu-8':
+      ret = this.cesu8Write(string, offset, length);
+      break;
+
     case 'ascii':
       ret = this.asciiWrite(string, offset, length);
       break;

--- a/src/node.cc
+++ b/src/node.cc
@@ -155,6 +155,10 @@ static Isolate* node_isolate = NULL;
 int WRITE_UTF8_FLAGS = v8::String::HINT_MANY_WRITES_EXPECTED |
                        v8::String::NO_NULL_TERMINATION;
 
+int WRITE_CESU8_FLAGS = v8::String::HINT_MANY_WRITES_EXPECTED |
+                        v8::String::NO_NULL_TERMINATION       |
+                        v8::String::ENCODE_AS_CESU_8;
+
 class ArrayBufferAllocator : public ArrayBuffer::Allocator {
  public:
   // Impose an upper limit to avoid out of memory errors that bring down
@@ -1173,6 +1177,10 @@ enum encoding ParseEncoding(Isolate* isolate,
     return UTF8;
   } else if (strcasecmp(*encoding, "utf-8") == 0) {
     return UTF8;
+  } else if (strcasecmp(*encoding, "cesu8") == 0) {
+    return CESU8;
+  } else if (strcasecmp(*encoding, "cesu-8") == 0) {
+    return CESU8;
   } else if (strcasecmp(*encoding, "ascii") == 0) {
     return ASCII;
   } else if (strcasecmp(*encoding, "base64") == 0) {

--- a/src/node.h
+++ b/src/node.h
@@ -267,7 +267,7 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
 }
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 
-enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
+enum encoding {ASCII, UTF8, CESU8, BASE64, UCS2, BINARY, HEX, BUFFER};
 enum encoding ParseEncoding(v8::Isolate* isolate,
                             v8::Handle<v8::Value> encoding_v,
                             enum encoding _default = BINARY);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -434,6 +434,9 @@ void Utf8Write(const FunctionCallbackInfo<Value>& args) {
   StringWrite<UTF8>(args);
 }
 
+void Cesu8Write(const FunctionCallbackInfo<Value>& args) {
+  StringWrite<CESU8>(args);
+}
 
 void Ucs2Write(const FunctionCallbackInfo<Value>& args) {
   StringWrite<UCS2>(args);
@@ -620,6 +623,7 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
   NODE_SET_METHOD(proto, "hexWrite", HexWrite);
   NODE_SET_METHOD(proto, "ucs2Write", Ucs2Write);
   NODE_SET_METHOD(proto, "utf8Write", Utf8Write);
+  NODE_SET_METHOD(proto, "cesu8Write", Cesu8Write);
 
   NODE_SET_METHOD(proto, "copy", Copy);
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -333,6 +333,15 @@ size_t StringBytes::Write(Isolate* isolate,
         len = str->WriteUtf8(buf, buflen, chars_written, WRITE_UTF8_FLAGS);
       break;
 
+    case CESU8:
+      if (is_extern)
+        // TODO(tjfontaine) should this validate invalid surrogate pairs as
+        // well?
+        memcpy(buf, data, len);
+      else
+        len = str->WriteUtf8(buf, buflen, chars_written, WRITE_CESU8_FLAGS);
+      break;
+
     case UCS2:
       if (is_extern)
         memcpy(buf, data, len * 2);
@@ -473,6 +482,10 @@ size_t StringBytes::Size(Isolate* isolate,
 
     case UTF8:
       data_size = str->Utf8Length();
+      break;
+
+    case CESU8:
+      data_size = str->Cesu8Length();
       break;
 
     case UCS2:

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -30,6 +30,7 @@
 namespace node {
 
 extern int WRITE_UTF8_FLAGS;
+extern int WRITE_CESU8_FLAGS;
 
 class StringBytes {
  public:

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -1187,3 +1187,9 @@ assert.throws(function() {
 
 // Regression test for https://github.com/iojs/io.js/issues/649.
 assert.throws(function() { Buffer(1422561062959).toString('utf8'); });
+
+// String encoded as CESU-8
+var grinning_face = new Buffer('f09f9880', 'hex').toString();
+var grinning_face_buf = new Buffer(grinning_face, 'cesu-8');
+var grinning_face_hex = grinning_face_buf.toString('hex').toLowerCase();
+assert.equal(grinning_face_hex, 'eda0bdedb880');


### PR DESCRIPTION
In our daily work it frequently occurs that we need to let Node.js apps communicate in binary with Java apps, which necessitates the CESU-8 encoding. Details about this encoding is observed in [1]. This pull request is a quick implementation of it. One test case has been added and passed.

Since it modifies the upstream v8 code, I am not sure about how to handle such kind of patches. It seems problematic to make changes naively onto the node repository. Please guide me on how to merge this code. Thank you very much!
- CESU-8 stands for Compatibility Encoding Scheme for UTF-16: 8-Bit
- Function VisitTwoByteString() was made virtual to call in CESU-8 mode
- Added a new class CesuVisitor inheriting from Visitor
- Added Smiling Face symbol as a test case
- New API - String::Cesu8Length()
- New String::WriteOptions - ENCODE_AS_CESU_8

[1] https://en.wikipedia.org/wiki/CESU-8
