### PR TITLE
test: make test-abort-fatal-error non flaky

### DIFF
--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -17,7 +17,6 @@ test-tls-securepair-server              : PASS,FLAKY
 test-timers-first-fire                  : PASS,FLAKY
  
 [$system==linux]
-test-abort-fatal-error                  : PASS,FLAKY
 test-debugger-client                    : PASS,FLAKY
 test-process-argv-0                     : PASS,FLAKY
 test-cluster-master-kill                : PASS,FLAKY
@@ -29,7 +28,6 @@ test-cluster-master-error               : PASS,FLAKY
 test-http-exit-delay                    : PASS,FLAKY
 
 [$system==solaris]
-test-abort-fatal-error                  : PASS,FLAKY
 test-debugger-repl                      : PASS,FLAKY
 test-debugger-repl-break-in-module      : PASS,FLAKY
 test-debugger-repl-utf8                 : PASS,FLAKY

--- a/test/simple/test-abort-fatal-error.js
+++ b/test/simple/test-abort-fatal-error.js
@@ -30,10 +30,21 @@ if (process.platform === 'win32') {
 var exec = require('child_process').exec;
 
 var cmdline = 'ulimit -c 0; ' + process.execPath;
-cmdline += ' --max-old-space-size=1 --max-new-space-size=1';
-cmdline += ' -e "setInterval(function() { new Buffer(1024); }, 1);"';
+cmdline += ' --max-old-space-size=4 --max-new-space-size=1';
+cmdline += ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
 
 exec(cmdline, function(err, stdout, stderr) {
-  assert(err);
-  assert(stderr.toString().match(/abort/i));
+  if (!err) {
+    console.log(stdout);
+    console.log(stderr);
+    assert(false, 'this test should fail');
+    return;
+  }
+
+  if (err.code !== 134 && err.signal !== 'SIGABRT') {
+    console.log(stdout);
+    console.log(stderr);
+    console.log(err);
+    assert(false, err);
+  }
 });


### PR DESCRIPTION
Before this change, test/simple/test-abort-fatal-error.js would fail in
some environments for reasons I wasn't able to fully understand. It was
marked as flaky on some systems, but not on others on which it was
failing sometimes (OSX).

This change basically syncs test-abort-fatal-error with how it's
implemented in v0.12. It back ports 429b587 (or rather the parts that
apply to it since it's a merge commit), 2f5e77f and 114bff4.

After backporting these changes in v0.10, test-abort-fatal-error is not
flaky anymore in environments for which it was flaky. It also has the
added benefit of being more robust because it checks exit codes and
signals instead of error messages.

Tested on OSX and SmartOS, the only platforms on which I could reproduce
the flakiness of this test.

This change also removes test-abort-fatal-error from the list of flaky
tests in test/simple/simple.status.

Fixes #25720.
