### PR TITLE
test: fix test-debug-port-from-cmdline

### DIFF
--- a/test/simple/test-debug-port-from-cmdline.js
+++ b/test/simple/test-debug-port-from-cmdline.js
@@ -24,11 +24,11 @@ var assert = require('assert');
 var spawn = require('child_process').spawn;
 
 var debugPort = common.PORT;
-var args = ['--debug-port=' + debugPort];
+var args = ['--interactive', '--debug-port=' + debugPort];
 var childOptions = { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] };
 var child = spawn(process.execPath, args, childOptions);
 
-child.stdin.end("process.send({ msg: 'childready' });");
+child.stdin.write("process.send({ msg: 'childready' });\n");
 
 child.stderr.on('data', function(data) {
   var lines = data.toString().replace(/\r/g, '').trim().split('\n');
@@ -43,6 +43,7 @@ child.on('message', function onChildMsg(message) {
 
 process.on('exit', function() {
   child.kill();
+  assertOutputLines();
 });
 
 var outputLines = [];
@@ -51,7 +52,6 @@ function processStderrLine(line) {
   outputLines.push(line);
 
   if (/Debugger listening/.test(line)) {
-    assertOutputLines();
     process.exit();
   }
 }


### PR DESCRIPTION
`test-debug-port-from-cmdline` became an issue in io.js in https://github.com/nodejs/io.js/issues/2094 , when it was noticed that it failed frequently on Windows 2008. The error messages displayed were not clear and threw investigation off from the real problem.

The problem turned out to be with the test itself, and it failed also on Linux but silently, which is also the case for v0.12. For example here: http://jenkins.nodejs.org/job/node-test-commit-unix/132/DESTCPU=ia32,label=linux/tapTestReport/simple.tap-126/ the output should have been 2 lines:

```
> Starting debugger agent.
> Debugger listening on port 12346
```

This fix changes the test so that it runs as expected and always asserts the expected result. Further details in the original PR: https://github.com/nodejs/io.js/pull/2186

/cc @joyent/node-collaborators 
