### PR TITLE
timers: Add instanceof check for all 'Timeout' methods

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -312,7 +312,18 @@ function unrefdHandle() {
 }
 
 
+var Timeout_call_context_error = "Trying to call 'Timeout' member method on non 'Timeout' context";
+
 Timeout.prototype.unref = function() {
+  // Prevent call 'Timeout' member method on non 'Timeout' context.
+  // For example this is wrong:
+  //   var t = setInterval(function() {}, 1);
+  //   process.nextTick(t.unref);
+  // But this is ok:
+  //   var t = setInterval(function() {}, 1);
+  //   process.nextTick(t.unref.bind(t));
+  if (!(this instanceof Timeout))
+    throw new Error(Timeout_call_context_error);
   if (!this._handle) {
     var now = Timer.now();
     if (!this._idleStart) this._idleStart = now;
@@ -331,11 +342,15 @@ Timeout.prototype.unref = function() {
 };
 
 Timeout.prototype.ref = function() {
+  if (!(this instanceof Timeout))
+    throw new Error(Timeout_call_context_error);
   if (this._handle)
     this._handle.ref();
 };
 
 Timeout.prototype.close = function() {
+  if (!(this instanceof Timeout))
+    throw new Error(Timeout_call_context_error);
   this._onTimeout = null;
   if (this._handle) {
     this._handle[kOnTimeout] = null;

--- a/test/simple/test-timers-unref.js
+++ b/test/simple/test-timers-unref.js
@@ -58,7 +58,16 @@ check_unref = setInterval(function() {
 // Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
 (function() {
   var t = setInterval(function() {}, 1);
-  process.nextTick(t.unref.bind({}));
+  assert.throws(
+    function() {
+      t.unref.bind({})();
+    },
+    function(err) {
+      if ((err instanceof Error) && /Trying to call/.test(err))
+        return true;
+    },
+    "Timeout should throw exception for non timeout context call"
+  );
   process.nextTick(t.unref.bind(t));
 })();
 


### PR DESCRIPTION
During the call of 'Timeout' member method, the call context may have
incorrect values or the  context  itself  can  be  completely  wrong.
It cause crash  or  hang  or  unknown error. In order to prevent this
situation  in  future  we  need  to  add  call  context  check.

Fixes #4261
