### PR TITLE
configure: add --without-mdb flag

### DIFF
--- a/configure
+++ b/configure
@@ -282,6 +282,11 @@ parser.add_option('--without-etw',
     dest='without_etw',
     help='build without ETW')
 
+parser.add_option('--without-mdb',
+    action='store_true',
+    dest='without_mdb',
+    help='build without mdb')
+
 parser.add_option('--without-npm',
     action='store_true',
     dest='without_npm',
@@ -554,7 +559,7 @@ def configure_node(o):
   # if we're on illumos based systems wrap the helper library into the
   # executable
   if flavor == 'solaris':
-    o['variables']['node_use_mdb'] = 'true'
+    o['variables']['node_use_mdb'] = b(not options.without_mdb)
   else:
     o['variables']['node_use_mdb'] = 'false'
 

--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -7,6 +7,7 @@ test-microtask-queue-run-domain   : PASS,FLAKY
 
 [$system==win32]
 test-timers-first-fire            : PASS,FLAKY
+test-http-pipeline-flood          : PASS,FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
Fixes build issues on Solaris based platforms where libproc.h is not
available or not compatible with the one shipped by SmartOS.

Fixes #6439.

This is just a PR that fixes the commit message from https://github.com/joyent/node/pull/9349. It's otherwise strictly identical.
