### PR TITLE
build: Intl: bump ICU4C from 54 to 55

### DIFF
--- a/configure
+++ b/configure
@@ -748,9 +748,9 @@ def glob_to_var(dir_base, dir_sub):
 def configure_intl(o):
   icus = [
     {
-      'url': 'http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.zip',
-      # from https://ssl.icu-project.org/files/icu4c/54.1/icu4c-src-54_1.md5:
-      'md5': '6b89d60e2f0e140898ae4d7f72323bca',
+      'url': 'http://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.zip',
+      # from https://ssl.icu-project.org/files/icu4c/55.1/icu4c-src-55_1.md5:
+      'md5': '4cddf1e1d47622fdd9de2cd7bb5001fd',
     },
   ]
   def icu_download(path):

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -111,8 +111,8 @@
             '<@(icu_src_i18n)'
           ],
           'conditions': [
-            [ 'icu_ver_major == 54', { 'sources!': [
-              ## Strip out the following for ICU 54 only.
+            [ 'icu_ver_major == 55', { 'sources!': [
+              ## Strip out the following for ICU 55 only.
               ## add more conditions in the future?
               ## if your compiler can dead-strip, this will
               ## make ZERO difference to binary size.
@@ -369,8 +369,8 @@
         '<@(icu_src_common)',
       ],
       'conditions': [
-        [ 'icu_ver_major == 54', { 'sources!': [
-          ## Strip out the following for ICU 54 only.
+        [ 'icu_ver_major == 55', { 'sources!': [
+          ## Strip out the following for ICU 55 only.
           ## add more conditions in the future?
           ## if your compiler can dead-strip, this will
           ## make ZERO difference to binary size.


### PR DESCRIPTION
Fixes: #25855 
node was using ICU4C 54 ( released 2014-oct-06 )
- Bump to ICU4C 55 ( released 2015-apr-08)
  - Timezone fixes, translation fixes, bug/performance fixes.
  - Speed improvements in date formatting
  - ICU4C 55 changelog: http://site.icu-project.org/download/55
  - CLDR 27 changelog: http://cldr.unicode.org/index/downloads/cldr-27
- Retarget the file exclusions from ICU4C 54 to ICU4C 55
  - (improves on-disk footprint on some platforms)

Originally-Fixes: https://github.com/nodejs/node/issues/2292
Original-PR-URL: https://github.com/nodejs/node/pull/2293

@orangemocha @joaocgreis or anyone any comments on the rebase?
