### PR TITLE
tls: do not hang without `newSession` handler

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -662,14 +662,17 @@ function onnewsession(key, session) {
   var self = this;
   var once = false;
 
-  self.server.emit('newSession', key, session, function() {
+  if (!self.server.emit('newSession', key, session, done))
+    done();
+
+  function done() {
     if (once)
       return;
     once = true;
 
     if (self.ssl)
       self.ssl.newSessionDone();
-  });
+  };
 }
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -201,7 +201,10 @@ function onnewsession(key, session) {
   var once = false;
 
   this._newSessionPending = true;
-  this.server.emit('newSession', key, session, function() {
+  if (!this.server.emit('newSession', key, session, done))
+    done();
+
+  function done() {
     if (once)
       return;
     once = true;
@@ -212,7 +215,7 @@ function onnewsession(key, session) {
     if (self._securePending)
       self._finishInit();
     self._securePending = false;
-  });
+  }
 }
 
 

--- a/test/simple/test-tls-new-session-hang.js
+++ b/test/simple/test-tls-new-session-hang.js
@@ -1,0 +1,42 @@
+var common = require('../common');
+
+if (!process.features.tls_ocsp) {
+  console.error('Skipping because node compiled without OpenSSL or ' +
+                'with old OpenSSL version.');
+  process.exit(0);
+}
+
+var assert = require('assert');
+var tls = require('tls');
+var constants = require('constants');
+var fs = require('fs');
+var join = require('path').join;
+
+var keyFile = join(common.fixturesDir, 'keys', 'agent1-key.pem');
+var certFile = join(common.fixturesDir, 'keys', 'agent1-cert.pem');
+var caFile = join(common.fixturesDir, 'keys', 'ca1-cert.pem');
+var key = fs.readFileSync(keyFile);
+var cert = fs.readFileSync(certFile);
+
+var server = tls.createServer({
+  cert: cert,
+  key: key
+}, function (socket) {
+  socket.destroySoon();
+});
+
+server.on('resumeSession', common.mustCall(function() {
+  // Should not be actually called
+}, 0));
+
+server.listen(common.PORT, function() {
+  var client = tls.connect({
+    rejectUnauthorized: false,
+    port: common.PORT,
+
+    // Just to make sure that `newSession` is going to be called
+    secureOptions: constants.SSL_OP_NO_TICKET
+  }, function() {
+    server.close();
+  });
+});


### PR DESCRIPTION
When listening for client hello parser events (like OCSP requests), do
not hang if `newSession` event handler is not present.
