### PR TITLE
test: mark test-signal-unregister as flaky

### DIFF
--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -10,6 +10,7 @@ test-timers-first-fire            : PASS,FLAKY
 test-http-pipeline-flood          : PASS,FLAKY
 
 [$system==linux]
+test-signal-unregister            : PASS,FLAKY
 
 [$system==macos]
 test-fs-watch                     : PASS,FLAKY


### PR DESCRIPTION
This test just failed on Ubuntu in Jenkins, for a change that
is 100% Windows-specific.

https://jenkins-iojs.nodesource.com/job/node-test-commit-linux/28/nodes=ubuntu1504-64/tapTestReport/test.tap-576/
