### PR TITLE
test: mark test-net-error-twice flaky on SmartOS

### DIFF
--- a/test/simple/simple.status
+++ b/test/simple/simple.status
@@ -32,3 +32,4 @@ test-debugger-repl                      : PASS,FLAKY
 test-debugger-repl-break-in-module      : PASS,FLAKY
 test-debugger-repl-utf8                 : PASS,FLAKY
 test-net-server-max-connections         : PASS,FLAKY
+test-net-error-twice                    : PASS,FLAKY


### PR DESCRIPTION
It seems that test-net-error-twice.js does not behave as expected. Its
goal is to test fireErrorCallbacks, but it doesn't do it correctly,
leading to false negatives on some platforms and failures on others.
This change marks this test as flaky so that we can use our CI to land
changes in the v0.10 branch until we can fix it properly.

See the corresponding issue at
https://github.com/joyent/node/issues/9325 for more details.
