### PR TITLE
doc/api/process: remove superfluous util.inspect()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -615,7 +615,7 @@ measured in bytes.
 
     var util = require('util');
 
-    console.log(util.inspect(process.memoryUsage()));
+    console.log(process.memoryUsage());
 
 This will generate:
 


### PR DESCRIPTION
Also, the rendered html is syntax highlighted @[link](https://nodejs.org/api/process.html#process_process_memoryusage), but the output of `console.log` is a plain string, not an object.
