### PR TITLE
net: ensure Socket reported address is current

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -124,6 +124,7 @@ function initSocketHandle(self) {
   self.destroyed = false;
   self.bytesRead = 0;
   self._bytesDispatched = 0;
+  self._sockname = null;
 
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {
@@ -488,6 +489,7 @@ Socket.prototype._destroy = function(exception, cb) {
     });
     this._handle.onread = noop;
     this._handle = null;
+    this._sockname = null;
   }
 
   // we set destroyed to true before firing error callbacks in order
@@ -869,6 +871,7 @@ Socket.prototype.connect = function(options, cb) {
     this.destroyed = false;
     this._handle = null;
     this._peername = null;
+    this._sockname = null;
   }
 
   var self = this;
@@ -995,6 +998,7 @@ function afterConnect(status, handle, req, readable, writable) {
 
   assert.ok(self._connecting);
   self._connecting = false;
+  self._sockname = null;
 
   if (status == 0) {
     self.readable = readable;

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -1,0 +1,36 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var conns = 0;
+var clientLocalPorts = [];
+var serverRemotePorts = [];
+
+var server = net.createServer(function(socket) {
+  serverRemotePorts.push(socket.remotePort);
+  conns++;
+});
+
+var client = new net.Socket();
+
+server.on('close', function() {
+  assert.deepEqual(clientLocalPorts, serverRemotePorts,
+                   'client and server should agree on the ports used');
+  assert.equal(2, conns);
+});
+
+server.listen(0, testConnect);
+
+function testConnect() {
+  if (conns == 2) {
+    return server.close();
+  }
+  client.connect(server.address().port, server.address().addr, function() {
+    clientLocalPorts.push(this.localPort);
+    this.once('close', function() {
+      setTimeout(testConnect, common.platformTimeout(100));
+    });
+    this.destroy();
+  });
+}


### PR DESCRIPTION
Any time the connection state or the underlying handle itself changes,
the socket's name (aka, local address) can change.

To deal with this we need to reset the cached sockname any time we
set or unset the internal handle or an existing handle establishes a
connection.

Fixes #25621
Same PR on iojs: nodejs/io.js#2095
