### PR TITLE
 { encodeURIComponent: 'gbkEncodeURIComponent' }

### DIFF
--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -29,7 +29,7 @@ Example:
     // Suppose gbkEncodeURIComponent function already exists,
     // it can encode string with `gbk` encoding
     querystring.stringify({ w: '中文', foo: 'bar' }, null, null,
-      { encodeURIComponent: gbkEncodeURIComponent })
+      { encodeURIComponent: 'gbkEncodeURIComponent' })
     // returns
     'w=%D6%D0%CE%C4&foo=bar'
 
@@ -54,7 +54,7 @@ Example:
     // Suppose gbkDecodeURIComponent function already exists,
     // it can decode `gbk` encoding string
     querystring.parse('w=%D6%D0%CE%C4&foo=bar', null, null,
-      { decodeURIComponent: gbkDecodeURIComponent })
+      { decodeURIComponent: 'gbkDecodeURIComponent' })
     // returns
     { w: '中文', foo: 'bar' }
 


### PR DESCRIPTION
 { encodeURIComponent: gbkEncodeURIComponent }, need ' '.
and I am not sure, I get it when I run the code in win10
w=%E4%B8%AD%E6%96%87&foo=bar
