### PR TITLE
src/node.cc: fix build error without OpenSSL support

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -82,7 +82,6 @@ typedef int mode_t;
 #include "node_script.h"
 #include "v8_typed_array.h"
 
-#include "node_crypto.h"
 #include "util.h"
 
 using namespace v8;
@@ -2564,8 +2563,10 @@ static void PrintHelp() {
          "  --trace-deprecation  show stack traces on deprecations\n"
          "  --v8-options         print v8 command line options\n"
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
+#if HAVE_OPENSSL
          "  --enable-ssl2        enable ssl2\n"
          "  --enable-ssl3        enable ssl3\n"
+#endif
          "\n"
          "Environment variables:\n"
 #ifdef _WIN32
@@ -2599,12 +2600,14 @@ static void ParseArgs(int argc, char **argv) {
       p = 1 + strchr(arg, '=');
       max_stack_size = atoi(p);
       argv[i] = const_cast<char*>("");
+#if HAVE_OPENSSL
     } else if (strcmp(arg, "--enable-ssl2") == 0) {
       SSL2_ENABLE = true;
       argv[i] = const_cast<char*>("");
     } else if (strcmp(arg, "--enable-ssl3") == 0) {
       SSL3_ENABLE = true;
       argv[i] = const_cast<char*>("");
+#endif
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);


### PR DESCRIPTION
Resubmit PR https://github.com/joyent/node/pull/8761 since the forked repo was closed by myself. This fixes the issue reported upstream: https://github.com/joyent/node/issues/8676

Commit d601c76f4d728dd7adfa2fbbed2fe86de2e6b479 introduced a bug which includes `node_crypto.h` twice. Once conditionally with `HAVE_OPENSSL` and once without it:

``` c
#if HAVE_OPENSSL
# include "node_crypto.h"
#endif
[...]
#include "node_crypto.h"
```

Fix this by removing the unconditional header include of `node_crypto.h` and add conditions for the OpenSSL related parts.
