### PR TITLE
Make http.request correctly parse {host: "hostname:port"}

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -80,10 +80,10 @@ function ClientRequest(options, cb) {
 
   var defaultPort = options.defaultPort || self.agent && self.agent.defaultPort;
 
-  var hostParts = options.host && options.host.split(':');
+  var hostParts = (options.host && options.host.split(':')) || [];
 
-  var port = options.port = options.port || (hostParts && hostParts[1]) || defaultPort || 80;
-  var host = options.host = options.hostname || (hostParts && hostParts[0]) || 'localhost';
+  var port = options.port = options.port || hostParts[1] || defaultPort || 80;
+  var host = options.host = options.hostname || hostParts[0] || 'localhost';
 
   if (util.isUndefined(options.setHost)) {
     var setHost = true;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -80,8 +80,10 @@ function ClientRequest(options, cb) {
 
   var defaultPort = options.defaultPort || self.agent && self.agent.defaultPort;
 
-  var port = options.port = options.port || defaultPort || 80;
-  var host = options.host = options.hostname || options.host || 'localhost';
+  var hostParts = options.host && options.host.split(':');
+
+  var port = options.port = options.port || (hostParts && hostParts[1]) || defaultPort || 80;
+  var host = options.host = options.hostname || (hostParts && hostParts[0]) || 'localhost';
 
   if (util.isUndefined(options.setHost)) {
     var setHost = true;

--- a/test/simple/test-http-request-host-port.js
+++ b/test/simple/test-http-request-host-port.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var connected = false;
+
+var server = http.createServer(function(req, res) {
+  connected = true;
+  res.writeHead(204);
+  res.end();
+});
+
+server.listen(common.PORT, function() {
+ http.get({
+    host: 'localhost:' + common.PORT
+  }, function(res) {
+    console.log(res.statusCode);
+    res.resume();
+    server.close();
+  }).on('error', function(e) {
+    console.log(e.message);
+    process.exit(1);
+  });
+});
+
+process.on('exit', function() {
+  assert(connected, 'http.request should correctly parse {host: "hostname:port"} and connect to the specified host');
+});


### PR DESCRIPTION
Fixes #25751 so that `http.request()` doesn't attempt an invalid dns lookup of `hostname:port` when it should only be looking up `hostname`.
